### PR TITLE
version: validate format of the git tag

### DIFF
--- a/.ci/Jenkinsfile-compile_mac
+++ b/.ci/Jenkinsfile-compile_mac
@@ -18,6 +18,7 @@ pipeline {
           steps {
             sh 'export'
             sh 'make distclean'
+            sh 'git fetch --tags'
             sh 'ccache -z'
             sh 'make px4_sitl_default'
             sh 'ccache -s'
@@ -39,6 +40,7 @@ pipeline {
           steps {
             sh 'export'
             sh 'make distclean'
+            sh 'git fetch --tags'
             sh 'ccache -z'
             sh 'make px4_fmu-v5_default'
             sh 'ccache -s'
@@ -60,6 +62,7 @@ pipeline {
           steps {
             sh 'export'
             sh 'make distclean'
+            sh 'git fetch --tags'
             sh 'ccache -z'
             sh 'make tests'
             sh 'ccache -s'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,7 @@ pipeline {
               cd catkin_ws;
               git -C ${WORKSPACE}/catkin_ws/src/Firmware submodule update --init --recursive --force Tools/sitl_gazebo
               git clone --recursive ${WORKSPACE}/catkin_ws/src/Firmware/Tools/sitl_gazebo src/mavlink_sitl_gazebo;
+              git -C ${WORKSPACE}/catkin_ws/src/Firmware fetch --tags;
               source /opt/ros/melodic/setup.bash;
               catkin init;
               catkin build -j$(nproc) -l$(nproc);
@@ -60,6 +61,7 @@ pipeline {
               cd colcon_ws;
               git -C ${WORKSPACE}/colcon_ws/src/Firmware submodule update --init --recursive --force Tools/sitl_gazebo
               git clone --recursive ${WORKSPACE}/colcon_ws/src/Firmware/Tools/sitl_gazebo src/mavlink_sitl_gazebo;
+              git -C ${WORKSPACE}/colcon_ws/src/Firmware fetch --tags;
               source /opt/ros/bouncy/setup.sh;
               source /opt/ros/melodic/setup.sh;
               colcon build --event-handlers console_direct+ --symlink-install;
@@ -338,6 +340,7 @@ pipeline {
           steps {
             sh 'export'
             sh 'make distclean'
+            sh 'git fetch --tags'
             sh 'make px4_fmu-v2_default stack_check'
           }
           post {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ build_script:
 # safe the repopath for switching to it in cygwin bash
 - for /f %%i in ('cygpath -u %%CD%%') do set repopath=%%i
 # build the make target
-- call bash --login -c "cd $repopath && make $PX4_CONFIG"
+- call bash --login -c "cd $repopath && git fetch --tags && make $PX4_CONFIG"
 
 # Note: using bash --login is important
 # because otherwise certain things (like python; import numpy) do not work

--- a/src/lib/version/CMakeLists.txt
+++ b/src/lib/version/CMakeLists.txt
@@ -53,7 +53,7 @@ endif()
 
 set(px4_git_ver_header ${CMAKE_CURRENT_BINARY_DIR}/build_git_version.h)
 add_custom_command(OUTPUT ${px4_git_ver_header}
-	COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/px_update_git_header.py ${px4_git_ver_header} > ${CMAKE_CURRENT_BINARY_DIR}/git_header.log
+	COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/px_update_git_header.py ${px4_git_ver_header} --validate
 	DEPENDS
 		${CMAKE_CURRENT_SOURCE_DIR}/px_update_git_header.py
 		${git_dir_path}/HEAD

--- a/src/lib/version/px_update_git_header.py
+++ b/src/lib/version/px_update_git_header.py
@@ -1,12 +1,25 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
+import argparse
 import os
 import sys
 import subprocess
 import re
 
-filename = sys.argv[1]
+parser = argparse.ArgumentParser(description="""Extract version info from git and
+generate a version header file. The working directory is expected to be
+the root of Firmware.""")
+parser.add_argument('filename', metavar='version.h', help='Header output file')
+parser.add_argument('-v', '--verbose', dest='verbose', action='store_true',
+                    help='Verbose output', default=False)
+parser.add_argument('--validate', dest='validate', action='store_true',
+                    help='Validate the tag format', default=False)
+
+args = parser.parse_args()
+filename = args.filename
+verbose = args.verbose
+validate = args.validate
 
 try:
     fp_header = open(filename, 'r')
@@ -26,6 +39,39 @@ header = """
 # PX4
 git_tag = subprocess.check_output('git describe --always --tags --dirty'.split(),
                                   stderr=subprocess.STDOUT).decode('utf-8').strip()
+if validate:
+    if verbose:
+        print("testing git tag: "+git_tag)
+    # remove optional '-dirty' at the end
+    git_tag_test = re.sub(r'-dirty$', '', git_tag)
+    # remove optional -<num_commits>-g<commit_hash> at the end (in case we are not on a tagged commit)
+    git_tag_test = re.sub(r'-[0-9]+-g[0-9a-fA-F]+$', '', git_tag_test)
+    # now check the version format
+    m = re.match(r'v([0-9]+)\.([0-9]+)\.[0-9]+(rc[0-9]+)?(-[0-9]+\.[0-9]+\.[0-9]+)?$', git_tag_test)
+    if m:
+        # format matches, check the major and minor numbers
+        major = int(m.group(1))
+        minor = int(m.group(2))
+        if major < 1 or (major == 1 and minor < 9):
+            print("")
+            print("Error: PX4 version too low, expected at least v1.9.0")
+            print("Check the git tag (current tag: '{:}')".format(git_tag_test))
+            print("")
+            sys.exit(1)
+    else:
+        print("")
+        print("Error: the git tag '{:}' does not match the expected format.".format(git_tag_test))
+        print("")
+        print("The expected format is 'v<PX4 version>[-<custom version>]'")
+        print("  <PX4 version>: v<major>.<minor>.<patch>[rc<rc>]")
+        print("  <custom version>: <major>.<minor>.<patch>")
+        print("Examples:")
+        print("  v1.9.0rc3")
+        print("  v1.9.0-1.0.0")
+        print("See also https://dev.px4.io/master/en/setup/building_px4.html#firmware_version")
+        print("")
+        sys.exit(1)
+
 git_version = subprocess.check_output('git rev-parse --verify HEAD'.split(),
                                       stderr=subprocess.STDOUT).decode('utf-8').strip()
 try:
@@ -94,6 +140,7 @@ if (os.path.exists('platforms/nuttx/NuttX/nuttx/.git')):
 
 
 if old_header != header:
-    print('Updating header {}'.format(sys.argv[1]))
+    if verbose:
+        print('Updating header {}'.format(filename))
     fp_header = open(filename, 'w')
     fp_header.write(header)


### PR DESCRIPTION
This fails the build if a wrong version tag is used.
A wrong tag leads to wrong reporting in QGC, and incorrect error messages about minimum required PX4 version.
It also leads to wrong statistics on Flight Review.
