### PR TITLE
FailureDetector - Ignore attitude check for MC in acro and FW in manual, acro and rattitude modes

### DIFF
--- a/src/modules/commander/failure_detector/FailureDetector.cpp
+++ b/src/modules/commander/failure_detector/FailureDetector.cpp
@@ -43,8 +43,20 @@
 FailureDetector::FailureDetector(ModuleParams *parent) :
 	ModuleParams(parent),
 	_sub_vehicle_attitude_setpoint(ORB_ID(vehicle_attitude_setpoint)),
-	_sub_vehicule_attitude(ORB_ID(vehicle_attitude))
+	_sub_vehicule_attitude(ORB_ID(vehicle_attitude)),
+	_sub_vehicle_status(ORB_ID(vehicle_status))
 {
+}
+
+bool FailureDetector::resetStatus()
+{
+	if (_status != FAILURE_NONE) {
+		_status = FAILURE_NONE;
+		return true;
+
+	} else {
+		return false;
+	}
 }
 
 bool
@@ -52,9 +64,46 @@ FailureDetector::update()
 {
 	bool updated(false);
 
-	updated = updateAttitudeStatus();
+	if (isAttitudeStabilized()) {
+		updated = updateAttitudeStatus();
+
+	} else {
+		updated = resetStatus();
+	}
 
 	return updated;
+}
+
+bool
+FailureDetector::isAttitudeStabilized()
+{
+
+	if (_sub_vehicle_status.update()) {
+		const vehicle_status_s &vehicle_status = _sub_vehicle_status.get();
+		const uint8_t vehicle_type = vehicle_status.vehicle_type;
+		const uint8_t nav_state = vehicle_status.nav_state;
+
+		if (vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
+			if (nav_state == vehicle_status_s::NAVIGATION_STATE_ACRO) {
+				_attitude_is_stabilized = false;
+
+			} else {
+				_attitude_is_stabilized = true;
+			}
+
+		} else if (vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
+			if (nav_state == vehicle_status_s::NAVIGATION_STATE_MANUAL ||
+			    nav_state == vehicle_status_s::NAVIGATION_STATE_ACRO ||
+			    nav_state == vehicle_status_s::NAVIGATION_STATE_RATTITUDE) {
+				_attitude_is_stabilized = false;
+
+			} else {
+				_attitude_is_stabilized = true;
+			}
+		}
+	}
+
+	return _attitude_is_stabilized;
 }
 
 bool

--- a/src/modules/commander/failure_detector/FailureDetector.hpp
+++ b/src/modules/commander/failure_detector/FailureDetector.hpp
@@ -85,11 +85,15 @@ private:
 	// Subscriptions
 	SubscriptionData<vehicle_attitude_s> _sub_vehicle_attitude_setpoint;
 	SubscriptionData<vehicle_attitude_s> _sub_vehicule_attitude;
+	SubscriptionData<vehicle_status_s> _sub_vehicle_status;
 
 	uint8_t _status{FAILURE_NONE};
+	bool _attitude_is_stabilized{false};
 
 	systemlib::Hysteresis _roll_failure_hysteresis{false};
 	systemlib::Hysteresis _pitch_failure_hysteresis{false};
 
+	bool resetStatus();
+	bool isAttitudeStabilized();
 	bool updateAttitudeStatus();
 };


### PR DESCRIPTION
The FailureDetector currently checks for attitude that exceeds a defined angle. This is done regardless the flight mode.

I added a check for acro in MC and acro+rattitude+manual mode in FW to ignore the attitude failure checks as the drone is expected to exceed the defined angles.

Briefly test in SITL.