### PR TITLE
px4io: force io firmware build

### DIFF
--- a/src/drivers/px4io/CMakeLists.txt
+++ b/src/drivers/px4io/CMakeLists.txt
@@ -59,6 +59,7 @@ ExternalProject_Add(px4io_firmware
 	INSTALL_COMMAND ""
 	USES_TERMINAL_BUILD true
 	DEPENDS git_nuttx git_nuttx_apps
+	BUILD_ALWAYS 1
 )
 
 ExternalProject_Get_Property(px4io_firmware BINARY_DIR)


### PR DESCRIPTION
This fixes incremental build of the px4io firmware on targets that use the px4io driver.

fixes #11036 #11042