### PR TITLE
vtol_att_control fix WQ scheduling

### DIFF
--- a/boards/px4/fmu-v2/multicopter.cmake
+++ b/boards/px4/fmu-v2/multicopter.cmake
@@ -29,7 +29,7 @@ px4_add_board(
 		imu/l3gd20
 		imu/lsm303d
 		imu/mpu6000
-		imu/mpu9250
+		#imu/mpu9250
 		irlock
 		lights/rgbled
 		magnetometer/hmc5883

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -132,7 +132,7 @@ public:
 	struct Params 					*get_params() {return &_params;}
 
 private:
-	/* handlers for subscriptions */
+
 	uORB::SubscriptionCallbackWorkItem _actuator_inputs_fw{this, ORB_ID(actuator_controls_virtual_fw)};
 	uORB::SubscriptionCallbackWorkItem _actuator_inputs_mc{this, ORB_ID(actuator_controls_virtual_mc)};
 


### PR DESCRIPTION
The `vtol_att_control` module runs after updates to both the mc_att_control (now at >= 1kHz typically) AND fw_att_control. The result is vtol_att_control running much faster than it needs to.