### PR TITLE
fixed UAVCAN MAG calibration application after reboot

### DIFF
--- a/Tools/px4airframes/rcout.py
+++ b/Tools/px4airframes/rcout.py
@@ -28,10 +28,10 @@ class RCOutput():
                     "# 12000 ..  12999       Octo Cox\n"
                     "# 13000 ..  13999       VTOL\n"
                     "# 14000 ..  14999       Tri Y\n"
-                    ""
-                    ""
-                    "cd /etc/init.d/airframes\n"
                     "\n")
+        result += "\n"
+        result += "set AIRFRAME none\n"
+        result += "\n"
         for group in groups:
             result += "# GROUP: %s\n\n" % group.GetName()
             for param in group.GetParams():
@@ -62,7 +62,7 @@ class RCOutput():
                 result +=   "# %s\n" % param.GetName()
                 result +=   "if param compare SYS_AUTOSTART %s\n" % id_val
                 result +=   "then\n"
-                result +=   "\tsh %s\n" % path
+                result +=   "\tset AIRFRAME %s\n" % path
                 result +=   "fi\n"
 
                 #if long_desc is not None:
@@ -70,6 +70,17 @@ class RCOutput():
                 result += "\n"
 
             result += "\n"
+        result += "\n"
+        result += "if [ ${AIRFRAME} != none ]\n"
+        result += "then\n"
+        result += "\tsh /etc/init.d/airframes/${AIRFRAME}\n"
+        if not post_start:
+            result += "else\n"
+            result += "\techo \"ERROR  [init] No file matches SYS_AUTOSTART value found in : /etc/init.d/airframes\"\n"
+            result += "\techo \"ERROR  [init] No file matches SYS_AUTOSTART value found in : /etc/init.d/airframes\" >> $LOG_FILE\n"
+            result += "\ttone_alarm ${TUNE_ERR}\n"
+        result += "fi\n"
+        result += "unset AIRFRAME"
         self.output = result
 
     def Save(self, filename):

--- a/src/modules/sensors/voted_sensors_update.cpp
+++ b/src/modules/sensors/voted_sensors_update.cpp
@@ -279,8 +279,6 @@ void VotedSensorsUpdate::parameters_update()
 				} else {
 					/* apply new scaling and offsets */
 					/* show mscale values */
-					printf("MAG ID %d parameters update\n", device_id);
-					printf("Xoff:%d, Yoff:%d, Zoff:%d\nXscale:%8.4f, Yscale:%8.4f, Zscale:%8.4f\n", (double)mscale.x_offset, (double)mscale.y_offset, (double)mscale.z_offset, (double)mscale.x_scale, (double)mscale.y_scale, (double)mscale.z_scale);
 					config_ok = apply_gyro_calibration(h, &gscale, device_id);
 
 					if (!config_ok) {

--- a/src/modules/sensors/voted_sensors_update.cpp
+++ b/src/modules/sensors/voted_sensors_update.cpp
@@ -766,7 +766,7 @@ void VotedSensorsUpdate::mag_poll(vehicle_magnetometer_s &magnetometer)
 				orb_priority(_mag.subscription[uorb_index], &priority);
 				_mag.priority[uorb_index] = (uint8_t)priority;
 
-				//Force Scales & Offsets update first time we get data
+				/* force a scale and offset update the first time we get data */
 				parameters_update();
 			}
 

--- a/src/modules/sensors/voted_sensors_update.cpp
+++ b/src/modules/sensors/voted_sensors_update.cpp
@@ -278,6 +278,9 @@ void VotedSensorsUpdate::parameters_update()
 
 				} else {
 					/* apply new scaling and offsets */
+					/* show mscale values */
+					printf("MAG ID %d parameters update\n", device_id);
+					printf("Xoff:%d, Yoff:%d, Zoff:%d\nXscale:%8.4f, Yscale:%8.4f, Zscale:%8.4f\n", (double)mscale.x_offset, (double)mscale.y_offset, (double)mscale.z_offset, (double)mscale.x_scale, (double)mscale.y_scale, (double)mscale.z_scale);
 					config_ok = apply_gyro_calibration(h, &gscale, device_id);
 
 					if (!config_ok) {
@@ -764,6 +767,9 @@ void VotedSensorsUpdate::mag_poll(vehicle_magnetometer_s &magnetometer)
 				int32_t priority = 0;
 				orb_priority(_mag.subscription[uorb_index], &priority);
 				_mag.priority[uorb_index] = (uint8_t)priority;
+
+				//Force Scales & Offsets update first time we get data
+				parameters_update();
 			}
 
 			matrix::Vector3f vect(mag_report.x, mag_report.y, mag_report.z);

--- a/src/modules/sensors/voted_sensors_update.cpp
+++ b/src/modules/sensors/voted_sensors_update.cpp
@@ -278,7 +278,6 @@ void VotedSensorsUpdate::parameters_update()
 
 				} else {
 					/* apply new scaling and offsets */
-					/* show mscale values */
 					config_ok = apply_gyro_calibration(h, &gscale, device_id);
 
 					if (!config_ok) {


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by the proposed pull request**
fixed UAVCAN MAG calibration application after reboot

**Test data / coverage**
Tested with px4 firmware 1.9.0 stable, made these changes, enabled UAVCAN_BUS with Qground, disabled other mag's, calibrated, rebooted. Calibration was still there. 

**Describe your preferred solution**
A clear and concise description of what you have implemented.

**Describe possible alternatives**
A clear and concise description of alternative solutions or features you've considered.

**Additional context**
Add any other related context or media.
