### PR TITLE
platforms: match usb-Hex_ProfiCNC device

### DIFF
--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -172,7 +172,7 @@ if (TARGET parameters_xml AND TARGET airframes_xml)
 				/dev/serial/by-id/usb-Bitcraze*
 				/dev/serial/by-id/pci-Bitcraze*
 				/dev/serial/by-id/usb-Gumstix*
-
+				/dev/serial/by-id/usb-Hex_ProfiCNC*
 				)
 
 		elseif(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Darwin")


### PR DESCRIPTION
This means that we are able to detect and flash the Pixhawk Cube Black.

We probably need to do the same in QGC.

Fixes #12768.