### PR TITLE
add statustext message in mavlink receiver

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -254,6 +254,10 @@ MavlinkReceiver::handle_message(mavlink_message_t *msg)
 		handle_message_debug_float_array(msg);
 		break;
 
+	case MAVLINK_MSG_ID_STATUSTEXT:
+		handle_message_statustext(msg);
+		break;
+
 	default:
 		break;
 	}
@@ -777,6 +781,51 @@ MavlinkReceiver::handle_message_att_pos_mocap(mavlink_message_t *msg)
 	int instance_id = 0;
 
 	orb_publish_auto(ORB_ID(vehicle_mocap_odometry), &_mocap_odometry_pub, &mocap_odom, &instance_id, ORB_PRIO_HIGH);
+}
+
+void
+MavlinkReceiver::handle_message_statustext(mavlink_message_t *msg)
+{
+	mavlink_statustext_t statustext;
+	mavlink_msg_statustext_decode(msg, &statustext);
+
+	switch (statustext.severity) {
+
+	case MAV_SEVERITY_EMERGENCY:
+		_mavlink->send_statustext_emergency(statustext.text);
+		break;
+
+	case MAV_SEVERITY_ALERT:
+		_mavlink->send_statustext_critical(statustext.text);
+		break;
+
+	case MAV_SEVERITY_CRITICAL:
+		_mavlink->send_statustext_critical(statustext.text);
+		break;
+
+	case MAV_SEVERITY_ERROR:
+		_mavlink->send_statustext_critical(statustext.text);
+		break;
+
+	case MAV_SEVERITY_WARNING:
+		_mavlink->send_statustext_critical(statustext.text);
+		break;
+
+	case MAV_SEVERITY_NOTICE:
+		_mavlink->send_statustext_info(statustext.text);
+		break;
+
+	case MAV_SEVERITY_INFO:
+		_mavlink->send_statustext_info(statustext.text);
+		break;
+
+	case MAV_SEVERITY_DEBUG:
+		_mavlink->send_statustext_info(statustext.text);
+		break;
+
+	default:
+		break;
+	}
 }
 
 void

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -154,6 +154,7 @@ private:
 	void handle_message_set_attitude_target(mavlink_message_t *msg);
 	void handle_message_set_mode(mavlink_message_t *msg);
 	void handle_message_set_position_target_local_ned(mavlink_message_t *msg);
+	void handle_message_statustext(mavlink_message_t *msg);
 	void handle_message_trajectory_representation_waypoints(mavlink_message_t *msg);
 	void handle_message_vision_position_estimate(mavlink_message_t *msg);
 


### PR DESCRIPTION
This PR adds a listener to the mavlink message [StatusText](https://mavlink.io/en/messages/common.html#STATUSTEXT). The received message will republished as a statustext stream.

This enables sending messages from other systems to be displayed on QGroundcontrol. E.g. in our case we could like to send CPU warnings from the companion computer. Now any string sent on the ROS topic `/statustext/send` will go through mavros into the firmware and from there to QGC