### PR TITLE
Commander: small user experience fixes found during demo testing

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1898,6 +1898,7 @@ Commander::run()
 			main_state_before_rtl == commander_state_s::MAIN_STATE_STAB;
 		const bool in_auto_mode =
 			internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_LAND ||
+			internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_RTL ||
 			internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_MISSION ||
 			internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_LOITER;
 

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1978,14 +1978,14 @@ Commander::run()
 			    (status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING || land_detector.landed) &&
 			    (stick_in_lower_left || arm_button_pressed || arm_switch_to_disarm_transition)) {
 
-				if (internal_state.main_state != commander_state_s::MAIN_STATE_MANUAL &&
-				    internal_state.main_state != commander_state_s::MAIN_STATE_ACRO &&
-				    internal_state.main_state != commander_state_s::MAIN_STATE_STAB &&
-				    internal_state.main_state != commander_state_s::MAIN_STATE_RATTITUDE &&
-				    !land_detector.landed) {
-					print_reject_arm("Not disarming! Not yet in manual mode or landed");
+				const bool manual_thrust_mode = internal_state.main_state == commander_state_s::MAIN_STATE_MANUAL
+								|| internal_state.main_state == commander_state_s::MAIN_STATE_ACRO
+								|| internal_state.main_state == commander_state_s::MAIN_STATE_STAB
+								|| internal_state.main_state == commander_state_s::MAIN_STATE_RATTITUDE;
+				const bool rc_wants_disarm = (stick_off_counter == rc_arm_hyst && stick_on_counter < rc_arm_hyst)
+							     || arm_switch_to_disarm_transition;
 
-				} else if ((stick_off_counter == rc_arm_hyst && stick_on_counter < rc_arm_hyst) || arm_switch_to_disarm_transition) {
+				if (rc_wants_disarm && (land_detector.landed || manual_thrust_mode)) {
 					arming_ret = arming_state_transition(&status, safety, vehicle_status_s::ARMING_STATE_STANDBY, &armed,
 									     true /* fRunPreArmChecks */,
 									     &mavlink_log_pub, &status_flags, arm_requirements, hrt_elapsed_time(&commander_boot_timestamp));


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
Two smaller problems:
- Since #12495 RC override is enabled by default for multicopter flight. RC override is not working in RTL even though it would make sense and is also documented here: https://docs.px4.io/master/en/flight_modes/return.html
- Since I myself was working on the arming logic 3 years ago: https://github.com/PX4/Firmware/commit/0dbdde34044631d08ddf5e0c5af382fe6382670d#diff-1d51a813dcb26f46616f71f28aacc70dR2585 we have this useless message given to the user telling him the vehicle is not disarming because it's not landed. In modes with manual thrust control disarming always gets executed. In Altitude controlled modes disarming happens automatically after land detection by default since https://github.com/PX4/Firmware/pull/12346. And if the user goes down and yaws (even when flying with a joystick) the message is very confusing and repeats itself.

**Test data / coverage**
The first commit was flown in testing for and at a demo. The second commit with the refactored condition was SITL tested and double-checked by boolean algebra on paper. Please review it again to make sure I didn't look over any of my own mistakes.

**Describe your preferred solution**
- RTL was added to RC override
- The message of not disarming with the stick in the lower left corner but not landed was removed.
