### PR TITLE
nxp_fmuk66-v3 disable px4flow temporarily

### DIFF
--- a/boards/nxp/fmuk66-v3/default.cmake
+++ b/boards/nxp/fmuk66-v3/default.cmake
@@ -40,7 +40,7 @@ px4_add_board(
 		lights/rgbled_pwm
 		magnetometer # all available magnetometer drivers
 		mkblctrl
-		optical_flow/px4flow
+		#optical_flow # all available optical flow drivers
 		pca9685
 		#pwm_input # NOT Portable YET drivers
 		pwm_out_sim


### PR DESCRIPTION
As a precaution while we debug the underlying issue.

@davids5 @igalloway 


https://review.px4.io/plot_app?log=0bcf24d7-b989-4283-a11d-c7443d9fd10d

Very high cpu usage in the I2C WQ from the px4flow.