### PR TITLE
deltaquad: remove deprecated parameter MAN_R_MAX

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
@@ -97,7 +97,6 @@ then
 	param set MPC_XY_VEL_MAX 5
 	param set MPC_ACC_HOR_MAX 2
 	param set MPC_LAND_SPEED 1.2
-	param set MPC_MAN_R_MAX 30
 	param set MPC_TILTMAX_LND 35
 	param set MPC_Z_VEL_MAX 1.5
 	param set MPC_Z_VEL_MAX_UP 1.5


### PR DESCRIPTION
@sanderux Just saw this parameter anyways doesn't exist anymore and you already set the `TILTMAX` which replaced it.