### PR TITLE
uORB::DeviceNode allocate buffer on advertise

### DIFF
--- a/src/modules/uORB/uORBDeviceNode.hpp
+++ b/src/modules/uORB/uORBDeviceNode.hpp
@@ -64,6 +64,8 @@ public:
 	DeviceNode(DeviceNode &&) = delete;
 	DeviceNode &operator=(DeviceNode &&) = delete;
 
+	int init() override;
+
 	/**
 	 * Method to create a subscriber instance and return the struct
 	 * pointing to the subscriber as a file pointer.
@@ -267,7 +269,7 @@ private:
 	const uint8_t _instance; /**< orb multi instance identifier */
 	uint8_t     *_data{nullptr};   /**< allocated object buffer */
 	hrt_abstime   _last_update{0}; /**< time the object was last updated */
-	volatile unsigned   _generation{0};  /**< object generation count */
+	unsigned   _generation{0};  /**< object generation count */
 	List<uORB::SubscriptionCallback *>	_callbacks;
 	uint8_t   _priority;  /**< priority of the topic */
 	bool _published{false};  /**< has ever data been published */

--- a/src/modules/uORB/uORB_tests/uORB_tests_main.cpp
+++ b/src/modules/uORB/uORB_tests/uORB_tests_main.cpp
@@ -50,9 +50,6 @@ static void usage()
 int
 uorb_tests_main(int argc, char *argv[])
 {
-
-#ifndef __PX4_QURT
-
 	/*
 	 * Test the driver/device.
 	 */
@@ -61,13 +58,11 @@ uorb_tests_main(int argc, char *argv[])
 		int rc = t.test();
 
 		if (rc == OK) {
-			fprintf(stdout, "  [uORBTest] \t\tPASS\n");
-			fflush(stdout);
+			PX4_INFO("PASS");
 			return 0;
 
 		} else {
-			fprintf(stderr, "  [uORBTest] \t\tFAIL\n");
-			fflush(stderr);
+			PX4_ERR("FAIL");
 			return -1;
 		}
 	}
@@ -89,8 +84,6 @@ uorb_tests_main(int argc, char *argv[])
 			return t.latency_test<struct orb_test>(ORB_ID(orb_test), true);
 		}
 	}
-
-#endif
 
 	usage();
 	return -EINVAL;


### PR DESCRIPTION
With the updated uORB::Subscription we've eliminated the majority of the unpublished uORB device nodes created from every orb_subscribe. As a result we can allocate the internal buffer immediately (on advertise) and relax the null checks (and interrupt context check).