### PR TITLE
commander: fix arming auth param translation

### DIFF
--- a/src/modules/commander/CMakeLists.txt
+++ b/src/modules/commander/CMakeLists.txt
@@ -39,7 +39,6 @@ px4_add_module(
 	STACK_MAIN 4096
 	STACK_MAX 2450
 	COMPILE_FLAGS
-		-Wno-cast-align # TODO: fix and enable
 	SRCS
 		accelerometer_calibration.cpp
 		airspeed_calibration.cpp

--- a/src/modules/mavlink/mavlink_command_sender.cpp
+++ b/src/modules/mavlink/mavlink_command_sender.cpp
@@ -123,8 +123,8 @@ void MavlinkCommandSender::handle_mavlink_command_ack(const mavlink_command_ack_
 	while (command_item_t *item = _commands.get_next()) {
 		// Check if the incoming ack matches any of the commands that we have sent.
 		if (item->command.command == ack.command &&
-		    from_sysid == item->command.target_system &&
-		    from_compid == item->command.target_component &&
+		    (item->command.target_system == 0 || from_sysid == item->command.target_system) &&
+		    (item->command.target_component == 0 || from_compid == item->command.target_component) &&
 		    item->num_sent_per_channel[channel] != -1) {
 			item->num_sent_per_channel[channel] = -2;	// mark this as acknowledged
 			break;


### PR DESCRIPTION
The int32 param COM_ARM_AUTH is mapped to a packed struct. However, this struct was not actually packed (anymore) and therefore the values were applied incorrectly.

I fixed this by applying the packed attribute. By using a union with a int32_t I could rid of the warning about address-of-packed-member.

This also fixes the issue where sysid and compid in the mavlink_command_sender do not match because the target_system and target_component are 0 (to all). This meant that the command was being re-transmitted multiple times even though an ack was received.

Tested in SITL so far.

Fixes #12685.