### PR TITLE
simple circleci.com px4_fmu-v5 build & archive example

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,19 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: px4io/px4-dev-nuttx:2019-07-29
+    steps:
+      - checkout
+      - run:
+          name: Fetch tags
+          command: git fetch --tags
+      - run:
+          name: Build px4_fmu-v5_default
+          command: make px4_fmu-v5_default
+      - store_artifacts:
+          path: build/px4_fmu-v5_default/px4_fmu-v5_default.px4
+          destination: px4_fmu-v5_default.px4
+      - store_artifacts:
+          path: build/px4_fmu-v5_default/px4_fmu-v5_default.elf
+          destination: px4_fmu-v5_default.elf


### PR DESCRIPTION
We don't need this in PX4/Firmware, but it serves as a nice simple example for both public and private forks. [Circleci](https://circleci.com/) is one of the only continuous integration services that has a free tier for private projects, so having this in tree (and maintained) makes it trivial to get started.

FYI @LorenzMeier @julianoes @mrpollo @hamishwillee 