### PR TITLE
Use Python 3 everywhere

### DIFF
--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -8,7 +8,7 @@ pipeline {
     stage('Build') {
       agent {
         docker {
-          image 'px4io/px4-dev-ros-melodic:2019-11-19'
+          image 'px4io/px4-dev-ros-melodic:2019-11-20'
           args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
         }
       }
@@ -130,7 +130,7 @@ def createTestNode(Map test_def) {
   return {
     node {
       cleanWs()
-      docker.image("px4io/px4-dev-ros-melodic:2019-11-19").inside('-e HOME=${WORKSPACE}') {
+      docker.image("px4io/px4-dev-ros-melodic:2019-11-20").inside('-e HOME=${WORKSPACE}') {
         stage(test_def.name) {
           def run_script = test_def.get('run_script', 'rostest_px4_run.sh')
           def test_ok = true

--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -8,7 +8,7 @@ pipeline {
     stage('Build') {
       agent {
         docker {
-          image 'px4io/px4-dev-ros-melodic:2019-10-24'
+          image 'px4io/px4-dev-ros-melodic:2019-11-19'
           args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
         }
       }
@@ -130,7 +130,7 @@ def createTestNode(Map test_def) {
   return {
     node {
       cleanWs()
-      docker.image("px4io/px4-dev-ros-melodic:2019-10-24").inside('-e HOME=${WORKSPACE}') {
+      docker.image("px4io/px4-dev-ros-melodic:2019-11-19").inside('-e HOME=${WORKSPACE}') {
         stage(test_def.name) {
           def run_script = test_def.get('run_script', 'rostest_px4_run.sh')
           def test_ok = true

--- a/.ci/Jenkinsfile-SITL_tests_ASan
+++ b/.ci/Jenkinsfile-SITL_tests_ASan
@@ -8,7 +8,7 @@ pipeline {
     stage('Build') {
       agent {
         docker {
-          image 'px4io/px4-dev-ros-melodic:2019-10-24'
+          image 'px4io/px4-dev-ros-melodic:2019-11-19'
           args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
         }
       }
@@ -131,7 +131,7 @@ def createTestNode(Map test_def) {
   return {
     node {
       cleanWs()
-      docker.image("px4io/px4-dev-ros-melodic:2019-10-24").inside('-e HOME=${WORKSPACE}') {
+      docker.image("px4io/px4-dev-ros-melodic:2019-11-19").inside('-e HOME=${WORKSPACE}') {
         stage(test_def.name) {
           def run_script = test_def.get('run_script', 'rostest_px4_run.sh')
           def test_ok = true

--- a/.ci/Jenkinsfile-SITL_tests_ASan
+++ b/.ci/Jenkinsfile-SITL_tests_ASan
@@ -8,7 +8,7 @@ pipeline {
     stage('Build') {
       agent {
         docker {
-          image 'px4io/px4-dev-ros-melodic:2019-11-19'
+          image 'px4io/px4-dev-ros-melodic:2019-11-20'
           args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
         }
       }
@@ -131,7 +131,7 @@ def createTestNode(Map test_def) {
   return {
     node {
       cleanWs()
-      docker.image("px4io/px4-dev-ros-melodic:2019-11-19").inside('-e HOME=${WORKSPACE}') {
+      docker.image("px4io/px4-dev-ros-melodic:2019-11-20").inside('-e HOME=${WORKSPACE}') {
         stage(test_def.name) {
           def run_script = test_def.get('run_script', 'rostest_px4_run.sh')
           def test_ok = true

--- a/.ci/Jenkinsfile-SITL_tests_coverage
+++ b/.ci/Jenkinsfile-SITL_tests_coverage
@@ -79,7 +79,7 @@ pipeline {
         stage('code coverage (python)') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2019-10-24'
+              image 'px4io/px4-dev-base-bionic:2019-11-19'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -99,7 +99,7 @@ pipeline {
         stage('unit tests') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2019-10-24'
+              image 'px4io/px4-dev-base-bionic:2019-11-19'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -137,7 +137,7 @@ def createTestNode(Map test_def) {
   return {
     node {
       cleanWs()
-      docker.image("px4io/px4-dev-ros-melodic:2019-10-24").inside('-e HOME=${WORKSPACE}') {
+      docker.image("px4io/px4-dev-ros-melodic:2019-11-19").inside('-e HOME=${WORKSPACE}') {
         stage(test_def.name) {
           def test_ok = true
           sh('export')

--- a/.ci/Jenkinsfile-SITL_tests_coverage
+++ b/.ci/Jenkinsfile-SITL_tests_coverage
@@ -79,7 +79,7 @@ pipeline {
         stage('code coverage (python)') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2019-11-19'
+              image 'px4io/px4-dev-base-bionic:2019-11-20'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -99,7 +99,7 @@ pipeline {
         stage('unit tests') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2019-11-19'
+              image 'px4io/px4-dev-base-bionic:2019-11-20'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -137,7 +137,7 @@ def createTestNode(Map test_def) {
   return {
     node {
       cleanWs()
-      docker.image("px4io/px4-dev-ros-melodic:2019-11-19").inside('-e HOME=${WORKSPACE}') {
+      docker.image("px4io/px4-dev-ros-melodic:2019-11-20").inside('-e HOME=${WORKSPACE}') {
         stage(test_def.name) {
           def test_ok = true
           sh('export')

--- a/.ci/Jenkinsfile-compile
+++ b/.ci/Jenkinsfile-compile
@@ -9,9 +9,9 @@ pipeline {
         script {
           def build_nodes = [:]
           def docker_images = [
-            armhf: "px4io/px4-dev-armhf:2019-11-19",
-            base: "px4io/px4-dev-base-bionic:2019-11-19",
-            nuttx: "px4io/px4-dev-nuttx:2019-11-19",
+            armhf: "px4io/px4-dev-armhf:2019-11-20",
+            base: "px4io/px4-dev-base-bionic:2019-11-20",
+            nuttx: "px4io/px4-dev-nuttx:2019-11-20",
             snapdragon: "lorenzmeier/px4-dev-snapdragon:2018-09-12"
           ]
 
@@ -70,7 +70,7 @@ pipeline {
     // TODO: actually upload artifacts to S3
     // stage('S3 Upload') {
     //   agent {
-    //     docker { image 'px4io/px4-dev-base-bionic:2019-11-19' }
+    //     docker { image 'px4io/px4-dev-base-bionic:2019-11-20' }
     //   }
     //   options {
     //         skipDefaultCheckout()

--- a/.ci/Jenkinsfile-compile
+++ b/.ci/Jenkinsfile-compile
@@ -9,9 +9,9 @@ pipeline {
         script {
           def build_nodes = [:]
           def docker_images = [
-            armhf: "px4io/px4-dev-armhf:2019-10-24",
-            base: "px4io/px4-dev-base-bionic:2019-10-24",
-            nuttx: "px4io/px4-dev-nuttx:2019-10-24",
+            armhf: "px4io/px4-dev-armhf:2019-11-19",
+            base: "px4io/px4-dev-base-bionic:2019-11-19",
+            nuttx: "px4io/px4-dev-nuttx:2019-11-19",
             snapdragon: "lorenzmeier/px4-dev-snapdragon:2018-09-12"
           ]
 
@@ -70,7 +70,7 @@ pipeline {
     // TODO: actually upload artifacts to S3
     // stage('S3 Upload') {
     //   agent {
-    //     docker { image 'px4io/px4-dev-base-bionic:2019-10-24' }
+    //     docker { image 'px4io/px4-dev-base-bionic:2019-11-19' }
     //   }
     //   options {
     //         skipDefaultCheckout()

--- a/.ci/Jenkinsfile-hardware
+++ b/.ci/Jenkinsfile-hardware
@@ -12,7 +12,7 @@ pipeline {
             stage("build px4_fmu-v2_test") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx:2019-10-24'
+                  image 'px4io/px4-dev-nuttx:2019-11-19'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -76,7 +76,7 @@ pipeline {
             stage("build px4_fmu-v3_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx:2019-10-24'
+                  image 'px4io/px4-dev-nuttx:2019-11-19'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -148,7 +148,7 @@ pipeline {
             stage("build px4_fmu-v4_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx:2019-10-24'
+                  image 'px4io/px4-dev-nuttx:2019-11-19'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -220,7 +220,7 @@ pipeline {
             stage("build px4_fmu-v4pro_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx:2019-10-24'
+                  image 'px4io/px4-dev-nuttx:2019-11-19'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -292,7 +292,7 @@ pipeline {
             stage("build px4_fmu-v5_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx:2019-10-24'
+                  image 'px4io/px4-dev-nuttx:2019-11-19'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -364,7 +364,7 @@ pipeline {
             stage("build modalai_fc-v1_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx:2019-10-24'
+                  image 'px4io/px4-dev-nuttx:2019-11-19'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -436,7 +436,7 @@ pipeline {
             stage("build holybro_durandal-v1_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx:2019-10-24'
+                  image 'px4io/px4-dev-nuttx:2019-11-19'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -509,7 +509,7 @@ pipeline {
             stage("build holybro_durandal-v1_stackcheck") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx:2019-10-24'
+                  image 'px4io/px4-dev-nuttx:2019-11-19'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -593,7 +593,7 @@ pipeline {
             stage("build nxp_fmuk66-v3_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx:2019-10-24'
+                  image 'px4io/px4-dev-nuttx:2019-11-19'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }

--- a/.ci/Jenkinsfile-hardware
+++ b/.ci/Jenkinsfile-hardware
@@ -12,7 +12,7 @@ pipeline {
             stage("build px4_fmu-v2_test") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx:2019-11-19'
+                  image 'px4io/px4-dev-nuttx:2019-11-20'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -76,7 +76,7 @@ pipeline {
             stage("build px4_fmu-v3_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx:2019-11-19'
+                  image 'px4io/px4-dev-nuttx:2019-11-20'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -148,7 +148,7 @@ pipeline {
             stage("build px4_fmu-v4_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx:2019-11-19'
+                  image 'px4io/px4-dev-nuttx:2019-11-20'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -220,7 +220,7 @@ pipeline {
             stage("build px4_fmu-v4pro_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx:2019-11-19'
+                  image 'px4io/px4-dev-nuttx:2019-11-20'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -292,7 +292,7 @@ pipeline {
             stage("build px4_fmu-v5_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx:2019-11-19'
+                  image 'px4io/px4-dev-nuttx:2019-11-20'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -364,7 +364,7 @@ pipeline {
             stage("build modalai_fc-v1_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx:2019-11-19'
+                  image 'px4io/px4-dev-nuttx:2019-11-20'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -436,7 +436,7 @@ pipeline {
             stage("build holybro_durandal-v1_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx:2019-11-19'
+                  image 'px4io/px4-dev-nuttx:2019-11-20'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -509,7 +509,7 @@ pipeline {
             stage("build holybro_durandal-v1_stackcheck") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx:2019-11-19'
+                  image 'px4io/px4-dev-nuttx:2019-11-20'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -593,7 +593,7 @@ pipeline {
             stage("build nxp_fmuk66-v3_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx:2019-11-19'
+                  image 'px4io/px4-dev-nuttx:2019-11-20'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: px4io/px4-dev-nuttx:2019-10-24
+      - image: px4io/px4-dev-nuttx:2019-11-19
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: px4io/px4-dev-nuttx:2019-11-19
+      - image: px4io/px4-dev-nuttx:2019-11-20
     steps:
       - checkout
       - run:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: px4io/px4-dev-base-bionic:2019-10-24
+    container: px4io/px4-dev-base-bionic:2019-11-19
     steps:
     - uses: actions/checkout@v1
     - name: make

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: px4io/px4-dev-base-bionic:2019-11-19
+    container: px4io/px4-dev-base-bionic:2019-11-20
     steps:
     - uses: actions/checkout@v1
     - name: make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,7 +266,7 @@ endif()
 
 # python
 include(px4_find_python_module)
-find_package(PythonInterp REQUIRED)
+find_package(PythonInterp 3 REQUIRED)
 
 option(PYTHON_COVERAGE "Python code coverage" OFF)
 if(PYTHON_COVERAGE)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
         stage('Catkin build on ROS workspace') {
           agent {
             docker {
-              image 'px4io/px4-dev-ros-melodic:2019-10-24'
+              image 'px4io/px4-dev-ros-melodic:2019-11-19'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
             }
           }
@@ -51,7 +51,7 @@ pipeline {
         stage('Colcon build on ROS2 workspace') {
           agent {
             docker {
-              image 'px4io/px4-dev-ros2-dashing:2019-10-24'
+              image 'px4io/px4-dev-ros2-dashing:2019-11-19'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
             }
           }
@@ -82,7 +82,7 @@ pipeline {
 
         stage('Style check') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-10-24' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-11-19' }
           }
           steps {
             sh 'make check_format'
@@ -129,7 +129,7 @@ pipeline {
         stage('px4_fmu-v2 (bloaty)') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-10-24'
+              image 'px4io/px4-dev-nuttx:2019-11-19'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -161,7 +161,7 @@ pipeline {
         stage('px4_fmu-v5 (bloaty)') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-10-24'
+              image 'px4io/px4-dev-nuttx:2019-11-19'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -193,7 +193,7 @@ pipeline {
         stage('px4_sitl (bloaty)') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-10-24'
+              image 'px4io/px4-dev-nuttx:2019-11-19'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -225,7 +225,7 @@ pipeline {
         stage('px4_fmu-v5 (no ninja)') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-10-24'
+              image 'px4io/px4-dev-nuttx:2019-11-19'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -251,7 +251,7 @@ pipeline {
         stage('px4_sitl (no ninja)') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-10-24'
+              image 'px4io/px4-dev-nuttx:2019-11-19'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -277,7 +277,7 @@ pipeline {
         stage('SITL unit tests') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2019-10-24'
+              image 'px4io/px4-dev-base-bionic:2019-11-19'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -317,7 +317,7 @@ pipeline {
         stage('Clang analyzer') {
           agent {
             docker {
-              image 'px4io/px4-dev-clang:2019-10-24'
+              image 'px4io/px4-dev-clang:2019-11-19'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -355,7 +355,7 @@ pipeline {
         stage('Clang tidy') {
           agent {
             docker {
-              image 'px4io/px4-dev-clang:2019-10-24'
+              image 'px4io/px4-dev-clang:2019-11-19'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -377,7 +377,7 @@ pipeline {
         stage('Cppcheck') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2019-10-24'
+              image 'px4io/px4-dev-base-bionic:2019-11-19'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -415,7 +415,7 @@ pipeline {
         stage('Check stack') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-10-24'
+              image 'px4io/px4-dev-nuttx:2019-11-19'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -435,7 +435,7 @@ pipeline {
         stage('ShellCheck') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-10-24'
+              image 'px4io/px4-dev-nuttx:2019-11-19'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -454,7 +454,7 @@ pipeline {
         stage('Module config validation') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2019-10-24'
+              image 'px4io/px4-dev-base-bionic:2019-11-19'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -479,7 +479,7 @@ pipeline {
 
         stage('Airframe') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-10-24' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-11-19' }
           }
           steps {
             sh 'make distclean'
@@ -498,7 +498,7 @@ pipeline {
 
         stage('Parameter') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-10-24' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-11-19' }
           }
           steps {
             sh 'make distclean'
@@ -517,7 +517,7 @@ pipeline {
 
         stage('Module') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-10-24' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-11-19' }
           }
           steps {
             sh 'make distclean'
@@ -537,7 +537,7 @@ pipeline {
         stage('uORB graphs') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-10-24'
+              image 'px4io/px4-dev-nuttx:2019-11-19'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -566,7 +566,7 @@ pipeline {
 
         stage('Devguide') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-10-24' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-11-19' }
           }
           steps {
             sh('export')
@@ -596,7 +596,7 @@ pipeline {
 
         stage('Userguide') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-10-24' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-11-19' }
           }
           steps {
             sh('export')
@@ -624,7 +624,7 @@ pipeline {
 
         stage('QGroundControl') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-10-24' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-11-19' }
           }
           steps {
             sh('export')
@@ -652,7 +652,7 @@ pipeline {
 
         stage('PX4 ROS msgs') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-10-24' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-11-19' }
           }
           steps {
             sh('export')
@@ -681,7 +681,7 @@ pipeline {
 
         stage('PX4 ROS2 bridge') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-10-24' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-11-19' }
           }
           steps {
             sh('export')
@@ -722,7 +722,7 @@ pipeline {
 
         stage('S3') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-10-24' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-11-19' }
           }
           steps {
             sh('export')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
         stage('Catkin build on ROS workspace') {
           agent {
             docker {
-              image 'px4io/px4-dev-ros-melodic:2019-11-19'
+              image 'px4io/px4-dev-ros-melodic:2019-11-20'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
             }
           }
@@ -51,7 +51,7 @@ pipeline {
         stage('Colcon build on ROS2 workspace') {
           agent {
             docker {
-              image 'px4io/px4-dev-ros2-dashing:2019-11-19'
+              image 'px4io/px4-dev-ros2-dashing:2019-11-20'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
             }
           }
@@ -82,7 +82,7 @@ pipeline {
 
         stage('Style check') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-11-19' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-11-20' }
           }
           steps {
             sh 'make check_format'
@@ -129,7 +129,7 @@ pipeline {
         stage('px4_fmu-v2 (bloaty)') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-11-19'
+              image 'px4io/px4-dev-nuttx:2019-11-20'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -161,7 +161,7 @@ pipeline {
         stage('px4_fmu-v5 (bloaty)') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-11-19'
+              image 'px4io/px4-dev-nuttx:2019-11-20'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -193,7 +193,7 @@ pipeline {
         stage('px4_sitl (bloaty)') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-11-19'
+              image 'px4io/px4-dev-nuttx:2019-11-20'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -225,7 +225,7 @@ pipeline {
         stage('px4_fmu-v5 (no ninja)') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-11-19'
+              image 'px4io/px4-dev-nuttx:2019-11-20'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -251,7 +251,7 @@ pipeline {
         stage('px4_sitl (no ninja)') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-11-19'
+              image 'px4io/px4-dev-nuttx:2019-11-20'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -277,7 +277,7 @@ pipeline {
         stage('SITL unit tests') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2019-11-19'
+              image 'px4io/px4-dev-base-bionic:2019-11-20'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -317,7 +317,7 @@ pipeline {
         stage('Clang analyzer') {
           agent {
             docker {
-              image 'px4io/px4-dev-clang:2019-11-19'
+              image 'px4io/px4-dev-clang:2019-11-20'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -355,7 +355,7 @@ pipeline {
         stage('Clang tidy') {
           agent {
             docker {
-              image 'px4io/px4-dev-clang:2019-11-19'
+              image 'px4io/px4-dev-clang:2019-11-20'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -377,7 +377,7 @@ pipeline {
         stage('Cppcheck') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2019-11-19'
+              image 'px4io/px4-dev-base-bionic:2019-11-20'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -415,7 +415,7 @@ pipeline {
         stage('Check stack') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-11-19'
+              image 'px4io/px4-dev-nuttx:2019-11-20'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -435,7 +435,7 @@ pipeline {
         stage('ShellCheck') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-11-19'
+              image 'px4io/px4-dev-nuttx:2019-11-20'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -454,7 +454,7 @@ pipeline {
         stage('Module config validation') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2019-11-19'
+              image 'px4io/px4-dev-base-bionic:2019-11-20'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -479,7 +479,7 @@ pipeline {
 
         stage('Airframe') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-11-19' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-11-20' }
           }
           steps {
             sh 'make distclean'
@@ -498,7 +498,7 @@ pipeline {
 
         stage('Parameter') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-11-19' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-11-20' }
           }
           steps {
             sh 'make distclean'
@@ -517,7 +517,7 @@ pipeline {
 
         stage('Module') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-11-19' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-11-20' }
           }
           steps {
             sh 'make distclean'
@@ -537,7 +537,7 @@ pipeline {
         stage('uORB graphs') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-11-19'
+              image 'px4io/px4-dev-nuttx:2019-11-20'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -566,7 +566,7 @@ pipeline {
 
         stage('Devguide') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-11-19' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-11-20' }
           }
           steps {
             sh('export')
@@ -596,7 +596,7 @@ pipeline {
 
         stage('Userguide') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-11-19' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-11-20' }
           }
           steps {
             sh('export')
@@ -624,7 +624,7 @@ pipeline {
 
         stage('QGroundControl') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-11-19' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-11-20' }
           }
           steps {
             sh('export')
@@ -652,7 +652,7 @@ pipeline {
 
         stage('PX4 ROS msgs') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-11-19' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-11-20' }
           }
           steps {
             sh('export')
@@ -681,7 +681,7 @@ pipeline {
 
         stage('PX4 ROS2 bridge') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-11-19' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-11-20' }
           }
           steps {
             sh('export')
@@ -722,7 +722,7 @@ pipeline {
 
         stage('S3') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-11-19' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-11-20' }
           }
           steps {
             sh('export')

--- a/Tools/docker_run.sh
+++ b/Tools/docker_run.sh
@@ -4,19 +4,19 @@ if [ -z ${PX4_DOCKER_REPO+x} ]; then
 	echo "guessing PX4_DOCKER_REPO based on input";
 	if [[ $@ =~ .*px4_fmu.* ]]; then
 		# nuttx-px4fmu-v{1,2,3,4,5}
-		PX4_DOCKER_REPO="px4io/px4-dev-nuttx:2019-11-19"
+		PX4_DOCKER_REPO="px4io/px4-dev-nuttx:2019-11-20"
 	elif [[ $@ =~ .*eagle.* ]] || [[ $@ =~ .*excelsior.* ]]; then
 		# eagle, excelsior
 		PX4_DOCKER_REPO="lorenzmeier/px4-dev-snapdragon:2018-09-12"
 	elif [[ $@ =~ .*ocpoc.* ]] || [[ $@ =~ .*navio2.* ]] || [[ $@ =~ .*raspberry.* ]] || [[ $@ =~ .*bebop.* ]]; then
 		# aerotenna_ocpoc_default, posix_rpi_cross, posix_bebop_default
-		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2019-11-19"
+		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2019-11-20"
 	elif [[ $@ =~ .*clang.* ]] || [[ $@ =~ .*scan-build.* ]]; then
 		# clang tools
-		PX4_DOCKER_REPO="px4io/px4-dev-clang:2019-11-19"
+		PX4_DOCKER_REPO="px4io/px4-dev-clang:2019-11-20"
 	elif [[ $@ =~ .*tests* ]]; then
 		# run all tests with simulation
-		PX4_DOCKER_REPO="px4io/px4-dev-simulation-bionic:2019-11-19"
+		PX4_DOCKER_REPO="px4io/px4-dev-simulation-bionic:2019-11-20"
 	fi
 else
 	echo "PX4_DOCKER_REPO is set to '$PX4_DOCKER_REPO'";
@@ -24,7 +24,7 @@ fi
 
 # otherwise default to nuttx
 if [ -z ${PX4_DOCKER_REPO+x} ]; then
-	PX4_DOCKER_REPO="px4io/px4-dev-nuttx:2019-11-19"
+	PX4_DOCKER_REPO="px4io/px4-dev-nuttx:2019-11-20"
 fi
 
 # docker hygiene

--- a/Tools/docker_run.sh
+++ b/Tools/docker_run.sh
@@ -4,19 +4,19 @@ if [ -z ${PX4_DOCKER_REPO+x} ]; then
 	echo "guessing PX4_DOCKER_REPO based on input";
 	if [[ $@ =~ .*px4_fmu.* ]]; then
 		# nuttx-px4fmu-v{1,2,3,4,5}
-		PX4_DOCKER_REPO="px4io/px4-dev-nuttx:2019-10-24"
+		PX4_DOCKER_REPO="px4io/px4-dev-nuttx:2019-11-19"
 	elif [[ $@ =~ .*eagle.* ]] || [[ $@ =~ .*excelsior.* ]]; then
 		# eagle, excelsior
 		PX4_DOCKER_REPO="lorenzmeier/px4-dev-snapdragon:2018-09-12"
 	elif [[ $@ =~ .*ocpoc.* ]] || [[ $@ =~ .*navio2.* ]] || [[ $@ =~ .*raspberry.* ]] || [[ $@ =~ .*bebop.* ]]; then
 		# aerotenna_ocpoc_default, posix_rpi_cross, posix_bebop_default
-		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2019-10-24"
+		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2019-11-19"
 	elif [[ $@ =~ .*clang.* ]] || [[ $@ =~ .*scan-build.* ]]; then
 		# clang tools
-		PX4_DOCKER_REPO="px4io/px4-dev-clang:2019-10-24"
+		PX4_DOCKER_REPO="px4io/px4-dev-clang:2019-11-19"
 	elif [[ $@ =~ .*tests* ]]; then
 		# run all tests with simulation
-		PX4_DOCKER_REPO="px4io/px4-dev-simulation-bionic:2019-10-24"
+		PX4_DOCKER_REPO="px4io/px4-dev-simulation-bionic:2019-11-19"
 	fi
 else
 	echo "PX4_DOCKER_REPO is set to '$PX4_DOCKER_REPO'";
@@ -24,7 +24,7 @@ fi
 
 # otherwise default to nuttx
 if [ -z ${PX4_DOCKER_REPO+x} ]; then
-	PX4_DOCKER_REPO="px4io/px4-dev-nuttx:2019-10-24"
+	PX4_DOCKER_REPO="px4io/px4-dev-nuttx:2019-11-19"
 fi
 
 # docker hygiene

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ install:
 # if the toolchain wasn't restored from build cache download and install it
 - ps: >-
     if (-not (Test-Path C:\PX4)) {
-        Invoke-WebRequest https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Windows+Cygwin+Toolchain+0.6.msi -OutFile C:\Toolchain.msi
+        Invoke-WebRequest https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Windows+Cygwin+Toolchain+0.7.msi -OutFile C:\Toolchain.msi
         Start-Process -Wait msiexec -ArgumentList '/I C:\Toolchain.msi /quiet /qn /norestart /log C:\install.log'
     }
 

--- a/cmake/px4_find_python_module.cmake
+++ b/cmake/px4_find_python_module.cmake
@@ -65,12 +65,12 @@ function(px4_find_python_module module)
 		endif()
 	endif()
 	find_package_handle_standard_args(PY_${module}
-		"couldn't find python module ${module}:
+		"couldn't find python3 module ${module}:
 		\nfor debian systems try: \
-		\n\tsudo apt-get install python-${module} \
+		\n\tsudo apt-get install python3-${module} \
 		\nor for all other OSs/debian: \
-		\n\tsudo -H pip install ${module}\n" PY_${module_upper})
+		\n\tsudo -H pip3 install ${module}\n" PY_${module_upper})
 	#if (NOT PY_${module}_FOUND)
-		#message(FATAL_ERROR "python module not found, exiting")
+		#message(FATAL_ERROR "python3 module not found, exiting")
 	#endif()
 endfunction(px4_find_python_module)

--- a/msg/tools/px_generate_uorb_topic_files.py
+++ b/msg/tools/px_generate_uorb_topic_files.py
@@ -60,11 +60,11 @@ Required python packages not installed.
 
 On a Debian/Ubuntu system please run:
 
-  sudo apt-get install python-empy
-  sudo pip install catkin_pkg
+  sudo apt-get install python3-empy
+  sudo pip3 install catkin_pkg
 
 On MacOS please run:
-  sudo pip install empy catkin_pkg
+  sudo pip3 install empy catkin_pkg
 
 On Windows please run:
   easy_install empy catkin_pkg

--- a/src/lib/mixer/MultirotorMixer/geometries/tools/px_generate_mixers.py
+++ b/src/lib/mixer/MultirotorMixer/geometries/tools/px_generate_mixers.py
@@ -44,10 +44,10 @@ try:
 except ImportError as e:
     print("python import error: ", e)
     print('''
-Required python packages not installed.
+Required python3 packages not installed.
 
 On a GNU/Linux or MacOS system please run:
-  sudo pip install numpy toml
+  sudo pip3 install numpy toml
 
 On Windows please run:
   easy_install numpy toml


### PR DESCRIPTION
Since Python 2 is retired in 4 months, we should move everything to 3.

Closes #12788.

@MaEtUgR do you mind checking appveyor? :smile: 