### PR TITLE
Fixed uninitialized variable

### DIFF
--- a/src/modules/rover_pos_control/RoverPositionControl.hpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.hpp
@@ -129,7 +129,7 @@ private:
 
 	ECL_L1_Pos_Controller				_gnd_control;
 
-	bool _waypoint_reached;
+	bool _waypoint_reached{false};
 
 	enum UGV_POSCTRL_MODE {
 		UGV_POSCTRL_MODE_AUTO,


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
`_waypoint_reached` var is uninitialized.

**Test data / coverage**
Ran Rover tests in SITL.

**Describe your preferred solution**
Initialized to `false`.