### PR TITLE
Fix up MAV_X_RATE as html tag doesn't render

### DIFF
--- a/src/modules/mavlink/module.yaml
+++ b/src/modules/mavlink/module.yaml
@@ -52,8 +52,9 @@ parameters:
                     If the configured streams exceed the maximum rate, the sending rate of
                     each stream is automatically decreased.
 
-                    If this is set to 0, a value of <baudrate>/20 is used, which corresponds to
-                    half of the theoretical maximum bandwidth.
+                    If this is set to 0 a value of half of the theoretical maximum bandwidth is used.
+                    This corresponds to baudrate/20 Bytes/s (baudrate/10 = maximum data rate on 
+                    81N-configured links).
 
             type: int32
             min: 0

--- a/src/modules/mavlink/module.yaml
+++ b/src/modules/mavlink/module.yaml
@@ -54,7 +54,7 @@ parameters:
 
                     If this is set to 0 a value of half of the theoretical maximum bandwidth is used.
                     This corresponds to baudrate/20 Bytes/s (baudrate/10 = maximum data rate on 
-                    81N-configured links).
+                    8N1-configured links).
 
             type: int32
             min: 0


### PR DESCRIPTION
A HTML tag in the MAV_X_PARAM doc is not rendered when the param is displayed in markdown so the text makes no sense. This removes the tags and also clarifies how maximum data rate is determined.

See https://github.com/PX4/px4_user_guide/pull/508/#discussion_r300914679 for more context.

@bkueng FYI, we can use `&gt;` etc if you want to use this kind of markup in params. 