### PR TITLE
WIP: Use loiter to alt & vtol land for RTL

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -398,7 +398,21 @@ Mission::find_mission_land_start()
 		    ((missionitem.nav_cmd == NAV_CMD_VTOL_LAND) && _navigator->get_vstatus()->is_vtol) ||
 		    (missionitem.nav_cmd == NAV_CMD_LAND)) {
 			_land_start_available = true;
+
 			_land_start_index = i;
+
+			if (i > 0 && _navigator->get_vstatus()->is_vtol) {
+
+				if (dm_read(dm_current, i - 1, &missionitem, len) != len) {
+					/* not supposed to happen unless the datamanager can't access the SD card, etc. */
+					PX4_ERR("dataman read failure");
+
+				} else if (missionitem.nav_cmd == NAV_CMD_LOITER_TO_ALT) {
+					_land_start_index = i - 1;
+				}
+			}
+
+
 			return true;
 		}
 	}


### PR DESCRIPTION
I wanted to find out what changes are required in order to improve the RTL behavior for VTOL.
A similar approach is already implemented for fixed wing where the vehicle will execute a planned mission landing during RTL if it's available. 

In[ this issue](https://github.com/PX4/Firmware/issues/12413) we are already discussing a new approach for back-transition approach where we loiter to transition altitude at a planned location and exit the loiter on the tangent to the landing point.

I now connected both ideas such that RTL will make the vehicle fly to the loiter point, loiter to altitude and then transition in a predictable manner toward the landing point.

Currently, in order to do this you need to do the following steps:

1) Plan a mission that at least contains a LOITER_TO_ALT waypoint followed by a VTOL_TRANSITION_AND_LAND waypoint. For the loiter waypoint make sure to set "Heading wait" to true and "Exit loiter from" to tangent.
Set the altitude of the loiter waypoint to the desired transition altitude.

2) Set RTL_TYPE to "Return to a planned mission landing, if available, via direct path, else return to home via direct path"

The following log shows the results from a real flight. Notice that we executed the transition at 20m which is much lower than most of the trees around the field. But it was not a problem as this approach makes the maneuver very predictable.
https://logs.px4.io/plot_app?log=6d36fc4a-a195-4666-a667-1f05289a9712

![image](https://user-images.githubusercontent.com/7610489/61169101-e9385900-a558-11e9-924f-1125b3e32067.png)


