### PR TITLE
uORB::PublicationQueued don't unadvertise on destruction

### DIFF
--- a/src/modules/uORB/PublicationQueued.hpp
+++ b/src/modules/uORB/PublicationQueued.hpp
@@ -59,7 +59,8 @@ public:
 	 * @param meta The uORB metadata (usually from the ORB_ID() macro) for the topic.
 	 */
 	PublicationQueued(const orb_metadata *meta) : _meta(meta) {}
-	~PublicationQueued() {
+	~PublicationQueued()
+	{
 		//orb_unadvertise(_handle);
 	}
 

--- a/src/modules/uORB/PublicationQueued.hpp
+++ b/src/modules/uORB/PublicationQueued.hpp
@@ -59,7 +59,9 @@ public:
 	 * @param meta The uORB metadata (usually from the ORB_ID() macro) for the topic.
 	 */
 	PublicationQueued(const orb_metadata *meta) : _meta(meta) {}
-	~PublicationQueued() { orb_unadvertise(_handle); }
+	~PublicationQueued() {
+		//orb_unadvertise(_handle);
+	}
 
 	/**
 	 * Publish the struct


### PR DESCRIPTION
Last night it occurred to me some of the stack allocated `uORB::PublicationQueued` usage is probably bogus for vehicle_command and vehicle_command_ack because the destructor unadvertises.

Example: `commander takeoff`
https://github.com/PX4/Firmware/blob/d70b024ec7a6d72de87f4ddc7de087d716929144/src/modules/commander/Commander.cpp#L269

One quick hack that came to mind is to simply skip the unadvertise (which only changes the internal published flag anyway). I'll come up with a more permanent solution once I'm back from travel.