### PR TITLE
Fix vehicle flight time

### DIFF
--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -190,7 +190,7 @@ void LandDetector::_update_state()
 void LandDetector::_update_total_flight_time()
 {
 	_total_flight_time = static_cast<uint64_t>(_param_total_flight_time_high.get()) << 32;
-	_total_flight_time |= _param_total_flight_time_low.get();
+	_total_flight_time |= static_cast<uint32_t>(_param_total_flight_time_low.get());
 }
 
 } // namespace land_detector


### PR DESCRIPTION
`_param_total_flight_time_low.get()` is an int32_t and gets sign-extended if cast directly to uint64_t. To avoid that we first cast to uint32_t.