### PR TITLE
Mavlink FTP - return ENOENT when directory doesn't exist

### DIFF
--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -353,7 +353,7 @@ MavlinkFTP::_workList(PayloadHeader *payload, bool list_hidden)
 
 	if (dp == nullptr) {
 		PX4_WARN("File open failed %s", _work_buffer1);
-		// this is not an FTP error, abort directory by simulating eof
+		// this is not an FTP error, abort directory by setting errno to ENOENT "No such file or directory"
 		errno = ENOENT;
 		return kErrFailErrno;
 	}

--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -275,7 +275,6 @@ out:
 
 		payload->data[0] = errorCode;
 
-
 		if (errorCode == kErrFailErrno) {
 			payload->size = 2;
 			payload->data[1] = r_errno;
@@ -353,14 +352,10 @@ MavlinkFTP::_workList(PayloadHeader *payload, bool list_hidden)
 	DIR *dp = opendir(_work_buffer1);
 
 	if (dp == nullptr) {
-#ifdef MAVLINK_FTP_UNIT_TEST
 		PX4_WARN("File open failed %s", _work_buffer1);
-#else
-		_mavlink->send_statustext_critical("FTP: can't open path (file system corrupted?)");
-		_mavlink->send_statustext_critical(_work_buffer1);
-#endif
 		// this is not an FTP error, abort directory by simulating eof
-		return kErrEOF;
+		errno = ENOENT;
+		return kErrFailErrno;
 	}
 
 #ifdef MAVLINK_FTP_DEBUG
@@ -381,13 +376,7 @@ MavlinkFTP::_workList(PayloadHeader *payload, bool list_hidden)
 		// read the directory entry
 		if (result == nullptr) {
 			if (errno) {
-#ifdef MAVLINK_FTP_UNIT_TEST
 				PX4_WARN("readdir failed");
-#else
-				_mavlink->send_statustext_critical("FTP: list readdir failure");
-				_mavlink->send_statustext_critical(_work_buffer1);
-#endif
-
 				payload->data[offset++] = kDirentSkip;
 				*((char *)&payload->data[offset]) = '\0';
 				offset++;


### PR DESCRIPTION
When listed directory doesn't exist return kErrFailErrno with errno set to ENOENT which is normally returned when a file doesn't exist.
Remove text status notifications to QGC as they could be triggered for example from companion computer.