### PR TITLE
cmake: fix fallthrough warnings with ccache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,12 @@ else
 	BUILD_DIR_SUFFIX :=
 endif
 
+# To prevent "// fallthrough" comments from being stripped by the preprocessor
+# before ccache looks at the cache.
+ifndef CCACHE_CPP2
+	export CCACHE_CPP2 = yes
+endif
+
 # additional config parameters passed to cmake
 ifdef EXTERNAL_MODULES_LOCATION
 	CMAKE_ARGS += -DEXTERNAL_MODULES_LOCATION:STRING=$(EXTERNAL_MODULES_LOCATION)


### PR DESCRIPTION
It turns out that we're getting compile warnings with arm-none-eabi-gcc 7.2.1 when used with ccache about implicit fallthroughs. By setting CCACHE_CPP2 we force ccache to look at the whole file not just the stripped version.

Fixes #12813, closes #12820.