### PR TITLE
FW: set default RTL_TYPE = 1 for fixed wing

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.fw_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.fw_defaults
@@ -30,6 +30,7 @@ then
 	param set EKF2_REQ_SACC 1
 	param set EKF2_REQ_VDRIFT 1.0
 
+	param set RTL_TYPE 1
 	param set RTL_RETURN_ALT 100
 	param set RTL_DESCEND_ALT 100
 	param set RTL_LAND_DELAY -1


### PR DESCRIPTION
This change adds the line "param set RTL_TYPE 1" to the default init scripts for fixed wing.  Similar to the other PR that sets default RTL_TYPE=1 for VTOLs, RTL_TYPE=1 should be default for normal fixed wings as well.  Reference: https://github.com/PX4/Firmware/pull/12746/files

Given that fixed wing aircraft do not have the option to land vertically like a VTOL, this default seems even more applicable to fixed wing.