### PR TITLE
Add parameter COM_PREARM_LOCK to lock actuators when prearmed

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2324,6 +2324,16 @@ Commander::run()
 				armed.prearmed = (hrt_elapsed_time(&commander_boot_timestamp) > 5_s);
 			}
 
+			/* Lock all actuator output until armed if the circuit breaker is set */
+			if (_param_com_prearm_lock.get()) {
+				if (armed.prearmed && !armed.armed) {
+					armed.lockdown = true;
+
+				} else {
+					armed.lockdown = false;
+				}
+			}
+
 			armed.timestamp = hrt_absolute_time();
 			_armed_pub.publish(armed);
 

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -139,7 +139,9 @@ private:
 
 		(ParamFloat<px4::params::COM_OF_LOSS_T>) _param_com_of_loss_t,
 		(ParamInt<px4::params::COM_OBL_ACT>) _param_com_obl_act,
-		(ParamInt<px4::params::COM_OBL_RC_ACT>) _param_com_obl_rc_act
+		(ParamInt<px4::params::COM_OBL_RC_ACT>) _param_com_obl_rc_act,
+
+		(ParamInt<px4::params::COM_PREARM_LOCK>) _param_com_prearm_lock
 
 	)
 

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -947,3 +947,14 @@ PARAM_DEFINE_INT32(COM_FLT_PROFILE, 0);
  * @boolean
  */
 PARAM_DEFINE_INT32(COM_ARM_CHK_ESCS, 1);
+
+/**
+ * Lock actuator outputs in pre-armed state
+ *
+ * Setting this parameter will lock all outputs to disarmed position when prearmed, until armed.
+ * Use together with CBRK_IO_SAFETY to prevent all actuator movement when the safety switch is disabled.
+ *
+ * @group Commander
+ * @boolean
+ */
+PARAM_DEFINE_INT32(COM_PREARM_LOCK, 0);


### PR DESCRIPTION
This parameter is meant to prevent any actuator motion when prearmed.

When the system is prearmed (i.e. the safety button is pressed, or the
safety button is disabled with CBRK_IO_SAFETY), non-throttle outputs
are active.
This is visible on platforms where servomotors control flight, like
the flaps on a fixed wing or the yaw servo on a tri-copter. If actuator
motion before arming is undesirable, set this parameter.

fixes #12457 