### PR TITLE
ak09916: fixed driver not reporting magnetometer as external

### DIFF
--- a/src/drivers/magnetometer/ak09916/ak09916.cpp
+++ b/src/drivers/magnetometer/ak09916/ak09916.cpp
@@ -252,6 +252,7 @@ AK09916::measure()
 		}
 
 		_px4_mag.set_error_count(perf_event_count(_mag_errors));
+		_px4_mag.set_external(external());
 		_px4_mag.update(timestamp_sample, raw_data.x, raw_data.y, raw_data.z);
 	}
 }


### PR DESCRIPTION
Tested on Pixhawk cube + Here 2 gps.
Magnetometer is now detected as external and QGC gives the option to specify the mag orientation.

![image](https://user-images.githubusercontent.com/7610489/61857749-03f9be80-aec5-11e9-8df0-e86587b2e384.png)
