### PR TITLE
update most parameter_update to uORB::Subscription consistently

### DIFF
--- a/src/drivers/heater/heater.cpp
+++ b/src/drivers/heater/heater.cpp
@@ -292,9 +292,13 @@ float Heater::temperature_setpoint(char *argv[])
 
 void Heater::update_params(const bool force)
 {
-	parameter_update_s param_update;
+	// check for parameter updates
+	if (_parameter_update_sub.updated() || force) {
+		// clear update
+		parameter_update_s pupdate;
+		_parameter_update_sub.copy(&pupdate);
 
-	if (_params_sub.update(&param_update) || force) {
+		// update parameters from storage
 		ModuleParams::updateParams();
 	}
 }

--- a/src/drivers/heater/heater.h
+++ b/src/drivers/heater/heater.h
@@ -174,7 +174,7 @@ private:
 
 	float _integrator_value = 0.0f;
 
-	uORB::Subscription _params_sub{ORB_ID(parameter_update)};
+	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
 
 	float _proportional_value = 0.0f;
 

--- a/src/drivers/lights/rgbled/rgbled.cpp
+++ b/src/drivers/lights/rgbled/rgbled.cpp
@@ -80,7 +80,8 @@ private:
 	volatile bool		_running{false};
 	volatile bool		_should_run{true};
 	bool			_leds_enabled{true};
-	uORB::Subscription	_param_sub{ORB_ID(parameter_update)};
+
+	uORB::Subscription	_parameter_update_sub{ORB_ID(parameter_update)};
 
 	LedController		_led_controller;
 
@@ -202,11 +203,13 @@ RGBLED::Run()
 		return;
 	}
 
-	if (_param_sub.updated()) {
+	// check for parameter updates
+	if (_parameter_update_sub.updated()) {
 		// clear update
 		parameter_update_s pupdate;
-		_param_sub.copy(&pupdate);
+		_parameter_update_sub.copy(&pupdate);
 
+		// update parameters from storage
 		update_params();
 
 		// Immediately update to change brightness

--- a/src/drivers/lights/rgbled_ncp5623c/rgbled_ncp5623c.cpp
+++ b/src/drivers/lights/rgbled_ncp5623c/rgbled_ncp5623c.cpp
@@ -80,7 +80,8 @@ private:
 	volatile bool		_running{false};
 	volatile bool		_should_run{true};
 	bool			_leds_enabled{true};
-	uORB::Subscription	_param_sub{ORB_ID(parameter_update)};
+
+	uORB::Subscription	_parameter_update_sub{ORB_ID(parameter_update)};
 
 	LedController		_led_controller;
 
@@ -166,11 +167,13 @@ RGBLED_NPC5623C::Run()
 		return;
 	}
 
-	if (_param_sub.updated()) {
+	// check for parameter updates
+	if (_parameter_update_sub.updated()) {
 		// clear update
 		parameter_update_s pupdate;
-		_param_sub.copy(&pupdate);
+		_parameter_update_sub.copy(&pupdate);
 
+		// update parameters from storage
 		update_params();
 
 		// Immediately update to change brightness

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -177,7 +177,7 @@ private:
 
 	unsigned	_current_update_rate{0};
 
-	uORB::Subscription _param_sub{ORB_ID(parameter_update)};
+	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
 
 
 	unsigned	_num_outputs{0};
@@ -767,7 +767,13 @@ PX4FMU::Run()
 		update_pwm_out_state(pwm_on);
 	}
 
-	if (_param_sub.updated()) {
+	// check for parameter updates
+	if (_parameter_update_sub.updated()) {
+		// clear update
+		parameter_update_s pupdate;
+		_parameter_update_sub.copy(&pupdate);
+
+		// update parameters from storage
 		update_params();
 	}
 
@@ -783,15 +789,11 @@ PX4FMU::Run()
 
 void PX4FMU::update_params()
 {
-	parameter_update_s pupdate;
-	_param_sub.update(&pupdate);
-
 	update_pwm_rev_mask();
 	update_pwm_trims();
 
 	updateParams();
 }
-
 
 int
 PX4FMU::ioctl(file *filp, int cmd, unsigned long arg)

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -256,7 +256,7 @@ private:
 	uORB::Subscription	_t_actuator_controls_3{ORB_ID(actuator_controls_3)};;	///< actuator controls group 3 topic
 	uORB::Subscription	_t_actuator_armed{ORB_ID(actuator_armed)};		///< system armed control topic
 	uORB::Subscription 	_t_vehicle_control_mode{ORB_ID(vehicle_control_mode)};	///< vehicle control mode topic
-	uORB::Subscription	_t_param{ORB_ID(parameter_update)};			///< parameter update topic
+	uORB::Subscription	_parameter_update_sub{ORB_ID(parameter_update)};	///< parameter update topic
 	uORB::Subscription	_t_vehicle_command{ORB_ID(vehicle_command)};		///< vehicle command topic
 
 	bool			_param_update_force;	///< force a parameter update
@@ -997,10 +997,14 @@ PX4IO::task_main()
 			 *
 			 * XXX this may be a bit spammy
 			 */
-			if (_t_param.updated() || _param_update_force) {
-				_param_update_force = false;
+
+			// check for parameter updates
+			if (_parameter_update_sub.updated() || _param_update_force) {
+				// clear update
 				parameter_update_s pupdate;
-				_t_param.copy(&pupdate);
+				_parameter_update_sub.copy(&pupdate);
+
+				_param_update_force = false;
 
 				if (!_rc_handling_disabled) {
 					/* re-upload RC input config as it may have changed */

--- a/src/drivers/tap_esc/tap_esc.cpp
+++ b/src/drivers/tap_esc/tap_esc.cpp
@@ -47,7 +47,7 @@
 #include <lib/cdev/CDev.hpp>
 #include <perf/perf_counter.h>
 #include <px4_module_params.h>
-#include <uORB/uORB.h>
+#include <uORB/Subscription.hpp>
 #include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/actuator_outputs.h>
 #include <uORB/topics/actuator_armed.h>
@@ -114,7 +114,9 @@ private:
 	bool 			_is_armed = false;
 	int			_armed_sub = -1;
 	int 			_test_motor_sub = -1;
-	int 			_params_sub = -1;
+
+	uORB::Subscription	_parameter_update_sub{ORB_ID(parameter_update)};
+
 	orb_advert_t        	_outputs_pub = nullptr;
 	actuator_outputs_s      _outputs = {};
 	actuator_armed_s	_armed = {};
@@ -191,7 +193,6 @@ TAP_ESC::~TAP_ESC()
 
 	orb_unsubscribe(_armed_sub);
 	orb_unsubscribe(_test_motor_sub);
-	orb_unsubscribe(_params_sub);
 
 	orb_unadvertise(_outputs_pub);
 	orb_unadvertise(_esc_feedback_pub);
@@ -336,7 +337,6 @@ int TAP_ESC::init()
 
 	_armed_sub = orb_subscribe(ORB_ID(actuator_armed));
 	_test_motor_sub = orb_subscribe(ORB_ID(test_motor));
-	_params_sub = orb_subscribe(ORB_ID(parameter_update));
 
 	return ret;
 }
@@ -609,13 +609,13 @@ void TAP_ESC::cycle()
 
 	}
 
-	/* check for parameter updates */
-	bool param_updated = false;
-	orb_check(_params_sub, &param_updated);
+	// check for parameter updates
+	if (_parameter_update_sub.updated()) {
+		// clear update
+		parameter_update_s pupdate;
+		_parameter_update_sub.copy(&pupdate);
 
-	if (param_updated) {
-		struct parameter_update_s update;
-		orb_copy(ORB_ID(parameter_update), _params_sub, &update);
+		// update parameters from storage
 		updateParams();
 	}
 }

--- a/src/examples/bottle_drop/bottle_drop.cpp
+++ b/src/examples/bottle_drop/bottle_drop.cpp
@@ -55,7 +55,7 @@
 #include <drivers/device/device.h>
 #include <drivers/drv_hrt.h>
 #include <arch/board/board.h>
-#include <uORB/uORB.h>
+#include <uORB/Subscription.hpp>
 #include <uORB/topics/vehicle_command.h>
 #include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/wind_estimate.h>
@@ -411,9 +411,7 @@ BottleDrop::task_main()
 
 	int vehicle_global_position_sub = orb_subscribe(ORB_ID(vehicle_global_position));
 
-	struct parameter_update_s update;
-	memset(&update, 0, sizeof(update));
-	int parameter_update_sub = orb_subscribe(ORB_ID(parameter_update));
+	uORB::Subscription parameter_update_sub{ORB_ID(parameter_update)};
 
 	struct mission_item_s flight_vector_s {};
 	struct mission_item_s flight_vector_e {};
@@ -492,12 +490,11 @@ BottleDrop::task_main()
 				orb_copy(ORB_ID(vehicle_global_position), vehicle_global_position_sub, &_global_pos);
 			}
 
-			// Get parameter updates
-			orb_check(parameter_update_sub, &updated);
-
-			if (updated) {
-				// copy global position
-				orb_copy(ORB_ID(parameter_update), parameter_update_sub, &update);
+			// check for parameter updates
+			if (parameter_update_sub.updated()) {
+				// clear update
+				parameter_update_s pupdate;
+				parameter_update_sub.copy(&pupdate);
 
 				// update all parameters
 				param_get(param_gproperties, &z_0);

--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -109,7 +109,7 @@ private:
 
 	int		_sensors_sub = -1;
 
-	uORB::Subscription		_params_sub{ORB_ID(parameter_update)};
+	uORB::Subscription		_parameter_update_sub{ORB_ID(parameter_update)};
 	uORB::Subscription		_global_pos_sub{ORB_ID(vehicle_global_position)};
 	uORB::Subscription		_vision_odom_sub{ORB_ID(vehicle_visual_odometry)};
 	uORB::Subscription		_mocap_odom_sub{ORB_ID(vehicle_mocap_odometry)};
@@ -437,10 +437,13 @@ void AttitudeEstimatorQ::task_main()
 
 void AttitudeEstimatorQ::update_parameters(bool force)
 {
-	if (_params_sub.updated()) {
-		parameter_update_s param_update;
-		_params_sub.copy(&param_update);
+	// check for parameter updates
+	if (_parameter_update_sub.updated() || force) {
+		// clear update
+		parameter_update_s pupdate;
+		_parameter_update_sub.copy(&pupdate);
 
+		// update parameters
 		param_get(_params_handles.w_acc, &_w_accel);
 		param_get(_params_handles.w_mag, &_w_mag);
 

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -87,7 +87,6 @@
 #include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/mavlink_log.h>
 #include <uORB/topics/mission.h>
-#include <uORB/topics/parameter_update.h>
 #include <uORB/topics/power_button_state.h>
 #include <uORB/topics/safety.h>
 #include <uORB/topics/subsystem_info.h>
@@ -1297,7 +1296,6 @@ Commander::run()
 	uORB::Subscription cpuload_sub{ORB_ID(cpuload)};
 	uORB::Subscription geofence_result_sub{ORB_ID(geofence_result)};
 	uORB::Subscription land_detector_sub{ORB_ID(vehicle_land_detected)};
-	uORB::Subscription param_changed_sub{ORB_ID(parameter_update)};
 	uORB::Subscription safety_sub{ORB_ID(safety)};
 	uORB::Subscription sp_man_sub{ORB_ID(manual_control_setpoint)};
 	uORB::Subscription subsys_sub{ORB_ID(subsystem_info)};
@@ -1418,14 +1416,14 @@ Commander::run()
 		transition_result_t arming_ret = TRANSITION_NOT_CHANGED;
 
 		/* update parameters */
-		bool params_updated = param_changed_sub.updated();
+		bool params_updated = _parameter_update_sub.updated();
 
 		if (params_updated || param_init_forced) {
+			// clear update
+			parameter_update_s update;
+			_parameter_update_sub.copy(&update);
 
-			/* parameters changed */
-			parameter_update_s param_changed;
-			param_changed_sub.copy(&param_changed);
-
+			// update parameters from storage
 			updateParams();
 
 			/* update parameters */

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -60,6 +60,7 @@
 #include <uORB/topics/iridiumsbd_status.h>
 #include <uORB/topics/mission_result.h>
 #include <uORB/topics/offboard_control_mode.h>
+#include <uORB/topics/parameter_update.h>
 #include <uORB/topics/telemetry_status.h>
 #include <uORB/topics/vehicle_acceleration.h>
 #include <uORB/topics/vehicle_command.h>
@@ -274,6 +275,7 @@ private:
 	bool _print_avoidance_msg_once{false};
 
 	// Subscriptions
+	uORB::Subscription					_parameter_update_sub{ORB_ID(parameter_update)};
 	uORB::Subscription					_vehicle_acceleration_sub{ORB_ID(vehicle_acceleration)};
 
 	uORB::SubscriptionData<airspeed_s>			_airspeed_sub{ORB_ID(airspeed)};

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -265,7 +265,7 @@ private:
 	uORB::Subscription _landing_target_pose_sub{ORB_ID(landing_target_pose)};
 	uORB::Subscription _magnetometer_sub{ORB_ID(vehicle_magnetometer)};
 	uORB::Subscription _optical_flow_sub{ORB_ID(optical_flow)};
-	uORB::Subscription _params_sub{ORB_ID(parameter_update)};
+	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
 	uORB::Subscription _sensor_selection_sub{ORB_ID(sensor_selection)};
 	uORB::Subscription _status_sub{ORB_ID(vehicle_status)};
 	uORB::Subscription _vehicle_land_detected_sub{ORB_ID(vehicle_land_detected)};
@@ -739,10 +739,13 @@ void Ekf2::run()
 
 		perf_begin(_perf_update_data);
 
-		if (_params_sub.updated()) {
-			// read from param to clear updated flag
-			parameter_update_s update;
-			_params_sub.copy(&update);
+		// check for parameter updates
+		if (_parameter_update_sub.updated()) {
+			// clear update
+			parameter_update_s pupdate;
+			_parameter_update_sub.copy(&pupdate);
+
+			// update parameters from storage
 			updateParams();
 		}
 

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -454,15 +454,16 @@ void FixedwingAttitudeControl::Run()
 
 	if (_att_sub.update(&_att)) {
 
-		/* only update parameters if they changed */
-		bool params_updated = _params_sub.updated();
+		// only update parameters if they changed
+		bool params_updated = _parameter_update_sub.updated();
 
+		// check for parameter updates
 		if (params_updated) {
-			/* read from param to clear updated flag */
-			parameter_update_s update;
-			_params_sub.copy(&update);
+			// clear update
+			parameter_update_s pupdate;
+			_parameter_update_sub.copy(&pupdate);
 
-			/* update parameters from storage */
+			// update parameters from storage
 			parameters_update();
 		}
 

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
@@ -101,7 +101,7 @@ private:
 	uORB::Subscription _battery_status_sub{ORB_ID(battery_status)};			/**< battery status subscription */
 	uORB::Subscription _global_pos_sub{ORB_ID(vehicle_global_position)};		/**< global position subscription */
 	uORB::Subscription _manual_sub{ORB_ID(manual_control_setpoint)};		/**< notification of manual control updates */
-	uORB::Subscription _params_sub{ORB_ID(parameter_update)};			/**< notification of parameter updates */
+	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};		/**< notification of parameter updates */
 	uORB::Subscription _rates_sp_sub{ORB_ID(vehicle_rates_setpoint)};		/**< vehicle rates setpoint */
 	uORB::Subscription _vcontrol_mode_sub{ORB_ID(vehicle_control_mode)};		/**< vehicle status subscription */
 	uORB::Subscription _vehicle_land_detected_sub{ORB_ID(vehicle_land_detected)};	/**< vehicle land detected subscription */

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1662,15 +1662,13 @@ FixedwingPositionControl::Run()
 	/* only run controller if position changed */
 	if (_global_pos_sub.update(&_global_pos)) {
 
-		/* only update parameters if they changed */
-		bool params_updated = _params_sub.updated();
+		// check for parameter updates
+		if (_parameter_update_sub.updated()) {
+			// clear update
+			parameter_update_s pupdate;
+			_parameter_update_sub.copy(&pupdate);
 
-		if (params_updated) {
-			/* read from param to clear updated flag */
-			parameter_update_s update;
-			_params_sub.copy(&update);
-
-			/* update parameters from storage */
+			// update parameters from storage
 			parameters_update();
 		}
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -156,7 +156,7 @@ private:
 	uORB::Subscription _control_mode_sub{ORB_ID(vehicle_control_mode)};		///< control mode subscription */
 	uORB::Subscription _local_pos_sub{ORB_ID(vehicle_local_position)};
 	uORB::Subscription _manual_control_sub{ORB_ID(manual_control_setpoint)};	///< notification of manual control updates */
-	uORB::Subscription _params_sub{ORB_ID(parameter_update)};			///< notification of parameter updates */
+	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};		///< notification of parameter updates */
 	uORB::Subscription _pos_sp_triplet_sub{ORB_ID(position_setpoint_triplet)};
 	uORB::Subscription _sensor_baro_sub{ORB_ID(sensor_baro)};
 	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};		///< vehicle attitude subscription */

--- a/src/modules/land_detector/FixedwingLandDetector.cpp
+++ b/src/modules/land_detector/FixedwingLandDetector.cpp
@@ -62,9 +62,13 @@ void FixedwingLandDetector::_update_topics()
 
 void FixedwingLandDetector::_update_params()
 {
-	parameter_update_s param_update;
+	// check for parameter updates
+	if (_parameter_update_sub.updated()) {
+		// clear update
+		parameter_update_s pupdate;
+		_parameter_update_sub.copy(&pupdate);
 
-	if (_param_update_sub.update(&param_update)) {
+		// update parameters from storage
 		_update_params();
 	}
 }

--- a/src/modules/land_detector/FixedwingLandDetector.h
+++ b/src/modules/land_detector/FixedwingLandDetector.h
@@ -73,7 +73,7 @@ private:
 	static constexpr hrt_abstime FLYING_TRIGGER_TIME_US = 0_us;
 
 	uORB::Subscription _airspeed_sub{ORB_ID(airspeed)};
-	uORB::Subscription _param_update_sub{ORB_ID(parameter_update)};
+	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
 	uORB::Subscription _vehicle_acceleration_sub{ORB_ID(vehicle_acceleration)};
 	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
 

--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -151,10 +151,15 @@ void LandDetector::Run()
 
 void LandDetector::_check_params(const bool force)
 {
-	parameter_update_s param_update;
+	// check for parameter updates
+	if (_parameter_update_sub.updated() || force) {
+		// clear update
+		parameter_update_s pupdate;
+		_parameter_update_sub.copy(&pupdate);
 
-	if (_param_update_sub.update(&param_update) || force) {
+		// update parameters from storage
 		_update_params();
+
 		_update_total_flight_time();
 	}
 }

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -174,7 +174,7 @@ private:
 	perf_counter_t _cycle_perf{perf_alloc(PC_ELAPSED, "land_detector_cycle")};
 
 	uORB::Subscription _actuator_armed_sub{ORB_ID(actuator_armed)};
-	uORB::Subscription _param_update_sub{ORB_ID(parameter_update)};
+	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(
 		ModuleParams,

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -976,9 +976,11 @@ void Logger::run()
 
 			/* Check if parameters have changed */
 			if (!_should_stop_file_log) { // do not record param changes after disarming
-				parameter_update_s param_update;
+				if (parameter_update_sub.updated()) {
+					// clear update
+					parameter_update_s pupdate;
+					parameter_update_sub.copy(&pupdate);
 
-				if (parameter_update_sub.update(&param_update)) {
 					write_changed_parameters(LogType::Full);
 				}
 			}

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2126,9 +2126,9 @@ Mavlink::task_main(int argc, char *argv[])
 		pthread_mutex_init(&_message_buffer_mutex, nullptr);
 	}
 
+	uORB::Subscription parameter_update_sub{ORB_ID(parameter_update)};
+
 	MavlinkOrbSubscription *cmd_sub = add_orb_subscription(ORB_ID(vehicle_command), 0, true);
-	MavlinkOrbSubscription *param_sub = add_orb_subscription(ORB_ID(parameter_update));
-	uint64_t param_time = 0;
 	MavlinkOrbSubscription *status_sub = add_orb_subscription(ORB_ID(vehicle_status));
 	uint64_t status_time = 0;
 	MavlinkOrbSubscription *ack_sub = add_orb_subscription(ORB_ID(vehicle_command_ack), 0, true);
@@ -2224,9 +2224,13 @@ Mavlink::task_main(int argc, char *argv[])
 
 		update_rate_mult();
 
-		parameter_update_s param_update;
+		// check for parameter updates
+		if (parameter_update_sub.updated()) {
+			// clear update
+			parameter_update_s pupdate;
+			parameter_update_sub.copy(&pupdate);
 
-		if (param_sub->update(&param_time, &param_update)) {
+			// update parameters from storage
 			mavlink_update_parameters();
 
 #if defined(CONFIG_NET)
@@ -2235,7 +2239,7 @@ Mavlink::task_main(int argc, char *argv[])
 				_src_addr_initialized = false;
 			}
 
-#endif
+#endif // CONFIG_NET
 		}
 
 		check_radio_config();

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2569,9 +2569,15 @@ MavlinkReceiver::Run()
 	hrt_abstime last_send_update = 0;
 
 	while (!_mavlink->_task_should_exit) {
-		// Check for updated parameters.
-		if (_param_update_sub.updated()) {
-			update_params();
+
+		// check for parameter updates
+		if (_parameter_update_sub.updated()) {
+			// clear update
+			parameter_update_s pupdate;
+			_parameter_update_sub.copy(&pupdate);
+
+			// update parameters from storage
+			updateParams();
 		}
 
 		if (poll(&fds[0], 1, timeout) > 0) {
@@ -2717,12 +2723,4 @@ MavlinkReceiver::receive_start(pthread_t *thread, Mavlink *parent)
 	pthread_create(thread, &receiveloop_attr, MavlinkReceiver::start_helper, (void *)parent);
 
 	pthread_attr_destroy(&receiveloop_attr);
-}
-
-void
-MavlinkReceiver::update_params()
-{
-	parameter_update_s param_update;
-	_param_update_sub.update(&param_update);
-	updateParams();
 }

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -259,7 +259,7 @@ private:
 	// ORB subscriptions
 	uORB::Subscription	_actuator_armed_sub{ORB_ID(actuator_armed)};
 	uORB::Subscription	_control_mode_sub{ORB_ID(vehicle_control_mode)};
-	uORB::Subscription	_param_update_sub{ORB_ID(parameter_update)};
+	uORB::Subscription	_parameter_update_sub{ORB_ID(parameter_update)};
 	uORB::Subscription	_vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
 	uORB::Subscription	_vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
 

--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -146,7 +146,7 @@ private:
 	uORB::Subscription _v_att_sp_sub{ORB_ID(vehicle_attitude_setpoint)};		/**< vehicle attitude setpoint subscription */
 	uORB::Subscription _v_rates_sp_sub{ORB_ID(vehicle_rates_setpoint)};		/**< vehicle rates setpoint subscription */
 	uORB::Subscription _v_control_mode_sub{ORB_ID(vehicle_control_mode)};		/**< vehicle control mode subscription */
-	uORB::Subscription _params_sub{ORB_ID(parameter_update)};			/**< parameter updates subscription */
+	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};		/**< parameter updates subscription */
 	uORB::Subscription _manual_control_sp_sub{ORB_ID(manual_control_setpoint)};	/**< manual control setpoint subscription */
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};			/**< vehicle status subscription */
 	uORB::Subscription _motor_limits_sub{ORB_ID(multirotor_motor_limits)};		/**< motor limits subscription */

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -137,11 +137,13 @@ MulticopterAttitudeControl::parameters_updated()
 void
 MulticopterAttitudeControl::parameter_update_poll()
 {
-	/* Check if parameters have changed */
-	parameter_update_s param_update;
+	// check for parameter updates
+	if (_parameter_update_sub.updated()) {
+		// clear update
+		parameter_update_s pupdate;
+		_parameter_update_sub.copy(&pupdate);
 
-	if (_params_sub.update(&param_update)) {
-		updateParams();
+		// update parameters from storage
 		parameters_updated();
 	}
 }

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -123,7 +123,7 @@ private:
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};			/**< vehicle status subscription */
 	uORB::Subscription _vehicle_land_detected_sub{ORB_ID(vehicle_land_detected)};	/**< vehicle land detected subscription */
 	uORB::Subscription _control_mode_sub{ORB_ID(vehicle_control_mode)};		/**< vehicle control mode subscription */
-	uORB::Subscription _params_sub{ORB_ID(parameter_update)};			/**< notification of parameter updates */
+	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};		/**< notification of parameter updates */
 	uORB::Subscription _att_sub{ORB_ID(vehicle_attitude)};				/**< vehicle attitude */
 	uORB::Subscription _home_pos_sub{ORB_ID(home_position)}; 			/**< home position */
 
@@ -312,10 +312,13 @@ MulticopterPositionControl::warn_rate_limited(const char *string)
 int
 MulticopterPositionControl::parameters_update(bool force)
 {
-	parameter_update_s param_upd;
-	bool updated = _params_sub.update(&param_upd);
+	// check for parameter updates
+	if (_parameter_update_sub.updated()) {
+		// clear update
+		parameter_update_s pupdate;
+		_parameter_update_sub.copy(&pupdate);
 
-	if (updated || force) {
+		// update parameters from storage
 		ModuleParams::updateParams();
 		SuperBlock::updateParams();
 

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -317,7 +317,7 @@ private:
 	uORB::Subscription _gps_pos_sub{ORB_ID(vehicle_gps_position)};		/**< gps position subscription */
 	uORB::Subscription _home_pos_sub{ORB_ID(home_position)};		/**< home position subscription */
 	uORB::Subscription _land_detected_sub{ORB_ID(vehicle_land_detected)};	/**< vehicle land detected subscription */
-	uORB::Subscription _param_update_sub{ORB_ID(parameter_update)};		/**< param update subscription */
+	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};	/**< param update subscription */
 	uORB::Subscription _pos_ctrl_landing_status_sub{ORB_ID(position_controller_landing_status)};	/**< position controller landing status subscription */
 	uORB::Subscription _traffic_sub{ORB_ID(transponder_report)};		/**< traffic subscription */
 	uORB::Subscription _vehicle_command_sub{ORB_ID(vehicle_command)};	/**< vehicle commands (onboard and offboard) */

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -119,9 +119,6 @@ Navigator::~Navigator()
 void
 Navigator::params_update()
 {
-	parameter_update_s param_update;
-	_param_update_sub.update(&param_update);
-
 	updateParams();
 
 	if (_handle_back_trans_dec_mss != PARAM_INVALID) {
@@ -202,8 +199,13 @@ Navigator::run()
 			}
 		}
 
-		/* parameters updated */
-		if (_param_update_sub.updated()) {
+		// check for parameter updates
+		if (_parameter_update_sub.updated()) {
+			// clear update
+			parameter_update_s pupdate;
+			_parameter_update_sub.copy(&pupdate);
+
+			// update parameters from storage
 			params_update();
 		}
 

--- a/src/modules/rover_pos_control/RoverPositionControl.hpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.hpp
@@ -105,10 +105,11 @@ private:
 	int		_global_pos_sub{-1};
 	int		_local_pos_sub{-1};
 	int		_manual_control_sub{-1};		/**< notification of manual control updates */
-	int		_params_sub{-1};			/**< notification of parameter updates */
 	int		_pos_sp_triplet_sub{-1};
 	int     _vehicle_attitude_sub{-1};
 	int		_sensor_combined_sub{-1};
+
+	uORB::Subscription	_parameter_update_sub{ORB_ID(parameter_update)};
 
 	manual_control_setpoint_s		_manual{};			    /**< r/c channel data */
 	position_setpoint_triplet_s		_pos_sp_triplet{};		/**< triplet of mission items */
@@ -167,7 +168,7 @@ private:
 	/**
 	 * Update our local parameter cache.
 	 */
-	void parameters_update(int parameter_update_sub, bool force = false);
+	void parameters_update(bool force = false);
 
 	void		manual_control_setpoint_poll();
 	void		position_setpoint_triplet_poll();

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -168,7 +168,7 @@ private:
 
 	uORB::Subscription	_actuator_ctrl_0_sub{ORB_ID(actuator_controls_0)};		/**< attitude controls sub */
 	uORB::Subscription	_diff_pres_sub{ORB_ID(differential_pressure)};			/**< raw differential pressure subscription */
-	uORB::Subscription	_params_sub{ORB_ID(parameter_update)};				/**< notification of parameter updates */
+	uORB::Subscription	_parameter_update_sub{ORB_ID(parameter_update)};				/**< notification of parameter updates */
 	uORB::Subscription	_vcontrol_mode_sub{ORB_ID(vehicle_control_mode)};		/**< vehicle control mode subscription */
 
 	uORB::Publication<airspeed_s>			_airspeed_pub{ORB_ID(airspeed)};			/**< airspeed */
@@ -364,12 +364,13 @@ Sensors::diff_pres_poll(const vehicle_air_data_s &raw)
 void
 Sensors::parameter_update_poll(bool forced)
 {
-	/* Check if any parameter has changed */
-	parameter_update_s update;
+	// check for parameter updates
+	if (_parameter_update_sub.updated() || forced) {
+		// clear update
+		parameter_update_s pupdate;
+		_parameter_update_sub.copy(&pupdate);
 
-	if (_params_sub.update(&update) || forced) {
-		/* read from param to clear updated flag */
-
+		// update parameters from storage
 		parameters_update();
 		updateParams();
 

--- a/src/modules/sih/sih.cpp
+++ b/src/modules/sih/sih.cpp
@@ -110,7 +110,6 @@ void Sih::run()
 	_actuator_out_sub = orb_subscribe(ORB_ID(actuator_outputs));
 
 	// initialize parameters
-	_parameter_update_sub = orb_subscribe(ORB_ID(parameter_update));
 	parameters_update_poll();
 
 	init_variables();
@@ -143,7 +142,6 @@ void Sih::run()
 	hrt_cancel(&_timer_call);   // close the periodic timer interruption
 	px4_sem_destroy(&_data_semaphore);
 	orb_unsubscribe(_actuator_out_sub);
-	orb_unsubscribe(_parameter_update_sub);
 }
 
 // timer_callback() is used as a real time callback to post the semaphore
@@ -186,13 +184,13 @@ void Sih::inner_loop()
 
 void Sih::parameters_update_poll()
 {
-	bool updated = false;
-	struct parameter_update_s param_upd;
+	// check for parameter updates
+	if (_parameter_update_sub.updated()) {
+		// clear update
+		parameter_update_s pupdate;
+		_parameter_update_sub.copy(&pupdate);
 
-	orb_check(_parameter_update_sub, &updated);
-
-	if (updated) {
-		orb_copy(ORB_ID(parameter_update), _parameter_update_sub, &param_upd);
+		// update parameters from storage
 		updateParams();
 		parameters_updated();
 	}

--- a/src/modules/sih/sih.hpp
+++ b/src/modules/sih/sih.hpp
@@ -46,6 +46,7 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/drivers/magnetometer/PX4Magnetometer.hpp>
 #include <perf/perf_counter.h>
+#include <uORB/Subscription.hpp>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/vehicle_angular_velocity.h>   // to publish groundtruth
 #include <uORB/topics/vehicle_attitude.h>           // to publish groundtruth
@@ -119,7 +120,7 @@ private:
 	vehicle_global_position_s           _gpos_gt{};
 	orb_advert_t                        _gpos_gt_pub{nullptr};
 
-	int _parameter_update_sub {-1};
+	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
 	int _actuator_out_sub {-1};
 
 	// hard constants

--- a/src/modules/simulator/simulator.cpp
+++ b/src/modules/simulator/simulator.cpp
@@ -77,17 +77,13 @@ void Simulator::write_gps_data(void *buf)
 
 void Simulator::parameters_update(bool force)
 {
-	bool updated;
-	struct parameter_update_s param_upd;
+	// check for parameter updates
+	if (_parameter_update_sub.updated() || force) {
+		// clear update
+		parameter_update_s pupdate;
+		_parameter_update_sub.copy(&pupdate);
 
-	orb_check(_param_sub, &updated);
-
-	if (updated) {
-		orb_copy(ORB_ID(parameter_update), _param_sub, &param_upd);
-	}
-
-	if (updated || force) {
-		// update C++ param system
+		// update parameters from storage
 		updateParams();
 	}
 }

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -53,6 +53,7 @@
 #include <perf/perf_counter.h>
 #include <px4_module_params.h>
 #include <px4_posix.h>
+#include <uORB/Subscription.hpp>
 #include <uORB/topics/actuator_outputs.h>
 #include <uORB/topics/battery_status.h>
 #include <uORB/topics/differential_pressure.h>
@@ -181,8 +182,6 @@ private:
 
 		_gps.writeData(&gps_data);
 
-		_param_sub = orb_subscribe(ORB_ID(parameter_update));
-
 		_battery_status.timestamp = hrt_absolute_time();
 
 		_px4_accel.set_sample_rate(250);
@@ -191,9 +190,6 @@ private:
 
 	~Simulator()
 	{
-		// Unsubscribe from uORB topics.
-		orb_unsubscribe(_param_sub);
-
 		// free perf counters
 		perf_free(_perf_gps);
 		perf_free(_perf_sim_delay);
@@ -230,7 +226,7 @@ private:
 	orb_advert_t _irlock_report_pub{nullptr};
 	orb_advert_t _visual_odometry_pub{nullptr};
 
-	int _param_sub{-1};
+	uORB::Subscription	_parameter_update_sub{ORB_ID(parameter_update)};
 
 	unsigned int _port{14560};
 

--- a/src/modules/vmount/vmount.cpp
+++ b/src/modules/vmount/vmount.cpp
@@ -61,7 +61,7 @@
 #include "output_rc.h"
 #include "output_mavlink.h"
 
-#include <uORB/uORB.h>
+#include <uORB/Subscription.hpp>
 #include <uORB/topics/parameter_update.h>
 
 #include <px4_config.h>
@@ -216,7 +216,7 @@ static int vmount_thread_main(int argc, char *argv[])
 		return -1;
 	}
 
-	int parameter_update_sub = orb_subscribe(ORB_ID(parameter_update));
+	uORB::Subscription parameter_update_sub{ORB_ID(parameter_update)};
 	thread_running = true;
 	ControlData *control_data = nullptr;
 	g_thread_data = &thread_data;
@@ -370,13 +370,14 @@ static int vmount_thread_main(int argc, char *argv[])
 			break;
 		}
 
+		// check for parameter updates
+		if (parameter_update_sub.updated()) {
+			// clear update
+			parameter_update_s pupdate;
+			parameter_update_sub.copy(&pupdate);
 
-		//check for parameter changes
-		bool updated;
-
-		if (orb_check(parameter_update_sub, &updated) == 0 && updated) {
-			parameter_update_s param_update;
-			orb_copy(ORB_ID(parameter_update), parameter_update_sub, &param_update);
+			// update parameters from storage
+			bool updated = false;
 			update_params(param_handles, params, updated);
 
 			if (updated) {
@@ -401,8 +402,6 @@ static int vmount_thread_main(int argc, char *argv[])
 	}
 
 	g_thread_data = nullptr;
-
-	orb_unsubscribe(parameter_update_sub);
 
 	for (int i = 0; i < input_objs_len_max; ++i) {
 		if (thread_data.input_objs[i]) {

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -333,13 +333,13 @@ VtolAttitudeControl::Run()
 	}
 
 	if (should_run) {
-		/* only update parameters if they changed */
-		if (_params_sub.updated()) {
-			/* read from param to clear updated flag */
-			parameter_update_s update;
-			_params_sub.copy(&update);
+		// check for parameter updates
+		if (_parameter_update_sub.updated()) {
+			// clear update
+			parameter_update_s pupdate;
+			_parameter_update_sub.copy(&pupdate);
 
-			/* update parameters from storage */
+			// update parameters from storage
 			parameters_update();
 		}
 

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -143,7 +143,7 @@ private:
 	uORB::Subscription _local_pos_sub{ORB_ID(vehicle_local_position)};			// sensor subscription
 	uORB::Subscription _manual_control_sp_sub{ORB_ID(manual_control_setpoint)};	//manual control setpoint subscription
 	uORB::Subscription _mc_virtual_att_sp_sub{ORB_ID(mc_virtual_attitude_setpoint)};
-	uORB::Subscription _params_sub{ORB_ID(parameter_update)};			//parameter updates subscription
+	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
 	uORB::Subscription _pos_sp_triplet_sub{ORB_ID(position_setpoint_triplet)};			// local position setpoint subscription
 	uORB::Subscription _tecs_status_sub{ORB_ID(tecs_status)};
 	uORB::Subscription _v_att_sub{ORB_ID(vehicle_attitude)};		//vehicle attitude subscription

--- a/src/templates/module/module.cpp
+++ b/src/templates/module/module.cpp
@@ -145,8 +145,7 @@ void Module::run()
 	fds[0].events = POLLIN;
 
 	// initialize parameters
-	int parameter_update_sub = orb_subscribe(ORB_ID(parameter_update));
-	parameters_update(parameter_update_sub, true);
+	parameters_update(true);
 
 	while (!should_exit()) {
 
@@ -170,26 +169,21 @@ void Module::run()
 
 		}
 
-
-		parameters_update(parameter_update_sub);
+		parameters_update();
 	}
 
 	orb_unsubscribe(sensor_combined_sub);
-	orb_unsubscribe(parameter_update_sub);
 }
 
-void Module::parameters_update(int parameter_update_sub, bool force)
+void Module::parameters_update(bool force)
 {
-	bool updated;
-	struct parameter_update_s param_upd;
+	// check for parameter updates
+	if (_parameter_update_sub.updated() || force) {
+		// clear update
+		parameter_update_s update;
+		_parameter_update_sub.copy(&update);
 
-	orb_check(parameter_update_sub, &updated);
-
-	if (updated) {
-		orb_copy(ORB_ID(parameter_update), parameter_update_sub, &param_upd);
-	}
-
-	if (force || updated) {
+		// update parameters from storage
 		updateParams();
 	}
 }

--- a/src/templates/module/module.h
+++ b/src/templates/module/module.h
@@ -35,6 +35,8 @@
 
 #include <px4_module.h>
 #include <px4_module_params.h>
+#include <uORB/Subscription.hpp>
+#include <uORB/topics/parameter_update.h>
 
 extern "C" __EXPORT int module_main(int argc, char *argv[]);
 
@@ -71,12 +73,16 @@ private:
 	 * @param parameter_update_sub uorb subscription to parameter_update
 	 * @param force for a parameter update
 	 */
-	void parameters_update(int parameter_update_sub, bool force = false);
+	void parameters_update(bool force = false);
 
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::SYS_AUTOSTART>) _param_sys_autostart,   /**< example parameter */
 		(ParamInt<px4::params::SYS_AUTOCONFIG>) _param_sys_autoconfig  /**< another parameter */
 	)
+
+	// Subscriptions
+	uORB::Subscription	_parameter_update_sub{ORB_ID(parameter_update)};
+
 };
 


### PR DESCRIPTION
This PR updates the majority of parameter_update uORB boiler plate to use uORB::Subscription and generally makes the pattern consistent across all modules.
