### PR TITLE
appveyor: fix PX4 version format check

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 # Build version
 version: "{build}"
-# shallow clone the main repo
-clone_depth: 1
+# do not shallow clone because we want to infer the version from the last tag
 
 branches:
   only:
@@ -36,7 +35,7 @@ build_script:
 # safe the repopath for switching to it in cygwin bash
 - for /f %%i in ('cygpath -u %%CD%%') do set repopath=%%i
 # build the make target
-- call bash --login -c "cd $repopath && git fetch --tags && make $PX4_CONFIG"
+- call bash --login -c "cd $repopath && make $PX4_CONFIG"
 
 # Note: using bash --login is important
 # because otherwise certain things (like python; import numpy) do not work


### PR DESCRIPTION
**Problem**
Failing Appveyor CI on latest master because of the version check failing. See e.g. https://ci.appveyor.com/project/Dronecode/firmware/builds/26230322/job/i5jp9dm6ldowt7pu#L168

**Solution**
Remove shallow clone such that we can infer the version from the latest tag with `git describe`.

**Additional context**
#12533