### PR TITLE
WQ decrease att_pos_ctrl stack

### DIFF
--- a/src/platforms/common/px4_work_queue/WorkQueueManager.hpp
+++ b/src/platforms/common/px4_work_queue/WorkQueueManager.hpp
@@ -62,7 +62,7 @@ static constexpr wq_config_t I2C2{"wq:I2C2", 1250, -8};
 static constexpr wq_config_t I2C3{"wq:I2C3", 1250, -9};
 static constexpr wq_config_t I2C4{"wq:I2C4", 1250, -10};
 
-static constexpr wq_config_t att_pos_ctrl{"wq:att_pos_ctrl", 7000, -11}; // PX4 att/pos controllers, highest priority after sensors
+static constexpr wq_config_t att_pos_ctrl{"wq:att_pos_ctrl", 2000, -11}; // PX4 att/pos controllers, highest priority after sensors
 
 static constexpr wq_config_t hp_default{"wq:hp_default", 1500, -12};
 static constexpr wq_config_t lp_default{"wq:lp_default", 1700, -50};


### PR DESCRIPTION
The relatively enormous stack isn't needed until this WQ thread needs to support EKF2. https://github.com/PX4/Firmware/pull/12227