### PR TITLE
Orbit failsafe: Prevent crashes because of zero thrust 

### DIFF
--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -598,7 +598,7 @@ bool set_nav_state(vehicle_status_s *status, actuator_armed_s *armed, commander_
 			internal_state->main_state = commander_state_s::MAIN_STATE_POSCTL;
 
 		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, true)) {
-			// failsafe: necessary position estimate lost; witching is done in check_invalid_pos_nav_state
+			// failsafe: necessary position estimate lost; switching is done in check_invalid_pos_nav_state
 
 			// Orbit can only be started via vehicle_command (mavlink). Consequently, recovery from failsafe into orbit
 			// is not possible and therefore the internal_state needs to be adjusted.

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -593,8 +593,17 @@ bool set_nav_state(vehicle_status_s *status, actuator_armed_s *armed, commander_
 			// failsafe: on engine failure
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
 
+			// Orbit can only be started via vehicle_command (mavlink). Recovery from failsafe into orbit
+			// is not possible and therefore the internal_state needs to be adjusted.
+			internal_state->main_state = commander_state_s::MAIN_STATE_POSCTL;
+
 		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, true)) {
-			// failsafe: necessary position estimate lost (nothing to do - everything done in check_invalid_pos_nav_state)
+			// failsafe: necessary position estimate lost; witching is done in check_invalid_pos_nav_state
+
+			// Orbit can only be started via vehicle_command (mavlink). Consequently, recovery from failsafe into orbit
+			// is not possible and therefore the internal_state needs to be adjusted.
+			internal_state->main_state = commander_state_s::MAIN_STATE_POSCTL;
+
 		} else if (status->data_link_lost && data_link_loss_act_configured && !landed && is_armed) {
 			// failsafe: just datalink is lost and we're in air
 			set_link_loss_nav_state(status, armed, status_flags, internal_state, data_link_loss_act,
@@ -602,12 +611,20 @@ bool set_nav_state(vehicle_status_s *status, actuator_armed_s *armed, commander_
 
 			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_datalink);
 
+			// Orbit can only be started via vehicle_command (mavlink). Consequently, recovery from failsafe into orbit
+			// is not possible and therefore the internal_state needs to be adjusted.
+			internal_state->main_state = commander_state_s::MAIN_STATE_POSCTL;
+
 		} else if (rc_lost && !data_link_loss_act_configured && is_armed) {
 			// failsafe: RC is lost, datalink loss is not set up and rc loss is not disabled
 			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_rc);
 
 			set_link_loss_nav_state(status, armed, status_flags, internal_state, rc_loss_act,
 						vehicle_status_s::NAVIGATION_STATE_AUTO_RCRECOVER);
+
+			// Orbit can only be started via vehicle_command (mavlink). Consequently, recovery from failsafe into orbit
+			// is not possible and therefore the internal_state needs to be adjusted.
+			internal_state->main_state = commander_state_s::MAIN_STATE_POSCTL;
 
 		} else {
 			// no failsafe, RC is not mandatory for orbit


### PR DESCRIPTION
**Issue**
In contrast to all tasks within Flighttasks, the orbit-task can only be invoked via vehicle_command msg, which is the uorb equivalent of the mavlink `MAV_CMD`-msg. The orbit-task currently cannot be activated solely via the usual commander-state -> navigation-state pattern, but rather requires a vehicle_command msg to be sent and received in Flighttasks, which then starts the orbit-task. During normal operation, that does not cause any issue. However, during failsafe (for instance RC-loss), the flight-mode changes from orbit into another failsafe mode (for instance RTL) and if there is a recovery (RC regained), then the commander wants to switch into orbit again, which internally also sets the `vehicle_status.nav_state` to `NAVIGATION_STATE_ORBIT`. Within `mc_pos_control`, the NAVIGATION_STATE_ORBIT will not ensure that Flighttasks will switch into FlightTaskOrbit (https://github.com/PX4/Firmware/blob/master/src/modules/mc_pos_control/mc_pos_control_main.cpp#L900-L901), but rather assumes that the vehicle_command will do that (https://github.com/PX4/Firmware/blob/master/src/lib/FlightTasks/FlightTasks.cpp#L152), which will never happen because during failsafe recovery no vehicle_command msg is published.  

This issue is quite serious because depending on the failsafe mechanism, the drone can be stuck in FlighttaskAuto while the rest of the system thinks it is back in orbit. Furthermore, if RC loss is only for a few loops, it can happen that FlighttaskAuto gets initialized with old triplets which can lead to flyaways or almost freefall. Both happened on a real vehicle and can be simulated via HITL (I think SITL could also work but requires different changes in the code).

**Solution**
During Orbit, switch internal-main state from Orbit to PositionCtl if failsafe is triggered. 

**Test data / coverage**
It was observed on a real vehicle  (the vehicle fell from the sky after RC loss-regain during orbit). Thanks to @potaito, the bug could be reproduced in HITL by generating fake rc-loss. In principle, using this branch https://github.com/PX4/Firmware/commits/px4/hotfix/debug/orbit-failsafe-recovery-into-posctl, the error can be reproduced.

**Describe your preferred solution**
Commander refactor  :laughing:


