### PR TITLE
Added check if instance mode is serial when trying to find if  mavlin…

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -419,13 +419,13 @@ Mavlink::get_status_all_instances(bool show_streams_status)
 }
 
 bool
-Mavlink::instance_exists(const char *device_name, Mavlink *self)
+Mavlink::serial_instance_exists(const char *device_name, Mavlink *self)
 {
 	Mavlink *inst = ::_mavlink_instances;
 
 	while (inst != nullptr) {
 
-		/* don't compare with itself */
+		/* don't compare with itself and with non serial instances*/
 		if ((inst != self) && (inst->get_protocol() == SERIAL) && !strcmp(device_name, inst->_device_name)) {
 			return true;
 		}
@@ -2074,7 +2074,7 @@ Mavlink::task_main(int argc, char *argv[])
 	}
 
 	if (get_protocol() == SERIAL) {
-		if (Mavlink::instance_exists(_device_name, this)) {
+		if (Mavlink::serial_instance_exists(_device_name, this)) {
 			PX4_ERR("%s already running", _device_name);
 			return PX4_ERROR;
 		}

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -426,7 +426,7 @@ Mavlink::instance_exists(const char *device_name, Mavlink *self)
 	while (inst != nullptr) {
 
 		/* don't compare with itself */
-		if (inst != self && !strcmp(device_name, inst->_device_name)) {
+		if ((inst != self) && (inst->get_protocol() == SERIAL) && !strcmp(device_name, inst->_device_name)) {
 			return true;
 		}
 

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -156,7 +156,7 @@ public:
 
 	static int		get_status_all_instances(bool show_streams_status);
 
-	static bool		instance_exists(const char *device_name, Mavlink *self);
+	static bool		serial_instance_exists(const char *device_name, Mavlink *self);
 
 	static void		forward_message(const mavlink_message_t *msg, Mavlink *self);
 


### PR DESCRIPTION
…k instance exists

**Describe problem solved by the proposed pull request**
If using mavlink with other communication other then serial (eth) and trying to open another mavlink instance with serial communication connected to /dev/ttyS1 mavlink will not allow it because device_name default is /dev/ttyS1 and from mavlink concern the instance already exists even though there is no real use in  that port.

**Describe your preferred solution**
at the same point where we check if the port is being used we check if it's a serial connection.
