### PR TITLE
Add max_altitude and _vehicle_attitude.timestamp validity checks to MulticopterLandDetector and standardize var naming

### DIFF
--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -42,16 +42,16 @@
 
 #pragma once
 
-#include <px4_module.h>
-#include <px4_module_params.h>
 #include <lib/hysteresis/hysteresis.h>
 #include <parameters/param.h>
 #include <perf/perf_counter.h>
+#include <px4_module.h>
+#include <px4_module_params.h>
+#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/actuator_armed.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/vehicle_land_detected.h>
-#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
 
 using namespace time_literals;
 

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -42,22 +42,19 @@
 
 #pragma once
 
-#include "LandDetector.h"
+#include <math.h>
 
-#include <parameters/param.h>
-#include <uORB/Subscription.hpp>
-#include <uORB/topics/vehicle_local_position.h>
-#include <uORB/topics/vehicle_local_position_setpoint.h>
-#include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/battery_status.h>
 #include <uORB/topics/parameter_update.h>
-#include <uORB/topics/sensor_bias.h>
 #include <uORB/topics/vehicle_acceleration.h>
 #include <uORB/topics/vehicle_angular_velocity.h>
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/vehicle_local_position.h>
+#include <uORB/topics/vehicle_local_position_setpoint.h>
+
+#include "LandDetector.h"
 
 using namespace time_literals;
 
@@ -122,7 +119,6 @@ private:
 
 	uORB::Subscription _actuator_controls_sub{ORB_ID(actuator_controls_0)};
 	uORB::Subscription _battery_sub{ORB_ID(battery_status)};
-	uORB::Subscription _sensor_bias_sub{ORB_ID(sensor_bias)};
 	uORB::Subscription _vehicle_acceleration_sub{ORB_ID(vehicle_acceleration)};
 	uORB::Subscription _vehicle_angular_velocity_sub{ORB_ID(vehicle_angular_velocity)};
 	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
@@ -132,17 +128,17 @@ private:
 
 	actuator_controls_s               _actuator_controls {};
 	battery_status_s                  _battery_status {};
-	vehicle_control_mode_s            _control_mode {};
 	vehicle_acceleration_s            _vehicle_acceleration{};
-	vehicle_attitude_s                _vehicle_attitude {};
 	vehicle_angular_velocity_s        _vehicle_angular_velocity{};
+	vehicle_attitude_s                _vehicle_attitude {};
+	vehicle_control_mode_s            _vehicle_control_mode {};
 	vehicle_local_position_s          _vehicle_local_position {};
 	vehicle_local_position_setpoint_s _vehicle_local_position_setpoint {};
 
-	hrt_abstime _min_trust_start{0};		///< timestamp when minimum trust was applied first
+	hrt_abstime _min_trust_start{0};	///< timestamp when minimum trust was applied first
 	hrt_abstime _landed_time{0};
 
-	bool _in_descend{false};	///< vehicle is desending
+	bool _in_descend{false};		///< vehicle is desending
 	bool _horizontal_movement{false};	///< vehicle is moving horizontally
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This PR adds validity checks to methods in the `MulticopterLandDetector` class: 
 - ~`_vehicle_local_position.v_z_valid` to `_get_ground_contact_state()`~ (already accomplished through `_has_altitude_lock()`)
 - `valid_altitude_max` validity check to `_get_max_altitude()`
 - `_vehicle_attitude.timestamp` check to `_get_maybe_landed_state()`

A few local vars are made snake_case to standardize against file convention and `control_mode` is renamed to `vehicle_control_mode` to match its typdef and the established class convention.

One unneeded `#include` is deleted from `LandDetector.h` and the `#include` list alphabetized.

**Test data / coverage**
Flight tested on a 250 quad with pixhawk 4 mini.  Landing detection results are identical to PX4:master.
 - https://review.px4.io/plot_app?log=34cd8f1f-0b28-4226-a044-76f6b26db336
 - https://review.px4.io/plot_app?log=07bd4561-c31e-4234-8a03-9d17a9a481bf

**Additional context**
These changes complete the `MulticopterLandDetector` logic changes introduced in #9756 . See also #11857 .

Please let me know if you'd like anything about this PR changed.  Thanks!

-Mark