### PR TITLE
FlightTaskAutoLine/SmoothVel: stop at waypoint 

### DIFF
--- a/src/lib/FlightTasks/tasks/AutoLine/FlightTaskAutoLine.cpp
+++ b/src/lib/FlightTasks/tasks/AutoLine/FlightTaskAutoLine.cpp
@@ -93,7 +93,7 @@ void FlightTaskAutoLine::_generateXYsetpoints()
 {
 	_setSpeedAtTarget();
 	Vector2f pos_sp_to_dest(_target - _position_setpoint);
-	const bool has_reached_altitude = fabsf(_target(2) - _position(2)) < _target_acceptance_radius;
+	const bool has_reached_altitude = fabsf(_target(2) - _position(2)) < _param_nav_mc_alt_rad.get();
 
 	if ((_speed_at_target < 0.001f && pos_sp_to_dest.length() < _target_acceptance_radius) ||
 	    (!has_reached_altitude && pos_sp_to_dest.length() < _target_acceptance_radius)) {

--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
@@ -247,10 +247,17 @@ void FlightTaskAutoLineSmoothVel::_prepareSetpoints()
 			Vector2f pos_traj_to_dest(pos_sp_xy - pos_traj);
 			Vector2f prev_to_pos(pos_traj - Vector2f(_prev_wp));
 			Vector2f u_pos_traj_to_dest_xy(Vector2f(pos_traj_to_dest).unit_or_zero());
+			const bool has_reached_altitude = fabsf(_position_setpoint(2) - _position(2)) < _param_nav_mc_alt_rad.get();
 
 			float speed_sp_track = _getMaxSpeedFromDistance(pos_traj_to_dest.length());
 
-			speed_sp_track = math::constrain(speed_sp_track, _getSpeedAtTarget(), _mc_cruise_speed);
+			if (has_reached_altitude) {
+				speed_sp_track = math::constrain(speed_sp_track, _getSpeedAtTarget(), _mc_cruise_speed);
+
+			} else {
+				speed_sp_track = math::constrain(speed_sp_track, 0.0f, _mc_cruise_speed);
+
+			}
 
 			Vector2f vel_sp_xy = u_pos_traj_to_dest_xy * speed_sp_track;
 


### PR DESCRIPTION
If altitude has not been reached, the vehicle should stop first at the waypoint before proceeding to the next waypoint. This will prevent the vehicle from overshooting the current target.