### PR TITLE
hotfix for logger: use '%i' instead of '%zu'

### DIFF
--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -2011,7 +2011,7 @@ void Logger::write_info(LogType type, const char *name, const char *value)
 
 	/* construct format key (type and name) */
 	size_t vlen = strlen(value);
-	msg.key_len = snprintf(msg.key, sizeof(msg.key), "char[%zu] %s", vlen, name);
+	msg.key_len = snprintf(msg.key, sizeof(msg.key), "char[%i] %s", (int)vlen, name);
 	size_t msg_size = sizeof(msg) - sizeof(msg.key) + msg.key_len;
 
 	/* copy string value directly to buffer */
@@ -2037,7 +2037,7 @@ void Logger::write_info_multiple(LogType type, const char *name, const char *val
 
 	/* construct format key (type and name) */
 	size_t vlen = strlen(value);
-	msg.key_len = snprintf(msg.key, sizeof(msg.key), "char[%zu] %s", vlen, name);
+	msg.key_len = snprintf(msg.key, sizeof(msg.key), "char[%i] %s", (int)vlen, name);
 	size_t msg_size = sizeof(msg) - sizeof(msg.key) + msg.key_len;
 
 	/* copy string value directly to buffer */


### PR DESCRIPTION
Work-around for https://github.com/PX4/Firmware/issues/12485.

This can be reverted after the root-cause is fixed.

The other uses of '%zu' (and alike) are important to get fixed, but I don't see them as critical (no invalid memory accessed), so I think we don't have to revert the NuttX upgrade.