### PR TITLE
Fix SITL segfault in camera trigger

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -162,6 +162,8 @@ then
 	param set SENS_DPRES_OFF 0.001
 	param set SYS_RESTART_TYPE 2
 
+	param set TRIG_INTERFACE 3
+
 	param set WEST_EN 0
 fi
 

--- a/src/drivers/camera_trigger/camera_trigger.cpp
+++ b/src/drivers/camera_trigger/camera_trigger.cpp
@@ -133,7 +133,7 @@ public:
 	/**
 	 * Start the task.
 	 */
-	void		start();
+	bool		start();
 
 	/**
 	 * Stop the task.
@@ -427,9 +427,17 @@ CameraTrigger::shoot_once()
 	}
 }
 
-void
+bool
 CameraTrigger::start()
 {
+	if (_camera_interface == nullptr) {
+		if (camera_trigger::g_camera_trigger != nullptr) {
+			delete (camera_trigger::g_camera_trigger);
+		}
+
+		return false;
+	}
+
 	if ((_trigger_mode == TRIGGER_MODE_INTERVAL_ALWAYS_ON ||
 	     _trigger_mode == TRIGGER_MODE_DISTANCE_ALWAYS_ON) &&
 	    _camera_interface->has_power_control() &&
@@ -456,6 +464,8 @@ CameraTrigger::start()
 
 	// start to monitor at high rate for trigger enable command
 	ScheduleNow();
+
+	return true;
 }
 
 void
@@ -827,7 +837,11 @@ int camera_trigger_main(int argc, char *argv[])
 			return 1;
 		}
 
-		camera_trigger::g_camera_trigger->start();
+		if (!camera_trigger::g_camera_trigger->start()) {
+			PX4_WARN("failed to start camera trigger");
+			return 1;
+		}
+
 		return 0;
 	}
 

--- a/src/drivers/camera_trigger/camera_trigger.cpp
+++ b/src/drivers/camera_trigger/camera_trigger.cpp
@@ -329,7 +329,9 @@ CameraTrigger::CameraTrigger() :
 
 CameraTrigger::~CameraTrigger()
 {
-	delete (_camera_interface);
+	if (_camera_interface != nullptr) {
+		delete (_camera_interface);
+	}
 
 	camera_trigger::g_camera_trigger = nullptr;
 }
@@ -433,6 +435,8 @@ CameraTrigger::start()
 	if (_camera_interface == nullptr) {
 		if (camera_trigger::g_camera_trigger != nullptr) {
 			delete (camera_trigger::g_camera_trigger);
+			camera_trigger::g_camera_trigger = nullptr;
+
 		}
 
 		return false;
@@ -482,6 +486,7 @@ CameraTrigger::stop()
 
 	if (camera_trigger::g_camera_trigger != nullptr) {
 		delete (camera_trigger::g_camera_trigger);
+		camera_trigger::g_camera_trigger = nullptr;
 	}
 }
 


### PR DESCRIPTION
In SITL the only supported camera interface mode is via mavlink. If the interface was not set to mavlink (and by default it was not set to that) then no camera interface was created and a null pointer was invoked.
This PR does the following:

1) For posix build set the default trigger mode to mavlink.
2) Exit cleanly if a camera interface was not created.
