### PR TITLE
Create mugin_vtol.main.mix

### DIFF
--- a/ROMFS/px4fmu_common/mixers/mugin_vtol.main.mix
+++ b/ROMFS/px4fmu_common/mixers/mugin_vtol.main.mix
@@ -1,0 +1,17 @@
+Mixer for Mugin VTOL with x motor configuration and additional motor controls
+===========================================================
+
+R: 4x 10000 10000 10000 0
+
+# Servo 1
+M: 1
+S: 1 4  0 10000     0 -10000  10000
+
+# Servo 2
+M: 1
+S: 1 5  0  10000    0 -10000  10000
+
+# Servo 3
+M: 1
+S: 1 6  0  10000    0 -10000  10000
+


### PR DESCRIPTION
This is a mixing file for the new proposed air frame of the Mugin VTOL. This is allows Main 1-7 to be used for aircraft control.
