### PR TITLE
Fix airframes incremental build

### DIFF
--- a/ROMFS/CMakeLists.txt
+++ b/ROMFS/CMakeLists.txt
@@ -107,6 +107,11 @@ add_custom_command(
 		${romfs_cmake_files}
 		${romfs_copy_files}
 		${PX4_SOURCE_DIR}/Tools/px_process_airframes.py
+		${PX4_SOURCE_DIR}/Tools/px4airframes/markdownout.py
+		${PX4_SOURCE_DIR}/Tools/px4airframes/rcout.py
+		${PX4_SOURCE_DIR}/Tools/px4airframes/srcparser.py
+		${PX4_SOURCE_DIR}/Tools/px4airframes/srcscanner.py
+		${PX4_SOURCE_DIR}/Tools/px4airframes/xmlout.py
 		${PX4_SOURCE_DIR}/Tools/serial/generate_config.py
 	COMMENT "ROMFS: copying, generating airframes"
 	)

--- a/ROMFS/px4fmu_common/init.d/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d/CMakeLists.txt
@@ -31,6 +31,8 @@
 #
 ############################################################################
 
+add_subdirectory(airframes)
+
 px4_add_romfs_files(
 	rc.fw_apps
 	rc.fw_defaults


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
Incremental build was not triggered when an airframe startup script, or one of the python scripts used to parse it, was modified.

**Describe your preferred solution**
Let cmake know about these files.

**Additional context**
To test:
- build
- modify ROMFS/px4fmu_common/init.d/airframes/4001_quad_x
- re build

Before this PR: nothing happens
With this PR: incremental build