### PR TITLE
jenkins: pub_test needs to start px4 in daemon mode

### DIFF
--- a/launch/pub_test.launch
+++ b/launch/pub_test.launch
@@ -1,6 +1,10 @@
 <launch>
     <!-- Test mavros posix sitl publishes pose at 30 Hz -->
-    <include file="$(find px4)/launch/mavros_posix_sitl.launch"/>
+    <include file="$(find px4)/launch/mavros_posix_sitl.launch">
+        <arg name="gui" value="false"/>
+        <arg name="interactive" value="false"/>
+        <arg name="verbose" value="true"/>
+    </include>
     <param name="pub_test/topic" value="/mavros/local_position/pose"/>
     <param name="pub_test/hz" value="30.0"/>
     <param name="pub_test/hzerror" value="1.0"/>


### PR DESCRIPTION
Addressing #12475. I remember this occurring in the past with our other tests. Jenkinsfile-SITL_tests are all run in daemon mode.

It looks like Jenkins does something weird with the interactive shell that shuts down px4.