### PR TITLE
Delete whitespace to quiet git hooks.

### DIFF
--- a/src/drivers/imu/bmi088/CMakeLists.txt
+++ b/src/drivers/imu/bmi088/CMakeLists.txt
@@ -36,7 +36,7 @@ px4_add_module(
 	STACK_MAIN 1500
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
-	SRCS		
+	SRCS
 		BMI088_accel.cpp
 		BMI088_gyro.cpp
 		bmi088_main.cpp

--- a/src/drivers/optical_flow/CMakeLists.txt
+++ b/src/drivers/optical_flow/CMakeLists.txt
@@ -34,4 +34,3 @@
 add_subdirectory(paw3902)
 add_subdirectory(pmw3901)
 add_subdirectory(px4flow)
-


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
The default git hooks in Ubuntu18.04+ don't allow merging upstream/master to complete until these whitespace fixes are applied.

Let me know if you have any questions on this PR.  Thanks!

-Mark
