### PR TITLE
Reduce a few LOC in rcS AUTOCNF logic

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -20,11 +20,7 @@ set +e
 # Do not add intra word spaces
 # it wastes flash
 #
-set AUTOCNF no
 set AUX_MODE pwm
-set BOARD_RC_DEFAULTS /etc/init.d/rc.board_defaults
-set BOARD_RC_EXTRAS /etc/init.d/rc.board_extras
-set BOARD_RC_SENSORS /etc/init.d/rc.board_sensors
 set DATAMAN_OPT ""
 set FAILSAFE none
 set FAILSAFE_AUX none
@@ -178,11 +174,13 @@ else
 	#
 	# Optional board defaults: rc.board_defaults
 	#
+	set BOARD_RC_DEFAULTS /etc/init.d/rc.board_defaults
 	if [ -f $BOARD_RC_DEFAULTS ]
 	then
 		echo "Board defaults: ${BOARD_RC_DEFAULTS}"
 		sh $BOARD_RC_DEFAULTS
 	fi
+	unset BOARD_RC_DEFAULTS
 
 	#
 	# Waypoint storage.
@@ -344,11 +342,13 @@ else
 		#
 		# board sensors: rc.sensors
 		#
+		set BOARD_RC_SENSORS /etc/init.d/rc.board_sensors
 		if [ -f $BOARD_RC_SENSORS ]
 		then
 			echo "Board sensors: ${BOARD_RC_SENSORS}"
 			sh $BOARD_RC_SENSORS
 		fi
+		unset BOARD_RC_SENSORS
 
 
 		sh /etc/init.d/rc.sensors
@@ -469,11 +469,13 @@ else
 	#
 	# Optional board supplied extras: rc.board_extras
 	#
+	set BOARD_RC_EXTRAS /etc/init.d/rc.board_extras
 	if [ -f $BOARD_RC_EXTRAS ]
 	then
 		echo "Board extras: ${BOARD_RC_EXTRAS}"
 		sh $BOARD_RC_EXTRAS
 	fi
+	unset BOARD_RC_EXTRAS
 
 	#
 	# Start any custom addons from the sdcard.
@@ -488,6 +490,7 @@ else
 	# Start the logger.
 	#
 	sh /etc/init.d/rc.logging
+
 
 	if ! param compare SYS_PARAM_VER ${PARAM_DEFAULTS_VER}
 	then
@@ -508,9 +511,6 @@ fi
 #
 unset AUTOCNF
 unset AUX_MODE
-unset BOARD_RC_DEFAULTS
-unset BOARD_RC_EXTRAS
-unset BOARD_RC_SENSORS
 unset DATAMAN_OPT
 unset FAILSAFE
 unset FAILSAFE_AUX

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -20,6 +20,7 @@ set +e
 # Do not add intra word spaces
 # it wastes flash
 #
+set AUTOCNF no
 set AUX_MODE pwm
 set DATAMAN_OPT ""
 set FAILSAFE none

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -20,7 +20,11 @@ set +e
 # Do not add intra word spaces
 # it wastes flash
 #
+set AUTOCNF no
 set AUX_MODE pwm
+set BOARD_RC_DEFAULTS /etc/init.d/rc.board_defaults
+set BOARD_RC_EXTRAS /etc/init.d/rc.board_extras
+set BOARD_RC_SENSORS /etc/init.d/rc.board_sensors
 set DATAMAN_OPT ""
 set FAILSAFE none
 set FAILSAFE_AUX none
@@ -160,30 +164,25 @@ else
 	#
 	# Set AUTOCNF flag to use it in AUTOSTART scripts.
 	#
-	if param compare SYS_AUTOCONFIG 1
+	if param greater SYS_AUTOCONFIG 0
 	then
-		# Wipe out params except RC*, flight modes, total flight time, accel cal, gyro cal
-		param reset_nostart RC* COM_FLTMODE* LND_FLIGHT_T_* TC_* CAL_ACC* CAL_GYRO*
-		set AUTOCNF yes
-	else
-		if param compare SYS_AUTOCONFIG 2
+		if param compare SYS_AUTOCONFIG 1
 		then
-			set AUTOCNF yes
-		else
-			set AUTOCNF no
+			# Wipe out params except RC*, flight modes, total flight time, accel cal, gyro cal
+			param reset_nostart RC* COM_FLTMODE* LND_FLIGHT_T_* TC_* CAL_ACC* CAL_GYRO*
 		fi
+
+		set AUTOCNF yes
 	fi
 
 	#
 	# Optional board defaults: rc.board_defaults
 	#
-	set BOARD_RC_DEFAULTS /etc/init.d/rc.board_defaults
 	if [ -f $BOARD_RC_DEFAULTS ]
 	then
 		echo "Board defaults: ${BOARD_RC_DEFAULTS}"
 		sh $BOARD_RC_DEFAULTS
 	fi
-	unset BOARD_RC_DEFAULTS
 
 	#
 	# Waypoint storage.
@@ -345,13 +344,11 @@ else
 		#
 		# board sensors: rc.sensors
 		#
-		set BOARD_RC_SENSORS /etc/init.d/rc.board_sensors
 		if [ -f $BOARD_RC_SENSORS ]
 		then
 			echo "Board sensors: ${BOARD_RC_SENSORS}"
 			sh $BOARD_RC_SENSORS
 		fi
-		unset BOARD_RC_SENSORS
 
 
 		sh /etc/init.d/rc.sensors
@@ -472,13 +469,11 @@ else
 	#
 	# Optional board supplied extras: rc.board_extras
 	#
-	set BOARD_RC_EXTRAS /etc/init.d/rc.board_extras
 	if [ -f $BOARD_RC_EXTRAS ]
 	then
 		echo "Board extras: ${BOARD_RC_EXTRAS}"
 		sh $BOARD_RC_EXTRAS
 	fi
-	unset BOARD_RC_EXTRAS
 
 	#
 	# Start any custom addons from the sdcard.
@@ -493,7 +488,6 @@ else
 	# Start the logger.
 	#
 	sh /etc/init.d/rc.logging
-
 
 	if ! param compare SYS_PARAM_VER ${PARAM_DEFAULTS_VER}
 	then
@@ -514,6 +508,9 @@ fi
 #
 unset AUTOCNF
 unset AUX_MODE
+unset BOARD_RC_DEFAULTS
+unset BOARD_RC_EXTRAS
+unset BOARD_RC_SENSORS
 unset DATAMAN_OPT
 unset FAILSAFE
 unset FAILSAFE_AUX


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This PR simplifies the rcS script `SYS_AUTOCONFIG` logic and drops a few LOC.  It also moves set/unset statements in the script to the top and bottom as housekeeping and saves about 50 bytes of flash.

**Test data / coverage**
The logic change is easily examined by inspection.  The set/unset copy/paste is also easily examined by inspection.

**Describe possible alternatives**
If this PR isn't helpful, please feel free to close it!

Thanks!
