### PR TITLE
Commander: offboard failsafe cleanup

### DIFF
--- a/cmake/px4_add_common_flags.cmake
+++ b/cmake/px4_add_common_flags.cmake
@@ -87,7 +87,6 @@ function(px4_add_common_flags)
 		-Wunused-variable
 
 		# disabled warnings
-		-Wno-implicit-fallthrough # set appropriate level and update
 		-Wno-missing-field-initializers
 		-Wno-missing-include-dirs # TODO: fix and enable
 		-Wno-unused-parameter

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -1882,6 +1882,7 @@ PX4FMU::pwm_ioctl(file *filp, int cmd, unsigned long arg)
 			break;
 		}
 
+	/* FALLTHROUGH */
 	case PWM_SERVO_GET(4):
 		if (_mode < MODE_5PWM1CAP) {
 			ret = -EINVAL;

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2278,8 +2278,8 @@ Commander::run()
 						       status_flags,
 						       land_detector.landed,
 						       (link_loss_actions_t)_param_nav_rcl_act.get(),
-						       _param_com_obl_act.get(),
-						       _param_com_obl_rc_act.get(),
+						       (offboard_loss_actions_t)_param_com_obl_act.get(),
+						       (offboard_loss_rc_actions_t)_param_com_obl_rc_act.get(),
 						       (position_nav_loss_actions_t)_param_com_posctl_navl.get());
 
 		if (status.failsafe != failsafe_old) {

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1213,9 +1213,6 @@ Commander::run()
 	param_t _param_airmode = param_find("MC_AIRMODE");
 	param_t _param_rc_map_arm_switch = param_find("RC_MAP_ARM_SW");
 
-	/* failsafe response to loss of navigation accuracy */
-	param_t _param_posctl_nav_loss_act = param_find("COM_POSCTL_NAVL");
-
 	status_flags.avoidance_system_required = _param_com_obs_avoid.get();
 
 	/* pthread for slow low prio thread */
@@ -1344,7 +1341,6 @@ Commander::run()
 	param_get(_param_rc_arm_hyst, &rc_arm_hyst);
 	rc_arm_hyst *= COMMANDER_MONITORING_LOOPSPERMSEC;
 
-	int32_t posctl_nav_loss_act = 0;
 	int32_t geofence_action = 0;
 	int32_t flight_uuid = 0;
 	int32_t airmode = 0;
@@ -1477,9 +1473,6 @@ Commander::run()
 			param_get(_param_fmode_4, &_flight_mode_slots[3]);
 			param_get(_param_fmode_5, &_flight_mode_slots[4]);
 			param_get(_param_fmode_6, &_flight_mode_slots[5]);
-
-			/* failsafe response to loss of navigation accuracy */
-			param_get(_param_posctl_nav_loss_act, &posctl_nav_loss_act);
 
 			param_get(_param_takeoff_finished_action, &takeoff_complete_act);
 
@@ -2287,7 +2280,7 @@ Commander::run()
 						       (link_loss_actions_t)_param_nav_rcl_act.get(),
 						       _param_com_obl_act.get(),
 						       _param_com_obl_rc_act.get(),
-						       posctl_nav_loss_act);
+						       (position_nav_loss_actions_t)_param_com_posctl_navl.get());
 
 		if (status.failsafe != failsafe_old) {
 			status_changed = true;

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -116,6 +116,7 @@ private:
 		(ParamFloat<px4::params::COM_POS_FS_EPH>) _param_com_pos_fs_eph,
 		(ParamFloat<px4::params::COM_POS_FS_EPV>) _param_com_pos_fs_epv,
 		(ParamFloat<px4::params::COM_VEL_FS_EVH>) _param_com_vel_fs_evh,
+		(ParamInt<px4::params::COM_POSCTL_NAVL>) _param_com_posctl_navl,	/* failsafe response to loss of navigation accuracy */
 
 		(ParamInt<px4::params::COM_POS_FS_DELAY>) _param_com_pos_fs_delay,
 		(ParamInt<px4::params::COM_POS_FS_PROB>) _param_com_pos_fs_prob,

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -344,9 +344,12 @@ PARAM_DEFINE_FLOAT(COM_OF_LOSS_T, 0.0f);
  * The offboard loss failsafe will only be entered after a timeout,
  * set by COM_OF_LOSS_T in seconds.
  *
- * @value 0 Land mode
- * @value 1 Hold mode
- * @value 2 Return mode
+ * @value -1 Disabled
+ * @value  0 Land mode
+ * @value  1 Hold mode
+ * @value  2 Return mode
+ * @value  3 Terminate
+ * @value  4 Lockdown
  *
  * @group Commander
  */
@@ -358,12 +361,15 @@ PARAM_DEFINE_INT32(COM_OBL_ACT, 0);
  * The offboard loss failsafe will only be entered after a timeout,
  * set by COM_OF_LOSS_T in seconds.
  *
- * @value 0 Position mode
- * @value 1 Altitude mode
- * @value 2 Manual
- * @value 3 Return mode
- * @value 4 Land mode
- * @value 5 Hold mode
+ * @value -1 Disabled
+ * @value  0 Position mode
+ * @value  1 Altitude mode
+ * @value  2 Manual
+ * @value  3 Return mode
+ * @value  4 Land mode
+ * @value  5 Hold mode
+ * @value  6 Terminate
+ * @value  7 Lockdown
  * @group Commander
  */
 PARAM_DEFINE_INT32(COM_OBL_RC_ACT, 0);

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -649,8 +649,8 @@ PARAM_DEFINE_INT32(COM_ARM_MIS_REQ, 0);
  * This sets the flight mode that will be used if navigation accuracy is no longer adequate for position control.
  * Navigation accuracy checks can be disabled using the CBRK_VELPOSERR parameter, but doing so will remove protection for all flight modes.
  *
- * @value 0 Assume use of remote control after fallback. Switch to Altitude mode if a height estimate is available, else switch to MANUAL.
- * @value 1 Assume no use of remote control after fallback. Switch to Land mode if a height estimate is available, else switch to TERMINATION.
+ * @value 0 Altitude/Manual. Assume use of remote control after fallback. Switch to Altitude mode if a height estimate is available, else switch to MANUAL.
+ * @value 1 Land/Terminate.  Assume no use of remote control after fallback. Switch to Land mode if a height estimate is available, else switch to TERMINATION.
  *
  * @group Commander
  */

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -393,7 +393,7 @@ bool set_nav_state(vehicle_status_s *status, actuator_armed_s *armed, commander_
 		   orb_advert_t *mavlink_log_pub, const link_loss_actions_t data_link_loss_act, const bool mission_finished,
 		   const bool stay_in_failsafe, const vehicle_status_flags_s &status_flags, bool landed,
 		   const link_loss_actions_t rc_loss_act, const int offb_loss_act, const int offb_loss_rc_act,
-		   const int posctl_nav_loss_act)
+		   const position_nav_loss_actions_t posctl_nav_loss_act)
 {
 	navigation_state_t nav_state_old = status->nav_state;
 
@@ -468,7 +468,8 @@ bool set_nav_state(vehicle_status_s *status, actuator_armed_s *armed, commander_
 				 * For fixedwing, a global position is needed. */
 
 			} else if (is_armed
-				   && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, !(posctl_nav_loss_act == 1),
+				   && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags,
+						   !(posctl_nav_loss_act == position_nav_loss_actions_t::LAND_TERMINATE),
 						   status->vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING)) {
 				// nothing to do - everything done in check_invalid_pos_nav_state
 

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -68,6 +68,27 @@ enum class link_loss_actions_t {
 	LOCKDOWN = 6,		// Kill the motors, same result as kill switch
 };
 
+enum class offboard_loss_actions_t {
+	DISABLED = -1,
+	AUTO_LAND = 0,		// Land mode
+	AUTO_LOITER = 1,	// Hold mode
+	AUTO_RTL = 2,		// Return mode
+	TERMINATE = 3,		// Turn off all controllers and set PWM outputs to failsafe value
+	LOCKDOWN = 4,		// Kill the motors, same result as kill switch
+};
+
+enum class offboard_loss_rc_actions_t {
+	DISABLED = -1, 		// Disabled
+	MANUAL_POSITION = 0, 	// Position mode
+	MANUAL_ALTITUDE = 1, 	// Altitude mode
+	MANUAL_ATTITUDE = 2, 	// Manual
+	AUTO_RTL = 3, 		// Return mode
+	AUTO_LAND = 4, 		// Land mode
+	AUTO_LOITER = 5, 	// Hold mode
+	TERMINATE = 6, 		// Turn off all controllers and set PWM outputs to failsafe value
+	LOCKDOWN = 7, 		// Kill the motors, same result as kill switch
+};
+
 enum class position_nav_loss_actions_t {
 	ALTITUDE_MANUAL = 0,	// Altitude/Manual. Assume use of remote control after fallback. Switch to Altitude mode if a height estimate is available, else switch to MANUAL.
 	LAND_TERMINATE = 1,	// Land/Terminate.  Assume no use of remote control after fallback. Switch to Land mode if a height estimate is available, else switch to TERMINATION.
@@ -99,7 +120,8 @@ void enable_failsafe(vehicle_status_s *status, bool old_failsafe, orb_advert_t *
 bool set_nav_state(vehicle_status_s *status, actuator_armed_s *armed, commander_state_s *internal_state,
 		   orb_advert_t *mavlink_log_pub, const link_loss_actions_t data_link_loss_act, const bool mission_finished,
 		   const bool stay_in_failsafe, const vehicle_status_flags_s &status_flags, bool landed,
-		   const link_loss_actions_t rc_loss_act, const int offb_loss_act, const int offb_loss_rc_act,
+		   const link_loss_actions_t rc_loss_act, const offboard_loss_actions_t offb_loss_act,
+		   const offboard_loss_rc_actions_t offb_loss_rc_act,
 		   const position_nav_loss_actions_t posctl_nav_loss_act);
 
 /*

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -68,6 +68,11 @@ enum class link_loss_actions_t {
 	LOCKDOWN = 6,		// Kill the motors, same result as kill switch
 };
 
+enum class position_nav_loss_actions_t {
+	ALTITUDE_MANUAL = 0,	// Altitude/Manual. Assume use of remote control after fallback. Switch to Altitude mode if a height estimate is available, else switch to MANUAL.
+	LAND_TERMINATE = 1,	// Land/Terminate.  Assume no use of remote control after fallback. Switch to Land mode if a height estimate is available, else switch to TERMINATION.
+};
+
 typedef enum {
 	ARM_REQ_NONE = 0,
 	ARM_REQ_MISSION_BIT = (1 << 0),
@@ -95,7 +100,7 @@ bool set_nav_state(vehicle_status_s *status, actuator_armed_s *armed, commander_
 		   orb_advert_t *mavlink_log_pub, const link_loss_actions_t data_link_loss_act, const bool mission_finished,
 		   const bool stay_in_failsafe, const vehicle_status_flags_s &status_flags, bool landed,
 		   const link_loss_actions_t rc_loss_act, const int offb_loss_act, const int offb_loss_rc_act,
-		   const int posctl_nav_loss_act);
+		   const position_nav_loss_actions_t posctl_nav_loss_act);
 
 /*
  * Checks the validty of position data aaainst the requirements of the current navigation

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -64,8 +64,8 @@ enum class link_loss_actions_t {
 	AUTO_RTL = 2,		// Return mode
 	AUTO_LAND = 3,		// Land mode
 	AUTO_RECOVER = 4,	// Data Link Auto Recovery (CASA Outback Challenge rules)
-	TERMINATE = 5,		// Turn off all controllers and set PWM outputs to failsafe value
-	LOCKDOWN = 6,		// Kill the motors, same result as kill switch
+	TERMINATE = 5,		// Terminate flight (set actuator outputs to failsafe values, and stop controllers)
+	LOCKDOWN = 6,		// Lock actuators (set actuator outputs to disarmed values)
 };
 
 enum class offboard_loss_actions_t {
@@ -73,8 +73,8 @@ enum class offboard_loss_actions_t {
 	AUTO_LAND = 0,		// Land mode
 	AUTO_LOITER = 1,	// Hold mode
 	AUTO_RTL = 2,		// Return mode
-	TERMINATE = 3,		// Turn off all controllers and set PWM outputs to failsafe value
-	LOCKDOWN = 4,		// Kill the motors, same result as kill switch
+	TERMINATE = 3,		// Terminate flight (set actuator outputs to failsafe values, and stop controllers)
+	LOCKDOWN = 4,		// Lock actuators (set actuator outputs to disarmed values)
 };
 
 enum class offboard_loss_rc_actions_t {
@@ -85,8 +85,8 @@ enum class offboard_loss_rc_actions_t {
 	AUTO_RTL = 3, 		// Return mode
 	AUTO_LAND = 4, 		// Land mode
 	AUTO_LOITER = 5, 	// Hold mode
-	TERMINATE = 6, 		// Turn off all controllers and set PWM outputs to failsafe value
-	LOCKDOWN = 7, 		// Kill the motors, same result as kill switch
+	TERMINATE = 6, 		// Terminate flight (set actuator outputs to failsafe values, and stop controllers)
+	LOCKDOWN = 7, 		// Lock actuators (set actuator outputs to disarmed values)
 };
 
 enum class position_nav_loss_actions_t {


### PR DESCRIPTION
Cleanup the handling of offboard loss in Commander:
- add DISABLED, LOCKDOWN and TERMINATE options
- use enums to avoid nested if statements
- move failsafe handling to dedicated functions
- offboard loss timeout: it seems that the timeout was ignored if COM_OBL_ACT or COM_OBL_RC_ACT were set out of range? This is no longer the case.

Other changes in this PR:
- re-enable implicit-fallthrough warning. This is useful to write correct switch blocks.
- move COM_POSCTL_NAVL to px4::params and use enum as well