### PR TITLE
Rename _accel_horz_lp -> _xy_accel_filtered, delete unneeded #includes in FixedwingLandDetector

### DIFF
--- a/src/modules/land_detector/FixedwingLandDetector.cpp
+++ b/src/modules/land_detector/FixedwingLandDetector.cpp
@@ -39,13 +39,9 @@
  * @author Julian Oes <julian@oes.ch>
  */
 
-#include "FixedwingLandDetector.h"
-
-#include <cmath>
-
-#include <px4_config.h>
-#include <px4_defines.h>
 #include <matrix/math.hpp>
+
+#include "FixedwingLandDetector.h"
 
 namespace land_detector
 {
@@ -90,7 +86,7 @@ bool FixedwingLandDetector::_get_landed_state()
 
 	bool landDetected = false;
 
-	if (hrt_elapsed_time(&_vehicle_local_position.timestamp) < 500 * 1000) {
+	if (hrt_elapsed_time(&_vehicle_local_position.timestamp) < 500_ms) {
 
 		// Horizontal velocity complimentary filter.
 		float val = 0.97f * _velocity_xy_filtered + 0.03f * sqrtf(_vehicle_local_position.vx * _vehicle_local_position.vx +
@@ -114,10 +110,10 @@ bool FixedwingLandDetector::_get_landed_state()
 		const matrix::Vector3f accel{_vehicle_acceleration.xyz};
 		const float acc_hor = sqrtf(accel(0) * accel(0) + accel(1) * accel(1));
 
-		_accel_horz_lp = _accel_horz_lp * 0.8f + acc_hor * 0.18f;
+		_xy_accel_filtered = _xy_accel_filtered * 0.8f + acc_hor * 0.18f;
 
 		// crude land detector for fixedwing
-		landDetected = _accel_horz_lp           < _param_lndfw_xyaccel_max.get()
+		landDetected = _xy_accel_filtered       < _param_lndfw_xyaccel_max.get()
 			       && _airspeed_filtered    < _param_lndfw_airspd.get()
 			       && _velocity_xy_filtered < _param_lndfw_vel_xy_max.get()
 			       && _velocity_z_filtered  < _param_lndfw_vel_z_max.get();

--- a/src/modules/land_detector/FixedwingLandDetector.h
+++ b/src/modules/land_detector/FixedwingLandDetector.h
@@ -42,7 +42,6 @@
 
 #pragma once
 
-#include <drivers/drv_hrt.h>
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/airspeed.h>
 #include <uORB/topics/vehicle_acceleration.h>
@@ -82,10 +81,10 @@ private:
 	vehicle_acceleration_s _vehicle_acceleration{};
 	vehicle_local_position_s _vehicle_local_position{};
 
-	float _accel_horz_lp{0.0f};
 	float _airspeed_filtered{0.0f};
 	float _velocity_xy_filtered{0.0f};
 	float _velocity_z_filtered{0.0f};
+	float _xy_accel_filtered{0.0f};
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(
 		LandDetector,


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This PR renames a variable to match the existing convention in the FixedwingLandDetector class, adds usage of a time literal, and deletes unneeded #includes .

**Additional context**
This PR simplifies the diff in #11874.

Let me know if you have any questions on this PR. Thanks!
