### PR TITLE
Fixed INA226 driver initialization

### DIFF
--- a/src/drivers/power_monitor/ina226/ina226.cpp
+++ b/src/drivers/power_monitor/ina226/ina226.cpp
@@ -314,6 +314,9 @@ INA226::init()
 
 	if (!_mode_trigged) {
 		ret = write(INA226_REG_CONFIGURATION, _config);
+
+	} else {
+		ret = OK;
 	}
 
 	set_device_address(INA226_BASEADDR);	/* set I2c Address */


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
The function `INA226::init()` will never return `OK` in the default configuration, so the driver will not start. This bug was introduced by refactoring in [this commit](https://github.com/PX4/Firmware/commit/e4926373e6febe9d6c133975f40bee8c605db5e2#diff-4920b5dd81390b42dd6c201706a8120d).

**Test data / coverage**
Connected INA226 to I2C A port on Pixhawk 4, and ran the following commands:

```
ina226 start -b 4
listener power_monitor -n 10
```

This showed that the driver was running correctly.

**Describe your preferred solution**
Return `OK` if no errors have happened.