### PR TITLE
ll40ls: Fix LIDAR-Lite v3 initialization

### DIFF
--- a/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.cpp
+++ b/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.cpp
@@ -189,8 +189,8 @@ int LidarLiteI2C::probe()
 			  check for unit id. It would be better if
 			  we had a proper WHOAMI register
 			 */
-			if (read_reg(LL40LS_UNIT_ID_HIGH, id_high) == OK && id_high > 0 &&
-			    read_reg(LL40LS_UNIT_ID_LOW, id_low) == OK && id_low > 0) {
+			if (read_reg(LL40LS_UNIT_ID_HIGH, id_high) == OK &&
+			    read_reg(LL40LS_UNIT_ID_LOW, id_low) == OK) {
 				_unit_id = (uint16_t)((id_high << 8) | id_low) & 0xFFFF;
 				goto ok;
 			}


### PR DESCRIPTION
The current initialisation code works only if every UID byte contains a non-zero value. According to the [manual](https://static.garmin.com/pumac/LIDAR_Lite_v3_Operation_Manual_and_Technical_Specifications.pdf) UNIT_ID is a unique value without any restrictions.