### PR TITLE
Enable Offboard support for Rover position control

### DIFF
--- a/src/modules/rover_pos_control/RoverPositionControl.cpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.cpp
@@ -157,7 +157,7 @@ RoverPositionControl::control_position(const matrix::Vector2f &current_position,
 	bool setpoint = true;
 
 	if ((_control_mode.flag_control_auto_enabled ||
-		_control_mode.flag_control_offboard_enabled) && pos_sp_triplet.current.valid) {
+	     _control_mode.flag_control_offboard_enabled) && pos_sp_triplet.current.valid) {
 		/* AUTONOMOUS FLIGHT */
 
 		_control_mode_current = UGV_POSCTRL_MODE_AUTO;
@@ -273,6 +273,7 @@ RoverPositionControl::run()
 {
 	_control_mode_sub = orb_subscribe(ORB_ID(vehicle_control_mode));
 	_global_pos_sub = orb_subscribe(ORB_ID(vehicle_global_position));
+	_local_pos_sub = orb_subscribe(ORB_ID(vehicle_local_position));
 	_manual_control_sub = orb_subscribe(ORB_ID(manual_control_setpoint));
 	_params_sub = orb_subscribe(ORB_ID(parameter_update));
 	_pos_sp_triplet_sub = orb_subscribe(ORB_ID(position_setpoint_triplet));
@@ -284,6 +285,7 @@ RoverPositionControl::run()
 
 	/* rate limit position updates to 50 Hz */
 	orb_set_interval(_global_pos_sub, 20);
+	orb_set_interval(_local_pos_sub, 20);
 
 	parameters_update(_params_sub, true);
 
@@ -326,6 +328,7 @@ RoverPositionControl::run()
 
 			/* load local copies */
 			orb_copy(ORB_ID(vehicle_global_position), _global_pos_sub, &_global_pos);
+			orb_copy(ORB_ID(vehicle_local_position), _local_pos_sub, &_local_pos);
 
 			position_setpoint_triplet_poll();
 			vehicle_attitude_poll();
@@ -339,6 +342,7 @@ RoverPositionControl::run()
 				} else {
 					globallocalconverter_toglobal(_pos_sp_triplet.current.x, _pos_sp_triplet.current.y, _pos_sp_triplet.current.z,
 								      &_pos_sp_triplet.current.lat, &_pos_sp_triplet.current.lon, &_pos_sp_triplet.current.alt);
+
 				}
 			}
 
@@ -424,6 +428,7 @@ RoverPositionControl::run()
 
 	orb_unsubscribe(_control_mode_sub);
 	orb_unsubscribe(_global_pos_sub);
+	orb_unsubscribe(_local_pos_sub);
 	orb_unsubscribe(_manual_control_sub);
 	orb_unsubscribe(_params_sub);
 	orb_unsubscribe(_pos_sp_triplet_sub);

--- a/src/modules/rover_pos_control/RoverPositionControl.hpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.hpp
@@ -64,6 +64,7 @@
 #include <uORB/topics/vehicle_attitude_setpoint.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/vehicle_global_position.h>
+#include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/ekf2_timestamps.h>
 #include <uORB/uORB.h>
@@ -102,6 +103,7 @@ private:
 
 	int		_control_mode_sub{-1};		/**< control mode subscription */
 	int		_global_pos_sub{-1};
+	int		_local_pos_sub{-1};
 	int		_manual_control_sub{-1};		/**< notification of manual control updates */
 	int		_params_sub{-1};			/**< notification of parameter updates */
 	int		_pos_sp_triplet_sub{-1};
@@ -112,6 +114,7 @@ private:
 	position_setpoint_triplet_s		_pos_sp_triplet{};		/**< triplet of mission items */
 	vehicle_control_mode_s			_control_mode{};		/**< control mode */
 	vehicle_global_position_s		_global_pos{};			/**< global vehicle position */
+	vehicle_local_position_s		_local_pos{};			/**< global vehicle position */
 	actuator_controls_s			    _act_controls{};		/**< direct control of actuators */
 	vehicle_attitude_s              _vehicle_att{};
 	sensor_combined_s				_sensor_combined{};


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
When streaming position setpoints with `SET_POSITION_TARGET_LOCAL_NED` to the rover, the rover is able to enter offboard mode but is not able to track the setpoint. This is because the rover position controller did not support offboard mode.

This Fixes #10936

**Test data / coverage**
The following log shows the log of testing in SITL by sending setpoints of [200m, 200m] in local coordinates.
https://review.px4.io/plot_app?log=4860d7a3-1366-4614-aee1-72f8dff95037

**Describe your preferred solution**
As the rover position controller runs on global coordinates, we need to convert the local offboard setpoints to global coordinates. This is done similar to the fixed wing support for offboard position setpoints in https://github.com/PX4/Firmware/pull/12532

**Additional context**
Offboard control is useful for prototyping advanced features from the companion computer. Added support for position control will enable applications running on the companion computer to rely on the firmware position controller rather than controlling the inputs directly. Other offboard setpoints such as velocity is not supported.
