### PR TITLE
Fixing and simplifying mavlink odometry handling

### DIFF
--- a/msg/vehicle_attitude.msg
+++ b/msg/vehicle_attitude.msg
@@ -2,7 +2,7 @@
 
 uint64 timestamp		# time since system start (microseconds)
 
-float32[4] q			# Quaternion rotation from NED earth frame to XYZ body frame
+float32[4] q			# Quaternion rotation from XYZ body frame to NED earth frame.
 float32[4] delta_q_reset 	# Amount by which quaternion has changed during last reset
 uint8 quat_reset_counter	# Quaternion reset counter
 

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -2451,7 +2451,7 @@ protected:
 
 		if (odom_updated) {
 			msg.time_usec = odom.timestamp;
-			msg.child_frame_id = MAV_FRAME_BODY_NED;
+			msg.child_frame_id = MAV_FRAME_BODY_FRD;
 
 			// Current position
 			msg.x = odom.x;
@@ -2464,11 +2464,11 @@ protected:
 			msg.q[2] = odom.q[2];
 			msg.q[3] = odom.q[3];
 
-			// Local NED to body-NED Dcm matrix
-			matrix::Dcmf Rlb(matrix::Quatf(odom.q));
+			// Body-FRD frame to local NED frame Dcm matrix
+			matrix::Dcmf R_body_to_local(matrix::Quatf(odom.q));
 
 			// Rotate linear and angular velocity from local NED to body-NED frame
-			matrix::Vector3f linvel_body(Rlb * matrix::Vector3f(odom.vx, odom.vy, odom.vz));
+			matrix::Vector3f linvel_body(R_body_to_local.transpose() * matrix::Vector3f(odom.vx, odom.vy, odom.vz));
 
 			// Current linear velocity
 			msg.vx = linvel_body(0);


### PR DESCRIPTION
Fixes wrong usage of attitude quaternion in transforming odometry information from body to local frame and vice versa . The quaternion of the EKF state rotates from body frame to local frame and not the other way.
The number of supported frames in mavlink_receiver are reduced to one, to make it clearer what is expected from the FCU. A few of the droped cases where also not making sense.

Until now most external velocity information reaching the EKF was not correct. Luckily, velocity estimates from external sensors were not used in the EKF. 

The name of some frames is also slightly adapted to follow the changes in https://github.com/mavlink/mavlink/pull/1207 .
