### PR TITLE
disable compiler warnings

### DIFF
--- a/cmake/px4_add_common_flags.cmake
+++ b/cmake/px4_add_common_flags.cmake
@@ -85,6 +85,7 @@ function(px4_add_common_flags)
 		-Wuninitialized
 		-Wunknown-pragmas
 		-Wunused-variable
+		-Wimplicit-fallthrough=0
 
 		# disabled warnings
 		-Wno-missing-field-initializers


### PR DESCRIPTION
Fixes issue #12813 for me.
I'm not sure if disabling the warnings is the right action to take. An alternative solution would be to add the C++17 fallthrough statement  `[[fallthrough]];` to all the failing cases. But I'm not sure if that is then compatible with other compilers.
