### PR TITLE
Add generic vtol tailsitter airframe and modifiy 4001_quad_x and 13001_caipirinha_vtol to simplify PR 9849

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/13001_caipirinha_vtol
+++ b/ROMFS/px4fmu_common/init.d/airframes/13001_caipirinha_vtol
@@ -17,16 +17,20 @@ sh /etc/init.d/rc.vtol_defaults
 
 if [ $AUTOCNF = yes ]
 then
+	param set MAV_TYPE 19
+
 	param set MC_ROLL_P 6
 	param set MC_ROLLRATE_P 0.12
 	param set MC_ROLLRATE_I 0.002
 	param set MC_ROLLRATE_D 0.003
 	param set MC_ROLLRATE_FF 0
+
 	param set MC_PITCH_P 4.5
 	param set MC_PITCHRATE_P 0.3
 	param set MC_PITCHRATE_I 0.002
 	param set MC_PITCHRATE_D 0.003
 	param set MC_PITCHRATE_FF 0
+
 	param set MC_YAW_P 3.8
 	param set MC_YAWRATE_P 0.22
 	param set MC_YAWRATE_I 0.02
@@ -37,10 +41,13 @@ then
 	param set VT_ELEV_MC_LOCK 0
 	param set VT_MOT_ID 12
 	param set VT_TYPE 0
+
+	# Indicate that FW roll direction was fixed in mixer, to be removed in v1.10
+	param set V19_VT_ROLLDIR 0
 fi
 
 set MAV_TYPE 19
 
-set MIXER caipirinha_vtol
+set MIXER vtol_tailsitter_duo
 
 set PWM_OUT 1234

--- a/ROMFS/px4fmu_common/init.d/airframes/13200_generic_vtol_tailsitter
+++ b/ROMFS/px4fmu_common/init.d/airframes/13200_generic_vtol_tailsitter
@@ -1,0 +1,30 @@
+#!/bin/sh
+#
+# @name Generic Tailsitter
+#
+# @type VTOL Duo Tailsitter
+# @class VTOL
+#
+# @output MAIN1 motor right
+# @output MAIN2 motor left
+# @output MAIN5 elevon right
+# @output MAIN6 elevon left
+#
+# @maintainer Roman Bapst <roman@px4.io>
+#
+
+sh /etc/init.d/rc.vtol_defaults
+
+if [ $AUTOCNF = yes ]
+then
+	param set VT_ELEV_MC_LOCK 0
+	param set VT_MOT_COUNT 2
+	param set VT_TYPE 0
+
+	param set MAV_TYPE 19
+fi
+
+set MAV_TYPE 19
+set MIXER vtol_tailsitter_duo
+
+set PWM_OUT 1234

--- a/ROMFS/px4fmu_common/init.d/airframes/4001_quad_x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4001_quad_x
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# @name Generic Quadrotor x
+# @name Generic Quadcopter
 #
 # @type Quadrotor x
 # @class Copter

--- a/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
@@ -132,6 +132,7 @@ px4_add_romfs_files(
 	13010_claire
 	13012_convergence
 	13013_deltaquad
+	13200_generic_vtol_tailsitter
 
 	# [14000, 14999] Tri Y
 	14001_tri_y_yaw+

--- a/ROMFS/px4fmu_common/mixers/vtol_tailsitter_duo.main.mix
+++ b/ROMFS/px4fmu_common/mixers/vtol_tailsitter_duo.main.mix
@@ -1,0 +1,39 @@
+Tailsitter duo mixer
+============================
+
+This file defines a mixer for a generic duo tailsitter VTOL (eg TBS Caipirinha tailsitter edition). This vehicle
+has two motors in total, one attached to each wing. It also has two elevons which
+are located in the slipstream of the propellers. This mixer generates 4 PWM outputs
+on the main PWM ouput port, two at 400Hz for the motors, and two at 50Hz for the
+elevon servos. Channels 1-4 are configured to run at 400Hz, while channels 5-8 run
+at the default rate of 50Hz. Note that channels 3 and 4 are assigned but not used.
+
+Motor mixer
+------------
+Channel 1 connects to the right (starboard) motor.
+Channel 2 connects to the left (port) motor.
+
+R: 2- 10000 10000 10000 0
+
+Zero mixer (2x)
+---------------
+Channels 3,4 are unused.
+
+Z:
+
+Z:
+
+Elevons mixer
+--------------
+Channel 5 connects to the right (starboard) elevon.
+Channel 6 connects to the left (port) elevon.
+
+M: 2
+O:        7500    7500    0 -10000  10000
+S: 1 0  -10000  -10000    0 -10000  10000
+S: 1 1   10000   10000    0 -10000  10000
+
+M: 2
+O:        7500    7500    0 -10000  10000
+S: 1 0  -10000  -10000    0 -10000  10000
+S: 1 1  -10000  -10000    0 -10000  10000


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This PR is designed to advance PR #9849.  A generic VTOL tailsitter airframe and mixer is added and the modifications to 4001_quad_x and 13001_caipirinha_vtol from PR #9849 are made here.

**Additional context**
This PR is a step toward accomplishing the work in #9489 in a piecewise process.  The full diff for the completed work can be seen [here](https://github.com/PX4/Firmware/compare/master...mcsauder:pr-airframe_cleanup).

Please let me know if you have any questions on this PR!  Thanks!

-Mark
