### PR TITLE
jMAVSim: disable GUI using HEADLESS=1

### DIFF
--- a/Tools/jmavsim_run.sh
+++ b/Tools/jmavsim_run.sh
@@ -49,6 +49,10 @@ else
 	device="-serial $device $baudrate"
 fi
 
+if [ "$HEADLESS" = "1" ]; then
+    extra_args="$extr_args -no-gui"
+fi
+
 # jMAVSim crashes with Java 9 on macOS, therefore we need to use Java 8
 if [ "$(uname)" == "Darwin" ]; then
     bold=$(tput bold)


### PR DESCRIPTION
@katzfey added the option to run jMAVSim without GUI. Now we just need to read the `HEADLESS` env variable to use it.