### PR TITLE
VTOL land detector: trigger land detector in fixed-wing mode if disarmed

### DIFF
--- a/src/modules/land_detector/VtolLandDetector.cpp
+++ b/src/modules/land_detector/VtolLandDetector.cpp
@@ -59,9 +59,9 @@ void VtolLandDetector::_update_topics()
 
 bool VtolLandDetector::_get_maybe_landed_state()
 {
-	// Only trigger in RW mode
+	// If in Fixed-wing mode, only trigger if disarmed
 	if ((_vehicle_status.timestamp != 0) && _vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
-		return false;
+		return !_actuator_armed.armed;
 	}
 
 	return MulticopterLandDetector::_get_maybe_landed_state();
@@ -69,9 +69,9 @@ bool VtolLandDetector::_get_maybe_landed_state()
 
 bool VtolLandDetector::_get_landed_state()
 {
-	// Only trigger in RW mode
+	// If in Fixed-wing mode, only trigger if disarmed
 	if ((_vehicle_status.timestamp != 0) && _vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
-		return false;
+		return !_actuator_armed.armed;
 	}
 
 	// this is returned from the mutlicopter land detector


### PR DESCRIPTION
With this PR the land detector for VTOL vehicles will give out "landed" if disarmed and in fixed-wing mode (so far was always at "not landed" in fixed-wing mode). 

It mainly fixes the annoying issue that QGC doesn't allow you to calibrate RC or sensors if in FW mode (which sometimes couldn't be avoided).