### PR TITLE
Support rally landing points

### DIFF
--- a/boards/px4/fmu-v2/fixedwing.cmake
+++ b/boards/px4/fmu-v2/fixedwing.cmake
@@ -10,6 +10,7 @@ px4_add_board(
 	IO px4_io-v2_default
 	#TESTING
 	#UAVCAN_INTERFACES 2
+	CONSTRAINED_FLASH
 
 	SERIAL_PORTS
 		GPS1:/dev/ttyS3

--- a/src/modules/dataman/dataman.cpp
+++ b/src/modules/dataman/dataman.cpp
@@ -228,7 +228,7 @@ static const unsigned g_per_item_max_index[DM_KEY_NUM_KEYS] = {
 
 /* Table of the len of each item type */
 static constexpr size_t g_per_item_size[DM_KEY_NUM_KEYS] = {
-	sizeof(struct mission_save_point_s) + DM_SECTOR_HDR_SIZE,
+	sizeof(struct mission_safe_point_s) + DM_SECTOR_HDR_SIZE,
 	sizeof(struct mission_fence_point_s) + DM_SECTOR_HDR_SIZE,
 	sizeof(struct mission_item_s) + DM_SECTOR_HDR_SIZE,
 	sizeof(struct mission_item_s) + DM_SECTOR_HDR_SIZE,

--- a/src/modules/dataman/dataman.h
+++ b/src/modules/dataman/dataman.h
@@ -103,7 +103,7 @@ struct dataman_compat_s {
 
 #define DM_COMPAT_KEY ((DM_COMPAT_VERSION << 32) + (sizeof(struct mission_item_s) << 24) + \
 		       (sizeof(struct mission_s) << 16) + (sizeof(struct mission_stats_entry_s) << 12) + \
-		       (sizeof(struct mission_fence_point_s) << 8) + (sizeof(struct mission_save_point_s) << 4) + \
+		       (sizeof(struct mission_fence_point_s) << 8) + (sizeof(struct mission_safe_point_s) << 4) + \
 		       sizeof(struct dataman_compat_s))
 
 /** Retrieve from the data manager store */

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -336,15 +336,15 @@ MavlinkMissionManager::send_mission_item(uint8_t sysid, uint8_t compid, uint16_t
 		break;
 
 	case MAV_MISSION_TYPE_RALLY: { // Read a safe point / rally point
-			mission_save_point_s mission_save_point;
-			read_success = dm_read(DM_KEY_SAFE_POINTS, seq + 1, &mission_save_point, sizeof(mission_save_point_s)) ==
-				       sizeof(mission_save_point_s);
+			mission_safe_point_s mission_safe_point;
+			read_success = dm_read(DM_KEY_SAFE_POINTS, seq + 1, &mission_safe_point, sizeof(mission_safe_point_s)) ==
+				       sizeof(mission_safe_point_s);
 
 			mission_item.nav_cmd = MAV_CMD_NAV_RALLY_POINT;
-			mission_item.frame = mission_save_point.frame;
-			mission_item.lat = mission_save_point.lat;
-			mission_item.lon = mission_save_point.lon;
-			mission_item.altitude = mission_save_point.alt;
+			mission_item.frame = mission_safe_point.frame;
+			mission_item.lat = mission_safe_point.lat;
+			mission_item.lon = mission_safe_point.lon;
+			mission_item.altitude = mission_safe_point.alt;
 		}
 		break;
 
@@ -1113,13 +1113,13 @@ MavlinkMissionManager::handle_mission_item_both(const mavlink_message_t *msg)
 			break;
 
 		case MAV_MISSION_TYPE_RALLY: { // Write a safe point / rally point
-				mission_save_point_s mission_save_point;
-				mission_save_point.lat = mission_item.lat;
-				mission_save_point.lon = mission_item.lon;
-				mission_save_point.alt = mission_item.altitude;
-				mission_save_point.frame = mission_item.frame;
-				write_failed = dm_write(DM_KEY_SAFE_POINTS, wp.seq + 1, DM_PERSIST_POWER_ON_RESET, &mission_save_point,
-							sizeof(mission_save_point_s)) != sizeof(mission_save_point_s);
+				mission_safe_point_s mission_safe_point;
+				mission_safe_point.lat = mission_item.lat;
+				mission_safe_point.lon = mission_item.lon;
+				mission_safe_point.alt = mission_item.altitude;
+				mission_safe_point.frame = mission_item.frame;
+				write_failed = dm_write(DM_KEY_SAFE_POINTS, wp.seq + 1, DM_PERSIST_POWER_ON_RESET, &mission_safe_point,
+							sizeof(mission_safe_point_s)) != sizeof(mission_safe_point_s);
 			}
 			break;
 

--- a/src/modules/mavlink/mavlink_mission.h
+++ b/src/modules/mavlink/mavlink_mission.h
@@ -145,7 +145,7 @@ private:
 		DM_KEY_FENCE_POINTS_MAX - 1,
 		DM_KEY_SAFE_POINTS_MAX - 1
 	};	/**< Maximum number of mission items for each type
-					(fence & save points use the first item for the stats) */
+					(fence & safe points use the first item for the stats) */
 
 	/** get the maximum number of item count for the current _mission_type */
 	uint16_t current_max_item_count();

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -376,17 +376,17 @@ Mission::set_execution_mode(const uint8_t mode)
 bool
 Mission::find_mission_land_start()
 {
-	/* return true if a MAV_CMD_DO_LAND_START is found and internally save the index
+	/* return true if a MAV_CMD_DO_LAND_START, NAV_CMD_VTOL_LAND or NAV_CMD_LAND is found and internally save the index
 	 *  return false if not found
-	 *
-	 * TODO: implement full spec and find closest landing point geographically
 	 */
 
 	const dm_item_t dm_current = (dm_item_t)_mission.dataman_id;
+	struct mission_item_s missionitem = {};
+	struct mission_item_s missionitem_prev = {}; //to store mission item before currently checked on, needed to get pos of wp before NAV_CMD_DO_LAND_START
 
-	for (size_t i = 0; i < _mission.count; i++) {
-		struct mission_item_s missionitem = {};
+	for (size_t i = 1; i < _mission.count; i++) {
 		const ssize_t len = sizeof(missionitem);
+		missionitem_prev = missionitem; // store the last mission item before reading a new one
 
 		if (dm_read(dm_current, i, &missionitem, len) != len) {
 			/* not supposed to happen unless the datamanager can't access the SD card, etc. */
@@ -394,11 +394,27 @@ Mission::find_mission_land_start()
 			break;
 		}
 
-		if ((missionitem.nav_cmd == NAV_CMD_DO_LAND_START) ||
-		    ((missionitem.nav_cmd == NAV_CMD_VTOL_LAND) && _navigator->get_vstatus()->is_vtol) ||
-		    (missionitem.nav_cmd == NAV_CMD_LAND)) {
+		// first check for DO_LAND_START marker
+		if ((missionitem.nav_cmd == NAV_CMD_DO_LAND_START) && (missionitem_prev.nav_cmd == NAV_CMD_WAYPOINT)) {
+
 			_land_start_available = true;
 			_land_start_index = i;
+			// the DO_LAND_START marker contains no position sp, so take them from the previous mission item
+			_landing_lat = missionitem_prev.lat;
+			_landing_lon = missionitem_prev.lon;
+			_landing_alt = missionitem_prev.altitude;
+			return true;
+
+			// if no DO_LAND_START marker available, also check for VTOL_LAND or normal LAND
+
+		} else if (((missionitem.nav_cmd == NAV_CMD_VTOL_LAND) && _navigator->get_vstatus()->is_vtol) ||
+			   (missionitem.nav_cmd == NAV_CMD_LAND)) {
+
+			_land_start_available = true;
+			_land_start_index = i;
+			_landing_lat = missionitem.lat;
+			_landing_lon = missionitem.lon;
+			_landing_alt = missionitem.altitude;
 			return true;
 		}
 	}

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -91,6 +91,9 @@ public:
 	bool get_mission_finished() const { return _mission_type == MISSION_TYPE_NONE; }
 	bool get_mission_changed() const { return _mission_changed ; }
 	bool get_mission_waypoints_changed() const { return _mission_waypoints_changed ; }
+	double get_landing_lat() { return _landing_lat; }
+	double get_landing_lon() { return _landing_lon; }
+	float get_landing_alt() { return _landing_alt; }
 
 	void set_closest_item_as_current();
 
@@ -251,6 +254,9 @@ private:
 	// track location of planned mission landing
 	bool	_land_start_available{false};
 	uint16_t _land_start_index{UINT16_MAX};		/**< index of DO_LAND_START, INVALID_DO_LAND_START if no planned landing */
+	double _landing_lat{0.0};
+	double _landing_lon{0.0};
+	float _landing_alt{0.0f};
 
 	bool _need_takeoff{true};					/**< if true, then takeoff must be performed before going to the first waypoint (if needed) */
 

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -217,10 +217,10 @@ struct mission_fence_point_s {
 };
 
 /**
- * Save Point (Rally Point).
+ * Safe Point (Rally Point).
  * Corresponds to the DM_KEY_SAFE_POINTS dataman item
  */
-struct mission_save_point_s {
+struct mission_safe_point_s {
 	double lat;
 	double lon;
 	float alt;

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -268,7 +268,11 @@ public:
 	bool		is_planned_mission() const { return _navigation_mode == &_mission; }
 	bool		on_mission_landing() { return _mission.landing(); }
 	bool		start_mission_landing() { return _mission.land_start(); }
-	bool		mission_start_land_available() { return _mission.get_land_start_available(); }
+	bool		get_mission_start_land_available() { return _mission.get_land_start_available(); }
+	int 		get_mission_landing_index() { return _mission.get_land_start_index(); }
+	double 	get_mission_landing_lat() { return _mission.get_landing_lat(); }
+	double 	get_mission_landing_lon() { return _mission.get_landing_lon(); }
+	float 	get_mission_landing_alt() { return _mission.get_landing_alt(); }
 
 	// RTL
 	bool		mission_landing_required() { return _rtl.rtl_type() == RTL::RTL_LAND; }

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -490,9 +490,16 @@ Navigator::run()
 				const bool rtl_activated = _previous_nav_state != vehicle_status_s::NAVIGATION_STATE_AUTO_RTL;
 
 				switch (rtl_type()) {
-				case RTL::RTL_LAND:
+				case RTL::RTL_LAND: // use mission landing
+				case RTL::RTL_CLOSEST:
 					if (rtl_activated) {
-						mavlink_and_console_log_info(get_mavlink_log_pub(), "RTL LAND activated");
+						if (rtl_type() == RTL::RTL_LAND) {
+							mavlink_and_console_log_info(get_mavlink_log_pub(), "RTL LAND activated");
+
+						} else {
+							mavlink_and_console_log_info(get_mavlink_log_pub(), "RTL Closest landing point activated");
+						}
+
 					}
 
 					// if RTL is set to use a mission landing and mission has a planned landing, then use MISSION to fly there directly
@@ -570,6 +577,7 @@ Navigator::run()
 
 					navigation_mode_new = &_rtl;
 					break;
+
 				}
 
 				break;

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2013-2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013-2019 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,6 +41,7 @@
 
 #include "rtl.h"
 #include "navigator.h"
+#include <dataman/dataman.h>
 
 
 static constexpr float DELAY_SIGMA = 0.01f;
@@ -68,6 +69,79 @@ void
 RTL::on_activation()
 {
 
+	// find the RTL destination: go through the safe points & home position
+	const home_position_s &home_position = *_navigator->get_home_position();
+	const vehicle_global_position_s &global_position = *_navigator->get_global_position();
+
+	mission_stats_entry_s stats;
+	int ret = dm_read(DM_KEY_SAFE_POINTS, 0, &stats, sizeof(mission_stats_entry_s));
+	int num_safe_points = 0;
+
+	if (ret == sizeof(mission_stats_entry_s)) {
+		num_safe_points = stats.num_items;
+	}
+
+	int closest_index = 0;
+	mission_safe_point_s closest_safe_point;
+
+	// take home position into account
+	double dlat = home_position.lat - global_position.lat;
+	double dlon = home_position.lon - global_position.lon;
+	double min_dist_squared = dlat * dlat + dlon * dlon;
+
+	// find the closest point
+	for (int current_seq = 1; current_seq <= num_safe_points; ++current_seq) {
+		mission_safe_point_s mission_safe_point;
+
+		if (dm_read(DM_KEY_SAFE_POINTS, current_seq, &mission_safe_point, sizeof(mission_safe_point_s)) !=
+		    sizeof(mission_safe_point_s)) {
+			PX4_ERR("dm_read failed");
+			continue;
+		}
+
+		// TODO: take altitude into account for distance measurement
+
+		dlat = mission_safe_point.lat - global_position.lat;
+		dlon = mission_safe_point.lon - global_position.lon;
+		double dist_squared = dlat * dlat + dlon * dlon;
+
+		if (dist_squared < min_dist_squared) {
+			closest_index = current_seq;
+			min_dist_squared = dist_squared;
+			closest_safe_point = mission_safe_point;
+		}
+	}
+
+	if (closest_index == 0) {
+		_destination.set(home_position);
+
+	} else {
+
+		// TODO: handle all possible mission_safe_point.frame cases
+		switch (closest_safe_point.frame) {
+		case 0: // MAV_FRAME_GLOBAL
+			_destination.safe_point_index = closest_index;
+			_destination.lat = closest_safe_point.lat;
+			_destination.lon = closest_safe_point.lon;
+			_destination.alt = closest_safe_point.alt;
+			_destination.yaw = home_position.yaw;
+			break;
+
+		case 3: // MAV_FRAME_GLOBAL_RELATIVE_ALT
+			_destination.safe_point_index = closest_index;
+			_destination.lat = closest_safe_point.lat;
+			_destination.lon = closest_safe_point.lon;
+			_destination.alt = closest_safe_point.alt + home_position.alt; // alt of safe point is rel to home
+			_destination.yaw = home_position.yaw;
+			break;
+
+		default:
+			mavlink_log_critical(_navigator->get_mavlink_log_pub(), "RTL: unsupported MAV_FRAME. Landing at HOME.");
+			_destination.set(home_position);
+			break;
+		}
+	}
+
 	_rtl_alt = calculate_return_alt_from_cone_half_angle((float)_param_rtl_cone_half_angle_deg.get());
 
 	if (_navigator->get_land_detected()->landed) {
@@ -77,8 +151,7 @@ RTL::on_activation()
 	} else if ((rtl_type() == RTL_LAND) && _navigator->on_mission_landing()) {
 		// RTL straight to RETURN state, but mission will takeover for landing.
 
-	} else if ((_navigator->get_global_position()->alt < _navigator->get_home_position()->alt + _param_rtl_return_alt.get())
-		   || _rtl_alt_min) {
+	} else if ((global_position.alt < _destination.alt + _param_rtl_return_alt.get()) || _rtl_alt_min) {
 
 		// If lower than return altitude, climb up first.
 		// If rtl_alt_min is true then forcing altitude change even if above.
@@ -111,7 +184,7 @@ void
 RTL::set_rtl_item()
 {
 	// RTL_TYPE: mission landing.
-	// Landing using planned mission landing, fly to DO_LAND_START instead of returning HOME.
+	// Landing using planned mission landing, fly to DO_LAND_START instead of returning _destination.
 	// Do nothing, let navigator takeover with mission landing.
 	if (rtl_type() == RTL_LAND) {
 		if (_rtl_state > RTL_STATE_CLIMB) {
@@ -128,16 +201,15 @@ RTL::set_rtl_item()
 
 	_navigator->set_can_loiter_at_sp(false);
 
-	const home_position_s &home = *_navigator->get_home_position();
 	const vehicle_global_position_s &gpos = *_navigator->get_global_position();
 
 	position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 
-	// Check if we are pretty close to home already.
-	const float home_dist = get_distance_to_next_waypoint(home.lat, home.lon, gpos.lat, gpos.lon);
+	// Check if we are pretty close to the destination already.
+	const float destination_dist = get_distance_to_next_waypoint(_destination.lat, _destination.lon, gpos.lat, gpos.lon);
 
 	// Compute the loiter altitude.
-	const float loiter_altitude = math::min(home.alt + _param_rtl_descend_alt.get(), gpos.alt);
+	const float loiter_altitude = math::min(_destination.alt + _param_rtl_descend_alt.get(), gpos.alt);
 
 	switch (_rtl_state) {
 	case RTL_STATE_CLIMB: {
@@ -153,8 +225,8 @@ RTL::set_rtl_item()
 			_mission_item.autocontinue = true;
 			_mission_item.origin = ORIGIN_ONBOARD;
 
-			mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: climb to %d m (%d m above home)",
-						     (int)ceilf(_rtl_alt), (int)ceilf(_rtl_alt - _navigator->get_home_position()->alt));
+			mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: climb to %d m (%d m above destination)",
+						     (int)ceilf(_rtl_alt), (int)ceilf(_rtl_alt - _destination.alt));
 			break;
 		}
 
@@ -162,19 +234,19 @@ RTL::set_rtl_item()
 
 			// Don't change altitude.
 			_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
-			_mission_item.lat = home.lat;
-			_mission_item.lon = home.lon;
+			_mission_item.lat = _destination.lat;
+			_mission_item.lon = _destination.lon;
 			_mission_item.altitude = _rtl_alt;
 			_mission_item.altitude_is_relative = false;
 
-			// Use home yaw if close to home.
-			// Check if we are pretty close to home already.
-			if (home_dist < _param_rtl_min_dist.get()) {
-				_mission_item.yaw = home.yaw;
+			// Use destination yaw if close to _destination.
+			// Check if we are pretty close to the destination already.
+			if (destination_dist < _param_rtl_min_dist.get()) {
+				_mission_item.yaw = _destination.yaw;
 
 			} else {
-				// Use current heading to home.
-				_mission_item.yaw = get_bearing_to_next_waypoint(gpos.lat, gpos.lon, home.lat, home.lon);
+				// Use current heading to _destination.
+				_mission_item.yaw = get_bearing_to_next_waypoint(gpos.lat, gpos.lon, _destination.lat, _destination.lon);
 			}
 
 			_mission_item.acceptance_radius = _navigator->get_acceptance_radius();
@@ -182,8 +254,8 @@ RTL::set_rtl_item()
 			_mission_item.autocontinue = true;
 			_mission_item.origin = ORIGIN_ONBOARD;
 
-			mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: return at %d m (%d m above home)",
-						     (int)ceilf(_mission_item.altitude), (int)ceilf(_mission_item.altitude - home.alt));
+			mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: return at %d m (%d m above destination)",
+						     (int)ceilf(_mission_item.altitude), (int)ceilf(_mission_item.altitude - _destination.alt));
 
 			break;
 		}
@@ -195,8 +267,8 @@ RTL::set_rtl_item()
 
 	case RTL_STATE_DESCEND: {
 			_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
-			_mission_item.lat = home.lat;
-			_mission_item.lon = home.lon;
+			_mission_item.lat = _destination.lat;
+			_mission_item.lon = _destination.lon;
 			_mission_item.altitude = loiter_altitude;
 			_mission_item.altitude_is_relative = false;
 
@@ -207,7 +279,7 @@ RTL::set_rtl_item()
 				_mission_item.yaw = get_bearing_to_next_waypoint(gpos.lat, gpos.lon, _mission_item.lat, _mission_item.lon);
 
 			} else {
-				_mission_item.yaw = home.yaw;
+				_mission_item.yaw = _destination.yaw;
 			}
 
 			_mission_item.acceptance_radius = _navigator->get_acceptance_radius();
@@ -218,8 +290,8 @@ RTL::set_rtl_item()
 			// Disable previous setpoint to prevent drift.
 			pos_sp_triplet->previous.valid = false;
 
-			mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: descend to %d m (%d m above home)",
-						     (int)ceilf(_mission_item.altitude), (int)ceilf(_mission_item.altitude - home.alt));
+			mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: descend to %d m (%d m above destination)",
+						     (int)ceilf(_mission_item.altitude), (int)ceilf(_mission_item.altitude - _destination.alt));
 			break;
 		}
 
@@ -227,11 +299,11 @@ RTL::set_rtl_item()
 			const bool autoland = (_param_rtl_land_delay.get() > FLT_EPSILON);
 
 			// Don't change altitude.
-			_mission_item.lat = home.lat;
-			_mission_item.lon = home.lon;
+			_mission_item.lat = _destination.lat;
+			_mission_item.lon = _destination.lon;
 			_mission_item.altitude = loiter_altitude;
 			_mission_item.altitude_is_relative = false;
-			_mission_item.yaw = home.yaw;
+			_mission_item.yaw = _destination.yaw;
 			_mission_item.loiter_radius = _navigator->get_loiter_radius();
 			_mission_item.acceptance_radius = _navigator->get_acceptance_radius();
 			_mission_item.time_inside = math::max(_param_rtl_land_delay.get(), 0.0f);
@@ -254,19 +326,19 @@ RTL::set_rtl_item()
 		}
 
 	case RTL_STATE_LAND: {
-			// Land at home position.
+			// Land at destination.
 			_mission_item.nav_cmd = NAV_CMD_LAND;
-			_mission_item.lat = home.lat;
-			_mission_item.lon = home.lon;
-			_mission_item.yaw = home.yaw;
-			_mission_item.altitude = home.alt;
+			_mission_item.lat = _destination.lat;
+			_mission_item.lon = _destination.lon;
+			_mission_item.yaw = _destination.yaw;
+			_mission_item.altitude = _destination.alt;
 			_mission_item.altitude_is_relative = false;
 			_mission_item.acceptance_radius = _navigator->get_acceptance_radius();
 			_mission_item.time_inside = 0.0f;
 			_mission_item.autocontinue = true;
 			_mission_item.origin = ORIGIN_ONBOARD;
 
-			mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: land at home");
+			mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: land at destination");
 			break;
 		}
 
@@ -352,34 +424,33 @@ RTL::advance_rtl()
 
 float RTL::calculate_return_alt_from_cone_half_angle(float cone_half_angle_deg)
 {
-	const home_position_s &home = *_navigator->get_home_position();
 	const vehicle_global_position_s &gpos = *_navigator->get_global_position();
 
-	// horizontal distance to home position
-	const float home_dist = get_distance_to_next_waypoint(home.lat, home.lon, gpos.lat, gpos.lon);
+	// horizontal distance to destination
+	const float destination_dist = get_distance_to_next_waypoint(_destination.lat, _destination.lon, gpos.lat, gpos.lon);
 
 	float rtl_altitude;
 
-	if (home_dist <= _param_rtl_min_dist.get()) {
-		rtl_altitude = home.alt + _param_rtl_descend_alt.get();
+	if (destination_dist <= _param_rtl_min_dist.get()) {
+		rtl_altitude = _destination.alt + _param_rtl_descend_alt.get();
 
-	} else if (gpos.alt > home.alt + _param_rtl_return_alt.get() || cone_half_angle_deg >= 90.0f) {
+	} else if (gpos.alt > _destination.alt + _param_rtl_return_alt.get() || cone_half_angle_deg >= 90.0f) {
 		rtl_altitude = gpos.alt;
 
 	} else if (cone_half_angle_deg <= 0) {
-		rtl_altitude = home.alt + _param_rtl_return_alt.get();
+		rtl_altitude = _destination.alt + _param_rtl_return_alt.get();
 
 	} else {
 
 		// constrain cone half angle to meaningful values. All other cases are already handled above.
 		const float cone_half_angle_rad = math::radians(math::constrain(cone_half_angle_deg, 1.0f, 89.0f));
 
-		// minimum height above home position required
-		float height_above_home_min = home_dist / tanf(cone_half_angle_rad);
+		// minimum height above destination required
+		float height_above_destination_min = destination_dist / tanf(cone_half_angle_rad);
 
 		// minimum altitude we need in order to be within the user defined cone
-		const float altitude_min = math::constrain(height_above_home_min + home.alt, home.alt,
-					   home.alt + _param_rtl_return_alt.get());
+		const float altitude_min = math::constrain(height_above_destination_min + _destination.alt, _destination.alt,
+					   _destination.alt + _param_rtl_return_alt.get());
 
 		if (gpos.alt < altitude_min) {
 			rtl_altitude = altitude_min;
@@ -390,7 +461,7 @@ float RTL::calculate_return_alt_from_cone_half_angle(float cone_half_angle_deg)
 	}
 
 	// always demand altitude which is higher or equal the RTL descend altitude
-	rtl_altitude = math::max(rtl_altitude, home.alt + _param_rtl_descend_alt.get());
+	rtl_altitude = math::max(rtl_altitude, _destination.alt + _param_rtl_descend_alt.get());
 
 	return rtl_altitude;
 }

--- a/src/modules/navigator/rtl.h
+++ b/src/modules/navigator/rtl.h
@@ -46,6 +46,8 @@
 #include "navigator_mode.h"
 #include "mission_block.h"
 
+#include <uORB/topics/home_position.h>
+
 class Navigator;
 
 class RTL : public MissionBlock, public ModuleParams
@@ -93,6 +95,25 @@ private:
 		RTL_STATE_LAND,
 		RTL_STATE_LANDED,
 	} _rtl_state{RTL_STATE_NONE};
+
+	struct RTLPosition {
+		double lat;
+		double lon;
+		float alt;
+		float yaw;
+		uint8_t safe_point_index; ///< 0 = home position
+
+		void set(const home_position_s &home_position)
+		{
+			lat = home_position.lat;
+			lon = home_position.lon;
+			alt = home_position.alt;
+			yaw = home_position.yaw;
+			safe_point_index = 0;
+		}
+	};
+
+	RTLPosition _destination; ///< the RTL position to fly to (typically the home position or a safe point)
 
 	float _rtl_alt{0.0f};	// AMSL altitude at which the vehicle should return to the home position
 	bool _rtl_alt_min{false};

--- a/src/modules/navigator/rtl.h
+++ b/src/modules/navigator/rtl.h
@@ -57,6 +57,13 @@ public:
 		RTL_HOME = 0,
 		RTL_LAND,
 		RTL_MISSION,
+		RTL_CLOSEST,
+	};
+
+	enum RTLDestinationType {
+		RTL_DESTINATION_HOME = 0,
+		RTL_DESTINATION_MISSION_LANDING,
+		RTL_DESTINATION_SAFE_POINT,
 	};
 
 	RTL(Navigator *navigator);
@@ -67,9 +74,14 @@ public:
 	void on_activation() override;
 	void on_active() override;
 
+	void find_closest_landing_point();
+	void find_RTL_destination();
+
 	void set_return_alt_min(bool min);
 
 	int rtl_type() const;
+
+	int rtl_destination();
 
 private:
 	/**
@@ -101,7 +113,8 @@ private:
 		double lon;
 		float alt;
 		float yaw;
-		uint8_t safe_point_index; ///< 0 = home position
+		uint8_t safe_point_index; ///< 0 = home position, 1 = mission landing, >1 = safe landing points (rally points)
+		RTLDestinationType type{RTL_DESTINATION_HOME};
 
 		void set(const home_position_s &home_position)
 		{
@@ -110,10 +123,11 @@ private:
 			alt = home_position.alt;
 			yaw = home_position.yaw;
 			safe_point_index = 0;
+			type = RTL_DESTINATION_HOME;
 		}
 	};
 
-	RTLPosition _destination; ///< the RTL position to fly to (typically the home position or a safe point)
+	RTLPosition _destination{}; ///< the RTL position to fly to (typically the home position or a safe point)
 
 	float _rtl_alt{0.0f};	// AMSL altitude at which the vehicle should return to the home position
 	bool _rtl_alt_min{false};

--- a/src/modules/navigator/rtl_params.c
+++ b/src/modules/navigator/rtl_params.c
@@ -97,7 +97,7 @@ PARAM_DEFINE_FLOAT(RTL_LAND_DELAY, -1.0f);
  *
  * @unit m
  * @min 0.5
- * @max 20
+ * @max 100
  * @decimal 1
  * @increment 0.5
  * @group Return Mode

--- a/src/modules/navigator/rtl_params.c
+++ b/src/modules/navigator/rtl_params.c
@@ -113,6 +113,7 @@ PARAM_DEFINE_FLOAT(RTL_MIN_DIST, 5.0f);
  * @value 0 Return home via direct path
  * @value 1 Return to a planned mission landing, if available, via direct path, else return to home via direct path
  * @value 2 Return to a planned mission landing, if available, using the mission path, else return to home via the reverse mission path
+ * @value 3 Return via direct way to whatever is closest: home, mission lading or safe point
  * @group Return Mode
  */
 PARAM_DEFINE_INT32(RTL_TYPE, 0);


### PR DESCRIPTION
This PR is a rebased and slightly modified version of https://github.com/PX4/Firmware/pull/7743 of @bkueng to enable landings at Rally Points during an RTL.

**Describe problem solved by the proposed pull request**
When a RTL is triggered, the vehicle will land at the closest Rally point or home it that's closer. If a mission landing is planned (applies mainly for VTOL or FW), then the DO_LAND_START marker replaces Home, meaning that it will check if that one is closer than any rally point, fly to it and then continue the landing procedure.

**Test data / coverage**
SITL tested.

**Additional context**
This is a first, basic, implementation of Rally points. There is especially some discussion and follow up work needed on when it should land at the closest Rally point, or really come all the way back to home. E.g. if the RTL was triggered by the user or due to RC loss, the expected behavior is that it comes to home. Battery empty RTL's make sense at the closes Rally point. 

Also, if flying a VTOL and a malfunction of the FW system is detected (either automatically or by the user) and it thus is in hover mode, landing at the closes Rally point is crucial as probably the distance to home is too large.


**EDIT**:
I've made some changes:
- nothing changes for RTL_TYPE 0,1,2 (so all that were there before this PR) 
- safe landing points are now only considered if RTL_TYPE=3 ("Return via direct way to whatever is closest: home, mission lading or safe point"
- if DO_LAND_START marker is available, then the distance to this one is compared to home/safe landing points if RTL_TYPE=3 
