### PR TITLE
LidarLite driver fix 

### DIFF
--- a/src/drivers/distance_sensor/ll40ls/LidarLite.cpp
+++ b/src/drivers/distance_sensor/ll40ls/LidarLite.cpp
@@ -45,7 +45,7 @@ LidarLite::LidarLite(uint8_t rotation) :
 	_px4_rangefinder(0 /* device id not yet used */, ORB_PRIO_DEFAULT, rotation)
 {
 	_px4_rangefinder.set_min_distance(LL40LS_MIN_DISTANCE);
-	_px4_rangefinder.set_max_distance(LL40LS_MAX_DISTANCE_V3);
+	_px4_rangefinder.set_max_distance(LL40LS_MAX_DISTANCE);
 	_px4_rangefinder.set_fov(0.008); // Divergence 8 mRadian
 }
 

--- a/src/drivers/distance_sensor/ll40ls/LidarLite.h
+++ b/src/drivers/distance_sensor/ll40ls/LidarLite.h
@@ -46,8 +46,8 @@
 
 /* Device limits */
 #define LL40LS_MIN_DISTANCE (0.05f)
-#define LL40LS_MAX_DISTANCE_V3 (35.00f)
-#define LL40LS_MAX_DISTANCE_V1 (25.00f)
+#define LL40LS_MAX_DISTANCE (35.00f)
+
 
 // normal conversion wait time
 #define LL40LS_CONVERSION_INTERVAL 50*1000UL /* 50ms */

--- a/src/drivers/distance_sensor/ll40ls/LidarLite.h
+++ b/src/drivers/distance_sensor/ll40ls/LidarLite.h
@@ -46,7 +46,8 @@
 
 /* Device limits */
 #define LL40LS_MIN_DISTANCE (0.05f)
-#define LL40LS_MAX_DISTANCE (35.00f)
+#define LL40LS_MAX_DISTANCE (25.00f)
+#define LL40LS_MAX_DISTANCE_V2 (35.00f)
 
 
 // normal conversion wait time

--- a/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.cpp
+++ b/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.cpp
@@ -131,8 +131,8 @@ LidarLiteI2C::probe()
 		/*
 		The probing is divided in two cases. One to detect v1, v2 and v3 and one to
 		detect v3HP. The reason for this is that registers are not consistent
-		between different versions. The v3HP doesn't have the HW and SW VERSION
-		registers while v1, v2 and some v3 don't have the unit id register.
+		between different versions. The v3HP doesn't have the HW VERSION (or at least no version is specified)
+		while v1, v2 and some v3 don't have the unit id register.
 		It would be better if we had a proper WHOAMI register.
 		*/
 
@@ -142,8 +142,7 @@ LidarLiteI2C::probe()
 		 */
 		if ((read_reg(LL40LS_HW_VERSION, _hw_version) == OK && _hw_version) > 0 &&
 		    (read_reg(LL40LS_SW_VERSION, _sw_version) == OK && _sw_version > 0)) {
-			_px4_rangefinder.set_max_distance(LL40LS_MAX_DISTANCE_V1);
-			printf("probe success - hw: %u, sw:%u\n", _hw_version, _sw_version);
+			PX4_INFO("probe success - hw: %u, sw:%u", _hw_version, _sw_version);
 			_retries = 3;
 			return reset_sensor();
 		}
@@ -154,12 +153,13 @@ LidarLiteI2C::probe()
 		if (read_reg(LL40LS_UNIT_ID_HIGH, id_high) == OK &&
 		    read_reg(LL40LS_UNIT_ID_LOW, id_low) == OK) {
 			_unit_id = (uint16_t)((id_high << 8) | id_low) & 0xFFFF;
-			printf("probe success - id: %u\n", _unit_id);
+			_is_V3hp = true;
+			PX4_INFO("probe success - id: %u", _unit_id);
 			_retries = 3;
 			return reset_sensor();
 		}
 
-		PX4_DEBUG("probe failed unit_id=0x%02x hw_version=0x%02x sw_version=0x%02x\n",
+		PX4_DEBUG("probe failed unit_id=0x%02x hw_version=0x%02x sw_version=0x%02x",
 			  (unsigned)_unit_id,
 			  (unsigned)_hw_version,
 			  (unsigned)_sw_version);
@@ -233,7 +233,7 @@ LidarLiteI2C::reset_sensor()
 		ret = read_reg(LL40LS_SIG_COUNT_VAL_REG, sig_cnt);
 
 		if ((ret != OK) || (sig_cnt != LL40LS_SIG_COUNT_VAL_DEFAULT)) {
-			printf("Error: ll40ls reset failure. Exiting!\n");
+			PX4_INFO("Error: ll40ls reset failure. Exiting!\n");
 			return ret;
 
 		}
@@ -377,49 +377,65 @@ int LidarLiteI2C::collect()
 
 	uint8_t ll40ls_signal_strength = val[0];
 
+	uint8_t signal_min = 0;
+	uint8_t signal_max = 0;
+	uint8_t signal_value = 0;
 
-	/* Absolute peak strength measurement, i.e. absolute strength of main signal peak*/
-	uint8_t peak_strength_reg = LL40LS_PEAK_STRENGTH_REG;
-	ret = lidar_transfer(&peak_strength_reg, 1, &val[0], 1);
+	// We detect if V3HP is being used
+	if (_is_V3hp) {
+		signal_min = LL40LS_SIGNAL_STRENGH_MIN_V3HP;
+		signal_max = LL40LS_SIGNAL_STRENGH_MAX_V3HP;
+		signal_value = ll40ls_signal_strength;
 
-	// check if the transfer failed
-	if (ret < 0) {
-		if (hrt_elapsed_time(&_acquire_time_usec) > LL40LS_CONVERSION_TIMEOUT) {
-			/*
-			  NACKs from the sensor are expected when we
-			  read before it is ready, so only consider it
-			  an error if more than 100ms has elapsed.
-			 */
-			PX4_INFO("peak strenght read failed");
+	} else {
+		/* Absolute peak strength measurement, i.e. absolute strength of main signal peak*/
+		uint8_t peak_strength_reg = LL40LS_PEAK_STRENGTH_REG;
+		ret = lidar_transfer(&peak_strength_reg, 1, &val[0], 1);
 
-			DEVICE_DEBUG("error reading peak strength from sensor: %d", ret);
-			perf_count(_comms_errors);
+		// check if the transfer failed
+		if (ret < 0) {
+			if (hrt_elapsed_time(&_acquire_time_usec) > LL40LS_CONVERSION_TIMEOUT) {
+				/*
+				NACKs from the sensor are expected when we
+				read before it is ready, so only consider it
+				an error if more than 100ms has elapsed.
+				*/
+				PX4_INFO("peak strenght read failed");
 
-			if (perf_event_count(_comms_errors) % 10 == 0) {
-				perf_count(_sensor_resets);
-				reset_sensor();
+				DEVICE_DEBUG("error reading peak strength from sensor: %d", ret);
+				perf_count(_comms_errors);
+
+				if (perf_event_count(_comms_errors) % 10 == 0) {
+					perf_count(_sensor_resets);
+					reset_sensor();
+				}
 			}
+
+			perf_end(_sample_perf);
+			// if we are getting lots of I2C transfer errors try
+			// resetting the sensor
+			return ret;
 		}
 
-		perf_end(_sample_perf);
-		// if we are getting lots of I2C transfer errors try
-		// resetting the sensor
-		return ret;
-	}
+		uint8_t ll40ls_peak_strength = val[0];
+		signal_min = LL40LS_PEAK_STRENGTH_LOW;
+		signal_max = LL40LS_PEAK_STRENGTH_HIGH;
 
-	uint8_t ll40ls_peak_strength = val[0];
+		// For v2 and v3 use ll40ls_signal_strength (a relative measure, i.e. peak strength to noise!) to reject potentially ambiguous measurements
+		if (ll40ls_signal_strength <= LL40LS_SIGNAL_STRENGTH_LOW) {
+			signal_value = 0;
+
+		} else {
+			signal_value = ll40ls_peak_strength;
+		}
+
+	}
 
 	/* Final data quality evaluation. This is based on the datasheet and simple heuristics retrieved from experiments*/
 	// Step 1: Normalize signal strength to 0...100 percent using the absolute signal peak strength.
-	uint8_t signal_quality = 100 * math::max(ll40ls_peak_strength - LL40LS_PEAK_STRENGTH_LOW,
-				 0) / (LL40LS_PEAK_STRENGTH_HIGH - LL40LS_PEAK_STRENGTH_LOW);
+	uint8_t signal_quality = 100 * math::max(signal_value - signal_min, 0) / (signal_max - signal_min);
 
-	// Step 2: Also use ll40ls_signal_strength (a relative measure, i.e. peak strength to noise!) to reject potentially ambiguous measurements
-	if (ll40ls_signal_strength <= LL40LS_SIGNAL_STRENGTH_LOW) {
-		signal_quality = 0;
-	}
-
-	// Step 3: Filter physically impossible measurements, which removes some crazy outliers that appear on LL40LS.
+	// Step 2: Filter physically impossible measurements, which removes some crazy outliers that appear on LL40LS.
 	if (distance_m < LL40LS_MIN_DISTANCE) {
 		signal_quality = 0;
 	}

--- a/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.cpp
+++ b/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.cpp
@@ -212,10 +212,31 @@ LidarLiteI2C::measure()
 int
 LidarLiteI2C::reset_sensor()
 {
-	int ret = write_reg(LL40LS_MEASURE_REG, LL40LS_MSRREG_RESET);
+	int ret;
+
+	px4_usleep(15000);
+
+	ret = write_reg(LL40LS_SIG_COUNT_VAL_REG, LL40LS_SIG_COUNT_VAL_MAX);
 
 	if (ret != OK) {
 		return ret;
+	}
+
+	px4_usleep(15000);
+	ret = write_reg(LL40LS_MEASURE_REG, LL40LS_MSRREG_RESET);
+
+
+	if (ret != OK) {
+		uint8_t sig_cnt;
+
+		px4_usleep(15000);
+		ret = read_reg(LL40LS_SIG_COUNT_VAL_REG, sig_cnt);
+
+		if ((ret != OK) || (sig_cnt != LL40LS_SIG_COUNT_VAL_DEFAULT)) {
+			printf("Error: ll40ls reset failure. Exiting!\n");
+			return ret;
+
+		}
 	}
 
 	// wait for sensor reset to complete

--- a/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.cpp
+++ b/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.cpp
@@ -128,17 +128,17 @@ LidarLiteI2C::probe()
 
 		set_device_address(addresses[i]);
 
-		/*
-		The probing is divided in two cases. One to detect v1, v2 and v3 and one to
-		detect v3HP. The reason for this is that registers are not consistent
-		between different versions. The v3HP doesn't have the HW VERSION (or at least no version is specified)
-		while v1, v2 and some v3 don't have the unit id register.
-		It would be better if we had a proper WHOAMI register.
-		*/
+		/**
+		 * The probing is divided into different cases. One to detect v2, one for v3 and v1 and one for v3HP.
+		 * The reason for this is that registers are not consistent between different versions.
+		 * The v3HP doesn't have the HW VERSION (or at least no version is specified),
+		 * v1 and v3 don't have the unit id register while v2 has both.
+		 * It would be better if we had a proper WHOAMI register.
+		 */
 
 
-		/*
-		  check for hw and sw versions for v1, v2 and v3
+		/**
+		 * check for hw and sw versions for v1, v2 and v3
 		 */
 		if ((read_reg(LL40LS_HW_VERSION, _hw_version) == OK) &&
 		    (read_reg(LL40LS_SW_VERSION, _sw_version) == OK)) {
@@ -397,8 +397,8 @@ int LidarLiteI2C::collect()
 
 	// We detect if V3HP is being used
 	if (_is_V3hp) {
-		signal_min = LL40LS_SIGNAL_STRENGH_MIN_V3HP;
-		signal_max = LL40LS_SIGNAL_STRENGH_MAX_V3HP;
+		signal_min = LL40LS_SIGNAL_STRENGTH_MIN_V3HP;
+		signal_max = LL40LS_SIGNAL_STRENGTH_MAX_V3HP;
 		signal_value = ll40ls_signal_strength;
 
 	} else {
@@ -414,7 +414,7 @@ int LidarLiteI2C::collect()
 				read before it is ready, so only consider it
 				an error if more than 100ms has elapsed.
 				*/
-				PX4_INFO("peak strenght read failed");
+				PX4_INFO("peak strength read failed");
 
 				DEVICE_DEBUG("error reading peak strength from sensor: %d", ret);
 				perf_count(_comms_errors);

--- a/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.h
+++ b/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.h
@@ -67,6 +67,8 @@ static constexpr uint8_t LL40LS_UNIT_ID_LOW	= 0x17;
 
 static constexpr uint8_t LL40LS_SIG_COUNT_VAL_REG	= 0x02;	/* Maximum acquisition count register */
 static constexpr uint8_t LL40LS_SIG_COUNT_VAL_MAX	= 0xFF;	/* Maximum acquisition count max value */
+static constexpr int LL40LS_SIGNAL_STRENGH_MIN_V3HP = 70;	// Min signal strength for V3HP
+static constexpr int LL40LS_SIGNAL_STRENGH_MAX_V3HP = 255;	// Max signal strength for V3HP
 
 static constexpr int LL40LS_SIGNAL_STRENGTH_LOW =
 	24;	// Minimum (relative) signal strength value for accepting a measurement
@@ -148,5 +150,6 @@ private:
 	uint8_t		_hw_version{0};
 	uint8_t		_sw_version{0};
 	uint16_t	_unit_id{0};
+	bool 		_is_V3hp{false};
 
 };

--- a/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.h
+++ b/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.h
@@ -49,6 +49,7 @@
 /* Configuration Constants */
 static constexpr uint8_t LL40LS_BASEADDR	= 0x62;	/* 7-bit address */
 static constexpr uint8_t LL40LS_BASEADDR_OLD	= 0x42;	/* previous 7-bit address */
+static constexpr uint8_t LL40LS_SIG_COUNT_VAL_DEFAULT = 0x80; /* Default maximum acquisition count */
 
 /* LL40LS Registers addresses */
 static constexpr uint8_t LL40LS_MEASURE_REG	= 0x00;	/* Measure range register */

--- a/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.h
+++ b/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.h
@@ -67,8 +67,8 @@ static constexpr uint8_t LL40LS_UNIT_ID_LOW	= 0x17;
 
 static constexpr uint8_t LL40LS_SIG_COUNT_VAL_REG	= 0x02;	/* Maximum acquisition count register */
 static constexpr uint8_t LL40LS_SIG_COUNT_VAL_MAX	= 0xFF;	/* Maximum acquisition count max value */
-static constexpr int LL40LS_SIGNAL_STRENGH_MIN_V3HP = 70;	// Min signal strength for V3HP
-static constexpr int LL40LS_SIGNAL_STRENGH_MAX_V3HP = 255;	// Max signal strength for V3HP
+static constexpr int LL40LS_SIGNAL_STRENGTH_MIN_V3HP = 70;	// Min signal strength for V3HP
+static constexpr int LL40LS_SIGNAL_STRENGTH_MAX_V3HP = 255;	// Max signal strength for V3HP
 
 static constexpr int LL40LS_SIGNAL_STRENGTH_LOW =
 	24;	// Minimum (relative) signal strength value for accepting a measurement


### PR DESCRIPTION
This PR addresses some issues that have been founded on Lidar Lite sensors:

- Unified the maximum distance of the sensor back to 35 meters: for v1/v2 sensors the previous value was 25 meters but was obtained empirically. According to the datasheets such sensors should be capable to read ~40m on 70% reflective surfaces, thus setting a general value at 35m could make sense to unify all the versions.
For altitude estimation the user has still the possibility to set `EKF2_RNG_A_HMAX`value to a more specific one.

- Improved probe() logic for distinguish v1/v2/v3 from v3hp.

- Fixed reset_sensor() logic: Thanks to Wingtra for the fix. Actually the v3 was not starting on current master. The proposed reset logic properly resets the sensors.

- Fixed v3HP signal quality reporting: The `LL40LS_PEAK_STRENGTH_REG` register is not available in the v3HP sensors thus signal quality was reported to be always 0. For the v3HP the signal quality is now computed by looking at the signal strength (`LL40LS_SIGNAL_STRENGTH_REG`).

- Refactored the start() method

**Test data / coverage**
Tested on v3 and v3hp. Will add logs tomorrow.

FYI @DanielePettenuzzo 
