### PR TITLE
px_update_git_header.py: allow -beta/-rc in tag

### DIFF
--- a/src/lib/version/px_update_git_header.py
+++ b/src/lib/version/px_update_git_header.py
@@ -47,7 +47,7 @@ if validate:
     # remove optional -<num_commits>-g<commit_hash> at the end (in case we are not on a tagged commit)
     git_tag_test = re.sub(r'-[0-9]+-g[0-9a-fA-F]+$', '', git_tag_test)
     # now check the version format
-    m = re.match(r'v([0-9]+)\.([0-9]+)\.[0-9]+(rc[0-9]+)?(-[0-9]+\.[0-9]+\.[0-9]+)?$', git_tag_test)
+    m = re.match(r'v([0-9]+)\.([0-9]+)\.[0-9]+([-]?rc[0-9]+)?(-beta[0-9]+)?(-[0-9]+\.[0-9]+\.[0-9]+)?$', git_tag_test)
     if m:
         # format matches, check the major and minor numbers
         major = int(m.group(1))
@@ -63,10 +63,12 @@ if validate:
         print("Error: the git tag '{:}' does not match the expected format.".format(git_tag_test))
         print("")
         print("The expected format is 'v<PX4 version>[-<custom version>]'")
-        print("  <PX4 version>: v<major>.<minor>.<patch>[rc<rc>]")
+        print("  <PX4 version>: v<major>.<minor>.<patch>[-rc<rc>|-beta<beta>]")
         print("  <custom version>: <major>.<minor>.<patch>")
         print("Examples:")
-        print("  v1.9.0rc3")
+        print("  v1.9.0rc3 (deprecated)")
+        print("  v1.9.0-rc3 (preferred)")
+        print("  v1.9.0-beta1")
         print("  v1.9.0-1.0.0")
         print("See also https://dev.px4.io/master/en/setup/building_px4.html#firmware_version")
         print("")


### PR DESCRIPTION
This changes two things:
- This adds "-beta" as a valid tag suffix.
- This changes "rc" without "-" to "-rc". "rc" without is now described
  as deprecated and with "-rc" is preferred.