### PR TITLE
uorb top sort statistics list alphabetically

### DIFF
--- a/src/modules/uORB/uORBDeviceMaster.cpp
+++ b/src/modules/uORB/uORBDeviceMaster.cpp
@@ -43,6 +43,8 @@
 #include <px4_platform_common/sem.hpp>
 #include <systemlib/px4_macros.h>
 
+#include <math.h>
+
 #ifndef __PX4_QURT // QuRT has no poll()
 #include <poll.h>
 #endif // PX4_QURT
@@ -58,7 +60,8 @@ uORB::DeviceMaster::~DeviceMaster()
 	px4_sem_destroy(&_lock);
 }
 
-int uORB::DeviceMaster::advertise(const struct orb_metadata *meta, bool is_advertiser, int *instance, ORB_PRIO priority)
+int
+uORB::DeviceMaster::advertise(const struct orb_metadata *meta, bool is_advertiser, int *instance, int priority)
 {
 	int ret = PX4_ERROR;
 
@@ -311,8 +314,6 @@ void uORB::DeviceMaster::showTop(char **topic_filter, int num_filters)
 		}
 	}
 
-	PX4_INFO_RAW("\033[2J\n"); //clear screen
-
 	lock();
 
 	if (_node_list.empty()) {
@@ -351,23 +352,28 @@ void uORB::DeviceMaster::showTop(char **topic_filter, int num_filters)
 
 #ifndef __PX4_QURT
 
-		/* Sleep 200 ms waiting for user input five times ~ 1s */
-		for (int k = 0; k < 5; k++) {
-			char c;
+		if (!only_once) {
+			/* Sleep 200 ms waiting for user input five times ~ 1.4s */
+			for (int k = 0; k < 7; k++) {
+				char c;
 
-			ret = ::poll(&fds, 1, 0); //just want to check if there is new data available
+				ret = ::poll(&fds, 1, 0); //just want to check if there is new data available
 
-			if (ret > 0) {
+				if (ret > 0) {
 
-				ret = ::read(stdin_fileno, &c, 1);
+					ret = ::read(stdin_fileno, &c, 1);
 
-				if (ret) {
-					quit = true;
-					break;
+					if (ret) {
+						quit = true;
+						break;
+					}
 				}
+
+				px4_usleep(200000);
 			}
 
-			px4_usleep(200000);
+		} else {
+			px4_usleep(2000000); // 2 seconds
 		}
 
 #endif
@@ -382,8 +388,8 @@ void uORB::DeviceMaster::showTop(char **topic_filter, int num_filters)
 			while (cur_node) {
 				uint32_t num_lost = cur_node->node->lost_message_count();
 				unsigned int num_msgs = cur_node->node->published_message_count();
-				cur_node->pub_msg_delta = (num_msgs - cur_node->last_pub_msg_count) / dt;
-				cur_node->lost_msg_delta = (num_lost - cur_node->last_lost_msg_count) / dt;
+				cur_node->pub_msg_delta = roundf((num_msgs - cur_node->last_pub_msg_count) / dt);
+				cur_node->lost_msg_delta = roundf((num_lost - cur_node->last_lost_msg_count) / dt);
 				cur_node->last_lost_msg_count = num_lost;
 				cur_node->last_pub_msg_count = num_msgs;
 				cur_node = cur_node->next;
@@ -392,21 +398,28 @@ void uORB::DeviceMaster::showTop(char **topic_filter, int num_filters)
 			start_time = current_time;
 
 
-			PX4_INFO_RAW("\033[H"); // move cursor home and clear screen
+			if (!only_once) {
+				PX4_INFO_RAW("\033[H"); // move cursor to top left corner
+			}
+
 			PX4_INFO_RAW(CLEAR_LINE "update: 1s, num topics: %i\n", num_topics);
-			PX4_INFO_RAW(CLEAR_LINE "%-*s INST #SUB #MSG #LOST #QSIZE\n", (int)max_topic_name_length - 2, "TOPIC NAME");
+			PX4_INFO_RAW(CLEAR_LINE "%-*s INST #SUB RATE #LOST #Q SIZE\n", (int)max_topic_name_length - 2, "TOPIC NAME");
 			cur_node = first_node;
 
 			while (cur_node) {
 
-				if (!print_active_only || cur_node->pub_msg_delta > 0) {
-					PX4_INFO_RAW(CLEAR_LINE "%-*s %2i %4i %4i %5i %i\n", (int)max_topic_name_length,
+				if (!print_active_only || (cur_node->pub_msg_delta > 0 && cur_node->node->subscriber_count() > 0)) {
+					PX4_INFO_RAW(CLEAR_LINE "%-*s %2i %4i %4i %5i %2i %4i \n", (int)max_topic_name_length,
 						     cur_node->node->get_meta()->o_name, (int)cur_node->node->get_instance(),
 						     (int)cur_node->node->subscriber_count(), cur_node->pub_msg_delta,
-						     (int)cur_node->lost_msg_delta, cur_node->node->get_queue_size());
+						     (int)cur_node->lost_msg_delta, cur_node->node->get_queue_size(), cur_node->node->get_meta()->o_size);
 				}
 
 				cur_node = cur_node->next;
+			}
+
+			if (!only_once) {
+				PX4_INFO_RAW("\033[0J"); // clear the rest of the screen
 			}
 
 			lock();

--- a/src/modules/uORB/uORBMain.cpp
+++ b/src/modules/uORB/uORBMain.cpp
@@ -77,7 +77,7 @@ $ uorb top
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("status", "Print topic statistics");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("top", "Monitor topic publication rates");
-	PRINT_MODULE_USAGE_PARAM_FLAG('a', "print all instead of only currently publishing topics", true);
+	PRINT_MODULE_USAGE_PARAM_FLAG('a', "print all instead of only currently publishing topics with subscribers", true);
 	PRINT_MODULE_USAGE_PARAM_FLAG('1', "run only once, then exit", true);
 	PRINT_MODULE_USAGE_ARG("<filter1> [<filter2>]", "topic(s) to match (implies -a)", true);
 }


### PR DESCRIPTION
With the uORB::Subscriptions no longer requiring a publication to be created for every subscription I think it's reasonable to change the `uorb top` default to display all topics (rather than only active). 
This makes the tool a little more useful when topics aren't jumping position every second.

![image](https://user-images.githubusercontent.com/84712/63640977-d1ceae80-c674-11e9-9e04-6de4e1822584.png)
