### PR TITLE
boards don't use px4_add_library for drivers_board

### DIFF
--- a/boards/aerotenna/ocpoc/src/CMakeLists.txt
+++ b/boards/aerotenna/ocpoc/src/CMakeLists.txt
@@ -31,6 +31,6 @@
 #
 ############################################################################
 
-px4_add_library(drivers_board
+add_library(drivers_board
 	${PX4_SOURCE_DIR}/src/drivers/boards/common/board_identity.c # TODO: this is horrible and should be fixed
 )

--- a/boards/airmind/mindpx-v2/src/CMakeLists.txt
+++ b/boards/airmind/mindpx-v2/src/CMakeLists.txt
@@ -31,7 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(drivers_board
+add_library(drivers_board
 	can.c
 	init.c
 	led.c

--- a/boards/atlflight/eagle/src/CMakeLists.txt
+++ b/boards/atlflight/eagle/src/CMakeLists.txt
@@ -31,7 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(drivers_board
+add_library(drivers_board
 	${PX4_SOURCE_DIR}/src/drivers/boards/common/board_identity.c # TODO: this is horrible and should be fixed
 	sitl_led.c
 )

--- a/boards/auav/esc35-v1/src/CMakeLists.txt
+++ b/boards/auav/esc35-v1/src/CMakeLists.txt
@@ -35,7 +35,7 @@ message(WARNING "Configuraton is incomplete")
 message(WARNING "DO NOT RUN THIS ON HW")
 message(WARNING "IT IS NOT PINED OUT TO HW")
 
-px4_add_library(drivers_board
+add_library(drivers_board
 	init.c
 	led.c
 	usb.c

--- a/boards/auav/x21/src/CMakeLists.txt
+++ b/boards/auav/x21/src/CMakeLists.txt
@@ -31,7 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(drivers_board
+add_library(drivers_board
 	can.c
 	init.c
 	led.c

--- a/boards/av/x-v1/src/CMakeLists.txt
+++ b/boards/av/x-v1/src/CMakeLists.txt
@@ -31,13 +31,14 @@
 #
 ############################################################################
 
-px4_add_library(drivers_board
+add_library(drivers_board
 	init.c
 	manifest.c
 	sdio.c
 	spi.cpp
 	timer_config.c
 )
+
 target_link_libraries(drivers_board
 	PRIVATE
 		drivers__led # drv_led_start

--- a/boards/beaglebone/blue/src/CMakeLists.txt
+++ b/boards/beaglebone/blue/src/CMakeLists.txt
@@ -33,7 +33,7 @@
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error")
 
-px4_add_library(drivers_board
+add_library(drivers_board
 	init.c
 	${PX4_SOURCE_DIR}/src/drivers/boards/common/board_identity.c # TODO: this is horrible and should be fixed
 )

--- a/boards/bitcraze/crazyflie/src/CMakeLists.txt
+++ b/boards/bitcraze/crazyflie/src/CMakeLists.txt
@@ -31,7 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(drivers_board
+add_library(drivers_board
 	init.c
 	led.c
 	spi.c

--- a/boards/bitcraze/crazyflie/src/spi.c
+++ b/boards/bitcraze/crazyflie/src/spi.c
@@ -3,7 +3,6 @@
  ************************************************************************************/
 
 #include <px4_config.h>
-#include <px4_log.h>
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -69,7 +68,7 @@ __EXPORT int stm32_spi_bus_initialize(void)
 	spi_expansion = stm32_spibus_initialize(PX4_SPI_BUS_EXPANSION);
 
 	if (!spi_expansion) {
-		PX4_ERR("[boot] FAILED to initialize SPI port %d\n", PX4_SPI_BUS_EXPANSION);
+		syslog(LOG_ERR, "[boot] FAILED to initialize SPI port %d\n", PX4_SPI_BUS_EXPANSION);
 		return -ENODEV;
 	}
 
@@ -77,7 +76,7 @@ __EXPORT int stm32_spi_bus_initialize(void)
 	int ret = mmcsd_spislotinitialize(CONFIG_NSH_MMCSDMINOR, CONFIG_NSH_MMCSDSLOTNO, spi_expansion);
 
 	if (ret != OK) {
-		PX4_ERR("[boot] FAILED to bind SPI port 1 to the MMCSD driver\n");
+		syslog(LOG_ERR, "[boot] FAILED to bind SPI port 1 to the MMCSD driver\n");
 		return -ENODEV;
 	}
 

--- a/boards/emlid/navio2/src/CMakeLists.txt
+++ b/boards/emlid/navio2/src/CMakeLists.txt
@@ -31,6 +31,6 @@
 #
 ############################################################################
 
-px4_add_library(drivers_board
+add_library(drivers_board
 	${PX4_SOURCE_DIR}/src/drivers/boards/common/board_identity.c # TODO: this is horrible and should be fixed
 )

--- a/boards/intel/aerofc-v1/src/CMakeLists.txt
+++ b/boards/intel/aerofc-v1/src/CMakeLists.txt
@@ -32,7 +32,7 @@
 #
 ############################################################################
 
-px4_add_library(drivers_board
+add_library(drivers_board
 	init.c
 	led.c
 	spi.c

--- a/boards/nxp/fmuk66-v3/src/CMakeLists.txt
+++ b/boards/nxp/fmuk66-v3/src/CMakeLists.txt
@@ -31,7 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(drivers_board
+add_library(drivers_board
 	autoleds.c
 	automount.c
 	can.c

--- a/boards/omnibus/f4sd/src/CMakeLists.txt
+++ b/boards/omnibus/f4sd/src/CMakeLists.txt
@@ -31,7 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(drivers_board
+add_library(drivers_board
 	init.c
 	led.c
 	spi.c

--- a/boards/parrot/bebop/src/CMakeLists.txt
+++ b/boards/parrot/bebop/src/CMakeLists.txt
@@ -31,6 +31,6 @@
 #
 ############################################################################
 
-px4_add_library(drivers_board
+add_library(drivers_board
 	${PX4_SOURCE_DIR}/src/drivers/boards/common/board_identity.c # TODO: this is horrible and should be fixed
 )

--- a/boards/px4/cannode-v1/src/CMakeLists.txt
+++ b/boards/px4/cannode-v1/src/CMakeLists.txt
@@ -31,7 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(drivers_board
+add_library(drivers_board
 	buttons.c
 	can.c
 	init.c

--- a/boards/px4/esc-v1/src/CMakeLists.txt
+++ b/boards/px4/esc-v1/src/CMakeLists.txt
@@ -31,7 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(drivers_board
+add_library(drivers_board
 	init.c
 	led.c
 	usb.c

--- a/boards/px4/fmu-v2/src/CMakeLists.txt
+++ b/boards/px4/fmu-v2/src/CMakeLists.txt
@@ -31,7 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(drivers_board
+add_library(drivers_board
 	can.c
 	i2c.c
 	init.c

--- a/boards/px4/fmu-v2/src/manifest.c
+++ b/boards/px4/fmu-v2/src/manifest.c
@@ -47,10 +47,12 @@
  * Included Files
  ****************************************************************************/
 
-#include <px4_config.h>
+#include <nuttx/config.h>
+#include <board_config.h>
+
 #include <stdbool.h>
+
 #include "systemlib/px4_macros.h"
-#include "px4_log.h"
 
 /****************************************************************************
  * Pre-Processor Definitions
@@ -134,7 +136,7 @@ __EXPORT px4_hw_mft_item board_query_manifest(px4_hw_mft_item_id_t id)
 		}
 
 		if (boards_manifest == px4_hw_mft_list_uninitialized) {
-			PX4_ERR("Board %4x is not supported!", ver_rev);
+			syslog(LOG_ERR, "[boot] Board %4x is not supported!\n", ver_rev);
 		}
 	}
 

--- a/boards/px4/fmu-v3/src/CMakeLists.txt
+++ b/boards/px4/fmu-v3/src/CMakeLists.txt
@@ -31,7 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(drivers_board
+add_library(drivers_board
 	can.c
 	i2c.c
 	init.c

--- a/boards/px4/fmu-v3/src/manifest.c
+++ b/boards/px4/fmu-v3/src/manifest.c
@@ -47,10 +47,12 @@
  * Included Files
  ****************************************************************************/
 
-#include <px4_config.h>
+#include <nuttx/config.h>
+#include <board_config.h>
+
 #include <stdbool.h>
+
 #include "systemlib/px4_macros.h"
-#include "px4_log.h"
 
 /****************************************************************************
  * Pre-Processor Definitions
@@ -134,7 +136,7 @@ __EXPORT px4_hw_mft_item board_query_manifest(px4_hw_mft_item_id_t id)
 		}
 
 		if (boards_manifest == px4_hw_mft_list_uninitialized) {
-			PX4_ERR("Board %4x is not supported!", ver_rev);
+			syslog(LOG_ERR, "[boot] Board %4x is not supported!\n", ver_rev);
 		}
 	}
 

--- a/boards/px4/fmu-v4/src/CMakeLists.txt
+++ b/boards/px4/fmu-v4/src/CMakeLists.txt
@@ -31,7 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(drivers_board
+add_library(drivers_board
 	can.c
 	init.c
 	led.c

--- a/boards/px4/fmu-v4pro/src/CMakeLists.txt
+++ b/boards/px4/fmu-v4pro/src/CMakeLists.txt
@@ -31,7 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(drivers_board
+add_library(drivers_board
 	can.c
 	init.c
 	led.c

--- a/boards/px4/io-v2/src/CMakeLists.txt
+++ b/boards/px4/io-v2/src/CMakeLists.txt
@@ -31,7 +31,12 @@
 #
 ############################################################################
 
-px4_add_library(drivers_board
+add_library(drivers_board
 	init.c
 	timer_config.c
+)
+
+target_link_libraries(drivers_board
+	PRIVATE
+		nuttx_arch
 )

--- a/boards/px4/raspberrypi/src/CMakeLists.txt
+++ b/boards/px4/raspberrypi/src/CMakeLists.txt
@@ -31,6 +31,6 @@
 #
 ############################################################################
 
-px4_add_library(drivers_board
+add_library(drivers_board
 	${PX4_SOURCE_DIR}/src/drivers/boards/common/board_identity.c # TODO: this is horrible and should be fixed
 )

--- a/boards/px4/sitl/src/CMakeLists.txt
+++ b/boards/px4/sitl/src/CMakeLists.txt
@@ -31,7 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(drivers_board
+add_library(drivers_board
 	${PX4_SOURCE_DIR}/src/drivers/boards/common/board_identity.c # TODO: this is horrible and should be fixed
 	sitl_led.c
 )

--- a/boards/thiemar/s2740vc-v1/src/CMakeLists.txt
+++ b/boards/thiemar/s2740vc-v1/src/CMakeLists.txt
@@ -35,7 +35,7 @@ message(WARNING "Configuraton is incomplete")
 message(WARNING "DO NOT RUN THIS ON HW")
 message(WARNING "IT IS NOT PINED OUT TO HW")
 
-px4_add_library(drivers_board
+add_library(drivers_board
 	can.c
 	init.c
 )


### PR DESCRIPTION
 - this prevents low level board support from using PX4 logging, uORB, etc
