### PR TITLE
Changed timing of actuator_controls_0 message from rover_pos_control

### DIFF
--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -61,12 +61,12 @@ pipeline {
               vehicle: "iris"
             ],
 
-            //[
-            //  name: "Rover 1",
-            //  test: "mavros_posix_test_mission.test",
-            //  mission: "rover_mission_1",
-            //  vehicle: "rover"
-            //],
+            [
+              name: "Rover 1",
+              test: "mavros_posix_test_mission.test",
+              mission: "rover_mission_1",
+              vehicle: "rover"
+            ],
 
             [
               name: "VTOL_standard",

--- a/.ci/Jenkinsfile-SITL_tests_ASan
+++ b/.ci/Jenkinsfile-SITL_tests_ASan
@@ -61,12 +61,12 @@ pipeline {
               vehicle: "iris"
             ],
 
-            //[
-            //  name: "Rover 1",
-            //  test: "mavros_posix_test_mission.test",
-            //  mission: "rover_mission_1",
-            //  vehicle: "rover"
-            //],
+            [
+              name: "Rover 1",
+              test: "mavros_posix_test_mission.test",
+              mission: "rover_mission_1",
+              vehicle: "rover"
+            ],
 
             [
               name: "VTOL_standard",

--- a/.ci/Jenkinsfile-SITL_tests_coverage
+++ b/.ci/Jenkinsfile-SITL_tests_coverage
@@ -35,12 +35,12 @@ pipeline {
               vehicle: "iris"
             ],
 
-            //[
-            //  name: "Rover 1",
-            //  test: "mavros_posix_test_mission.test",
-            //  mission: "rover_mission_1",
-            //  vehicle: "rover"
-            //],
+            [
+              name: "Rover 1",
+              test: "mavros_posix_test_mission.test",
+              mission: "rover_mission_1",
+              vehicle: "rover"
+            ],
 
             [
               name: "VTOL_standard",

--- a/src/modules/rover_pos_control/RoverPositionControl.hpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.hpp
@@ -59,6 +59,7 @@
 #include <uORB/topics/position_controller_status.h>
 #include <uORB/topics/position_setpoint_triplet.h>
 #include <uORB/topics/sensor_bias.h>
+#include <uORB/topics/sensor_combined.h>
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/vehicle_attitude_setpoint.h>
 #include <uORB/topics/vehicle_control_mode.h>
@@ -105,6 +106,7 @@ private:
 	int		_params_sub{-1};			/**< notification of parameter updates */
 	int		_pos_sp_triplet_sub{-1};
 	int     _vehicle_attitude_sub{-1};
+	int		_sensor_combined_sub{-1};
 
 	manual_control_setpoint_s		_manual{};			    /**< r/c channel data */
 	position_setpoint_triplet_s		_pos_sp_triplet{};		/**< triplet of mission items */
@@ -112,6 +114,7 @@ private:
 	vehicle_global_position_s		_global_pos{};			/**< global vehicle position */
 	actuator_controls_s			    _act_controls{};		/**< direct control of actuators */
 	vehicle_attitude_s              _vehicle_att{};
+	sensor_combined_s				_sensor_combined{};
 
 	SubscriptionData<sensor_bias_s>	_sub_sensors;
 


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
The `rover_pos_control` module was publishing `actuator_controls_0` messages at a constant 250Hz, independent of any polling on any other UOrb topic. This was causing issues with Gazebo where it would get slightly out of sync with sensor readings. Closes #12490 

**Test data / coverage**
Ran several missions in Gazebo.

**Describe your preferred solution**
Changed `rover_pos_control` to poll on `sensor_combined` to time the publication of `actuator_controls_0`. This sensor data is not actually used, it is only necessary for timing.