### PR TITLE
Mavlink FTP - process only messages that have our component id

### DIFF
--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -132,10 +132,12 @@ MavlinkFTP::handle_message(const mavlink_message_t *msg)
 		mavlink_msg_file_transfer_protocol_decode(msg, &ftp_request);
 
 #ifdef MAVLINK_FTP_DEBUG
-		PX4_INFO("FTP: received ftp protocol message target_system: %d", ftp_request.target_system);
+		PX4_INFO("FTP: received ftp protocol message target_system: %d target_component: %d",
+			 ftp_request.target_system, ftp_request.target_component);
 #endif
 
-		if (ftp_request.target_system == _getServerSystemId()) {
+		if ((ftp_request.target_system == _getServerSystemId() || ftp_request.target_system == 0) &&
+		    (ftp_request.target_component == _getServerComponentId() || ftp_request.target_component == 0)) {
 			_process_request(&ftp_request, msg->sysid);
 		}
 	}


### PR DESCRIPTION
Current implementation of Mavlink FTP server in firmware doesn't filter messages on target component.
When the UAV system contains a companion computer as a second component that also implements Mavlink FTP server the autopilot responds to messages that are not destined to it.

To solve this problem check mavlink file transfer protocol messages for system id and component id.
Respond also to broadcast requests when target_system or target_component is 0.