### PR TITLE
Fixed temperature for batteries

### DIFF
--- a/msg/battery_status.msg
+++ b/msg/battery_status.msg
@@ -7,7 +7,7 @@ float32 average_current_a		# Battery current average in amperes, -1 if unknown
 float32 discharged_mah		# Discharged amount in mAh, -1 if unknown
 float32 remaining		# From 1 to 0, -1 if unknown
 float32 scale		# Power scaling factor, >= 1, or -1 if unknown
-float32 temperature         # temperature of the battery
+float32 temperature         # temperature of the battery. NaN if unknown
 int32 cell_count		# Number of cells
 bool connected			# Whether or not a battery is connected, based on a voltage threshold
 bool system_source		# Whether or not a this battery is the active power source for VDD_5V_IN

--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -97,6 +97,8 @@ Battery::updateBatteryStatus(hrt_abstime timestamp, float voltage_v, float curre
 		battery_status->system_source = selected_source;
 		battery_status->priority = priority;
 	}
+
+	battery_status->temperature = NAN;
 }
 
 void

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -706,17 +706,8 @@ protected:
 				bat_msg.current_battery = (battery_status.connected) ? battery_status.current_filtered_a * 100 : -1;
 				bat_msg.battery_remaining = (battery_status.connected) ? ceilf(battery_status.remaining * 100.0f) : -1;
 
-				// isnan(...) seems to be undefined in some environments. So, only use it if it is available.
-#ifdef isnan
-				const bool temp_is_nan = isnan(battery_status.temperature);
-#else
-				// All comparisons with NaN return false. The normal way to use this to find NaNs would be:
-				//  bool isnan(float a){ return a != a;}
-				// However, with the -Werror=float-equal compiler flag, I can't compare floats directly.
-				// So, change it to >=.
-				const bool temp_is_nan = !(battery_status.temperature >= battery_status.temperature);
-#endif
-				bool temperature_valid = battery_status.connected && !temp_is_nan;
+
+				bool temperature_valid = battery_status.connected && PX4_ISFINITE(battery_status.temperature);
 				bat_msg.temperature = temperature_valid ? (int16_t)(battery_status.temperature * 100.0f) : INT16_MAX;
 				//bat_msg.average_current_battery = (battery_status.connected) ? battery_status.average_current_a * 100.0f : -1;
 				//bat_msg.serial_number = (battery_status.connected) ? battery_status.serial_number : 0;


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
The current implementation for batteries does not measure temperature, so it was reporting the temperature as 0C.

**Test data / coverage**
Used the MAVLink console in QGC to verify that the temperature is correctly reported as `INT16_MAX`.

**Describe your preferred solution**
Changed internal UOrb `battery_status` message to use `NAN` to represent unknown temperature. Changed `mavlink_messages.cpp` to correctly convert this to `INT16_MAX` as per the [MAVLink message spec](https://mavlink.io/en/messages/common.html#BATTERY_STATUS).