### PR TITLE
fix typo that was causing build to fail rpi.

### DIFF
--- a/src/drivers/rpi_rc_in/rpi_rc_in.h
+++ b/src/drivers/rpi_rc_in/rpi_rc_in.h
@@ -61,7 +61,7 @@
 
 namespace rpi_rc_in
 {
-class RcInput, public px4::ScheduledWorkItem
+class RcInput : public px4::ScheduledWorkItem
 {
 public:
 	RcInput() : ScheduledWorkItem(px4::wq_configurations::hp_default) {}


### PR DESCRIPTION
Simple typo that was causing build error for Raspberry Pi.
Built successfully with the fix
Thanks
