### PR TITLE
Delete unnecessary driver #includes continued...

### DIFF
--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -42,9 +42,6 @@
  */
 
 #include "batt_smbus.h"
-#include <px4_getopt.h>
-
-#include <stdlib.h>
 
 extern "C" __EXPORT int batt_smbus_main(int argc, char *argv[]);
 

--- a/src/drivers/batt_smbus/batt_smbus.h
+++ b/src/drivers/batt_smbus/batt_smbus.h
@@ -43,48 +43,49 @@
 
 #pragma once
 
-#include <drivers/drv_hrt.h>
 #include <ecl/geo/geo.h>
 #include <lib/drivers/smbus/SMBus.hpp>
 #include <mathlib/mathlib.h>
-#include <px4_config.h>
-#include <px4_work_queue/ScheduledWorkItem.hpp>
 #include <perf/perf_counter.h>
 #include <platforms/px4_module.h>
+#include <px4_getopt.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 #include <uORB/topics/battery_status.h>
 
-#define DATA_BUFFER_SIZE				                32
+#include "board_config.h"
 
-#define BATT_CELL_VOLTAGE_THRESHOLD_RTL                 0.5f                    ///< Threshold in volts to RTL if cells are imbalanced
-#define BATT_CELL_VOLTAGE_THRESHOLD_FAILED              1.5f                    ///< Threshold in volts to Land if cells are imbalanced
+#define DATA_BUFFER_SIZE                                32
 
-#define BATT_CURRENT_UNDERVOLTAGE_THRESHOLD             5.0f                    ///< Threshold in amps to disable undervoltage protection
-#define BATT_VOLTAGE_UNDERVOLTAGE_THRESHOLD             3.4f                    ///< Threshold in volts to re-enable undervoltage protection
+#define BATT_CELL_VOLTAGE_THRESHOLD_RTL                 0.5f            ///< Threshold in volts to RTL if cells are imbalanced
+#define BATT_CELL_VOLTAGE_THRESHOLD_FAILED              1.5f            ///< Threshold in volts to Land if cells are imbalanced
 
-#define BATT_SMBUS_CURRENT                              0x0A                    ///< current register
-#define BATT_SMBUS_AVERAGE_CURRENT                      0x0B                    ///< current register
-#define BATT_SMBUS_ADDR                                 0x0B                    ///< Default 7 bit address I2C address. 8 bit = 0x16
-#define BATT_SMBUS_ADDR_MIN                             0x00                    ///< lowest possible address
-#define BATT_SMBUS_ADDR_MAX                             0xFF                    ///< highest possible address
-#define BATT_SMBUS_PEC_POLYNOMIAL                       0x07                    ///< Polynomial for calculating PEC
-#define BATT_SMBUS_TEMP                                 0x08                    ///< temperature register
-#define BATT_SMBUS_VOLTAGE                              0x09                    ///< voltage register
-#define BATT_SMBUS_FULL_CHARGE_CAPACITY                 0x10                    ///< capacity when fully charged
-#define BATT_SMBUS_RUN_TIME_TO_EMPTY                    0x11                    ///< predicted remaining battery capacity based on the present rate of discharge in min
-#define BATT_SMBUS_AVERAGE_TIME_TO_EMPTY                0x12                    ///< predicted remaining battery capacity based on the present rate of discharge in min
-#define BATT_SMBUS_REMAINING_CAPACITY                   0x0F                    ///< predicted remaining battery capacity as a percentage
-#define BATT_SMBUS_CYCLE_COUNT                          0x17                    ///< number of cycles the battery has experienced
-#define BATT_SMBUS_DESIGN_CAPACITY                      0x18                    ///< design capacity register
-#define BATT_SMBUS_DESIGN_VOLTAGE                       0x19                    ///< design voltage register
-#define BATT_SMBUS_MANUFACTURER_NAME                    0x20                    ///< manufacturer name
-#define BATT_SMBUS_MANUFACTURE_DATE                     0x1B                    ///< manufacture date register
-#define BATT_SMBUS_SERIAL_NUMBER                        0x1C                    ///< serial number register
-#define BATT_SMBUS_MEASUREMENT_INTERVAL_US              100000                  ///< time in microseconds, measure at 10Hz
-#define BATT_SMBUS_TIMEOUT_US                           1000000                 ///< timeout looking for battery 10seconds after startup
+#define BATT_CURRENT_UNDERVOLTAGE_THRESHOLD             5.0f            ///< Threshold in amps to disable undervoltage protection
+#define BATT_VOLTAGE_UNDERVOLTAGE_THRESHOLD             3.4f            ///< Threshold in volts to re-enable undervoltage protection
+
+#define BATT_SMBUS_CURRENT                              0x0A            ///< current register
+#define BATT_SMBUS_AVERAGE_CURRENT                      0x0B            ///< current register
+#define BATT_SMBUS_ADDR                                 0x0B            ///< Default 7 bit address I2C address. 8 bit = 0x16
+#define BATT_SMBUS_ADDR_MIN                             0x00            ///< lowest possible address
+#define BATT_SMBUS_ADDR_MAX                             0xFF            ///< highest possible address
+#define BATT_SMBUS_PEC_POLYNOMIAL                       0x07            ///< Polynomial for calculating PEC
+#define BATT_SMBUS_TEMP                                 0x08            ///< temperature register
+#define BATT_SMBUS_VOLTAGE                              0x09            ///< voltage register
+#define BATT_SMBUS_FULL_CHARGE_CAPACITY                 0x10            ///< capacity when fully charged
+#define BATT_SMBUS_RUN_TIME_TO_EMPTY                    0x11            ///< predicted remaining battery capacity based on the present rate of discharge in min
+#define BATT_SMBUS_AVERAGE_TIME_TO_EMPTY                0x12            ///< predicted remaining battery capacity based on the present rate of discharge in min
+#define BATT_SMBUS_REMAINING_CAPACITY                   0x0F            ///< predicted remaining battery capacity as a percentage
+#define BATT_SMBUS_CYCLE_COUNT                          0x17            ///< number of cycles the battery has experienced
+#define BATT_SMBUS_DESIGN_CAPACITY                      0x18            ///< design capacity register
+#define BATT_SMBUS_DESIGN_VOLTAGE                       0x19            ///< design voltage register
+#define BATT_SMBUS_MANUFACTURER_NAME                    0x20            ///< manufacturer name
+#define BATT_SMBUS_MANUFACTURE_DATE                     0x1B            ///< manufacture date register
+#define BATT_SMBUS_SERIAL_NUMBER                        0x1C            ///< serial number register
+#define BATT_SMBUS_MEASUREMENT_INTERVAL_US              100000          ///< time in microseconds, measure at 10Hz
+#define BATT_SMBUS_TIMEOUT_US                           1000000         ///< timeout looking for battery 10seconds after startup
 #define BATT_SMBUS_MANUFACTURER_ACCESS                  0x00
-#define BATT_SMBUS_MANUFACTURER_DATA			        0x23
+#define BATT_SMBUS_MANUFACTURER_DATA                    0x23
 #define BATT_SMBUS_MANUFACTURER_BLOCK_ACCESS            0x44
-#define BATT_SMBUS_SECURITY_KEYS			            0x0035
+#define BATT_SMBUS_SECURITY_KEYS                        0x0035
 #define BATT_SMBUS_CELL_1_VOLTAGE                       0x3F
 #define BATT_SMBUS_CELL_2_VOLTAGE                       0x3E
 #define BATT_SMBUS_CELL_3_VOLTAGE                       0x3D
@@ -94,8 +95,8 @@
 #define BATT_SMBUS_ENABLED_PROTECTIONS_A_ADDRESS        0x4938
 #define BATT_SMBUS_SEAL                                 0x0030
 
-#define BATT_SMBUS_ENABLED_PROTECTIONS_A_DEFAULT		0xcf
-#define BATT_SMBUS_ENABLED_PROTECTIONS_A_CUV_DISABLED	0xce
+#define BATT_SMBUS_ENABLED_PROTECTIONS_A_DEFAULT        0xcf
+#define BATT_SMBUS_ENABLED_PROTECTIONS_A_CUV_DISABLED   0xce
 
 #define NUM_BUS_OPTIONS (sizeof(bus_options)/sizeof(bus_options[0]))
 

--- a/src/drivers/camera_capture/camera_capture.hpp
+++ b/src/drivers/camera_capture/camera_capture.hpp
@@ -38,31 +38,22 @@
 
 #pragma once
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <fcntl.h>
-#include <stdbool.h>
-#include <poll.h>
-#include <mathlib/mathlib.h>
-#include <systemlib/err.h>
-#include <parameters/param.h>
+#include <string.h>
 
-#include <px4_config.h>
+#include <parameters/param.h>
 #include <px4_defines.h>
-#include <px4_module.h>
-#include <px4_tasks.h>
 #include <px4_workqueue.h>
 
+#include <drivers/device/ringbuffer.h>
 #include <drivers/drv_hrt.h>
 #include <drivers/drv_pwm_output.h>
 #include <drivers/drv_input_capture.h>
-#include <drivers/device/ringbuffer.h>
 
-#include <uORB/uORB.h>
 #include <uORB/topics/camera_trigger.h>
 #include <uORB/topics/vehicle_command.h>
 #include <uORB/topics/vehicle_command_ack.h>
+#include <uORB/uORB.h>
 
 #define PX4FMU_DEVICE_PATH	"/dev/px4fmu"
 

--- a/src/drivers/differential_pressure/ets/ets_airspeed.cpp
+++ b/src/drivers/differential_pressure/ets/ets_airspeed.cpp
@@ -40,22 +40,8 @@
 
 #include <float.h>
 
-#include <px4_config.h>
-
-#include <drivers/device/i2c.h>
-
-#include <systemlib/err.h>
-#include <parameters/param.h>
-#include <perf/perf_counter.h>
-#include <px4_getopt.h>
-
-#include <drivers/drv_airspeed.h>
-#include <drivers/drv_hrt.h>
-#include <drivers/device/ringbuffer.h>
-
-#include <uORB/uORB.h>
-#include <uORB/topics/differential_pressure.h>
 #include <drivers/airspeed/airspeed.h>
+#include <px4_getopt.h>
 
 /* I2C bus address */
 #define I2C_ADDRESS	0x75	/* 7-bit address. 8-bit address is 0xEA */

--- a/src/drivers/differential_pressure/ms4525/ms4525_airspeed.cpp
+++ b/src/drivers/differential_pressure/ms4525/ms4525_airspeed.cpp
@@ -49,22 +49,8 @@
  *    - Interfacing to MEAS Digital Pressure Modules (http://www.meas-spec.com/downloads/Interfacing_to_MEAS_Digital_Pressure_Modules.pdf)
  */
 
-#include <px4_config.h>
-#include <px4_getopt.h>
-
-#include <drivers/device/i2c.h>
-
-#include <systemlib/err.h>
-#include <parameters/param.h>
-#include <perf/perf_counter.h>
-
 #include <mathlib/math/filter/LowPassFilter2p.hpp>
-
-#include <drivers/drv_airspeed.h>
-#include <drivers/drv_hrt.h>
-
-#include <uORB/uORB.h>
-#include <uORB/topics/differential_pressure.h>
+#include <px4_getopt.h>
 #include <uORB/topics/system_power.h>
 
 #include <drivers/airspeed/airspeed.h>

--- a/src/drivers/differential_pressure/ms5525/MS5525.hpp
+++ b/src/drivers/differential_pressure/ms5525/MS5525.hpp
@@ -35,15 +35,9 @@
 #define DRIVERS_MS5525_AIRSPEED_HPP_
 
 #include <drivers/airspeed/airspeed.h>
-#include <drivers/device/i2c.h>
-#include <drivers/drv_airspeed.h>
 #include <math.h>
 #include <mathlib/math/filter/LowPassFilter2p.hpp>
-#include <px4_config.h>
-#include <sys/types.h>
-#include <perf/perf_counter.h>
-#include <uORB/topics/differential_pressure.h>
-#include <uORB/uORB.h>
+#include <px4_getopt.h>
 
 /* The MS5525DSO address is 111011Cx, where C is the complementary value of the pin CSB */
 static constexpr uint8_t I2C_ADDRESS_1_MS5525DSO = 0x76;

--- a/src/drivers/differential_pressure/ms5525/MS5525_main.cpp
+++ b/src/drivers/differential_pressure/ms5525/MS5525_main.cpp
@@ -33,10 +33,6 @@
 
 #include "MS5525.hpp"
 
-#include <px4_getopt.h>
-
-#include <stdlib.h>
-
 // Driver 'main' command.
 extern "C" __EXPORT int ms5525_airspeed_main(int argc, char *argv[]);
 

--- a/src/drivers/differential_pressure/sdp3x/SDP3X.cpp
+++ b/src/drivers/differential_pressure/sdp3x/SDP3X.cpp
@@ -31,14 +31,14 @@
  *
  ****************************************************************************/
 
-#include "SDP3X.hpp"
-
 /**
  * @file SDP3X.hpp
  *
  * Driver for Sensirion SDP3X Differential Pressure Sensor
  *
  */
+
+#include "SDP3X.hpp"
 
 int
 SDP3X::probe()

--- a/src/drivers/differential_pressure/sdp3x/SDP3X.hpp
+++ b/src/drivers/differential_pressure/sdp3x/SDP3X.hpp
@@ -43,15 +43,9 @@
 #define DRIVERS_SDP3X_AIRSPEED_HPP_
 
 #include <drivers/airspeed/airspeed.h>
-#include <drivers/device/i2c.h>
-#include <drivers/drv_airspeed.h>
 #include <math.h>
 #include <mathlib/math/filter/LowPassFilter2p.hpp>
-#include <px4_config.h>
-#include <sys/types.h>
-#include <perf/perf_counter.h>
-#include <uORB/topics/differential_pressure.h>
-#include <uORB/uORB.h>
+#include <px4_getopt.h>
 
 #define I2C_ADDRESS_1_SDP3X		0x21
 #define I2C_ADDRESS_2_SDP3X		0x22

--- a/src/drivers/differential_pressure/sdp3x/SDP3X_main.cpp
+++ b/src/drivers/differential_pressure/sdp3x/SDP3X_main.cpp
@@ -33,10 +33,6 @@
 
 #include "SDP3X.hpp"
 
-#include <px4_getopt.h>
-
-#include <stdlib.h>
-
 // Driver 'main' command.
 extern "C" __EXPORT int sdp3x_airspeed_main(int argc, char *argv[]);
 

--- a/src/drivers/gps/definitions.h
+++ b/src/drivers/gps/definitions.h
@@ -39,19 +39,16 @@
 
 #pragma once
 
+#include <drivers/drv_hrt.h>
 #include <px4_defines.h>
-#include <px4_time.h>
+#include <uORB/topics/vehicle_gps_position.h>
+#include <uORB/topics/satellite_info.h>
 
 #define GPS_INFO(...) PX4_INFO(__VA_ARGS__)
 #define GPS_WARN(...) PX4_WARN(__VA_ARGS__)
 #define GPS_ERR(...) PX4_ERR(__VA_ARGS__)
 
-#include <uORB/topics/vehicle_gps_position.h>
-#include <uORB/topics/satellite_info.h>
-
 #define gps_usleep px4_usleep
-
-#include <drivers/drv_hrt.h>
 
 /**
  * Get the current time in us. Function signature:

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -41,52 +41,25 @@
 #include <nuttx/arch.h>
 #endif
 
-
-#include <termios.h>
-
 #ifndef __PX4_QURT
 #include <poll.h>
 #endif
 
+#include <termios.h>
 
-#include <fcntl.h>
-#include <sys/ioctl.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdbool.h>
-#include <stdlib.h>
-#include <string.h>
-#include <poll.h>
-#include <errno.h>
-#include <stdio.h>
-#include <math.h>
-#include <unistd.h>
-#include <px4_cli.h>
-#include <px4_config.h>
-#include <px4_getopt.h>
-#include <px4_module.h>
-#include <px4_tasks.h>
-#include <px4_time.h>
-#include <arch/board/board.h>
-#include <drivers/drv_hrt.h>
 #include <mathlib/mathlib.h>
 #include <matrix/math.hpp>
-#include <systemlib/err.h>
-#include <parameters/param.h>
+#include <px4_cli.h>
+#include <px4_getopt.h>
+#include <px4_module.h>
 #include <uORB/Subscription.hpp>
-#include <uORB/topics/vehicle_gps_position.h>
-#include <uORB/topics/satellite_info.h>
-#include <uORB/topics/gps_inject_data.h>
 #include <uORB/topics/gps_dump.h>
+#include <uORB/topics/gps_inject_data.h>
 
-#include <board_config.h>
-
-#include "devices/src/ubx.h"
-#include "devices/src/mtk.h"
 #include "devices/src/ashtech.h"
 #include "devices/src/emlid_reach.h"
+#include "devices/src/mtk.h"
+#include "devices/src/ubx.h"
 
 #ifdef __PX4_LINUX
 #include <linux/spi/spidev.h>

--- a/src/drivers/heater/heater.h
+++ b/src/drivers/heater/heater.h
@@ -41,12 +41,11 @@
 
 #pragma once
 
-#include <px4_work_queue/ScheduledWorkItem.hpp>
-#include <px4_module.h>
-#include <px4_module_params.h>
 #include <px4_config.h>
 #include <px4_getopt.h>
-
+#include <px4_module.h>
+#include <px4_module_params.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/sensor_accel.h>

--- a/src/drivers/imu/adis16448/ADIS16448.h
+++ b/src/drivers/imu/adis16448/ADIS16448.h
@@ -42,15 +42,15 @@
  * @author Lorenz Meier <lm@inf.ethz.ch>
  */
 
-#include <ecl/geo/geo.h>
-#include <perf/perf_counter.h>
 #include <drivers/device/spi.h>
-#include <px4_work_queue/ScheduledWorkItem.hpp>
-#include <conversion/rotation.h>
+#include <ecl/geo/geo.h>
+#include <lib/conversion/rotation.h>
 #include <lib/drivers/accelerometer/PX4Accelerometer.hpp>
 #include <lib/drivers/barometer/PX4Barometer.hpp>
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/drivers/magnetometer/PX4Magnetometer.hpp>
+#include <perf/perf_counter.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 
 using namespace time_literals;
 

--- a/src/drivers/imu/adis16477/ADIS16477.cpp
+++ b/src/drivers/imu/adis16477/ADIS16477.cpp
@@ -33,9 +33,6 @@
 
 #include "ADIS16477.hpp"
 
-#include <px4_config.h>
-#include <ecl/geo/geo.h>
-
 #define DIR_READ				0x00
 #define DIR_WRITE				0x80
 

--- a/src/drivers/imu/adis16477/ADIS16477.hpp
+++ b/src/drivers/imu/adis16477/ADIS16477.hpp
@@ -39,12 +39,13 @@
 #pragma once
 
 #include <drivers/device/spi.h>
-#include <lib/conversion/rotation.h>
-#include <perf/perf_counter.h>
 #include <ecl/geo/geo.h>
-#include <px4_work_queue/ScheduledWorkItem.hpp>
+#include <lib/conversion/rotation.h>
 #include <lib/drivers/accelerometer/PX4Accelerometer.hpp>
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
+#include <perf/perf_counter.h>
+#include <px4_getopt.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 
 class ADIS16477 : public device::SPI, public px4::ScheduledWorkItem
 {

--- a/src/drivers/imu/adis16477/adis16477_main.cpp
+++ b/src/drivers/imu/adis16477/adis16477_main.cpp
@@ -33,8 +33,6 @@
 
 #include "ADIS16477.hpp"
 
-#include <px4_getopt.h>
-
 extern "C" { __EXPORT int adis16477_main(int argc, char *argv[]); }
 
 /**

--- a/src/drivers/imu/adis16497/ADIS16497.cpp
+++ b/src/drivers/imu/adis16497/ADIS16497.cpp
@@ -33,9 +33,6 @@
 
 #include "ADIS16497.hpp"
 
-#include <px4_config.h>
-#include <ecl/geo/geo.h>
-
 #define DIR_READ				0x00
 #define DIR_WRITE				0x80
 

--- a/src/drivers/imu/adis16497/ADIS16497.hpp
+++ b/src/drivers/imu/adis16497/ADIS16497.hpp
@@ -39,12 +39,13 @@
 #pragma once
 
 #include <drivers/device/spi.h>
-#include <lib/conversion/rotation.h>
-#include <perf/perf_counter.h>
 #include <ecl/geo/geo.h>
-#include <px4_work_queue/ScheduledWorkItem.hpp>
+#include <lib/conversion/rotation.h>
 #include <lib/drivers/accelerometer/PX4Accelerometer.hpp>
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
+#include <perf/perf_counter.h>
+#include <px4_getopt.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 
 // TODO : This is a copy of the NuttX CRC32 table
 static constexpr uint32_t crc32_tab[] = {

--- a/src/drivers/imu/adis16497/adis16497_main.cpp
+++ b/src/drivers/imu/adis16497/adis16497_main.cpp
@@ -33,8 +33,6 @@
 
 #include "ADIS16497.hpp"
 
-#include <px4_getopt.h>
-
 extern "C" { __EXPORT int adis16497_main(int argc, char *argv[]); }
 
 /**

--- a/src/drivers/imu/bmi055/BMI055.hpp
+++ b/src/drivers/imu/bmi055/BMI055.hpp
@@ -33,14 +33,10 @@
 
 #pragma once
 
-#include <drivers/device/integrator.h>
 #include <drivers/device/spi.h>
-#include <drivers/drv_hrt.h>
-#include <lib/conversion/rotation.h>
+#include <ecl/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_config.h>
-#include <systemlib/conversions.h>
-#include <systemlib/err.h>
+#include <px4_getopt.h>
 #include <px4_work_queue/ScheduledWorkItem.hpp>
 
 #define DIR_READ                0x80

--- a/src/drivers/imu/bmi055/BMI055_accel.cpp
+++ b/src/drivers/imu/bmi055/BMI055_accel.cpp
@@ -33,8 +33,6 @@
 
 #include "BMI055_accel.hpp"
 
-#include <ecl/geo/geo.h>
-
 /*
   list of registers that will be checked in check_registers(). Note
   that ADDR_WHO_AM_I must be first in the list.

--- a/src/drivers/imu/bmi055/BMI055_accel.hpp
+++ b/src/drivers/imu/bmi055/BMI055_accel.hpp
@@ -33,15 +33,9 @@
 
 #pragma once
 
-#include "BMI055.hpp"
-
-#include <drivers/device/spi.h>
-#include <drivers/drv_hrt.h>
-#include <lib/conversion/rotation.h>
-#include <lib/perf/perf_counter.h>
 #include <lib/drivers/accelerometer/PX4Accelerometer.hpp>
-#include <px4_config.h>
-#include <systemlib/conversions.h>
+
+#include "BMI055.hpp"
 
 #define BMI055_DEVICE_PATH_ACCEL	"/dev/bmi055_accel"
 #define BMI055_DEVICE_PATH_ACCEL_EXT	"/dev/bmi055_accel_ext"

--- a/src/drivers/imu/bmi055/BMI055_gyro.hpp
+++ b/src/drivers/imu/bmi055/BMI055_gyro.hpp
@@ -33,15 +33,9 @@
 
 #pragma once
 
-#include "BMI055.hpp"
-
-#include <drivers/device/spi.h>
-#include <drivers/drv_hrt.h>
-#include <lib/conversion/rotation.h>
-#include <lib/perf/perf_counter.h>
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
-#include <px4_config.h>
-#include <systemlib/conversions.h>
+
+#include "BMI055.hpp"
 
 #define BMI055_DEVICE_PATH_GYRO		"/dev/bmi055_gyro"
 #define BMI055_DEVICE_PATH_GYRO_EXT	"/dev/bmi055_gyro_ext"

--- a/src/drivers/imu/bmi055/bmi055_main.cpp
+++ b/src/drivers/imu/bmi055/bmi055_main.cpp
@@ -34,9 +34,6 @@
 #include "BMI055_accel.hpp"
 #include "BMI055_gyro.hpp"
 
-#include <px4_config.h>
-#include <px4_getopt.h>
-
 /** driver 'main' command */
 extern "C" { __EXPORT int bmi055_main(int argc, char *argv[]); }
 

--- a/src/drivers/imu/bmi160/bmi160.cpp
+++ b/src/drivers/imu/bmi160/bmi160.cpp
@@ -1,5 +1,37 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
 #include "bmi160.hpp"
-#include <ecl/geo/geo.h>
 
 /*
   list of registers that will be checked in check_registers(). Note

--- a/src/drivers/imu/bmi160/bmi160.hpp
+++ b/src/drivers/imu/bmi160/bmi160.hpp
@@ -1,15 +1,47 @@
-#ifndef BMI160_HPP_
-#define BMI160_HPP_
+/****************************************************************************
+ *
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
 
-#include <px4_config.h>
-#include <perf/perf_counter.h>
-#include <systemlib/conversions.h>
-#include <drivers/drv_hrt.h>
+#pragma once
+
 #include <drivers/device/spi.h>
+#include <ecl/geo/geo.h>
 #include <lib/conversion/rotation.h>
-#include <px4_work_queue/ScheduledWorkItem.hpp>
 #include <lib/drivers/accelerometer/PX4Accelerometer.hpp>
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
+#include <perf/perf_counter.h>
+#include <px4_getopt.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
+#include <systemlib/conversions.h>
 
 #define DIR_READ                0x80
 #define DIR_WRITE               0x00
@@ -379,7 +411,3 @@ private:
 	};
 #pragma pack(pop)
 };
-
-
-
-#endif /* BMI160_HPP_ */

--- a/src/drivers/imu/bmi160/bmi160_main.cpp
+++ b/src/drivers/imu/bmi160/bmi160_main.cpp
@@ -1,8 +1,37 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
 
 #include "bmi160.hpp"
-
-#include <px4_config.h>
-#include <px4_getopt.h>
 
 /** driver 'main' command */
 extern "C" { __EXPORT int bmi160_main(int argc, char *argv[]); }

--- a/src/drivers/imu/fxas21002c/FXAS21002C.cpp
+++ b/src/drivers/imu/fxas21002c/FXAS21002C.cpp
@@ -33,12 +33,6 @@
 
 #include "FXAS21002C.hpp"
 
-#include <drivers/drv_hrt.h>
-#include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
-#include <px4_config.h>
-#include <px4_defines.h>
-#include <px4_work_queue/ScheduledWorkItem.hpp>
-
 /* SPI protocol address bits */
 #define DIR_READ(a)                     ((a) | (1 << 7))
 #define DIR_WRITE(a)                    ((a) & 0x7f)

--- a/src/drivers/imu/fxas21002c/FXAS21002C.hpp
+++ b/src/drivers/imu/fxas21002c/FXAS21002C.hpp
@@ -40,13 +40,11 @@
 #pragma once
 
 #include <drivers/device/spi.h>
-#include <drivers/drv_hrt.h>
-#include <lib/conversion/rotation.h>
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <perf/perf_counter.h>
-#include <px4_config.h>
-#include <px4_defines.h>
+#include <px4_getopt.h>
 #include <px4_work_queue/ScheduledWorkItem.hpp>
+
 
 class FXAS21002C : public device::SPI, public px4::ScheduledWorkItem
 {

--- a/src/drivers/imu/fxas21002c/fxas21002c_main.cpp
+++ b/src/drivers/imu/fxas21002c/fxas21002c_main.cpp
@@ -33,10 +33,6 @@
 
 #include "FXAS21002C.hpp"
 
-#include <px4_getopt.h>
-#include <px4_config.h>
-#include <px4_defines.h>
-
 extern "C" { __EXPORT int fxas21002c_main(int argc, char *argv[]); }
 
 /**

--- a/src/drivers/imu/fxos8701cq/fxos8701cq.cpp
+++ b/src/drivers/imu/fxos8701cq/fxos8701cq.cpp
@@ -37,48 +37,21 @@
  * magnetometer connected via SPI.
  */
 
-#include <px4_config.h>
-#include <px4_defines.h>
-#include <ecl/geo/geo.h>
-
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <stdint.h>
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdlib.h>
-#include <semaphore.h>
-#include <string.h>
-#include <fcntl.h>
-#include <poll.h>
-#include <errno.h>
-#include <stdio.h>
-#include <math.h>
-#include <unistd.h>
-
-
-#include <px4_log.h>
-
-#include <perf/perf_counter.h>
-
-#include <nuttx/arch.h>
-#include <nuttx/clock.h>
-
-#include <drivers/drv_hrt.h>
+#include <drivers/device/integrator.h>
+#include <drivers/device/ringbuffer.h>
 #include <drivers/device/spi.h>
 #include <drivers/drv_accel.h>
+#include <ecl/geo/geo.h>
+#include <lib/conversion/rotation.h>
+#include <mathlib/math/filter/LowPassFilter2p.hpp>
+#include <perf/perf_counter.h>
+#include <px4_getopt.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
+#include <systemlib/err.h>
+
 #if !defined(BOARD_HAS_NOISY_FXOS8700_MAG)
 #  include <drivers/drv_mag.h>
 #endif
-#include <drivers/device/ringbuffer.h>
-#include <drivers/device/integrator.h>
-
-#include <board_config.h>
-#include <mathlib/math/filter/LowPassFilter2p.hpp>
-#include <lib/conversion/rotation.h>
-#include <px4_getopt.h>
-#include <systemlib/err.h>
-#include <px4_work_queue/ScheduledWorkItem.hpp>
 
 /* SPI protocol address bits */
 #define DIR_READ(a)                     ((a) & 0x7f)

--- a/src/drivers/imu/icm20948/accel.cpp
+++ b/src/drivers/imu/icm20948/accel.cpp
@@ -41,33 +41,9 @@
  * based on the mpu6000 driver
  */
 
-#include <px4_config.h>
-#include <ecl/geo/geo.h>
-
-#include <sys/types.h>
-#include <stdint.h>
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdlib.h>
-#include <errno.h>
-#include <stdio.h>
-
-#include <perf/perf_counter.h>
-
-#include <board_config.h>
-#include <drivers/drv_hrt.h>
-
 #include <drivers/device/spi.h>
-#include <drivers/device/ringbuffer.h>
-#include <drivers/device/integrator.h>
-#include <drivers/drv_accel.h>
-#include <drivers/drv_gyro.h>
-#include <drivers/drv_mag.h>
-#include <mathlib/math/filter/LowPassFilter2p.hpp>
-#include <lib/conversion/rotation.h>
 
-#include "mag.h"
-#include "gyro.h"
+#include "accel.h"
 #include "icm20948.h"
 
 ICM20948_accel::ICM20948_accel(ICM20948 *parent, const char *path) :

--- a/src/drivers/imu/icm20948/accel.h
+++ b/src/drivers/imu/icm20948/accel.h
@@ -33,6 +33,10 @@
 
 #pragma once
 
+#include <drivers/device/device.h>
+#include <drivers/drv_accel.h>
+#include <uORB/uORB.h>
+
 class ICM20948;
 
 /**

--- a/src/drivers/imu/icm20948/gyro.cpp
+++ b/src/drivers/imu/icm20948/gyro.cpp
@@ -40,18 +40,6 @@
  * based on the mpu9250 driver
  */
 
-#include <px4_config.h>
-#include <lib/perf/perf_counter.h>
-#include <drivers/device/spi.h>
-#include <drivers/device/ringbuffer.h>
-#include <drivers/device/integrator.h>
-#include <drivers/drv_accel.h>
-#include <drivers/drv_gyro.h>
-#include <drivers/drv_mag.h>
-#include <lib/mathlib/math/filter/LowPassFilter2p.hpp>
-#include <lib/conversion/rotation.h>
-
-#include "mag.h"
 #include "gyro.h"
 #include "icm20948.h"
 

--- a/src/drivers/imu/icm20948/gyro.h
+++ b/src/drivers/imu/icm20948/gyro.h
@@ -33,6 +33,10 @@
 
 #pragma once
 
+#include <drivers/device/device.h>
+#include <drivers/drv_gyro.h>
+#include <uORB/uORB.h>
+
 class ICM20948;
 
 /**

--- a/src/drivers/imu/icm20948/icm20948.cpp
+++ b/src/drivers/imu/icm20948/icm20948.cpp
@@ -36,29 +36,9 @@
  *
  * Driver for the Invensense ICM20948 connected via I2C or SPI.
  *
- *
  * based on the mpu9250 driver
  */
 
-#include <px4_config.h>
-#include <px4_time.h>
-#include <lib/ecl/geo/geo.h>
-#include <lib/perf/perf_counter.h>
-#include <systemlib/conversions.h>
-#include <systemlib/px4_macros.h>
-#include <drivers/drv_hrt.h>
-#include <drivers/device/spi.h>
-#include <drivers/device/ringbuffer.h>
-#include <drivers/device/integrator.h>
-#include <drivers/drv_accel.h>
-#include <drivers/drv_gyro.h>
-#include <drivers/drv_mag.h>
-#include <lib/mathlib/math/filter/LowPassFilter2p.hpp>
-#include <lib/conversion/rotation.h>
-
-#include "mag.h"
-#include "accel.h"
-#include "gyro.h"
 #include "icm20948.h"
 
 /*

--- a/src/drivers/imu/icm20948/icm20948.h
+++ b/src/drivers/imu/icm20948/icm20948.h
@@ -31,30 +31,26 @@
  *
  ****************************************************************************/
 
-#include <stdint.h>
-
-#include <perf/perf_counter.h>
-#include <systemlib/conversions.h>
-
 #include <board_config.h>
 #include <drivers/drv_hrt.h>
-
 #include <drivers/device/ringbuffer.h>
 #include <drivers/device/integrator.h>
-#include <drivers/drv_accel.h>
-#include <drivers/drv_gyro.h>
-#include <drivers/drv_mag.h>
-#include <mathlib/math/filter/LowPassFilter2p.hpp>
+#include <lib/mathlib/math/filter/LowPassFilter2p.hpp>
 #include <lib/conversion/rotation.h>
-#include <systemlib/err.h>
+#include <lib/ecl/geo/geo.h>
+#include <lib/perf/perf_counter.h>
+#include <px4_config.h>
+#include <px4_getopt.h>
 #include <px4_work_queue/ScheduledWorkItem.hpp>
-
+#include <sys/types.h>
+#include <systemlib/conversions.h>
+#include <systemlib/err.h>
+#include <systemlib/px4_macros.h>
 #include <uORB/uORB.h>
-#include <uORB/topics/debug_key_value.h>
 
-#include "mag.h"
 #include "accel.h"
 #include "gyro.h"
+#include "mag.h"
 
 
 #if defined(PX4_I2C_OBDEV_MPU9250) || defined(PX4_I2C_BUS_EXPANSION)

--- a/src/drivers/imu/icm20948/icm20948_i2c.cpp
+++ b/src/drivers/imu/icm20948/icm20948_i2c.cpp
@@ -37,10 +37,7 @@
  * I2C interface for ICM20948
  */
 
-#include <px4_config.h>
 #include <drivers/device/i2c.h>
-#include <drivers/drv_accel.h>
-#include <drivers/drv_device.h>
 
 #include "icm20948.h"
 

--- a/src/drivers/imu/icm20948/icm20948_spi.cpp
+++ b/src/drivers/imu/icm20948/icm20948_spi.cpp
@@ -41,10 +41,7 @@
  * @author David sidrane
  */
 
-#include <px4_config.h>
 #include <drivers/device/spi.h>
-#include <drivers/drv_accel.h>
-#include <drivers/drv_device.h>
 
 #include "icm20948.h"
 

--- a/src/drivers/imu/icm20948/mag.cpp
+++ b/src/drivers/imu/icm20948/mag.cpp
@@ -40,20 +40,6 @@
  *
  */
 
-#include <px4_config.h>
-#include <px4_log.h>
-#include <px4_time.h>
-#include <lib/perf/perf_counter.h>
-#include <drivers/drv_hrt.h>
-#include <drivers/device/spi.h>
-#include <drivers/device/ringbuffer.h>
-#include <drivers/device/integrator.h>
-#include <drivers/drv_accel.h>
-#include <drivers/drv_gyro.h>
-#include <drivers/drv_mag.h>
-#include <lib/mathlib/math/filter/LowPassFilter2p.hpp>
-#include <lib/conversion/rotation.h>
-
 #include "mag.h"
 #include "icm20948.h"
 

--- a/src/drivers/imu/icm20948/mag.h
+++ b/src/drivers/imu/icm20948/mag.h
@@ -33,9 +33,12 @@
 
 #pragma once
 
-#include "drivers/device/ringbuffer.h"	// ringbuffer::RingBuffer
-#include "drivers/drv_mag.h"		// mag_calibration_s
-#include <perf/perf_counter.h>
+#include <drivers/device/i2c.h>
+#include <drivers/device/ringbuffer.h>
+#include <drivers/drv_device.h>
+#include <drivers/drv_mag.h>
+#include <lib/perf/perf_counter.h>
+#include <uORB/uORB.h>
 
 /* in 16-bit sampling mode the mag resolution is 1.5 milli Gauss per bit */
 

--- a/src/drivers/imu/icm20948/mag_i2c.cpp
+++ b/src/drivers/imu/icm20948/mag_i2c.cpp
@@ -37,11 +37,6 @@
  * I2C interface for AK8963
  */
 
-#include <px4_config.h>
-#include <drivers/device/i2c.h>
-#include <drivers/drv_accel.h>
-#include <drivers/drv_device.h>
-
 #include "icm20948.h"
 #include "mag.h"
 

--- a/src/drivers/imu/icm20948/main.cpp
+++ b/src/drivers/imu/icm20948/main.cpp
@@ -39,33 +39,6 @@
  * based on the mpu9250 driver
  */
 
-#include <px4_config.h>
-
-#include <sys/types.h>
-#include <stdint.h>
-#include <stdbool.h>
-#include <stdlib.h>
-#include <fcntl.h>
-#include <errno.h>
-#include <stdio.h>
-#include <px4_getopt.h>
-
-#include <perf/perf_counter.h>
-#include <systemlib/err.h>
-#include <systemlib/conversions.h>
-
-#include <board_config.h>
-#include <drivers/drv_hrt.h>
-
-#include <drivers/device/spi.h>
-#include <drivers/device/ringbuffer.h>
-#include <drivers/device/integrator.h>
-#include <drivers/drv_accel.h>
-#include <drivers/drv_gyro.h>
-#include <drivers/drv_mag.h>
-#include <mathlib/math/filter/LowPassFilter2p.hpp>
-#include <lib/conversion/rotation.h>
-
 #include "icm20948.h"
 
 #define ICM_DEVICE_PATH_ACCEL_EXT  "/dev/icm20948_accel_ext"

--- a/src/drivers/imu/l3gd20/l3gd20.cpp
+++ b/src/drivers/imu/l3gd20/l3gd20.cpp
@@ -39,14 +39,12 @@
  *       also supported by this driver.
  */
 
-#include <px4_config.h>
-#include <px4_defines.h>
-#include <px4_getopt.h>
-#include <perf/perf_counter.h>
 #include <drivers/device/spi.h>
 #include <lib/conversion/rotation.h>
-#include <px4_work_queue/ScheduledWorkItem.hpp>
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
+#include <perf/perf_counter.h>
+#include <px4_getopt.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 
 #define L3GD20_DEVICE_PATH "/dev/l3gd20"
 

--- a/src/drivers/imu/lsm303d/lsm303d.cpp
+++ b/src/drivers/imu/lsm303d/lsm303d.cpp
@@ -36,43 +36,19 @@
  * Driver for the ST LSM303D MEMS accelerometer / magnetometer connected via SPI.
  */
 
-#include <px4_config.h>
-#include <px4_defines.h>
-#include <ecl/geo/geo.h>
-
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <stdint.h>
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdlib.h>
-#include <semaphore.h>
-#include <string.h>
-#include <fcntl.h>
-#include <poll.h>
-#include <errno.h>
-#include <stdio.h>
-#include <math.h>
-#include <unistd.h>
-#include <px4_getopt.h>
-
-#include <perf/perf_counter.h>
-#include <systemlib/err.h>
-
-#include <nuttx/arch.h>
-#include <nuttx/clock.h>
-
-#include <drivers/drv_hrt.h>
+#include <drivers/device/integrator.h>
+#include <drivers/device/ringbuffer.h>
 #include <drivers/device/spi.h>
 #include <drivers/drv_accel.h>
 #include <drivers/drv_mag.h>
-#include <drivers/device/ringbuffer.h>
-#include <drivers/device/integrator.h>
-
-#include <board_config.h>
-#include <mathlib/math/filter/LowPassFilter2p.hpp>
+#include <ecl/geo/geo.h>
 #include <lib/conversion/rotation.h>
+#include <mathlib/math/filter/LowPassFilter2p.hpp>
+#include <perf/perf_counter.h>
+#include <px4_getopt.h>
 #include <px4_work_queue/ScheduledWorkItem.hpp>
+#include <systemlib/err.h>
+
 
 /* SPI protocol address bits */
 #define DIR_READ				(1<<7)

--- a/src/drivers/imu/mpu6000/MPU6000.hpp
+++ b/src/drivers/imu/mpu6000/MPU6000.hpp
@@ -55,20 +55,18 @@
  * @author David Sidrane
  */
 
-#include <drivers/drv_hrt.h>
-#include <lib/cdev/CDev.hpp>
+#include <lib/conversion/rotation.h>
 #include <lib/drivers/accelerometer/PX4Accelerometer.hpp>
+#include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/drivers/device/i2c.h>
 #include <lib/drivers/device/spi.h>
-#include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/ecl/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_config.h>
 #include <px4_getopt.h>
-#include <px4_time.h>
 #include <px4_work_queue/ScheduledWorkItem.hpp>
 #include <systemlib/conversions.h>
 #include <systemlib/px4_macros.h>
+
 
 /*
   we set the timer interrupt to run a bit faster than the desired

--- a/src/drivers/imu/mpu6000/MPU6000_I2C.cpp
+++ b/src/drivers/imu/mpu6000/MPU6000_I2C.cpp
@@ -37,10 +37,7 @@
  * I2C interface for MPU6000 /MPU6050
  */
 
-#include <px4_config.h>
 #include <drivers/device/i2c.h>
-#include <drivers/drv_accel.h>
-#include <drivers/drv_device.h>
 
 #include "MPU6000.hpp"
 

--- a/src/drivers/imu/mpu6000/MPU6000_SPI.cpp
+++ b/src/drivers/imu/mpu6000/MPU6000_SPI.cpp
@@ -41,14 +41,9 @@
  * @author David sidrane
  */
 
-#include <px4_config.h>
 #include <drivers/device/spi.h>
-#include <drivers/drv_accel.h>
-#include <drivers/drv_device.h>
 
 #include "MPU6000.hpp"
-
-#include <string.h>
 
 #define DIR_READ			0x80
 #define DIR_WRITE			0x00

--- a/src/drivers/imu/mpu9250/MPU9250_mag.cpp
+++ b/src/drivers/imu/mpu9250/MPU9250_mag.cpp
@@ -40,12 +40,6 @@
  *
  */
 
-#include <px4_config.h>
-#include <px4_log.h>
-#include <px4_time.h>
-#include <lib/perf/perf_counter.h>
-#include <drivers/drv_hrt.h>
-
 #include "MPU9250_mag.h"
 #include "mpu9250.h"
 

--- a/src/drivers/imu/mpu9250/mpu9250.cpp
+++ b/src/drivers/imu/mpu9250/mpu9250.cpp
@@ -41,17 +41,6 @@
  * based on the mpu6000 driver
  */
 
-#include <px4_config.h>
-#include <px4_time.h>
-#include <lib/ecl/geo/geo.h>
-#include <lib/perf/perf_counter.h>
-#include <systemlib/conversions.h>
-#include <systemlib/px4_macros.h>
-#include <drivers/drv_hrt.h>
-#include <drivers/device/spi.h>
-#include <lib/conversion/rotation.h>
-
-#include "MPU9250_mag.h"
 #include "mpu9250.h"
 
 /*

--- a/src/drivers/imu/mpu9250/mpu9250.h
+++ b/src/drivers/imu/mpu9250/mpu9250.h
@@ -31,18 +31,16 @@
  *
  ****************************************************************************/
 
-#include <stdint.h>
-
-#include <perf/perf_counter.h>
-#include <systemlib/conversions.h>
-#include <drivers/drv_hrt.h>
 #include <lib/drivers/accelerometer/PX4Accelerometer.hpp>
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
-#include <lib/conversion/rotation.h>
+#include <lib/ecl/geo/geo.h>
+#include <px4_getopt.h>
 #include <px4_work_queue/ScheduledWorkItem.hpp>
-#include <uORB/uORB.h>
+#include <systemlib/conversions.h>
+#include <systemlib/px4_macros.h>
 
 #include "MPU9250_mag.h"
+
 
 #if defined(PX4_I2C_OBDEV_MPU9250) || defined(PX4_I2C_BUS_EXPANSION)
 #  define USE_I2C

--- a/src/drivers/imu/mpu9250/mpu9250_i2c.cpp
+++ b/src/drivers/imu/mpu9250/mpu9250_i2c.cpp
@@ -37,9 +37,7 @@
  * I2C interface for MPU9250
  */
 
-#include <px4_config.h>
 #include <drivers/device/i2c.h>
-#include <drivers/drv_device.h>
 
 #include "mpu9250.h"
 

--- a/src/drivers/imu/mpu9250/mpu9250_main.cpp
+++ b/src/drivers/imu/mpu9250/mpu9250_main.cpp
@@ -42,15 +42,6 @@
  * based on the mpu6000 driver
  */
 
-#include <px4_config.h>
-#include <px4_getopt.h>
-#include <lib/perf/perf_counter.h>
-#include <lib/systemlib/conversions.h>
-#include <board_config.h>
-#include <drivers/drv_hrt.h>
-#include <drivers/device/spi.h>
-#include <lib/conversion/rotation.h>
-
 #include "mpu9250.h"
 
 #define MPU_DEVICE_PATH			"/dev/mpu9250"

--- a/src/drivers/imu/mpu9250/mpu9250_spi.cpp
+++ b/src/drivers/imu/mpu9250/mpu9250_spi.cpp
@@ -41,10 +41,7 @@
  * @author David sidrane
  */
 
-#include <px4_config.h>
 #include <drivers/device/spi.h>
-#include <drivers/drv_device.h>
-
 #include "mpu9250.h"
 
 #define DIR_READ			0x80

--- a/src/drivers/irlock/irlock.cpp
+++ b/src/drivers/irlock/irlock.cpp
@@ -40,22 +40,12 @@
  * Created on: Nov 12, 2014
  **/
 
-#include <fcntl.h>
-#include <stdint.h>
-#include <stdbool.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
-#include <sys/types.h>
 
-#include <board_config.h>
 #include <drivers/device/i2c.h>
 #include <drivers/device/ringbuffer.h>
-#include <drivers/drv_hrt.h>
 
 #include <px4_getopt.h>
-
-#include <nuttx/clock.h>
 #include <px4_work_queue/ScheduledWorkItem.hpp>
 #include <systemlib/err.h>
 

--- a/src/drivers/lights/blinkm/blinkm.cpp
+++ b/src/drivers/lights/blinkm/blinkm.cpp
@@ -93,38 +93,20 @@
  *
  */
 
-#include <strings.h>
-
-#include <px4_config.h>
-
-#include <sys/types.h>
-#include <stdint.h>
-#include <string.h>
-#include <stdlib.h>
-#include <stdbool.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <stdio.h>
 #include <ctype.h>
-#include <poll.h>
-
-#include <px4_work_queue/ScheduledWorkItem.hpp>
-
-#include <perf/perf_counter.h>
-#include <systemlib/err.h>
-
-#include <board_config.h>
+#include <string.h>
+#include <strings.h>
 
 #include <drivers/device/i2c.h>
 #include <drivers/drv_blinkm.h>
-
-#include <uORB/uORB.h>
-#include <uORB/topics/vehicle_status.h>
-#include <uORB/topics/battery_status.h>
-#include <uORB/topics/vehicle_control_mode.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
+#include <systemlib/err.h>
 #include <uORB/topics/actuator_armed.h>
-#include <uORB/topics/vehicle_gps_position.h>
+#include <uORB/topics/battery_status.h>
 #include <uORB/topics/safety.h>
+#include <uORB/topics/vehicle_control_mode.h>
+#include <uORB/topics/vehicle_gps_position.h>
+#include <uORB/topics/vehicle_status.h>
 
 static const int LED_ONTIME = 120;
 static const int LED_OFFTIME = 120;

--- a/src/drivers/lights/oreoled/oreoled.cpp
+++ b/src/drivers/lights/oreoled/oreoled.cpp
@@ -39,34 +39,16 @@
  *
  */
 
-#include <px4_config.h>
+#include <string.h>
+#include <sys/stat.h>
 
 #include <drivers/device/i2c.h>
-#include <drivers/drv_hrt.h>
-
-#include <sys/types.h>
-#include <stdint.h>
-#include <string.h>
-#include <stdlib.h>
-#include <stdbool.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <stdio.h>
-#include <ctype.h>
-#include <sys/stat.h>
-#include <px4_getopt.h>
-
-#include <nuttx/arch.h>
-#include <px4_work_queue/ScheduledWorkItem.hpp>
-#include <nuttx/clock.h>
-
-#include <perf/perf_counter.h>
-#include <systemlib/err.h>
-
-#include <board_config.h>
-
-#include <drivers/drv_oreoled.h>
 #include <drivers/device/ringbuffer.h>
+#include <drivers/drv_oreoled.h>
+#include <perf/perf_counter.h>
+#include <px4_getopt.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
+#include <systemlib/err.h>
 
 #define OREOLED_NUM_LEDS		4			///< maximum number of LEDs the oreo led driver can support
 #define OREOLED_BASE_I2C_ADDR	0x68		///< base i2c address (7-bit)

--- a/src/drivers/lights/pca8574/pca8574.cpp
+++ b/src/drivers/lights/pca8574/pca8574.cpp
@@ -41,29 +41,14 @@
  * @author Anton Babushkin <anton.babushkin@me.com>
  */
 
-#include <px4_config.h>
+#include <string.h>
 
 #include <drivers/device/i2c.h>
-
-#include <sys/types.h>
-#include <stdint.h>
-#include <string.h>
-#include <stdlib.h>
-#include <stdbool.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <stdio.h>
-#include <ctype.h>
+#include <drivers/drv_io_expander.h>
 #include <px4_getopt.h>
-
 #include <px4_work_queue/ScheduledWorkItem.hpp>
-
-#include <perf/perf_counter.h>
 #include <systemlib/err.h>
 
-#include <board_config.h>
-
-#include <drivers/drv_io_expander.h>
 
 #define PCA8574_ONTIME 120
 #define PCA8574_OFFTIME 120

--- a/src/drivers/lights/rgbled/rgbled.cpp
+++ b/src/drivers/lights/rgbled/rgbled.cpp
@@ -40,31 +40,12 @@
  * @author Anton Babushkin <anton.babushkin@me.com>
  */
 
-#include <px4_config.h>
-#include <px4_getopt.h>
+#include <string.h>
 
 #include <drivers/device/i2c.h>
-
-#include <sys/types.h>
-#include <stdint.h>
-#include <string.h>
-#include <stdlib.h>
-#include <stdbool.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <stdio.h>
-#include <ctype.h>
-
-#include <px4_work_queue/ScheduledWorkItem.hpp>
-
-#include <perf/perf_counter.h>
-#include <systemlib/err.h>
-
-#include <board_config.h>
-
-#include <drivers/drv_led.h>
 #include <lib/led/led.h>
-
+#include <px4_getopt.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 #include "uORB/topics/parameter_update.h"
 
 #define RGBLED_ONTIME 120

--- a/src/drivers/lights/rgbled_ncp5623c/rgbled_ncp5623c.cpp
+++ b/src/drivers/lights/rgbled_ncp5623c/rgbled_ncp5623c.cpp
@@ -39,32 +39,14 @@
  * @author CUAVcaijie <caijie@cuav.net>
  */
 
-#include <px4_config.h>
-#include <px4_getopt.h>
+#include <string.h>
 
 #include <drivers/device/i2c.h>
-
-#include <sys/types.h>
-#include <stdint.h>
-#include <string.h>
-#include <stdlib.h>
-#include <stdbool.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <stdio.h>
-#include <ctype.h>
-
-#include <px4_work_queue/ScheduledWorkItem.hpp>
-
-#include <perf/perf_counter.h>
-#include <systemlib/err.h>
-
-#include <board_config.h>
-
-#include <drivers/drv_led.h>
 #include <lib/led/led.h>
-
+#include <px4_getopt.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 #include "uORB/topics/parameter_update.h"
+
 
 #define ADDR			0x39	/**< I2C adress of NCP5623C */
 

--- a/src/drivers/lights/rgbled_pwm/rgbled_pwm.cpp
+++ b/src/drivers/lights/rgbled_pwm/rgbled_pwm.cpp
@@ -39,32 +39,12 @@
  *
  */
 
-#include <nuttx/config.h>
-
-//#include <drivers/device/i2c.h>
-
-#include <sys/types.h>
-#include <stdint.h>
 #include <string.h>
-#include <stdlib.h>
-#include <stdbool.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <stdio.h>
-#include <ctype.h>
-#include <px4_getopt.h>
 
-#include <px4_work_queue/ScheduledWorkItem.hpp>
-#include <drivers/drv_hrt.h>
-
-#include <perf/perf_counter.h>
-#include <systemlib/err.h>
-
-#include <board_config.h>
-
-#include <drivers/drv_led.h>
-#include <lib/led/led.h>
 #include <drivers/device/device.h>
+#include <lib/led/led.h>
+#include <px4_getopt.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 #include <systemlib/err.h>
 
 #define RGBLED_ONTIME 120


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
There are a lot of unnecessary #includes in the drivers in general. This is a second pass at the driver directory. I have organized most #includes to header files to avoid duplication and make use of the #pragma once preprocessor directive. This is continuation of similar work in PR #12431.

**Test data / coverage**
No logic was touched in this PR. All builds succeeding in the CI tools is sufficient proof that nothing essential has been deleted.

**Additional context**
This is mostly janitorial work geared at keeping the code base clean.

Please let me know if you have any questions on this PR. Thanks!

-Mark