### PR TITLE
[WIP]: handle gyro filter (IMU_GYRO_CUTOFF) in vehicle_angular_velocity

### DIFF
--- a/msg/sensor_gyro_control.msg
+++ b/msg/sensor_gyro_control.msg
@@ -8,4 +8,4 @@ uint64 timestamp	# time since system start (microseconds)
 
 uint64 timestamp_sample	# time the raw data was sampled (microseconds)
 
-float32[3] xyz		# filtered angular velocity in the board axis in rad/s
+float32[3] xyz		# angular velocity in the board axis in rad/s

--- a/src/drivers/imu/adis16448/ADIS16448.cpp
+++ b/src/drivers/imu/adis16448/ADIS16448.cpp
@@ -260,7 +260,6 @@ ADIS16448::set_sample_rate(uint16_t desired_sample_rate_hz)
 	}
 
 	_px4_accel.set_sample_rate(desired_sample_rate_hz);
-	_px4_gyro.set_sample_rate(desired_sample_rate_hz);
 
 	return true;
 }

--- a/src/drivers/imu/adis16477/ADIS16477.cpp
+++ b/src/drivers/imu/adis16477/ADIS16477.cpp
@@ -72,7 +72,6 @@ ADIS16477::ADIS16477(int bus, uint32_t device, enum Rotation rotation) :
 	_px4_accel.set_scale(1.25f * CONSTANTS_ONE_G / 1000.0f); // accel 1.25 mg/LSB
 
 	_px4_gyro.set_device_type(DRV_GYR_DEVTYPE_ADIS16477);
-	_px4_gyro.set_sample_rate(ADIS16477_DEFAULT_RATE);
 	_px4_gyro.set_scale(math::radians(0.025f)); // gyro 0.025 °/sec/LSB
 }
 

--- a/src/drivers/imu/adis16497/ADIS16497.cpp
+++ b/src/drivers/imu/adis16497/ADIS16497.cpp
@@ -85,7 +85,6 @@ ADIS16497::ADIS16497(int bus, uint32_t device, enum Rotation rotation) :
 	_px4_accel.set_scale(1.25f * CONSTANTS_ONE_G / 1000.0f); // accel 1.25 mg/LSB
 
 	_px4_gyro.set_device_type(DRV_GYR_DEVTYPE_ADIS16497);
-	_px4_gyro.set_sample_rate(ADIS16497_DEFAULT_RATE);
 	_px4_gyro.set_scale(math::radians(0.025f)); // gyro 0.025 °/sec/LSB
 }
 

--- a/src/drivers/imu/fxas21002c/FXAS21002C.cpp
+++ b/src/drivers/imu/fxas21002c/FXAS21002C.cpp
@@ -432,8 +432,6 @@ FXAS21002C::set_samplerate(unsigned frequency)
 	modify_reg(FXAS21002C_CTRL_REG1, CTRL_REG1_DR_MASK, bits);
 	set_standby(_current_rate, false);
 
-	_px4_gyro.set_sample_rate(_current_rate);
-
 	return OK;
 }
 

--- a/src/lib/perf/perf_counter.cpp
+++ b/src/lib/perf/perf_counter.cpp
@@ -571,6 +571,31 @@ perf_event_count(perf_counter_t handle)
 	return 0;
 }
 
+float
+perf_mean(perf_counter_t handle)
+{
+	if (handle == nullptr) {
+		return 0;
+	}
+
+	switch (handle->type) {
+	case PC_ELAPSED: {
+			struct perf_ctr_elapsed *pce = (struct perf_ctr_elapsed *)handle;
+			return pce->mean;
+		}
+
+	case PC_INTERVAL: {
+			struct perf_ctr_interval *pci = (struct perf_ctr_interval *)handle;
+			return pci->mean;
+		}
+
+	default:
+		break;
+	}
+
+	return 0.0f;
+}
+
 void
 perf_iterate_all(perf_callback cb, void *user)
 {

--- a/src/lib/perf/perf_counter.h
+++ b/src/lib/perf/perf_counter.h
@@ -228,6 +228,14 @@ __EXPORT extern void		perf_reset_all(void);
  */
 __EXPORT extern uint64_t	perf_event_count(perf_counter_t handle);
 
+/**
+ * Return current mean
+ *
+ * @param handle		The handle returned from perf_alloc.
+ * @param return		mean
+ */
+__EXPORT extern float		perf_mean(perf_counter_t handle);
+
 __END_DECLS
 
 #endif

--- a/src/modules/sensors/CMakeLists.txt
+++ b/src/modules/sensors/CMakeLists.txt
@@ -54,6 +54,6 @@ px4_add_module(
 		git_ecl
 		ecl_validation
 		mathlib
-		sensors__vehicle_acceleration
-		sensors__vehicle_angular_velocity
+		vehicle_acceleration
+		vehicle_angular_velocity
 	)

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -208,21 +208,6 @@ PARAM_DEFINE_FLOAT(SENS_BOARD_Z_OFF, 0.0f);
 PARAM_DEFINE_INT32(SENS_EN_THERMAL, -1);
 
 /**
-* Driver level cutoff frequency for gyro
-*
-* The cutoff frequency for the 2nd order butterworth filter on the gyro driver. This features
-* is currently supported by the mpu6000 and mpu9250. This only affects the signal sent to the
-* controllers, not the estimators. 0 disables the filter.
-*
-* @min 0
-* @max 1000
-* @unit Hz
-* @reboot_required true
-* @group Sensors
-*/
-PARAM_DEFINE_FLOAT(IMU_GYRO_CUTOFF, 30.0f);
-
-/**
 * Driver level cutoff frequency for accel
 *
 * The cutoff frequency for the 2nd order butterworth filter on the accel driver. This features

--- a/src/modules/sensors/vehicle_acceleration/CMakeLists.txt
+++ b/src/modules/sensors/vehicle_acceleration/CMakeLists.txt
@@ -31,7 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(sensors__vehicle_acceleration
+px4_add_library(vehicle_acceleration
 	VehicleAcceleration.cpp
 )
-target_link_libraries(sensors__vehicle_acceleration PRIVATE px4_work_queue)
+target_link_libraries(vehicle_acceleration PRIVATE px4_work_queue)

--- a/src/modules/sensors/vehicle_angular_velocity/CMakeLists.txt
+++ b/src/modules/sensors/vehicle_angular_velocity/CMakeLists.txt
@@ -31,7 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(sensors__vehicle_angular_velocity
+px4_add_library(vehicle_angular_velocity
 	VehicleAngularVelocity.cpp
 )
-target_link_libraries(sensors__vehicle_angular_velocity PRIVATE px4_work_queue)
+target_link_libraries(vehicle_angular_velocity PRIVATE px4_work_queue)

--- a/src/modules/sensors/vehicle_angular_velocity/parameters.c
+++ b/src/modules/sensors/vehicle_angular_velocity/parameters.c
@@ -34,14 +34,13 @@
 /**
 * Driver level cutoff frequency for gyro
 *
-* The cutoff frequency for the 2nd order butterworth filter on the gyro driver. This features
-* is currently supported by the mpu6000 and mpu9250. This only affects the signal sent to the
-* controllers, not the estimators. 0 disables the filter.
+* The cutoff frequency for the 2nd order butterworth filter on the gyro driver.
+* This only affects the signal sent to the controllers, not the estimators.
+* 0 disables the filter.
 *
 * @min 0
 * @max 1000
 * @unit Hz
-* @reboot_required true
 * @group Sensors
 */
 PARAM_DEFINE_FLOAT(IMU_GYRO_CUTOFF, 30.0f);

--- a/src/modules/sensors/vehicle_angular_velocity/parameters.c
+++ b/src/modules/sensors/vehicle_angular_velocity/parameters.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,48 +31,17 @@
  *
  ****************************************************************************/
 
-#pragma once
-
-#include <drivers/device/integrator.h>
-#include <drivers/drv_gyro.h>
-#include <drivers/drv_hrt.h>
-#include <lib/cdev/CDev.hpp>
-#include <lib/conversion/rotation.h>
-#include <uORB/uORB.h>
-#include <uORB/PublicationMulti.hpp>
-#include <uORB/topics/sensor_gyro.h>
-#include <uORB/topics/sensor_gyro_control.h>
-
-class PX4Gyroscope : public cdev::CDev
-{
-
-public:
-	PX4Gyroscope(uint32_t device_id, uint8_t priority = ORB_PRIO_DEFAULT, enum Rotation rotation = ROTATION_NONE);
-	~PX4Gyroscope() override;
-
-	int	ioctl(cdev::file_t *filp, int cmd, unsigned long arg) override;
-
-	void set_device_type(uint8_t devtype);
-	void set_error_count(uint64_t error_count) { _sensor_gyro_pub.get().error_count = error_count; }
-	void set_scale(float scale) { _sensor_gyro_pub.get().scaling = scale; }
-	void set_temperature(float temperature) { _sensor_gyro_pub.get().temperature = temperature; }
-
-	void update(hrt_abstime timestamp, float x, float y, float z);
-
-	void print_status();
-
-private:
-
-	uORB::PublicationMultiData<sensor_gyro_s>		_sensor_gyro_pub;
-	uORB::PublicationMultiData<sensor_gyro_control_s>	_sensor_gyro_control_pub;
-
-	Integrator _integrator{4000, true};
-
-	const enum Rotation	_rotation;
-
-	matrix::Vector3f	_calibration_scale{1.0f, 1.0f, 1.0f};
-	matrix::Vector3f	_calibration_offset{0.0f, 0.0f, 0.0f};
-
-	int			_class_device_instance{-1};
-
-};
+/**
+* Driver level cutoff frequency for gyro
+*
+* The cutoff frequency for the 2nd order butterworth filter on the gyro driver. This features
+* is currently supported by the mpu6000 and mpu9250. This only affects the signal sent to the
+* controllers, not the estimators. 0 disables the filter.
+*
+* @min 0
+* @max 1000
+* @unit Hz
+* @reboot_required true
+* @group Sensors
+*/
+PARAM_DEFINE_FLOAT(IMU_GYRO_CUTOFF, 30.0f);

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -186,7 +186,6 @@ private:
 		_battery_status.timestamp = hrt_absolute_time();
 
 		_px4_accel.set_sample_rate(250);
-		_px4_gyro.set_sample_rate(250);
 	}
 
 	~Simulator()


### PR DESCRIPTION
Saves a small amount of cpu by only filtering the primary gyro instead of every single sensor, plus some sensors weren't setting the update data properly.