### PR TITLE
UAVCAN esc: relax threshold for detecting offline escs.

### DIFF
--- a/src/drivers/uavcan/actuators/esc.cpp
+++ b/src/drivers/uavcan/actuators/esc.cpp
@@ -240,7 +240,7 @@ uint8_t UavcanEscController::check_escs_status()
 
 	for (int index = 0; index < esc_status_s::CONNECTED_ESC_MAX; index++) {
 
-		if (_esc_status.esc[index].timestamp > 0 && now - _esc_status.esc[index].timestamp < 800_ms) {
+		if (_esc_status.esc[index].timestamp > 0 && now - _esc_status.esc[index].timestamp < 1200_ms) {
 			esc_status_flags |= (1 << index);
 		}
 


### PR DESCRIPTION
While testing the new Holybro Kotleta ESCs I realized that the current threshold of 800ms for detecting an offline ESC was triggering a lot of false positives.

As can be seen in the picture below,  `esc_status.esc_online_flags` was constantly flagging false positives.

![image](https://user-images.githubusercontent.com/7490213/63599946-e8b4c880-c5c2-11e9-909f-add9e9db19bd.png)
Checking the delta time of two consecutive packets coming from the escs confirmed that they may be take about 800ms to provide status.
Reporting here a small snippet of the times:
deltatime esc 0: 918054 
deltatime esc 1: 616267 
deltatime esc 2: 517467 
deltatime esc 3: 816505 
deltatime esc 0: 19093 
deltatime esc 1: 717264 
deltatime esc 2: 618464 
deltatime esc 3: 917502 
deltatime esc 0: 117313 
deltatime esc 1: 815484 
deltatime esc 2: 716684 
deltatime esc 3: 15728 

Given that this is affecting a pre-flight check a more relaxed threshold is still safe.
The new threshold has been set to 1200ms. No more false positives.


