### PR TITLE
Fix wrong inizialization value for pwm rate on aux 

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.mc_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.mc_defaults
@@ -26,4 +26,3 @@ fi
 set MIXER_AUX pass
 
 set PWM_AUX_OUT 1234
-set PWM_AUX_RATE 50

--- a/ROMFS/px4fmu_common/init.d/rc.rover_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.rover_defaults
@@ -40,4 +40,3 @@ set PWM_RATE 50
 #
 set MIXER_AUX pass
 set PWM_AUX_OUT 1234
-set PWM_AUX_RATE 50


### PR DESCRIPTION
This PR fixes wrong initialization of  `PWM_AUX_RATE` variable in the startup scripts.
In the current firmware state pwm rate on aux channels is always set at 50 Hz, regardless the value specified in the parameter.
The variable is properly initialized in the rcS https://github.com/PX4/Firmware/blob/a7c541d7e287756403fdd115ee375bab4218d514/ROMFS/px4fmu_common/init.d/rcS#L50

This bug is affecting performances on all the vehicles running ESCs on aux pins causing them to be updated at 50Hz instead of 400hz (or even oneshot), which translates in a drastic decrease in performances.

FYI @bkueng 