### PR TITLE
cmake nuttx ignore linking target warning

### DIFF
--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -73,6 +73,10 @@ file(RELATIVE_PATH PX4_BINARY_DIR_REL ${CMAKE_CURRENT_BINARY_DIR} ${PX4_BINARY_D
 # because even relative linker script paths are different for linux, mac and windows
 CYGPATH(PX4_BINARY_DIR PX4_BINARY_DIR_CYG)
 
+if(POLICY CMP0079)
+	cmake_policy(SET CMP0079 NEW)
+endif()
+
 target_link_libraries(nuttx_arch
 	INTERFACE
 		drivers_board


### PR DESCRIPTION
Quiet this annoying cmake output.

![image](https://user-images.githubusercontent.com/84712/63904277-666f3e80-c9de-11e9-8e57-abc78320923d.png)
