### PR TITLE
add .gitattributes to force all line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf


### PR DESCRIPTION
Forcing the line endings to LF makes for a slightly saner windows development story.

VSCode on Windows with the new WSL remove extensio works really well. https://code.visualstudio.com/docs/remote/wsl

Using regular Windows VSCode, windows Github, etc. The actual build environment and terminal are within WSL (Ubuntu).

![2019-08-18](https://user-images.githubusercontent.com/84712/63228111-e4e90680-c1bc-11e9-94c8-cc9e41142c23.png)

![2019-08-18 (2)](https://user-images.githubusercontent.com/84712/63228112-e87c8d80-c1bc-11e9-9d2b-ecf0e7b5db9f.png)


FYI @MaEtUgR @hamishwillee 
