### PR TITLE
param: fix potential nullptr dereferencing on param import

### DIFF
--- a/src/systemcmds/param/param.cpp
+++ b/src/systemcmds/param/param.cpp
@@ -395,7 +395,11 @@ do_load(const char *param_file_name)
 	}
 
 	if (result < 0) {
-		PX4_ERR("importing from '%s' failed (%i)", param_file_name, result);
+		if (param_file_name) {
+			PX4_ERR("importing from '%s' failed (%i)", param_file_name, result);
+		} else {
+			PX4_ERR("importing failed (%i)", result);
+		}
 		return 1;
 	}
 
@@ -421,7 +425,11 @@ do_import(const char *param_file_name)
 	}
 
 	if (result < 0) {
-		PX4_ERR("importing from '%s' failed (%i)", param_file_name, result);
+		if (param_file_name) {
+			PX4_ERR("importing from '%s' failed (%i)", param_file_name, result);
+		} else {
+			PX4_ERR("importing failed (%i)", result);
+		}
 		return 1;
 	}
 


### PR DESCRIPTION
NuttX 7.28 seemed to handle this gracefully, but officially passing NULL as '%s' argument results in undefined behavior, and with 7.29 leads to a hardfault.

This happens on configs with flash-based params, on the first unsuccessful import attempt.