### PR TITLE
Removed rover CI test

### DIFF
--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -61,12 +61,12 @@ pipeline {
               vehicle: "iris"
             ],
 
-            [
-              name: "Rover 1",
-              test: "mavros_posix_test_mission.test",
-              mission: "rover_mission_1",
-              vehicle: "rover"
-            ],
+            //[
+            //  name: "Rover 1",
+            //  test: "mavros_posix_test_mission.test",
+            //  mission: "rover_mission_1",
+            //  vehicle: "rover"
+            //],
 
             [
               name: "VTOL_standard",

--- a/.ci/Jenkinsfile-SITL_tests_ASan
+++ b/.ci/Jenkinsfile-SITL_tests_ASan
@@ -61,12 +61,12 @@ pipeline {
               vehicle: "iris"
             ],
 
-            [
-              name: "Rover 1",
-              test: "mavros_posix_test_mission.test",
-              mission: "rover_mission_1",
-              vehicle: "rover"
-            ],
+            //[
+            //  name: "Rover 1",
+            //  test: "mavros_posix_test_mission.test",
+            //  mission: "rover_mission_1",
+            //  vehicle: "rover"
+            //],
 
             [
               name: "VTOL_standard",

--- a/.ci/Jenkinsfile-SITL_tests_coverage
+++ b/.ci/Jenkinsfile-SITL_tests_coverage
@@ -35,12 +35,12 @@ pipeline {
               vehicle: "iris"
             ],
 
-            [
-              name: "Rover 1",
-              test: "mavros_posix_test_mission.test",
-              mission: "rover_mission_1",
-              vehicle: "rover"
-            ],
+            //[
+            //  name: "Rover 1",
+            //  test: "mavros_posix_test_mission.test",
+            //  mission: "rover_mission_1",
+            //  vehicle: "rover"
+            //],
 
             [
               name: "VTOL_standard",


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
The Rover CI test is failing seemingly at random, due to a timeout between the `actuator_controls_0` topic and Gazebo. See [this build](http://ci.px4.io:8080/blue/organizations/jenkins/PX4_misc%2FFirmware-SITL_tests/detail/PR-12389/7/pipeline/) and Issue #12490 

The PR of the linked build does not change anything that should cause this build failure, so future PRs may also fail this test for no apparent reason. Therefore, this PR disables that test entirely so that it can be fixed. As long as it is broken, other PRs will need to be force-merged while failing the SITL tests.

**Describe your preferred solution**
Commented out the `rover_mission_1` SITL test in the Jenkins files.

**Describe possible alternatives**
This test will need to be properly fixed in the future. This is only a temporary bandage to prevent build failures.