### PR TITLE
Added better logic to encode NAN as INT16_MAX to transfer to IO from FMU

### DIFF
--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1305,13 +1305,13 @@ PX4IO::io_set_control_state(unsigned group)
 		/* ensure FLOAT_TO_REG does not produce an integer overflow */
 		const float ctrl = math::constrain(controls.control[i], -1.0f, 1.0f);
 
-		if (!isfinite(ctrl)) {
+		if (isnan(ctrl)) {
+			//Encode NAN as INT16_MAX for disarm passthrough
 			regs[i] = INT16_MAX;
 
 		} else {
 			regs[i] = FLOAT_TO_REG(ctrl);
 		}
-
 
 	}
 


### PR DESCRIPTION
A follow up on PR https://github.com/PX4/Firmware/pull/12743.

Changed logic to isnan() from !isfinite() to prevent INF or -INF getting encoded as NAN to the PX4IO.