### PR TITLE
mc_att_control: output zero throttle in manual mode when landed

### DIFF
--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -209,15 +209,17 @@ MulticopterAttitudeControl::vehicle_attitude_poll()
 float
 MulticopterAttitudeControl::throttle_curve(float throttle_stick_input)
 {
+	float throttle_min = _vehicle_land_detected.landed ? 0.0f : _param_mpc_manthr_min.get();
+
 	// throttle_stick_input is in range [0, 1]
 	switch (_param_mpc_thr_curve.get()) {
 	case 1: // no rescaling to hover throttle
-		return _param_mpc_manthr_min.get() + throttle_stick_input * (_param_mpc_thr_max.get() - _param_mpc_manthr_min.get());
+		return throttle_min + throttle_stick_input * (_param_mpc_thr_max.get() - throttle_min);
 
 	default: // 0 or other: rescale to hover throttle at 0.5 stick
 		if (throttle_stick_input < 0.5f) {
-			return (_param_mpc_thr_hover.get() - _param_mpc_manthr_min.get()) / 0.5f * throttle_stick_input +
-			       _param_mpc_manthr_min.get();
+			return (_param_mpc_thr_hover.get() - throttle_min) / 0.5f * throttle_stick_input +
+			       throttle_min;
 
 		} else {
 			return (_param_mpc_thr_max.get() - _param_mpc_thr_hover.get()) / 0.5f * (throttle_stick_input - 1.0f) +


### PR DESCRIPTION
MPC_MANTHR_MIN is used as minimum throttle in attitude control mode when
the vehicle is in air. This is useful to retain some control around roll and
pitch axis if airmode is not enabled and the user demands zero throttle.
However, when the vehicle is landed there is not need to keep the throttle
at a higher value than zero.

SITL testing:
![image](https://user-images.githubusercontent.com/7610489/61717003-8ae15680-ad60-11e9-9320-b88a02ee0ef9.png)

Log:
https://logs.px4.io/plot_app?log=d6e6fc13-9e50-44aa-888a-47a9f66801d2

