### PR TITLE
jenkins: archive catkin test logs on failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,6 +38,9 @@ pipeline {
             always {
               sh 'rm -rf catkin_ws'
             }
+            failure {
+              archiveArtifacts(allowEmptyArchive: false, artifacts: '.ros/**/*.xml, .ros/**/*.log')
+            }
           }
           options {
             checkoutToSubdirectory('catkin_ws/src/Firmware')


### PR DESCRIPTION
Archive rostest logs on failure of the _Catkin build_ stage. The goal is to catch something in relation to #12475.

EDIT: Yup. This was useful.