### PR TITLE
Fix odometry velocities in mavlink receiver

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1160,8 +1160,10 @@ MavlinkReceiver::handle_message_odometry(mavlink_message_t *msg)
 	}
 
 	if (odom.child_frame_id == MAV_FRAME_BODY_FRD) { /* WRT to estimated vehicle body-fixed frame */
-		/* get quaternion from the msg quaternion itself and build DCM matrix from it */
-		const matrix::Dcmf Rbl = matrix::Dcmf(matrix::Quatf(odometry.q)).I();
+		/* Get quaternion from the msg quaternion itself and build DCM matrix from it 
+		 * Note that the msg quaternion represents the rotation of the msg frame to the msg child frame
+		 * but rotates msg child frame *data* into the msg frame */
+		const matrix::Dcmf Rbl = matrix::Dcmf(matrix::Quatf(odometry.q));
 
 		/* the linear velocities needs to be transformed to the local NED frame */
 		matrix::Vector3<float> linvel_local(Rbl * matrix::Vector3<float>(odom.vx, odom.vy, odom.vz));
@@ -1179,8 +1181,10 @@ MavlinkReceiver::handle_message_odometry(mavlink_message_t *msg)
 		}
 
 	} else if (odom.child_frame_id == MAV_FRAME_BODY_FLU) { /* WRT to estimated vehicle body-fixed frame */
-		/* get quaternion from the msg quaternion itself and build DCM matrix from it */
-		const matrix::Dcmf Rbl = matrix::Dcmf(matrix::Quatf(odometry.q)).I();
+		/* Get quaternion from the msg quaternion itself and build DCM matrix from it
+		 * Note that the msg quaternion represents the rotation of the msg frame to the msg child frame
+		 * but rotates msg child frame *data* into the msg frame */
+		const matrix::Dcmf Rbl = matrix::Dcmf(matrix::Quatf(odometry.q));
 
 		/* the position needs to be transformed to the local NED frame */
 		matrix::Vector3f pos(Rbl * matrix::Vector3<float>(odom.x, -odom.y, -odom.z));
@@ -1206,8 +1210,10 @@ MavlinkReceiver::handle_message_odometry(mavlink_message_t *msg)
 	} else if (odom.child_frame_id == MAV_FRAME_BODY_NED) { /* WRT to vehicle body-NED frame */
 		if (_vehicle_attitude_sub.copy(&_att)) {
 
-			/* get quaternion from vehicle_attitude quaternion and build DCM matrix from it */
-			const matrix::Dcmf Rbl = matrix::Dcmf(matrix::Quatf(_att.q)).I();
+			/* Get quaternion from vehicle_attitude quaternion and build DCM matrix from it
+			 * Note that the msg quaternion represents the rotation of the msg frame to the msg child frame
+			 * but rotates msg child frame *data* into the msg frame */
+			const matrix::Dcmf Rbl = matrix::Dcmf(matrix::Quatf(_att.q));
 
 			/* the linear velocities needs to be transformed to the local NED frame */
 			matrix::Vector3<float> linvel_local(Rbl * matrix::Vector3<float>(odom.vx, odom.vy, odom.vz));


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
Current mavlink receiver code presumes that odometry orientation was a way to rotate data from parent frame to child frame, so to rotate child to parent, it was taking the inverse rotation of the odometry orientation,
but orientation rotates the parent frame to the child frame, whereas for data, it represents a rotation from child to parent; hence, the rotation inverse operations were removed.

**Test data / coverage**
Checked that vehicle_mocap_odometry and vehicle_local_position gave correct linear velocities.

**Describe your preferred solution**
Use correct rotation to transform data from child frame to parent frame


Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.