### PR TITLE
Clarify TRIG_PINS on FMU

### DIFF
--- a/src/drivers/camera_trigger/camera_trigger_params.c
+++ b/src/drivers/camera_trigger/camera_trigger_params.c
@@ -112,9 +112,8 @@ PARAM_DEFINE_INT32(TRIG_MODE, 0);
 /**
  * Camera trigger pin
  *
- * Selects which FMU pin is used, ranges from 1 to 6 (AUX1-AUX6 on Pixhawk controllers
- * with an I/O board, MAIN1-MAIN6 on controllers without an I/O board, and the rail
- * pins on px4_fmu-v4). The PWM interface takes two pins per camera, while relay
+ * Selects which FMU pin is used (range: AUX1-AUX6 on Pixhawk controllers with an I/O board, 
+ * MAIN1-MAIN6 on controllers without an I/O board. The PWM interface takes two pins per camera, while relay
  * triggers on every pin individually. Example: Value 56 would trigger on pins 5 and 6.
  * For GPIO mode Pin 6 will be triggered followed by 5. With a value of 65 pin 5 will
  * be triggered followed by 6. Pins may be non contiguous. I.E. 16 or 61.

--- a/src/drivers/camera_trigger/camera_trigger_params.c
+++ b/src/drivers/camera_trigger/camera_trigger_params.c
@@ -112,7 +112,8 @@ PARAM_DEFINE_INT32(TRIG_MODE, 0);
 /**
  * Camera trigger pin
  *
- * Selects which pin is used, ranges from 1 to 6 (AUX1-AUX6 on px4_fmu-v2 and the rail
+ * Selects which FMU pin is used, ranges from 1 to 6 (AUX1-AUX6 on Pixhawk controllers
+ * with an I/O board, MAIN1-MAIN6 on controllers without an I/O board, and the rail
  * pins on px4_fmu-v4). The PWM interface takes two pins per camera, while relay
  * triggers on every pin individually. Example: Value 56 would trigger on pins 5 and 6.
  * For GPIO mode Pin 6 will be triggered followed by 5. With a value of 65 pin 5 will

--- a/src/drivers/camera_trigger/camera_trigger_params.c
+++ b/src/drivers/camera_trigger/camera_trigger_params.c
@@ -112,7 +112,7 @@ PARAM_DEFINE_INT32(TRIG_MODE, 0);
 /**
  * Camera trigger pin
  *
- * Selects which FMU pin is used (range: AUX1-AUX6 on Pixhawk controllers with an I/O board, 
+ * Selects which FMU pin is used (range: AUX1-AUX6 on Pixhawk controllers with an I/O board,
  * MAIN1-MAIN6 on controllers without an I/O board. The PWM interface takes two pins per camera, while relay
  * triggers on every pin individually. Example: Value 56 would trigger on pins 5 and 6.
  * For GPIO mode Pin 6 will be triggered followed by 5. With a value of 65 pin 5 will


### PR DESCRIPTION
The TRIG_PINS docs refer to AUX, but this driver uses direct pin access to FMU. So on a pixhawk board that has no I/O board it will actually map to MAIN.

This follows on from https://github.com/PX4/Devguide/pull/852#issuecomment-521628887