### PR TITLE
Add airframe .post scripts on NuttX targets

### DIFF
--- a/ROMFS/CMakeLists.txt
+++ b/ROMFS/CMakeLists.txt
@@ -83,6 +83,7 @@ add_custom_command(
 		${romfs_gen_root_dir}/init.d/rcS
 		${romfs_gen_root_dir}/init.d/rc.serial
 		${romfs_gen_root_dir}/init.d/rc.autostart
+		${romfs_gen_root_dir}/init.d/rc.autostart.post
 		romfs_copy.stamp
 	COMMAND ${CMAKE_COMMAND} -E remove_directory ${romfs_gen_root_dir}
 	# TODO: we should only copy the files in ${romfs_copy_files}

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -490,6 +490,13 @@ else
 	#
 	sh /etc/init.d/rc.logging
 
+	#
+	# Set additional parameters and env variables for selected AUTOSTART.
+	#
+	if ! param compare SYS_AUTOSTART 0
+	then
+		sh /etc/init.d/rc.autostart.post
+	fi
 
 	if ! param compare SYS_PARAM_VER ${PARAM_DEFAULTS_VER}
 	then

--- a/Tools/px4airframes/rcout.py
+++ b/Tools/px4airframes/rcout.py
@@ -3,7 +3,7 @@ import codecs
 import os
 
 class RCOutput():
-    def __init__(self, groups, board):
+    def __init__(self, groups, board, post_start=False):
 
         result = (  "#\n"
                     "#\n"
@@ -41,7 +41,19 @@ class RCOutput():
                         excluded = True
                 if excluded:
                     continue
-                path = os.path.split(param.GetPath())[1]
+
+                if post_start:
+                    # Path to post-start sript
+                    path = param.GetPostPath()
+                else:
+                    # Path to start script
+                    path = param.GetPath()
+
+                if not path:
+                    continue
+
+                path = os.path.split(path)[1]
+
                 id_val = param.GetId()
                 name = param.GetFieldValue("short_desc")
                 long_desc = param.GetFieldValue("long_desc")
@@ -58,7 +70,7 @@ class RCOutput():
                 result += "\n"
 
             result += "\n"
-        self.output = result;
+        self.output = result
 
     def Save(self, filename):
         with codecs.open(filename, 'w', 'utf-8') as f:

--- a/Tools/px4airframes/srcparser.py
+++ b/Tools/px4airframes/srcparser.py
@@ -29,7 +29,7 @@ class ParameterGroup(object):
         Get parameter group vehicle type.
         """
         return self.af_class
-        
+
     def GetImageName(self):
         """
         Get parameter group image base name (w/o extension)
@@ -127,11 +127,12 @@ class Parameter(object):
         # all others == 0 (sorted alphabetically)
     }
 
-    def __init__(self, path, name, airframe_type, airframe_class, airframe_id, maintainer):
+    def __init__(self, path, post_path, name, airframe_type, airframe_class, airframe_id, maintainer):
         self.fields = {}
         self.outputs = {}
         self.archs = {}
         self.path = path
+        self.post_path = post_path
         self.name = name
         self.type = airframe_type
         self.af_class = airframe_class
@@ -140,6 +141,9 @@ class Parameter(object):
 
     def GetPath(self):
         return self.path
+
+    def GetPostPath(self):
+        return self.post_path
 
     def GetName(self):
         return self.name
@@ -384,8 +388,14 @@ class SourceParser(object):
             sys.stderr.write("Aborting due to missing @name tag in file: '%s'\n" % path)
             return False
 
+        # Check if a .post script exists
+        if os.path.isfile(path + '.post'):
+            post_path = path + '.post'
+        else:
+            post_path = None
+
         # We already know this is an airframe config, so add it
-        param = Parameter(path, airframe_name, airframe_type, airframe_class, airframe_id, maintainer)
+        param = Parameter(path, post_path, airframe_name, airframe_type, airframe_class, airframe_id, maintainer)
 
         # Done with file, store
         for tag in tags:
@@ -407,13 +417,10 @@ class SourceParser(object):
         # Store outputs
         for arch in archs:
             param.SetArch(arch, archs[arch])
-            
-
-        
 
         # Store the parameter
-        
-        #Create a class-specific airframe group. This is needed to catch cases where an airframe type might cross classes (e.g. simulation)
+
+        # Create a class-specific airframe group. This is needed to catch cases where an airframe type might cross classes (e.g. simulation)
         class_group_identifier=airframe_type+airframe_class
         if class_group_identifier not in self.param_groups:
             #self.param_groups[airframe_type] = ParameterGroup(airframe_type)  #HW TEST REMOVE
@@ -458,7 +465,7 @@ class SourceParser(object):
         groups = sorted(groups, key=lambda x: x.GetName())
         groups = sorted(groups, key=lambda x: x.GetClass())
         groups = sorted(groups, key=lambda x: self.priority.get(x.GetName(), 0), reverse=True)
-        
+
         #Rename duplicate groups to include the class (creating unique headings in page TOC)
         duplicate_test=set()
         duplicate_set=set()
@@ -471,5 +478,4 @@ class SourceParser(object):
             if group.GetName() in duplicate_set:
                 group.name=group.GetName()+' (%s)' % group.GetClass()
 
-        
         return groups

--- a/Tools/px4airframes/srcparser.py
+++ b/Tools/px4airframes/srcparser.py
@@ -140,24 +140,45 @@ class Parameter(object):
         self.maintainer = maintainer
 
     def GetPath(self):
+        """
+        Get path to airframe startup script
+        """
         return self.path
 
     def GetPostPath(self):
+        """
+        Get path to airframe post startup script
+        """
         return self.post_path
 
     def GetName(self):
+        """
+        Get airframe name
+        """
         return self.name
 
     def GetType(self):
+        """
+        Get airframe type
+        """
         return self.type
 
     def GetClass(self):
+        """
+        Get airframe class
+        """
         return self.af_class
 
     def GetId(self):
+        """
+        Get airframe id
+        """
         return self.id
 
     def GetMaintainer(self):
+        """
+        Get airframe maintainer
+        """
         return self.maintainer
 
     def SetField(self, code, value):

--- a/Tools/px_process_airframes.py
+++ b/Tools/px_process_airframes.py
@@ -118,10 +118,18 @@ def main():
         out = markdownout.MarkdownTablesOutput(param_groups, args.board, args.image_path)
         out.Save(args.markdown)
 
+    # Output to start scripts
     if args.start_script:
+        # Airframe start script
         if args.verbose: print("Creating start script " + args.start_script)
         out = rcout.RCOutput(param_groups, args.board)
         out.Save(args.start_script)
+
+        # Airframe post-start script
+        post_start_script = args.start_script + '.post'
+        if args.verbose: print("Creating post-start script " + post_start_script)
+        out_post = rcout.RCOutput(param_groups, args.board, post_start=True)
+        out_post.Save(post_start_script)
 
     if (args.verbose): print("All done!")
 


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
On POSIX targets, it is possible to add a `.post` script that will be run at the end of the startup.
See for example `ROMFS/px4fmu_common/init.d-posix/1013_iris_vision.post`.

On Nuttx targets, this is not supported.

**Describe your preferred solution**
Add support for `.post` scripts on NuttX targets.

**Additional context**
Similar to how `ROMFS/px4fmu_common/init.d/rc.autostart` is generated at compile time, this PR generates a new file `ROMFS/px4fmu_common/init.d/rc.autostart.post` which is called at the end of `ROMFS/px4fmu_common/init.d/rcS`.

Test example:
- add a file `ROMFS/px4fmu_common/init.d/airframes/4001_quad_x.post`
- with the following content `mavlink stream -d /dev/ttyS1 -s DEBUG_VECT -r 2`
- add an entry `4001_quad_x.post` in `ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt`
- rebuild
- the default rate for the mavlink message DEBUG_VECT is now 2Hz instead of 1Hz

@bkueng this is what we discussed on Slack. By default the new script is emtpy so it does not increase the flash usage.
@hamishwillee this should not affect the autogenerated airframe mardown file, but better double check.