### PR TITLE
enable pmw3901 flow if (new) parameter SENS_EN_PMW_FLOW is true

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -103,6 +103,12 @@ then
 	teraranger start -a
 fi
 
+# Possible pmw3901 optical flow sensor
+if param greater SENS_EN_PMW3901 0
+then
+	pmw3901 start
+fi
+
 ###############################################################################
 #                            End Optional drivers                             #
 ###############################################################################

--- a/boards/av/x-v1/init/rc.board_sensors
+++ b/boards/av/x-v1/init/rc.board_sensors
@@ -12,10 +12,9 @@ lsm303agr -R 4 start
 
 ms4525_airspeed -T 4515 -b 3 start
 
-# try to autostart pmw3901 on SPI2 (external)
-if ! pmw3901 start
+if ! param greater SENS_EN_PMW3901 0
 then
-	# if pmw3901 failed to start, try starting the adis16497 (SPI2)
+	# try to start adis16497 only if pmw3901 isn't enabled, or parameter doesn't exists
 	adis16497 start
 fi
 

--- a/boards/bitcraze/crazyflie/init/rc.board_sensors
+++ b/boards/bitcraze/crazyflie/init/rc.board_sensors
@@ -12,4 +12,3 @@ lps25h start
 
 # Optical flow deck
 vl53lxx start
-pmw3901 start

--- a/boards/px4/fmu-v4/init/rc.board_sensors
+++ b/boards/px4/fmu-v4/init/rc.board_sensors
@@ -68,5 +68,3 @@ then
 	# BMI160 internal SPI bus
 	bmi160 start
 fi
-
-pmw3901 start

--- a/boards/px4/fmu-v5/init/rc.board_sensors
+++ b/boards/px4/fmu-v5/init/rc.board_sensors
@@ -24,9 +24,3 @@ lis3mdl -X start
 
 # Possible internal compass
 ist8310 -C -b 5 start
-
-# Possible pmw3901 optical flow sensor
-pmw3901 start
-
-# Internal SPI
-ms5611 -s start

--- a/boards/px4/fmu-v5x/init/rc.board_sensors
+++ b/boards/px4/fmu-v5x/init/rc.board_sensors
@@ -31,6 +31,3 @@ bmm150 start
 # Possible internal Barro
 bmp388 -I start
 #bmp388 -J start fixme
-
-# Possible pmw3901 optical flow sensor
-pmw3901 start

--- a/src/drivers/optical_flow/pmw3901/parameters.c
+++ b/src/drivers/optical_flow/pmw3901/parameters.c
@@ -1,0 +1,42 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * PMW3901 Optical Flow
+ *
+ * @reboot_required true
+ *
+ * @boolean
+ * @group Sensors
+ */
+PARAM_DEFINE_INT32(SENS_EN_PMW3901, 0);


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
the startup scripts try to start the pmw3901 flow on some boards by default. even if the drone doesn't has one connected.
that cause false errors on startup script for drones that doesn't has the sensors (most of the configurations)

> ERROR [pmw3901] driver start failed

**Describe your preferred solution**
New SENS_EN_PMW_FLOW parameter that allows to define if the sensor should be or not on the system.

**Describe possible alternatives**
With this parameter, starting the flow can moved to common rc.sensors file. curently its only on boards that compile the pmw3901.
In that case, boards that don't have the driver compiled will show "Parameter SENS_EN_PMW_FLOW not found" (that is being delt on #12832)
does that prefered?
