### PR TITLE
don't allow moving outside FOV

### DIFF
--- a/src/lib/CollisionPrevention/CollisionPrevention.cpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.cpp
@@ -218,7 +218,6 @@ void CollisionPrevention::_calculateConstrainedSetpoint(Vector2f &setpoint,
 			int distances_array_size = sizeof(obstacle.distances) / sizeof(obstacle.distances[0]);
 			float min_dist_to_keep = math::max(obstacle.min_distance / 100.0f, col_prev_d);
 
-
 			for (int i = 0; i < distances_array_size; i++) {
 
 				if ((float)i * obstacle.increment < 360.f) { //disregard unused bins at the end of the message
@@ -253,7 +252,7 @@ void CollisionPrevention::_calculateConstrainedSetpoint(Vector2f &setpoint,
 
 					} else if (obstacle.distances[i] == UINT16_MAX) {
 						float sp_bin = setpoint_dir.dot(bin_direction);
-						float ang_half_bin = abs(cosf(obstacle.increment / 2.f));
+						float ang_half_bin = cosf(math::radians(obstacle.increment) / 2.f);
 
 						//if the setpoint lies outside the FOV set velocity to zero
 						if (sp_bin > 0 && sp_bin > ang_half_bin) {

--- a/src/lib/CollisionPrevention/CollisionPrevention.cpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.cpp
@@ -212,37 +212,55 @@ void CollisionPrevention::_calculateConstrainedSetpoint(Vector2f &setpoint,
 			Vector2f setpoint_dir = setpoint / setpoint_length;
 			float vel_max = setpoint_length;
 			int distances_array_size = sizeof(obstacle.distances) / sizeof(obstacle.distances[0]);
+			float min_dist_to_keep = math::max(obstacle.min_distance / 100.0f, _param_mpc_col_prev_d.get());
+
 
 			for (int i = 0; i < distances_array_size; i++) {
 
-				if (obstacle.distances[i] < obstacle.max_distance &&
-				    obstacle.distances[i] > obstacle.min_distance && (float)i * obstacle.increment < 360.f) {
-					float distance = obstacle.distances[i] / 100.0f; //convert to meters
-					float angle = math::radians((float)i * obstacle.increment);
+				if ((float)i * obstacle.increment < 360.f) { //disregard unused bins at the end of the message
 
-					if (obstacle.angle_offset > 0.f) {
-						angle += math::radians(obstacle.angle_offset);
-					}
+					float angle = math::radians((float)i * obstacle.increment);
+					float distance = obstacle.distances[i] / 100.0f; //convert to meters
 
 					//check if the bin must be considered regarding the given stick input
 					Vector2f bin_direction = {cos(angle), sin(angle)};
 
-					if (setpoint_dir.dot(bin_direction) > 0
-					    && setpoint_dir.dot(bin_direction) > cosf(math::radians(_param_mpc_col_prev_ang.get()))) {
-						//calculate max allowed velocity with a P-controller (same gain as in the position controller)
-						float curr_vel_parallel = math::max(0.f, curr_vel.dot(bin_direction));
-						float delay_distance = curr_vel_parallel * _param_mpc_col_prev_dly.get();
-						float vel_max_posctrl = math::max(0.f,
-										  _param_mpc_xy_p.get() * (distance - _param_mpc_col_prev_d.get() - delay_distance));
-						Vector2f  vel_max_vec = bin_direction * vel_max_posctrl;
-						float vel_max_bin = vel_max_vec.dot(setpoint_dir);
+					if (obstacle.distances[i] < obstacle.max_distance &&
+					    obstacle.distances[i] > obstacle.min_distance && (float)i * obstacle.increment < 360.f) {
 
-						//constrain the velocity
-						if (vel_max_bin >= 0) {
-							vel_max = math::min(vel_max, vel_max_bin);
+						if (obstacle.angle_offset > 0.f) {
+							angle += math::radians(obstacle.angle_offset);
 						}
+
+						if (setpoint_dir.dot(bin_direction) > 0
+						    && setpoint_dir.dot(bin_direction) > cosf(math::radians(_param_mpc_col_prev_ang.get()))) {
+							//calculate max allowed velocity with a P-controller (same gain as in the position controller)
+							float curr_vel_parallel = math::max(0.f, curr_vel.dot(bin_direction));
+							float delay_distance = curr_vel_parallel * _param_mpc_col_prev_dly.get();
+							float vel_max_posctrl = math::max(0.f,
+											  _param_mpc_xy_p.get() * (distance - min_dist_to_keep - delay_distance));
+							Vector2f  vel_max_vec = bin_direction * vel_max_posctrl;
+							float vel_max_bin = vel_max_vec.dot(setpoint_dir);
+
+							//constrain the velocity
+							if (vel_max_bin >= 0) {
+								vel_max = math::min(vel_max, vel_max_bin);
+							}
+						}
+
+					} else if (obstacle.distances[i] == UINT16_MAX) {
+						float sp_bin = setpoint_dir.dot(bin_direction);
+						float ang_half_bin = abs(cosf(obstacle.increment / 2.f));
+
+						//if the setpoint lies outside the FOV set velocity to zero
+						if (sp_bin > 0 && sp_bin > ang_half_bin) {
+							vel_max = 0.f;
+						}
+
 					}
 				}
+
+
 			}
 
 			setpoint = setpoint_dir * vel_max;

--- a/src/lib/CollisionPrevention/CollisionPrevention.cpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.cpp
@@ -255,7 +255,7 @@ void CollisionPrevention::_calculateConstrainedSetpoint(Vector2f &setpoint,
 						float ang_half_bin = cosf(math::radians(obstacle.increment) / 2.f);
 
 						//if the setpoint lies outside the FOV set velocity to zero
-						if (sp_bin > 0 && sp_bin > ang_half_bin) {
+						if (sp_bin > ang_half_bin) {
 							vel_max = 0.f;
 						}
 

--- a/src/lib/CollisionPrevention/CollisionPrevention.cpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.cpp
@@ -222,18 +222,18 @@ void CollisionPrevention::_calculateConstrainedSetpoint(Vector2f &setpoint,
 
 				if ((float)i * obstacle.increment < 360.f) { //disregard unused bins at the end of the message
 
-					float angle = math::radians((float)i * obstacle.increment);
 					float distance = obstacle.distances[i] / 100.0f; //convert to meters
+					float angle = math::radians((float)i * obstacle.increment);
 
-					//check if the bin must be considered regarding the given stick input
+					if (obstacle.angle_offset > 0.f) {
+						angle += math::radians(obstacle.angle_offset);
+					}
+
+					//get direction of current bin
 					Vector2f bin_direction = {cos(angle), sin(angle)};
 
 					if (obstacle.distances[i] < obstacle.max_distance &&
 					    obstacle.distances[i] > obstacle.min_distance && (float)i * obstacle.increment < 360.f) {
-
-						if (obstacle.angle_offset > 0.f) {
-							angle += math::radians(obstacle.angle_offset);
-						}
 
 						if (setpoint_dir.dot(bin_direction) > 0
 						    && setpoint_dir.dot(bin_direction) > cosf(col_prev_ang_rad)) {
@@ -261,8 +261,6 @@ void CollisionPrevention::_calculateConstrainedSetpoint(Vector2f &setpoint,
 
 					}
 				}
-
-
 			}
 
 			setpoint = setpoint_dir * vel_max;

--- a/src/lib/CollisionPrevention/CollisionPreventionTest.cpp
+++ b/src/lib/CollisionPrevention/CollisionPreventionTest.cpp
@@ -233,7 +233,7 @@ TEST_F(CollisionPreventionTest, outsideFOV)
 
 		} else {
 			// THEN: outside the FOV the setpoint should be clamped to zero
-			EXPECT_EQ(modified_setpoint.norm(), 0.f);
+			EXPECT_FLOAT_EQ(modified_setpoint.norm(), 0.f);
 		}
 
 	}

--- a/src/lib/CollisionPrevention/CollisionPreventionTest.cpp
+++ b/src/lib/CollisionPrevention/CollisionPreventionTest.cpp
@@ -182,3 +182,62 @@ TEST_F(CollisionPreventionTest, noBias)
 	EXPECT_FLOAT_EQ(original_setpoint.normalized()(0), modified_setpoint.normalized()(0));
 	EXPECT_FLOAT_EQ(original_setpoint.normalized()(1), modified_setpoint.normalized()(1));
 }
+
+TEST_F(CollisionPreventionTest, outsideFOV)
+{
+	// GIVEN: a simple setup condition
+	TestCollisionPrevention cp;
+	float max_speed = 3;
+	matrix::Vector2f curr_pos(0, 0);
+	matrix::Vector2f curr_vel(2, 0);
+
+	// AND: a parameter handle
+	param_t param = param_handle(px4::params::MPC_COL_PREV_D);
+	float value = 5; // try to keep 5m distance
+	param_set(param, &value);
+	cp.paramsChanged();
+
+	// AND: an obstacle message
+	obstacle_distance_s message;
+	memset(&message, 0xDEAD, sizeof(message));
+	message.min_distance = 100;
+	message.max_distance = 2000;
+	int distances_array_size = sizeof(message.distances) / sizeof(message.distances[0]);
+	message.increment = 360 / distances_array_size;
+
+	//fov from i = 1/4 * distances_array_size to i = 3/4 * distances_array_size
+	for (int i = 0; i < distances_array_size; i++) {
+		if (i > 0.25f * distances_array_size && i < 0.75f * distances_array_size) {
+			message.distances[i] = 700;
+
+		} else {
+			message.distances[i] = UINT16_MAX;
+		}
+	}
+
+	// WHEN: we publish the message and modify the setpoint for different demanded setpoints
+	orb_advert_t obstacle_distance_pub = orb_advertise(ORB_ID(obstacle_distance), &message);
+
+	for (int i = 0; i < distances_array_size; i++) {
+
+		float angle = math::radians((float)i * message.increment);
+		matrix::Vector2f original_setpoint = {10.f *(float)cos(angle), 10.f *(float)sin(angle)};
+		matrix::Vector2f modified_setpoint = original_setpoint;
+		message.timestamp = hrt_absolute_time();
+		orb_publish(ORB_ID(obstacle_distance), obstacle_distance_pub, &message);
+		cp.modifySetpoint(modified_setpoint, max_speed, curr_pos, curr_vel);
+
+		if (i > 0.25f * distances_array_size && i < 0.75f * distances_array_size) {
+			// THEN: inside the FOV the setpoint should be limited
+			EXPECT_GT(modified_setpoint.norm(), 0.f);
+			EXPECT_LT(modified_setpoint.norm(), 10.f);
+
+		} else {
+			// THEN: outside the FOV the setpoint should be clamped to zero
+			EXPECT_EQ(modified_setpoint.norm(), 0.f);
+		}
+
+	}
+
+	orb_unadvertise(obstacle_distance_pub);
+}

--- a/src/lib/CollisionPrevention/CollisionPreventionTest.cpp
+++ b/src/lib/CollisionPrevention/CollisionPreventionTest.cpp
@@ -131,10 +131,9 @@ TEST_F(CollisionPreventionTest, testBehaviorOnWithAnObstacle)
 		message.distances[i] = 101;
 	}
 
-	orb_advert_t obstacle_distance_pub = orb_advertise(ORB_ID(obstacle_distance), &message);
-
-
 	// WHEN: we publish the message and set the parameter and then run the setpoint modification
+	orb_advert_t obstacle_distance_pub = orb_advertise(ORB_ID(obstacle_distance), &message);
+	orb_publish(ORB_ID(obstacle_distance), obstacle_distance_pub, &message);
 	matrix::Vector2f modified_setpoint = original_setpoint;
 	cp.modifySetpoint(modified_setpoint, max_speed, curr_pos, curr_vel);
 	orb_unadvertise(obstacle_distance_pub);
@@ -171,9 +170,9 @@ TEST_F(CollisionPreventionTest, noBias)
 		message.distances[i] = 700;
 	}
 
-	orb_advert_t obstacle_distance_pub = orb_advertise(ORB_ID(obstacle_distance), &message);
-
 	// WHEN: we publish the message and set the parameter and then run the setpoint modification
+	orb_advert_t obstacle_distance_pub = orb_advertise(ORB_ID(obstacle_distance), &message);
+	orb_publish(ORB_ID(obstacle_distance), obstacle_distance_pub, &message);
 	matrix::Vector2f modified_setpoint = original_setpoint;
 	cp.modifySetpoint(modified_setpoint, max_speed, curr_pos, curr_vel);
 	orb_unadvertise(obstacle_distance_pub);

--- a/src/lib/CollisionPrevention/CollisionPreventionTest.cpp
+++ b/src/lib/CollisionPrevention/CollisionPreventionTest.cpp
@@ -131,8 +131,7 @@ TEST_F(CollisionPreventionTest, testBehaviorOnWithAnObstacle)
 	orb_unadvertise(obstacle_distance_pub);
 
 	// THEN: it should be cut down to zero
-	EXPECT_EQ(0.f, modified_setpoint.x());
-	EXPECT_EQ(0.f, modified_setpoint.y());
+	EXPECT_FLOAT_EQ(0.f, modified_setpoint.norm());
 }
 
 TEST_F(CollisionPreventionTest, noBias)
@@ -171,5 +170,6 @@ TEST_F(CollisionPreventionTest, noBias)
 	orb_unadvertise(obstacle_distance_pub);
 
 	// THEN: setpoint should go into the same direction as the stick input
-	EXPECT_EQ(original_setpoint.normalized(), modified_setpoint.normalized());
+	EXPECT_FLOAT_EQ(original_setpoint.normalized()(0), modified_setpoint.normalized()(0));
+	EXPECT_FLOAT_EQ(original_setpoint.normalized()(1), modified_setpoint.normalized()(1));
 }


### PR DESCRIPTION
This PR makes sure unknown data in the range scan (UINT16_MAX) is treated as blocking. So far there was no speed limit outside the FOV, so the drone could crash whenever the demanded movement direction was outside the FOV. NOw the drone will not move anywhere where there is no sensor data
