### PR TITLE
update babyshark VTOl config

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
+++ b/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
@@ -28,7 +28,6 @@ then
 	param set FW_AIRSPD_MAX   30
 	param set FW_AIRSPD_MIN   19
 	param set FW_AIRSPD_TRIM  23
-	param set FW_CLMBOUT_DIFF 0.1
 	param set FW_L1_R_SLEW_MAX 40
 	param set FW_LND_EARLYCFG 1
 	param set FW_MAN_P_MAX	30
@@ -63,8 +62,7 @@ then
 	param set MC_YAWRATE_MAX 40
 	param set MC_YAWRATE_P 0.3
 
-	param set MIS_TAKEOFF_ALT	20
-	param set MIS_YAW_TMT	10
+	param set MIS_TAKEOFF_ALT	30
 
 	param set MPC_ACC_DOWN_MAX	2
 	param set MPC_ACC_HOR_MAX	2
@@ -75,10 +73,10 @@ then
 	param set MPC_MAN_TILT_MAX 25
 	param set MPC_MAN_Y_MAX 40
 	param set MPC_POS_MODE 3
-	param set MPC_SPOOLUP_TIME 2
+	param set MPC_SPOOLUP_TIME 1.5
 	param set MPC_THR_HOVER 0.45
 	param set MPC_TILTMAX_AIR 25
-	param set MPC_TKO_RAMP_T 3
+	param set MPC_TKO_RAMP_T 1.8
 	param set MPC_TKO_SPEED	1
 	param set MPC_VEL_MANUAL 3
 	param set MPC_XY_CRUISE 3
@@ -97,6 +95,7 @@ then
 
 	param set VT_ARSP_BLEND 10
 	param set VT_ARSP_TRANS 21
+	param set VT_B_DEC_MSS 1.5
 	param set VT_B_TRANS_DUR 12
 	param set VT_ELEV_MC_LOCK 0
 	param set VT_FWD_THRUST_SC 1.2


### PR DESCRIPTION
some parameter changes in the babyshark VTOL config:

-remove FW_CLMBOUT_DIFF from config as default value is fine
-increase MIS_TAKEOFF_ALT to 30 to account for big vehicle size
-remove MIS_YAW_TMT as already set in vtol_defaults
-reduce MPC_TKO_RAMP_T to 1.8 to have faster and more level takeoff
-reduce MPC_SPOOLUP_TIME to 1.5
