### PR TITLE
logger: fix rare case where logging stops

### DIFF
--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -974,8 +974,6 @@ void Logger::run()
 				}
 			}
 
-			bool data_written = false;
-
 			/* Check if parameters have changed */
 			if (!_should_stop_file_log) { // do not record param changes after disarming
 				parameter_update_s param_update;
@@ -1017,8 +1015,6 @@ void Logger::run()
 #ifdef DBGPRINT
 						total_bytes += msg_size;
 #endif /* DBGPRINT */
-
-						data_written = true;
 					}
 
 					// mission log
@@ -1031,9 +1027,7 @@ void Logger::run()
 									_mission_subscriptions[sub_idx].next_write_time = (loop_time / 100000) + delta_time / 100;
 								}
 
-								if (write_message(LogType::Mission, _msg_buffer, msg_size)) {
-									data_written = true;
-								}
+								write_message(LogType::Mission, _msg_buffer, msg_size);
 							}
 						}
 					}
@@ -1094,10 +1088,8 @@ void Logger::run()
 			/* release the log buffer */
 			_writer.unlock();
 
-			/* notify the writer thread if data is available */
-			if (data_written) {
-				_writer.notify();
-			}
+			/* notify the writer thread */
+			_writer.notify();
 
 			/* subscription update */
 			if (next_subscribe_topic_index != -1) {


### PR DESCRIPTION
The file writer thread could get into a state where it blocked infinitely
on pthread_cond_wait() (or rather until the logging stops).

This is very rare and the following conditions must be met:
- the buffer is almost empty (<4KB filled), so that the writer thread does
  not write anything.
- an fsync call is scheduled (happens once every second)
- the fsync call takes a long time (several 100ms), during which time the
  complete log buffer fills up.

The main thread would then get into dropout state where it does not call
_writer.notify() anymore.

Notifying the writer thread on every loop update of the main thread fixes
that.

It does not increase resource usage.

This can go to stable as well.

Fixes https://github.com/PX4/Firmware/issues/12565