### PR TITLE
ubuntu.py: update to dual install to Python2

### DIFF
--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -158,8 +158,8 @@ if [[ $INSTALL_SIM == "true" ]]; then
 	# java (jmavsim or fastrtps)
 	sudo apt-get -yy --quiet --no-install-recommends install \
 		ant \
-		default-jre-headless \
-		default-jdk-headless \
+		openjdk-8-jre \
+		openjdk-8-jdk \
 		;
 
 	# Gazebo

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -166,6 +166,20 @@ if [[ $INSTALL_SIM == "true" ]]; then
 	sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
 	wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
 	sudo apt-get update -yy --quiet
-	sudo apt-get -yy --quiet --no-install-recommends install gazebo9
+	sudo apt-get -yy --quiet --no-install-recommends install \
+		gazebo9 \
+		gstreamer1.0-plugins-bad \
+		gstreamer1.0-plugins-base \
+		gstreamer1.0-plugins-good \
+		gstreamer1.0-plugins-ugly \
+		libeigen3-dev \
+		libgazebo9-dev \
+		libgstreamer-plugins-base1.0-dev \
+		libimage-exiftool-perl \
+		libopencv-dev \
+		libxml2-utils \
+		pkg-config \
+		protobuf-compiler \
+		;
 
 fi

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -73,6 +73,8 @@ sudo apt-get -yy --quiet --no-install-recommends install \
 	python3-pip \
 	python3-pygments \
 	python3-setuptools \
+	python-pip \
+	python-dev \
 	rsync \
 	shellcheck \
 	unzip \
@@ -87,6 +89,14 @@ echo
 echo "Installing PX4 Python3 dependencies"
 sudo python3 -m pip install --upgrade pip setuptools wheel
 sudo python3 -m pip install -r ${DIR}/requirements.txt
+
+
+# Python2 dependencies
+echo
+echo "Installing PX4 Python2 dependencies"
+sudo python2 -m pip install --upgrade pip setuptools wheel
+sudo python2 -m pip install -r ${DIR}/requirements.txt
+
 
 # NuttX toolchain (arm-none-eabi-gcc)
 if [[ $INSTALL_NUTTX == "true" ]]; then


### PR DESCRIPTION
The current build depends on some Python 2; this just adds all python 2 depdendencies to the "user build script".

Note is WIP. Jmavsim works, but Gazebo (9) isn't starting on ubuntu 16.04. More testing required.