### PR TITLE
now checks if board has "px4-io" in its name instead of just "io"

### DIFF
--- a/src/drivers/boards/common/CMakeLists.txt
+++ b/src/drivers/boards/common/CMakeLists.txt
@@ -32,7 +32,7 @@
 ############################################################################
 
 # common board drivers (currently only for nuttx fmu boards)
-if ((${PX4_PLATFORM} MATCHES "nuttx") AND NOT ${PX4_BOARD} MATCHES "io")
+if ((${PX4_PLATFORM} MATCHES "nuttx") AND NOT ${PX4_BOARD} MATCHES "px4_io")
 
 	add_library(drivers_boards_common
 		board_crashdump.c


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
boards that their name contains "io" in it will be treated as fmu-io boards, even though that's not the intention.

**Describe your preferred solution**
I added the prefix of "px4-" to isolate the check to only px4-io boards as intended.
