### PR TITLE
VTOL: set RTL_TYPE default for VTOL to 1

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
@@ -26,6 +26,7 @@ then
 	param set PWM_RATE 400
 
 	param set RTL_LAND_DELAY 0
+	param set RTL_TYPE 1
 
 	param set WV_EN 1
 fi


### PR DESCRIPTION
As discussed in https://github.com/PX4/Firmware/pull/12464, if makes sense to use a mission landing pattern in VTOL mode (if available) for a RTL approach. 

This PR sets the RTL_TYPE to 1 for VTOLs, which enables that ("Return to a planned mission landing, if available, via direct path, else return to home via direct path").
