### PR TITLE
[WIP]: NuttX preparation for SPI DMA

### DIFF
--- a/src/drivers/barometer/ms5611/ms5611_spi.cpp
+++ b/src/drivers/barometer/ms5611/ms5611_spi.cpp
@@ -124,14 +124,7 @@ MS5611_SPI::MS5611_SPI(uint8_t bus, uint32_t device, ms5611::prom_u &prom_buf) :
 int
 MS5611_SPI::init()
 {
-	int ret;
-
-#if defined(PX4_SPI_BUS_RAMTRON) && \
-	(PX4_SPI_BUS_BARO == PX4_SPI_BUS_RAMTRON)
-	SPI::set_lockmode(LOCK_THREADS);
-#endif
-
-	ret = SPI::init();
+	int ret = SPI::init();
 
 	if (ret != OK) {
 		PX4_DEBUG("SPI init failed");

--- a/src/drivers/boards/common/CMakeLists.txt
+++ b/src/drivers/boards/common/CMakeLists.txt
@@ -36,7 +36,7 @@ if ((${PX4_PLATFORM} MATCHES "nuttx") AND NOT ${PX4_BOARD} MATCHES "io")
 
 	add_library(drivers_boards_common
 		board_crashdump.c
-		board_dma_alloc.c
+		board_dma_alloc.cpp
 		board_fat_dma_alloc.c
 		board_gpio_init.c
 		)

--- a/src/drivers/boards/common/board_dma_alloc.cpp
+++ b/src/drivers/boards/common/board_dma_alloc.cpp
@@ -58,6 +58,8 @@
 
 #if defined(CONFIG_GRAN)
 
+__BEGIN_DECLS
+
 static GRAN_HANDLE dma_allocator;
 
 /*
@@ -70,6 +72,7 @@ static GRAN_HANDLE dma_allocator;
  * We use a fundamental alignment / granule size of 64B; this is sufficient
  * to guarantee alignment for the largest STM32 DMA burst (16 beats x 32bits).
  */
+static_assert(!(BOARD_DMA_ALLOC_POOL_SIZE % 512), "DMA alloc pool multiple of 512");
 static uint8_t g_dma_heap[BOARD_DMA_ALLOC_POOL_SIZE] __attribute__((aligned(64)));
 static perf_counter_t g_dma_perf;
 static uint16_t dma_heap_inuse;
@@ -132,6 +135,8 @@ board_dma_free(FAR void *memory, size_t size)
 	gran_free(dma_allocator, memory, size);
 	dma_heap_inuse -= size;
 }
+
+__END_DECLS
 
 #endif /* CONFIG_GRAN */
 #endif /* BOARD_DMA_ALLOC_POOL_SIZE */

--- a/src/drivers/boards/common/board_dma_alloc.h
+++ b/src/drivers/boards/common/board_dma_alloc.h
@@ -44,6 +44,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+__BEGIN_DECLS
+
 /************************************************************************************
  * Name: board_dma_alloc_init
  *
@@ -112,7 +114,7 @@ __EXPORT int board_get_dma_usage(uint16_t *dma_total, uint16_t *dma_used, uint16
 #if defined(BOARD_DMA_ALLOC_POOL_SIZE)
 __EXPORT void *board_dma_alloc(size_t size);
 #else
-#define board_dma_alloc(size) (NULL)
+#define board_dma_alloc(size) malloc(size)
 #endif
 
 /************************************************************************************
@@ -129,5 +131,7 @@ __EXPORT void *board_dma_alloc(size_t size);
 #if defined(BOARD_DMA_ALLOC_POOL_SIZE)
 __EXPORT void board_dma_free(FAR void *memory, size_t size);
 #else
-#define board_dma_free(memory, size) ()
+#define board_dma_free(memory, size) free(memory)
 #endif
+
+__END_DECLS

--- a/src/drivers/optical_flow/paw3902/PAW3902.cpp
+++ b/src/drivers/optical_flow/paw3902/PAW3902.cpp
@@ -71,9 +71,6 @@ PAW3902::init()
 		}
 	}
 
-	/* For devices competing with NuttX SPI drivers on a bus (Crazyflie SD Card expansion board) */
-	SPI::set_lockmode(LOCK_THREADS);
-
 	/* do SPI init (and probe) first */
 	if (SPI::init() != OK) {
 		return PX4_ERROR;

--- a/src/drivers/optical_flow/pmw3901/pmw3901.cpp
+++ b/src/drivers/optical_flow/pmw3901/pmw3901.cpp
@@ -341,9 +341,6 @@ PMW3901::init()
 		_yaw_rotation = (enum Rotation)val;
 	}
 
-	/* For devices competing with NuttX SPI drivers on a bus (Crazyflie SD Card expansion board) */
-	SPI::set_lockmode(LOCK_THREADS);
-
 	/* do SPI init (and probe) first */
 	if (SPI::init() != OK) {
 		goto out;

--- a/src/lib/drivers/device/nuttx/SPI.hpp
+++ b/src/lib/drivers/device/nuttx/SPI.hpp
@@ -32,7 +32,7 @@
  ****************************************************************************/
 
 /**
- * @file spi.h
+ * @file SPI.hpp
  *
  * Base class for devices connected via SPI.
  */
@@ -61,22 +61,8 @@ protected:
 	 * @param mode		SPI clock/data mode
 	 * @param frequency	SPI clock frequency
 	 */
-	SPI(const char *name,
-	    const char *devname,
-	    int bus,
-	    uint32_t device,
-	    enum spi_mode_e mode,
-	    uint32_t frequency);
+	SPI(const char *name, const char *devname, int bus, uint32_t device, enum spi_mode_e mode, uint32_t frequency);
 	virtual ~SPI();
-
-	/**
-	 * Locking modes supported by the driver.
-	 */
-	enum LockMode {
-		LOCK_PREEMPTION,	/**< the default; lock against all forms of preemption. */
-		LOCK_THREADS,		/**< lock only against other threads, using SPI_LOCK */
-		LOCK_NONE		/**< perform no locking, only safe if the bus is entirely private */
-	};
 
 	virtual int	init();
 
@@ -137,33 +123,19 @@ protected:
 	 * @param frequency	Frequency to set (Hz)
 	 */
 	void		set_frequency(uint32_t frequency) { _frequency = frequency; }
-
-	/**
-	 * Set the SPI bus locking mode
-	 *
-	 * This set the SPI locking mode. For devices competing with NuttX SPI
-	 * drivers on a bus the right lock mode is LOCK_THREADS.
-	 *
-	 * @param mode	Locking mode
-	 */
-	void		set_lockmode(enum LockMode mode) { locking_mode = mode; }
-
-	LockMode	locking_mode;	/**< selected locking mode */
+	uint32_t	get_frequency() { return _frequency; }
 
 private:
-	uint32_t			_device;
+	uint32_t		_device;
 	enum spi_mode_e		_mode;
 	uint32_t		_frequency;
-	struct spi_dev_s	*_dev;
+	struct spi_dev_s	*_dev {nullptr};
 
 	/* this class does not allow copying */
 	SPI(const SPI &);
 	SPI operator=(const SPI &);
 
 protected:
-	int	_transfer(uint8_t *send, uint8_t *recv, unsigned len);
-
-	int	_transferhword(uint16_t *send, uint16_t *recv, unsigned len);
 
 	bool	external() { return px4_spi_bus_external(get_device_bus()); }
 

--- a/src/lib/drivers/device/posix/SPI.cpp
+++ b/src/lib/drivers/device/posix/SPI.cpp
@@ -65,8 +65,6 @@ SPI::SPI(const char *name, const char *devname, int bus, uint32_t device, enum s
 	_device_id.devid_s.bus_type = DeviceBusType_SPI;
 	_device_id.devid_s.bus = bus;
 	_device_id.devid_s.address = (uint8_t)device;
-	// devtype needs to be filled in by the driver
-	_device_id.devid_s.devtype = 0;
 }
 
 SPI::~SPI()
@@ -80,8 +78,6 @@ SPI::~SPI()
 int
 SPI::init()
 {
-	int ret = OK;
-
 	// Open the actual SPI device
 	char dev_path[16];
 	snprintf(dev_path, sizeof(dev_path), "/dev/spidev%i.%i", get_device_bus(), PX4_SPI_DEV_ID(_device));
@@ -94,7 +90,7 @@ SPI::init()
 	}
 
 	/* call the probe function to check whether the device is present */
-	ret = probe();
+	int ret = probe();
 
 	if (ret != OK) {
 		DEVICE_DEBUG("probe failed");

--- a/src/lib/drivers/device/posix/SPI.hpp
+++ b/src/lib/drivers/device/posix/SPI.hpp
@@ -79,15 +79,6 @@ protected:
 	SPI(const char *name, const char *devname, int bus, uint32_t device, enum spi_mode_e mode, uint32_t frequency);
 	virtual ~SPI();
 
-	/**
-	 * Locking modes supported by the driver.
-	 */
-	enum LockMode {
-		LOCK_PREEMPTION,	/**< the default; lock against all forms of preemption. */
-		LOCK_THREADS,		/**< lock only against other threads, using SPI_LOCK */
-		LOCK_NONE		/**< perform no locking, only safe if the bus is entirely private */
-	};
-
 	virtual int	init();
 
 	/**
@@ -147,17 +138,7 @@ protected:
 	 * @param frequency	Frequency to set (Hz)
 	 */
 	void		set_frequency(uint32_t frequency) { _frequency = frequency; }
-	uint32_t		get_frequency() { return _frequency; }
-
-	/**
-	 * Set the SPI bus locking mode
-	 *
-	 * This set the SPI locking mode. For devices competing with NuttX SPI
-	 * drivers on a bus the right lock mode is LOCK_THREADS.
-	 *
-	 * @param mode	Locking mode
-	 */
-	void		set_lockmode(enum LockMode mode) {}
+	uint32_t	get_frequency() { return _frequency; }
 
 private:
 	int 			_fd{-1};


### PR DESCRIPTION
 - fix board_dma_alloc
 - SPI always use SPI_LOCK()
 - NuttX stm32f7 hack stm32_dmacapable to skip buffer end DCACHE alignment check (https://github.com/PX4/NuttX/pull/61)
