### PR TITLE
Orbit approach with a line trajectory library

### DIFF
--- a/src/lib/FlightTasks/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/lib/FlightTasks/tasks/Orbit/FlightTaskOrbit.cpp
@@ -183,6 +183,8 @@ bool FlightTaskOrbit::update()
 
 	Vector2f center_to_position = Vector2f(_position) - _center;
 
+	// make vehicle front always point towards the center
+	_yaw_setpoint = atan2f(center_to_position(1), center_to_position(0)) + M_PI_F;
 
 	if (_in_circle_approach) {
 		generate_circle_approach_setpoints();
@@ -191,12 +193,7 @@ bool FlightTaskOrbit::update()
 		generate_circle_setpoints(center_to_position);
 	}
 
-	// make vehicle front always point towards the center
-	_yaw_setpoint = atan2f(center_to_position(1), center_to_position(0)) + M_PI_F;
-	// yawspeed feed-forward because we know the necessary angular rate
-	_yawspeed_setpoint = _v / _r;
-
-	// publish telemetry
+	// publish information to UI
 	sendTelemetry();
 
 	return true;
@@ -217,6 +214,9 @@ void FlightTaskOrbit::generate_circle_approach_setpoints()
 	// follow the planned line and switch to orbiting once the circle is reached
 	_circle_approach_line.generateSetpoints(_position_setpoint, _velocity_setpoint);
 	_in_circle_approach = !_circle_approach_line.isEndReached();
+
+	// yaw stays constant
+	_yawspeed_setpoint = NAN;
 }
 
 void FlightTaskOrbit::generate_circle_setpoints(Vector2f center_to_position)
@@ -232,4 +232,7 @@ void FlightTaskOrbit::generate_circle_setpoints(Vector2f center_to_position)
 	_velocity_setpoint(0) = velocity_xy(0);
 	_velocity_setpoint(1) = velocity_xy(1);
 	_position_setpoint(0) = _position_setpoint(1) = NAN;
+
+	// yawspeed feed-forward because we know the necessary angular rate
+	_yawspeed_setpoint = _v / _r;
 }

--- a/src/lib/FlightTasks/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/lib/FlightTasks/tasks/Orbit/FlightTaskOrbit.cpp
@@ -92,6 +92,9 @@ bool FlightTaskOrbit::applyCommandParameters(const vehicle_command_s &command)
 		}
 	}
 
+	// perpendicularly approach the orbit circle again when new parameters get commanded
+	_in_circle_approach = true;
+
 	return ret;
 }
 
@@ -179,12 +182,7 @@ bool FlightTaskOrbit::update()
 	setVelocity(v);
 
 	Vector2f center_to_position = Vector2f(_position) - _center;
-	const float distance_to_center = center_to_position.norm();
 
-	// perpendicularly approach the orbit circle if further away than 3 meters
-	if (!_in_circle_approach && !math::isInRange(distance_to_center, _r - 3.f, _r + 3.f)) {
-		_in_circle_approach = true;
-	}
 
 	if (_in_circle_approach) {
 		generate_circle_approach_setpoints();

--- a/src/lib/FlightTasks/tasks/Orbit/FlightTaskOrbit.hpp
+++ b/src/lib/FlightTasks/tasks/Orbit/FlightTaskOrbit.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2017-2019 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -43,6 +43,7 @@
 
 #include "FlightTaskManualAltitudeSmooth.hpp"
 #include <uORB/uORB.h>
+#include <StraightLine.hpp>
 
 class FlightTaskOrbit : public FlightTaskManualAltitudeSmooth
 {
@@ -86,9 +87,15 @@ protected:
 	bool setVelocity(const float v);
 
 private:
+	void generate_circle_approach_setpoints(); /**< generates setpoints to smoothly reach the closest point on the circle when starting from far away */
+	void generate_circle_setpoints(matrix::Vector2f center_to_position); /**< generates xy setpoints to orbit the vehicle */
+
 	float _r = 0.f; /**< radius with which to orbit the target */
 	float _v = 0.f; /**< clockwise tangential velocity for orbiting in m/s */
 	matrix::Vector2f _center; /**< local frame coordinates of the center point */
+
+	bool _in_circle_approach = false;
+	StraightLine _circle_approach_line;
 
 	// TODO: create/use parameters for limits
 	const float _radius_min = 1.f;
@@ -97,4 +104,8 @@ private:
 	const float _acceleration_max = 2.f;
 
 	orb_advert_t _orbit_status_pub = nullptr;
+
+	DEFINE_PARAMETERS(
+		(ParamFloat<px4::params::MPC_XY_CRUISE>) _param_mpc_xy_cruise /**< cruise speed for circle approach */
+	)
 };

--- a/src/lib/FlightTasks/tasks/Utility/StraightLine.cpp
+++ b/src/lib/FlightTasks/tasks/Utility/StraightLine.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018-2019 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,205 +37,54 @@
 
 #include "StraightLine.hpp"
 #include <mathlib/mathlib.h>
-#include <float.h>
 #include <px4_defines.h>
-
-#define VEL_ZERO_THRESHOLD 0.001f // Threshold to compare if the target velocity is zero
-#define DECELERATION_MAX 8.0f     // The vehicles maximum deceleration TODO check to create param
 
 using namespace matrix;
 
-StraightLine::StraightLine(ModuleParams *parent, const float &deltatime, const matrix::Vector3f &pos) :
-	ModuleParams(parent),
-	_deltatime(deltatime), _pos(pos)
-{
-
-}
-
 void StraightLine::generateSetpoints(matrix::Vector3f &position_setpoint, matrix::Vector3f &velocity_setpoint)
 {
-	// Check if target position has been reached
-	if (_desired_speed_at_target < VEL_ZERO_THRESHOLD &&
-	    (_pos - _target).length() < _param_nav_acc_rad.get()) {
-		// Vehicle has reached target. Lock position
-		position_setpoint = _target;
-		velocity_setpoint = Vector3f(0.0f, 0.0f, 0.0f);
-
+	if (isEndReached()) {
+		// Vehicle has reached target, lock position
+		position_setpoint = _end;
+		velocity_setpoint.setNaN();
 		return;
 	}
 
-	// unit vector in the direction of the straight line
-	Vector3f u_orig_to_target = (_target - _origin).unit_or_zero();
-	// vector from origin to current position
-	Vector3f orig_to_pos = _pos - _origin;
-	// current position projected perpendicularly onto desired line
-	Vector3f closest_pt_on_line = _origin + u_orig_to_target * (orig_to_pos * u_orig_to_target);
-	// previous velocity in the direction of the line
-	float speed_sp_prev = math::max(velocity_setpoint * u_orig_to_target, 0.0f);
+	Vector3f start_to_end = _end - _start;
+	float distance_start_to_end = start_to_end.norm();
 
-	// Calculate accelerating/decelerating distance depending on speed, speed at target and acceleration/deceleration
-	float acc_dec_distance = fabs((_desired_speed * _desired_speed) - (_desired_speed_at_target *
-				      _desired_speed_at_target)) / 2.0f;
-	acc_dec_distance /= _desired_speed > _desired_speed_at_target ? _desired_deceleration : _desired_acceleration;
+	// capture progress as ratio between 0 and 1 of entire distance
+	Vector3f vehicle_to_end = _end - _position;
+	float distance_vehicle_to_end = vehicle_to_end.norm();
+	float distance_from_start = Vector3f(_start - _position).norm();
+	float progress = distance_from_start / (distance_from_start + distance_vehicle_to_end);
 
-	float dist_to_target = (_target - _pos).length(); // distance to target
+	float distance_from_boundary = 0.f;
 
-	// Either accelerate or decelerate
-	float speed_sp    = dist_to_target > acc_dec_distance ? _desired_speed        :  _desired_speed_at_target;
-	float max_acc_dec = speed_sp > speed_sp_prev          ? _desired_acceleration : -_desired_deceleration;
-
-	float acc_track = 0.0f;
-
-	if (_deltatime > FLT_EPSILON) {
-		acc_track = (speed_sp - speed_sp_prev) / _deltatime;
-	}
-
-	if (fabs(acc_track) > fabs(max_acc_dec)) {
-		// accelerate/decelerate with desired acceleration/deceleration towards target
-		speed_sp = speed_sp_prev + max_acc_dec * _deltatime;
-	}
-
-	// constrain the velocity
-	speed_sp = math::constrain(speed_sp, 0.0f, _desired_speed);
-
-	// set the position and velocity setpoints
-	position_setpoint = closest_pt_on_line;
-	velocity_setpoint = u_orig_to_target * speed_sp;
-}
-
-float StraightLine::getMaxAcc()
-{
-	// check if origin and target are different points
-	if ((_target - _origin).length() < FLT_EPSILON) {
-		return _param_mpc_acc_hor_max.get();
-	}
-
-	// unit vector in the direction of the straight line
-	Vector3f u_orig_to_target = (_target - _origin).unit_or_zero();
-
-	// calculate the maximal horizontal acceleration
-	float divider = Vector2f(u_orig_to_target).length();
-	float max_acc_hor = _param_mpc_acc_hor_max.get();
-
-	if (divider > FLT_EPSILON) {
-		max_acc_hor /= divider;
+	// calculate the distance to the closer boundary
+	if (progress < 0.5f) {
+		distance_from_boundary = (2 * progress) * distance_start_to_end;
 
 	} else {
-		max_acc_hor *= 1000.0f;
+		distance_from_boundary = (2 * (1 - progress)) * distance_start_to_end;
 	}
 
-	// calculate the maximal vertical acceleration
-	float max_acc_vert_original = u_orig_to_target(2) < 0 ? _param_mpc_acc_up_max.get() : _param_mpc_acc_down_max.get();
-	float max_acc_vert = max_acc_vert_original;
+	// ramp velocity based on the distance to the boundary
+	float velocity = 0.5f + (distance_from_boundary / 4.f);
+	velocity = math::min(velocity, _speed);
+	velocity_setpoint = vehicle_to_end.unit_or_zero() * velocity;
 
-	if (fabs(u_orig_to_target(2)) > FLT_EPSILON) {
-		max_acc_vert /= fabs(u_orig_to_target(2));
-
-	} else {
-		max_acc_vert *= 1000.0f;
-	}
-
-	return math::min(max_acc_hor, max_acc_vert);
-}
-
-float StraightLine::getMaxVel()
-{
-	// check if origin and target are different points
-	if ((_target - _origin).length() < FLT_EPSILON) {
-		return _param_mpc_xy_vel_max.get();
-	}
-
-	// unit vector in the direction of the straight line
-	Vector3f u_orig_to_target = (_target - _origin).unit_or_zero();
-
-	// calculate the maximal horizontal velocity
-	float divider = Vector2f(u_orig_to_target).length();
-	float max_vel_hor = _param_mpc_xy_vel_max.get();
-
-	if (divider > FLT_EPSILON) {
-		max_vel_hor /= divider;
-
-	} else {
-		max_vel_hor *= 1000.0f;
-	}
-
-	// calculate the maximal vertical velocity
-	float max_vel_vert_directional = u_orig_to_target(2) < 0 ? _param_mpc_z_vel_max_up.get() :
-					 _param_mpc_z_vel_max_dn.get();
-	float max_vel_vert = max_vel_vert_directional;
-
-	if (fabs(u_orig_to_target(2)) > FLT_EPSILON) {
-		max_vel_vert /= fabs(u_orig_to_target(2));
-
-	} else {
-		max_vel_vert *= 1000.0f;
-	}
-
-	return math::min(max_vel_hor, max_vel_vert);
-}
-
-void StraightLine::setAllDefaults()
-{
-	_desired_speed = getMaxVel();
-	_desired_speed_at_target = 0.0f;
-	_desired_acceleration = getMaxAcc();
-	_desired_deceleration = DECELERATION_MAX;
-}
-
-void StraightLine::setLineFromTo(const matrix::Vector3f &origin, const matrix::Vector3f &target)
-{
-	if (PX4_ISFINITE(target(0)) && PX4_ISFINITE(target(1)) && PX4_ISFINITE(target(2)) &&
-	    PX4_ISFINITE(origin(0)) && PX4_ISFINITE(origin(1)) && PX4_ISFINITE(origin(2))) {
-		_target = target;
-		_origin = origin;
-
-		// set all parameters to their default value (depends on the direction)
-		setAllDefaults();
+	// check if we plan to go against the line direction which indicates we reached the goal
+	if (start_to_end * vehicle_to_end < 0) {
+		end_reached = true;
 	}
 }
 
-void StraightLine::setSpeed(const float &speed)
+void StraightLine::setLineFromTo(const Vector3f &start, const Vector3f &end)
 {
-	float vel_max = getMaxVel();
-
-	if (speed > FLT_EPSILON && speed < vel_max) {
-		_desired_speed = speed;
-
-	} else if (speed > vel_max) {
-		_desired_speed = vel_max;
-	}
-}
-
-void StraightLine::setSpeedAtTarget(const float &speed_at_target)
-{
-	float vel_max = getMaxVel();
-
-	if (speed_at_target > FLT_EPSILON && speed_at_target < vel_max) {
-		_desired_speed_at_target = speed_at_target;
-
-	} else if (speed_at_target > vel_max) {
-		_desired_speed_at_target = vel_max;
-	}
-}
-
-void StraightLine::setAcceleration(const float &acc)
-{
-	float acc_max = getMaxVel();
-
-	if (acc > FLT_EPSILON && acc < acc_max) {
-		_desired_acceleration = acc;
-
-	} else if (acc > acc_max) {
-		_desired_acceleration = acc_max;
-	}
-}
-
-void StraightLine::setDeceleration(const float &dec)
-{
-	if (dec > FLT_EPSILON && dec < DECELERATION_MAX) {
-		_desired_deceleration = dec;
-
-	} else if (dec > DECELERATION_MAX) {
-		_desired_deceleration = DECELERATION_MAX;
+	if (PX4_ISFINITE(start.norm_squared()) && PX4_ISFINITE(end.norm_squared())) {
+		_start = start;
+		_end = end;
+		end_reached = false;
 	}
 }


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
As requested by @RomanBapst I'm fixing the initial approach of the vehicle to the circle in orbit mode. This should vastly improve the user experience when using the Orbit mode.

**Test data / coverage**
SITL tested. @RomanBapst please submit your feedback on user experience.

**Describe your preferred solution**
The `StraightLine` library is supposed to implement a motion primitive to move the vehicle from point A to B on a planned trajectory such that this functionality can be reused where such setpoint generation is useful. The initial approach to the orbit circle is a very good example of such a use case and is now the first client code to test the interface of the library.

The `StraightLine` implementation currently does a velocity ramp based on the progress measured in distance between the start and endpoint. It ramps up the velocity for half the way and down the second half. The velocity is then limited to the specified speed e.g. the cruise speed.

**Describe possible alternatives**
The `StraightLine` implementation here is working but not yet optimal. The idea is to have a minimum viable implementation now to set a baseline that can be tested and built on. I would be very interested to bring in @bresch's jerk optimized planning to be reused in this form.
