### PR TITLE
uORB add RTPS message id for new wheel_encoders msg

### DIFF
--- a/msg/tools/uorb_rtps_message_ids.yaml
+++ b/msg/tools/uorb_rtps_message_ids.yaml
@@ -252,6 +252,8 @@ rtps:
     id: 109
   - msg: landing_gear
     id: 110
+  - msg: wheel_encoders
+    id: 111
   # multi topics
   - msg: actuator_controls_0
     id: 120


### PR DESCRIPTION
This broke master because https://github.com/PX4/Firmware/pull/12416 merged after @TSC21's change to make RTPS ids required (https://github.com/PX4/Firmware/commit/a747116eabc4f87c3eacbff0085f27396feb6ee1#diff-6e2baaf3b97dbeef01c0043275f9a0e7). 

We need to make sure PRs are updated and pass CI one last time before merging. 