### PR TITLE
Leddar one driver work to fix Issue #12508, simplify logic, improve update rate, and inherit from PX4RangeFinder

### DIFF
--- a/src/drivers/distance_sensor/leddar_one/leddar_one.cpp
+++ b/src/drivers/distance_sensor/leddar_one/leddar_one.cpp
@@ -168,8 +168,6 @@ private:
 
 	perf_counter_t _comms_error{perf_alloc(PC_COUNT, "leddar_one_comms_error")};
 	perf_counter_t _sample_perf{perf_alloc(PC_ELAPSED, "leddar_one_sample")};
-
-	orb_advert_t _distance_sensor_topic{nullptr};
 };
 
 LeddarOne::LeddarOne(const char *device_path, const char *serial_port, uint8_t device_orientation):
@@ -182,20 +180,14 @@ LeddarOne::LeddarOne(const char *device_path, const char *serial_port, uint8_t d
 	_px4_rangefinder.set_device_type(distance_sensor_s::MAV_DISTANCE_SENSOR_LASER);
 	_px4_rangefinder.set_max_distance(LEDDAR_ONE_MAX_DISTANCE);
 	_px4_rangefinder.set_min_distance(LEDDAR_ONE_MIN_DISTANCE);
-	_px4_rangefinder.set_fov(0.008); // Divergence 8 mRadian
+	_px4_rangefinder.set_fov(0.105); // FOV cone angle of 6 degrees.
 	_px4_rangefinder.set_orientation(device_orientation);
 }
 
 LeddarOne::~LeddarOne()
 {
 	stop();
-
 	free((char *)_serial_port);
-
-	if (_distance_sensor_topic) {
-		orb_unadvertise(_distance_sensor_topic);
-	}
-
 	perf_free(_comms_error);
 	perf_free(_sample_perf);
 }

--- a/src/drivers/distance_sensor/leddar_one/leddar_one.cpp
+++ b/src/drivers/distance_sensor/leddar_one/leddar_one.cpp
@@ -54,6 +54,8 @@ using namespace time_literals;
 #define DEVICE_PATH                     "/dev/LeddarOne"
 #define LEDDAR_ONE_DEFAULT_SERIAL_PORT  "/dev/ttyS3"
 
+#define LEDDAR_ONE_FIELD_OF_VIEW        (0.105f) // 6 deg cone angle.
+
 #define LEDDAR_ONE_MAX_DISTANCE         40.0f
 #define LEDDAR_ONE_MIN_DISTANCE         0.01f
 
@@ -180,7 +182,7 @@ LeddarOne::LeddarOne(const char *device_path, const char *serial_port, uint8_t d
 	_px4_rangefinder.set_device_type(distance_sensor_s::MAV_DISTANCE_SENSOR_LASER);
 	_px4_rangefinder.set_max_distance(LEDDAR_ONE_MAX_DISTANCE);
 	_px4_rangefinder.set_min_distance(LEDDAR_ONE_MIN_DISTANCE);
-	_px4_rangefinder.set_fov(0.105); // FOV cone angle of 6 degrees.
+	_px4_rangefinder.set_fov(LEDDAR_ONE_FIELD_OF_VIEW);
 	_px4_rangefinder.set_orientation(device_orientation);
 }
 
@@ -309,7 +311,7 @@ LeddarOne::init()
 int
 LeddarOne::measure()
 {
-	// Flush the recieve buffer.
+	// Flush the receive buffer.
 	tcflush(_file_descriptor, TCIFLUSH);
 
 	int num_bytes = ::write(_file_descriptor, request_reading_msg, sizeof(request_reading_msg));

--- a/src/drivers/distance_sensor/leddar_one/leddar_one.cpp
+++ b/src/drivers/distance_sensor/leddar_one/leddar_one.cpp
@@ -31,24 +31,22 @@
  *
  ****************************************************************************/
 
-#include <px4_config.h>
-#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
-#include <px4_getopt.h>
-#include <px4_defines.h>
-#include <px4_module.h>
 
 #include <stdlib.h>
 #include <string.h>
 #include <termios.h>
 
 #include <arch/board/board.h>
-
 #include <drivers/device/device.h>
 #include <drivers/device/ringbuffer.h>
 #include <drivers/drv_hrt.h>
-
+#include <lib/drivers/rangefinder/PX4Rangefinder.hpp>
 #include <perf/perf_counter.h>
-
+#include <px4_config.h>
+#include <px4_defines.h>
+#include <px4_getopt.h>
+#include <px4_module.h>
+#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
 #include <uORB/topics/distance_sensor.h>
 
 using namespace time_literals;
@@ -241,7 +239,7 @@ LeddarOne::collect()
 
 	if (msg->slave_addr != MODBUS_SLAVE_ADDRESS ||
 	    msg->function != MODBUS_READING_FUNCTION) {
-		PX4_ERR("slave address or reading function error");
+		PX4_ERR("slave address or function read error");
 		perf_count(_comms_error);
 		perf_end(_sample_perf);
 		return measure();
@@ -272,11 +270,10 @@ LeddarOne::collect()
 
 	orb_publish(ORB_ID(distance_sensor), _distance_sensor_topic, &report);
 
-	// Trigger the next measurement.
-	measure();
-
 	perf_end(_sample_perf);
-	return PX4_OK;
+
+	// Trigger the next measurement.
+	return measure();;
 }
 
 int

--- a/src/drivers/distance_sensor/leddar_one/module.yaml
+++ b/src/drivers/distance_sensor/leddar_one/module.yaml
@@ -4,4 +4,3 @@ serial_config:
       port_config_param:
         name: SENS_LEDDAR1_CFG
         group: Sensors
-

--- a/src/lib/drivers/rangefinder/PX4Rangefinder.cpp
+++ b/src/lib/drivers/rangefinder/PX4Rangefinder.cpp
@@ -35,16 +35,14 @@
 
 #include <lib/drivers/device/Device.hpp>
 
-PX4Rangefinder::PX4Rangefinder(uint32_t device_id, uint8_t priority, uint8_t rotation) :
+PX4Rangefinder::PX4Rangefinder(const uint32_t device_id, const uint8_t priority, const uint8_t device_orientation) :
 	CDev(nullptr),
 	_distance_sensor_pub{ORB_ID(distance_sensor), priority}
 {
 	_class_device_instance = register_class_devname(RANGE_FINDER_BASE_DEVICE_PATH);
 
-	// TODO: range finders should have device ids
-	//_distance_sensor_pub.get().device_id = device_id;
-
-	_distance_sensor_pub.get().orientation = rotation;
+	set_device_id(device_id);
+	set_orientation(device_orientation);
 }
 
 PX4Rangefinder::~PX4Rangefinder()
@@ -55,7 +53,7 @@ PX4Rangefinder::~PX4Rangefinder()
 }
 
 void
-PX4Rangefinder::set_device_type(uint8_t devtype)
+PX4Rangefinder::set_device_type(uint8_t device_type)
 {
 	// TODO: range finders should have device ids
 
@@ -71,13 +69,19 @@ PX4Rangefinder::set_device_type(uint8_t devtype)
 }
 
 void
-PX4Rangefinder::update(hrt_abstime timestamp, float distance, int8_t quality)
+PX4Rangefinder::set_orientation(const uint8_t device_orientation)
+{
+	_distance_sensor_pub.get().orientation = device_orientation;
+}
+
+void
+PX4Rangefinder::update(const hrt_abstime timestamp, const float distance, const int8_t quality)
 {
 	distance_sensor_s &report = _distance_sensor_pub.get();
 
-	report.timestamp = timestamp;
 	report.current_distance = distance;
-	report.signal_quality = quality;
+	report.signal_quality   = quality;
+	report.timestamp        = timestamp;
 
 	_distance_sensor_pub.update();
 }

--- a/src/lib/drivers/rangefinder/PX4Rangefinder.hpp
+++ b/src/lib/drivers/rangefinder/PX4Rangefinder.hpp
@@ -45,27 +45,33 @@ class PX4Rangefinder : public cdev::CDev
 {
 
 public:
-	PX4Rangefinder(uint32_t device_id, uint8_t priority, uint8_t rotation);
+	PX4Rangefinder(const uint32_t device_id,
+		       const uint8_t priority,
+		       const uint8_t device_orientation = distance_sensor_s::ROTATION_DOWNWARD_FACING);
 	~PX4Rangefinder() override;
-
-	void set_device_type(uint8_t devtype);
-	//void set_error_count(uint64_t error_count) { _distance_sensor_pub.get().error_count = error_count; }
-
-	void set_min_distance(float distance) { _distance_sensor_pub.get().min_distance = distance; }
-	void set_max_distance(float distance) { _distance_sensor_pub.get().max_distance = distance; }
-
-	void set_hfov(float fov) { _distance_sensor_pub.get().h_fov = fov; }
-	void set_vfov(float fov) { _distance_sensor_pub.get().v_fov = fov; }
-	void set_fov(float fov) { set_hfov(fov); set_vfov(fov); }
-
-	void update(hrt_abstime timestamp, float distance, int8_t quality = -1);
 
 	void print_status();
 
+	void set_device_type(uint8_t device_type);
+	//void set_error_count(uint64_t error_count) { _distance_sensor_pub.get().error_count = error_count; }
+
+	void set_device_id(const uint8_t device_id) { _distance_sensor_pub.get().id = device_id; };
+
+	void set_fov(const float fov) { set_hfov(fov); set_vfov(fov); }
+	void set_hfov(const float fov) { _distance_sensor_pub.get().h_fov = fov; }
+	void set_vfov(const float fov) { _distance_sensor_pub.get().v_fov = fov; }
+
+	void set_max_distance(const float distance) { _distance_sensor_pub.get().max_distance = distance; }
+	void set_min_distance(const float distance) { _distance_sensor_pub.get().min_distance = distance; }
+
+	void set_orientation(const uint8_t device_orientation = distance_sensor_s::ROTATION_DOWNWARD_FACING);
+
+	void update(const hrt_abstime timestamp, const float distance, const int8_t quality = -1);
+
 private:
 
-	uORB::PublicationMultiData<distance_sensor_s>	_distance_sensor_pub;
+	uORB::PublicationMultiData<distance_sensor_s> _distance_sensor_pub;
 
-	int			_class_device_instance{-1};
+	int _class_device_instance{-1};
 
 };


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This PR fixes issue #12508.  This PR also improves the update rate of the sensor from ~8.6Hz to ~9.1Hz and simplifies the timing logic to use `ScheduleOnInterval()` rather than `ScheduleDelayed` and timeout logic that exists in v1.19.2 and previous.  Lastly, this PR fixes the broken test() method for the driver.

**Test data / coverage**
My recent PR #11858 on the LeddarOne driver broke automatic starting of the driver, (I apologize for causing that breakage and not catching it in bench testing.)  I have tested driver start on boot with telem 1,2, and 4 in this PR.  The driver functions as expected and as it does in v1.9.2:
![image](https://user-images.githubusercontent.com/2497951/63990137-1eb0eb80-caa0-11e9-8aed-9a0b3a94e711.png)

**Describe possible alternatives**
One alternative to this PR would be to revert the driver to its' state in v1.9.2.  I am in favor of this PR because it simplifies the driver quite a bit while getting better update rates over v1.9.2.

**Additional context**
See also #12508.  This work also benefits #11977 and migrates the Terraranger driver closer to common base class method structure and functionality.

It is probably best to incorporate these changes or revert the driver to v1.9.2 code prior to v1.10.

@tomcattigerkkk, if you get a chance, could you test this PR?  Thank you!

Please let me know if you have any questions or feedback on this PR.  Thanks!

-Mark
