### PR TITLE
Increase default STACK_MAIN 1024 -> 2048 and don't set in most modules and drivers

### DIFF
--- a/boards/bitcraze/crazyflie/syslink/CMakeLists.txt
+++ b/boards/bitcraze/crazyflie/syslink/CMakeLists.txt
@@ -36,7 +36,6 @@ px4_add_module(
 	MAIN syslink
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
-	STACK_MAIN 1300
 	SRCS
 		syslink_main.cpp
 		syslink_bridge.cpp

--- a/boards/emlid/navio2/navio_sysfs_rc_in/CMakeLists.txt
+++ b/boards/emlid/navio2/navio_sysfs_rc_in/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__navio_sysfs_rc_in
 	MAIN navio_sysfs_rc_in
-	STACK_MAIN 1200
 	COMPILE_FLAGS
 	SRCS
 		navio_sysfs_rc_in.cpp

--- a/cmake/px4_add_module.cmake
+++ b/cmake/px4_add_module.cmake
@@ -42,7 +42,6 @@ include(px4_base)
 #	Usage:
 #		px4_add_module(MODULE <string>
 #			MAIN <string>
-#			[ STACK <string> ] !!!!!DEPRECATED, USE STACK_MAIN INSTEAD!!!!!!!!!
 #			[ STACK_MAIN <string> ]
 #			[ STACK_MAX <string> ]
 #			[ COMPILE_FLAGS <list> ]
@@ -87,7 +86,7 @@ function(px4_add_module)
 
 	px4_parse_function_args(
 		NAME px4_add_module
-		ONE_VALUE MODULE MAIN STACK STACK_MAIN STACK_MAX PRIORITY
+		ONE_VALUE MODULE MAIN STACK_MAIN STACK_MAX PRIORITY
 		MULTI_VALUE COMPILE_FLAGS LINK_FLAGS SRCS INCLUDES DEPENDS MODULE_CONFIG
 		OPTIONS EXTERNAL DYNAMIC UNITY_BUILD
 		REQUIRED MODULE MAIN
@@ -166,7 +165,7 @@ function(px4_add_module)
 
 	# set defaults if not set
 	set(MAIN_DEFAULT MAIN-NOTFOUND)
-	set(STACK_MAIN_DEFAULT 1024)
+	set(STACK_MAIN_DEFAULT 2048)
 	set(PRIORITY_DEFAULT SCHED_PRIORITY_DEFAULT)
 
 	foreach(property MAIN STACK_MAIN PRIORITY)

--- a/src/drivers/barometer/bmp280/CMakeLists.txt
+++ b/src/drivers/barometer/bmp280/CMakeLists.txt
@@ -35,9 +35,7 @@ px4_add_module(
 	MODULE drivers__bmp280
 	MAIN bmp280
 	COMPILE_FLAGS
-		-Wno-cast-align # TODO: fix and enable	
-	STACK_MAIN
-		1200
+		-Wno-cast-align # TODO: fix and enable
 	SRCS
 		bmp280_spi.cpp
 		bmp280_i2c.cpp

--- a/src/drivers/barometer/lps25h/CMakeLists.txt
+++ b/src/drivers/barometer/lps25h/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__lps25h
 	MAIN lps25h
-	STACK_MAIN 1200
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/drivers/barometer/mpl3115a2/CMakeLists.txt
+++ b/src/drivers/barometer/mpl3115a2/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__mpl3115a2
 	MAIN mpl3115a2
-	STACK_MAIN 1200
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/drivers/barometer/ms5611/CMakeLists.txt
+++ b/src/drivers/barometer/ms5611/CMakeLists.txt
@@ -34,7 +34,6 @@
 px4_add_module(
 	MODULE drivers__ms5611
 	MAIN ms5611
-	STACK_MAIN 1500
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/drivers/batt_smbus/CMakeLists.txt
+++ b/src/drivers/batt_smbus/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__batt_smbus
 	MAIN batt_smbus
-	STACK_MAIN 1100
 	COMPILE_FLAGS
 	SRCS
 		batt_smbus.cpp

--- a/src/drivers/camera_trigger/CMakeLists.txt
+++ b/src/drivers/camera_trigger/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__camera_trigger
 	MAIN camera_trigger
-	STACK_MAIN 1200
 	COMPILE_FLAGS
 	SRCS
 		camera_trigger.cpp

--- a/src/drivers/differential_pressure/ets/CMakeLists.txt
+++ b/src/drivers/differential_pressure/ets/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__ets_airspeed
 	MAIN ets_airspeed
-	STACK_MAIN 1200
 	COMPILE_FLAGS
 	SRCS
 		ets_airspeed.cpp

--- a/src/drivers/differential_pressure/ms4525/CMakeLists.txt
+++ b/src/drivers/differential_pressure/ms4525/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__ms4525_airspeed
 	MAIN ms4525_airspeed
-	STACK_MAIN 1200
 	COMPILE_FLAGS
 	SRCS
 		ms4525_airspeed.cpp

--- a/src/drivers/differential_pressure/ms5525/CMakeLists.txt
+++ b/src/drivers/differential_pressure/ms5525/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__ms5525_airspeed
 	MAIN ms5525_airspeed
-	STACK_MAIN 1200
 	COMPILE_FLAGS
 	SRCS
 		MS5525.cpp

--- a/src/drivers/differential_pressure/sdp3x/CMakeLists.txt
+++ b/src/drivers/differential_pressure/sdp3x/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__sdp3x_airspeed
 	MAIN sdp3x_airspeed
-	STACK_MAIN 1200
 	COMPILE_FLAGS
 	SRCS
 		SDP3X.cpp

--- a/src/drivers/distance_sensor/cm8jl65/CMakeLists.txt
+++ b/src/drivers/distance_sensor/cm8jl65/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__cm8jl65
 	MAIN cm8jl65
-	STACK_MAIN 1200
 	SRCS
 		cm8jl65.cpp
   MODULE_CONFIG

--- a/src/drivers/distance_sensor/hc_sr04/CMakeLists.txt
+++ b/src/drivers/distance_sensor/hc_sr04/CMakeLists.txt
@@ -34,7 +34,6 @@
 px4_add_module(
 	MODULE drivers__hc_sr04
 	MAIN hc_sr04
-	STACK_MAIN 1200
 	COMPILE_FLAGS
 	SRCS
 		hc_sr04.cpp

--- a/src/drivers/distance_sensor/leddar_one/CMakeLists.txt
+++ b/src/drivers/distance_sensor/leddar_one/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__leddar_one
 	MAIN leddar_one
-	STACK_MAIN 1200
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/drivers/distance_sensor/ll40ls/CMakeLists.txt
+++ b/src/drivers/distance_sensor/ll40ls/CMakeLists.txt
@@ -35,8 +35,6 @@ px4_add_module(
 	MAIN ll40ls
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
-	STACK_MAIN
-		1500
 	SRCS
 		ll40ls.cpp
 		LidarLite.cpp

--- a/src/drivers/distance_sensor/mappydot/CMakeLists.txt
+++ b/src/drivers/distance_sensor/mappydot/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__mappydot
 	MAIN mappydot
-	STACK_MAIN 1200
 	SRCS
 		MappyDot.cpp
 	)

--- a/src/drivers/distance_sensor/mb12xx/CMakeLists.txt
+++ b/src/drivers/distance_sensor/mb12xx/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__mb12xx
 	MAIN mb12xx
-	STACK_MAIN 1400
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/drivers/distance_sensor/srf02/CMakeLists.txt
+++ b/src/drivers/distance_sensor/srf02/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__srf02
 	MAIN srf02
-	STACK_MAIN 1500
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/drivers/distance_sensor/teraranger/CMakeLists.txt
+++ b/src/drivers/distance_sensor/teraranger/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__teraranger
 	MAIN teraranger
-	STACK_MAIN 1200
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/drivers/gps/CMakeLists.txt
+++ b/src/drivers/gps/CMakeLists.txt
@@ -36,7 +36,6 @@ px4_add_git_submodule(TARGET git_gps_devices PATH "devices")
 px4_add_module(
 	MODULE drivers__gps
 	MAIN gps
-	STACK_MAIN 1200
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/drivers/heater/CMakeLists.txt
+++ b/src/drivers/heater/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__heater
 	MAIN heater
-	STACK_MAIN 1024
 	COMPILE_FLAGS
 	SRCS
 		heater.cpp

--- a/src/drivers/imu/adis16448/CMakeLists.txt
+++ b/src/drivers/imu/adis16448/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__imu__adis16448
 	MAIN adis16448
-	STACK_MAIN 1400
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/drivers/imu/adis16477/CMakeLists.txt
+++ b/src/drivers/imu/adis16477/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__imu__adis16477
 	MAIN adis16477
-	STACK_MAIN 1200
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/drivers/imu/adis16497/CMakeLists.txt
+++ b/src/drivers/imu/adis16497/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__imu__adis16497
 	MAIN adis16497
-	STACK_MAIN 1200
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/drivers/imu/bmi055/CMakeLists.txt
+++ b/src/drivers/imu/bmi055/CMakeLists.txt
@@ -33,10 +33,9 @@
 px4_add_module(
 	MODULE drivers__bmi055
 	MAIN bmi055
-	STACK_MAIN 1500
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
-	SRCS		
+	SRCS
 		BMI055_accel.cpp
 		BMI055_gyro.cpp
 		bmi055_main.cpp

--- a/src/drivers/imu/bmi088/CMakeLists.txt
+++ b/src/drivers/imu/bmi088/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__bmi88
 	MAIN bmi088
-	STACK_MAIN 1500
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/drivers/imu/bmi160/CMakeLists.txt
+++ b/src/drivers/imu/bmi160/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__bmi160
 	MAIN bmi160
-	STACK_MAIN 1200
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/drivers/imu/fxas21002c/CMakeLists.txt
+++ b/src/drivers/imu/fxas21002c/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__fxas21002c
 	MAIN fxas21002c
-	STACK_MAIN 1500
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/drivers/imu/fxos8701cq/CMakeLists.txt
+++ b/src/drivers/imu/fxos8701cq/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__fxos8701cq
 	MAIN fxos8701cq
-	STACK_MAIN 1500
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/drivers/imu/icm20948/CMakeLists.txt
+++ b/src/drivers/imu/icm20948/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__icm20948
 	MAIN icm20948
-	STACK_MAIN 1500
 	COMPILE_FLAGS
 	SRCS
 		icm20948.cpp

--- a/src/drivers/imu/l3gd20/CMakeLists.txt
+++ b/src/drivers/imu/l3gd20/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__l3gd20
 	MAIN l3gd20
-	STACK_MAIN 1500
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/drivers/imu/lsm303d/CMakeLists.txt
+++ b/src/drivers/imu/lsm303d/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__lsm303d
 	MAIN lsm303d
-	STACK_MAIN 1500
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/drivers/imu/mpu6000/CMakeLists.txt
+++ b/src/drivers/imu/mpu6000/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__mpu6000
 	MAIN mpu6000
-	STACK_MAIN 1500
 	SRCS
 		MPU6000.cpp
 		MPU6000_I2C.cpp

--- a/src/drivers/imu/mpu9250/CMakeLists.txt
+++ b/src/drivers/imu/mpu9250/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__mpu9250
 	MAIN mpu9250
-	STACK_MAIN 1500
 	COMPILE_FLAGS
 	SRCS
 		AK8963_I2C.cpp

--- a/src/drivers/lights/oreoled/CMakeLists.txt
+++ b/src/drivers/lights/oreoled/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__oreoled
 	MAIN oreoled
-	STACK_MAIN 1024
 	COMPILE_FLAGS
 	SRCS
 		oreoled.cpp

--- a/src/drivers/lights/rgbled/CMakeLists.txt
+++ b/src/drivers/lights/rgbled/CMakeLists.txt
@@ -34,8 +34,6 @@
 px4_add_module(
 	MODULE drivers__rgbled
 	MAIN rgbled
-	STACK_MAIN
-		1500
 	SRCS
 		rgbled.cpp
 	DEPENDS

--- a/src/drivers/lights/rgbled_ncp5623c/CMakeLists.txt
+++ b/src/drivers/lights/rgbled_ncp5623c/CMakeLists.txt
@@ -34,8 +34,6 @@
 px4_add_module(
 	MODULE drivers__rgbled_ncp5623c
 	MAIN rgbled_ncp5623c
-	STACK_MAIN
-		1500
 	SRCS
 		rgbled_ncp5623c.cpp
 	DEPENDS

--- a/src/drivers/lights/rgbled_pwm/CMakeLists.txt
+++ b/src/drivers/lights/rgbled_pwm/CMakeLists.txt
@@ -34,8 +34,6 @@
 px4_add_module(
 	MODULE drivers__rgbled_pwm
 	MAIN rgbled_pwm
-	STACK_MAIN
-		1500
 	SRCS
 		rgbled_pwm.cpp
 	DEPENDS

--- a/src/drivers/magnetometer/ak09916/CMakeLists.txt
+++ b/src/drivers/magnetometer/ak09916/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__ak09916
 	MAIN ak09916
-	STACK_MAIN 1200
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/drivers/magnetometer/bmm150/CMakeLists.txt
+++ b/src/drivers/magnetometer/bmm150/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__bmm150
 	MAIN bmm150
-	STACK_MAIN 1200
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/drivers/magnetometer/hmc5883/CMakeLists.txt
+++ b/src/drivers/magnetometer/hmc5883/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__hmc5883
 	MAIN hmc5883
-	STACK_MAIN 1500
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/drivers/magnetometer/ist8310/CMakeLists.txt
+++ b/src/drivers/magnetometer/ist8310/CMakeLists.txt
@@ -35,7 +35,6 @@ px4_add_module(
 	MAIN ist8310
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
-	STACK_MAIN 1500
 	SRCS
 		ist8310.cpp
 	DEPENDS

--- a/src/drivers/magnetometer/lis3mdl/CMakeLists.txt
+++ b/src/drivers/magnetometer/lis3mdl/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__lis3mdl
 	MAIN lis3mdl
-	STACK_MAIN 1500
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/drivers/magnetometer/qmc5883/CMakeLists.txt
+++ b/src/drivers/magnetometer/qmc5883/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__qmc5883
 	MAIN qmc5883
-	STACK_MAIN 1500
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/drivers/magnetometer/rm3100/CMakeLists.txt
+++ b/src/drivers/magnetometer/rm3100/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__rm3100
 	MAIN rm3100
-	STACK_MAIN 1200
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/drivers/optical_flow/paw3902/CMakeLists.txt
+++ b/src/drivers/optical_flow/paw3902/CMakeLists.txt
@@ -34,7 +34,6 @@
 px4_add_module(
 	MODULE drivers__optical_flow__paw3902
 	MAIN paw3902
-	STACK_MAIN 1500
 	SRCS
 		paw3902_main.cpp
 		PAW3902.cpp

--- a/src/drivers/optical_flow/pmw3901/CMakeLists.txt
+++ b/src/drivers/optical_flow/pmw3901/CMakeLists.txt
@@ -36,7 +36,6 @@ px4_add_module(
 	MAIN pmw3901
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
-	STACK_MAIN 1400
 	SRCS
 		pmw3901.cpp
 	)

--- a/src/drivers/optical_flow/px4flow/CMakeLists.txt
+++ b/src/drivers/optical_flow/px4flow/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__px4flow
 	MAIN px4flow
-	STACK_MAIN 1500
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/drivers/protocol_splitter/CMakeLists.txt
+++ b/src/drivers/protocol_splitter/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__protocol_splitter
 	MAIN protocol_splitter
-	STACK_MAIN 1200
 	SRCS
 		protocol_splitter.cpp
 	DEPENDS

--- a/src/drivers/pwm_input/CMakeLists.txt
+++ b/src/drivers/pwm_input/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__pwm_input
 	MAIN pwm_input
-	STACK_MAIN 1024
 	COMPILE_FLAGS
 		-Wno-pmf-conversions
 		-Wno-cast-align # TODO: fix and enable

--- a/src/drivers/px4fmu/CMakeLists.txt
+++ b/src/drivers/px4fmu/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__px4fmu
 	MAIN fmu
-	STACK_MAIN 1200
 	COMPILE_FLAGS
 	SRCS
 		fmu.cpp

--- a/src/drivers/px4io/CMakeLists.txt
+++ b/src/drivers/px4io/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__px4io
 	MAIN px4io
-	STACK_MAIN 1816
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/drivers/qurt/fc_addon/mpu_spi/CMakeLists.txt
+++ b/src/drivers/qurt/fc_addon/mpu_spi/CMakeLists.txt
@@ -47,7 +47,6 @@ set_target_properties(mpu9x50 PROPERTIES IMPORTED_LOCATION ${FC_ADDON}/flight_co
 px4_add_module(
 	MODULE platforms__qurt__fc_addon__mpu_spi
 	MAIN mpu9x50
-	STACK_MAIN 1200
 	INCLUDES
 		${FC_ADDON}/flight_controller/hexagon/inc
 	SRCS

--- a/src/drivers/qurt/fc_addon/rc_receiver/CMakeLists.txt
+++ b/src/drivers/qurt/fc_addon/rc_receiver/CMakeLists.txt
@@ -47,7 +47,6 @@ set_target_properties(rc_receiver PROPERTIES IMPORTED_LOCATION ${FC_ADDON}/fligh
 px4_add_module(
 	MODULE platforms__qurt__fc_addon__rc_receiver
 	MAIN rc_receiver
-	STACK_MAIN 1200
 	INCLUDES
 		${FC_ADDON}/flight_controller/hexagon/inc
         SRCS

--- a/src/drivers/qurt/fc_addon/uart_esc/CMakeLists.txt
+++ b/src/drivers/qurt/fc_addon/uart_esc/CMakeLists.txt
@@ -47,7 +47,6 @@ set_target_properties(uart_esc PROPERTIES IMPORTED_LOCATION ${FC_ADDON}/flight_c
 px4_add_module(
 	MODULE platforms__qurt__fc_addon__uart_esc
 	MAIN uart_esc
-	STACK_MAIN 1200
 	INCLUDES
 		${FC_ADDON}/flight_controller/hexagon/inc
 	SRCS

--- a/src/drivers/rc_input/CMakeLists.txt
+++ b/src/drivers/rc_input/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__rc_input
 	MAIN rc_input
-	STACK_MAIN 1200
 	COMPILE_FLAGS
 	SRCS
 		RCInput.cpp

--- a/src/drivers/rpi_rc_in/CMakeLists.txt
+++ b/src/drivers/rpi_rc_in/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__rpi_rc_in
 	MAIN rpi_rc_in
-	STACK_MAIN 1200
 	COMPILE_FLAGS
 	SRCS
 		rpi_rc_in.cpp

--- a/src/drivers/safety_button/CMakeLists.txt
+++ b/src/drivers/safety_button/CMakeLists.txt
@@ -34,8 +34,6 @@
 px4_add_module(
 	MODULE drivers__safety_button
 	MAIN safety_button
-	STACK_MAIN
-		1500
 	SRCS
 		SafetyButton.cpp
 	DEPENDS

--- a/src/drivers/telemetry/bst/CMakeLists.txt
+++ b/src/drivers/telemetry/bst/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__bst
 	MAIN bst
-	STACK_MAIN 1200
 	COMPILE_FLAGS
 	SRCS
 		bst.cpp

--- a/src/drivers/telemetry/frsky_telemetry/CMakeLists.txt
+++ b/src/drivers/telemetry/frsky_telemetry/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__frsky_telemetry
 	MAIN frsky_telemetry
-	STACK_MAIN 1500
 	COMPILE_FLAGS
 	SRCS
 		frsky_data.cpp

--- a/src/drivers/telemetry/iridiumsbd/CMakeLists.txt
+++ b/src/drivers/telemetry/iridiumsbd/CMakeLists.txt
@@ -34,7 +34,6 @@ px4_add_module(
 	MODULE drivers__iridiumsbd
 	MAIN iridiumsbd
 	STACK 1024
-	STACK_MAIN 1024
 	COMPILE_FLAGS
 	SRCS
 		IridiumSBD.cpp

--- a/src/drivers/test_ppm/CMakeLists.txt
+++ b/src/drivers/test_ppm/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__test_ppm
 	MAIN test_ppm
-	STACK_MAIN 1200
 	COMPILE_FLAGS
 	SRCS
 		test_ppm.cpp

--- a/src/drivers/uavcan/CMakeLists.txt
+++ b/src/drivers/uavcan/CMakeLists.txt
@@ -92,8 +92,6 @@ add_custom_target(px4_uavcan_dsdlc DEPENDS px4_uavcan_dsdlc_run.stamp)
 px4_add_module(
 	MODULE modules__uavcan
 	MAIN uavcan
-	STACK_MAIN 3200
-	STACK_MAX 1500
 	INCLUDES
 		${DSDLC_OUTPUT}
 		${PX4_SOURCE_DIR}/mavlink/include/mavlink

--- a/src/examples/bottle_drop/CMakeLists.txt
+++ b/src/examples/bottle_drop/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE modules__bottle_drop
 	MAIN bottle_drop
-	STACK_MAIN 1200
 	COMPILE_FLAGS
 	SRCS
 		bottle_drop.cpp

--- a/src/examples/fixedwing_control/CMakeLists.txt
+++ b/src/examples/fixedwing_control/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE examples__fixedwing_control
 	MAIN ex_fixedwing_control
-	STACK_MAIN 1200
 	STACK_MAX 1300
 	SRCS
 		main.cpp

--- a/src/examples/hwtest/CMakeLists.txt
+++ b/src/examples/hwtest/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE examples__hwtest
 	MAIN ex_hwtest
-	STACK_MAIN 2000
 	SRCS
 		hwtest.c
 	DEPENDS

--- a/src/examples/matlab_csv_serial/CMakeLists.txt
+++ b/src/examples/matlab_csv_serial/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE examples__matlab_csv_serial
 	MAIN matlab_csv_serial
-	STACK_MAIN 2000
 	SRCS
 		matlab_csv_serial.c
 	DEPENDS

--- a/src/examples/px4_mavlink_debug/CMakeLists.txt
+++ b/src/examples/px4_mavlink_debug/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE examples__px4_mavlink_debug
 	MAIN px4_mavlink_debug
-	STACK_MAIN 2000
 	SRCS
 		px4_mavlink_debug.cpp
 	DEPENDS

--- a/src/examples/px4_simple_app/CMakeLists.txt
+++ b/src/examples/px4_simple_app/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE examples__px4_simple_app
 	MAIN px4_simple_app
-	STACK_MAIN 2000
 	SRCS
 		px4_simple_app.c
 	DEPENDS

--- a/src/examples/rover_steering_control/CMakeLists.txt
+++ b/src/examples/rover_steering_control/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE examples__rover_steering_control
 	MAIN rover_steering_control
-	STACK_MAIN 1200
 	STACK_MAX 1300
 	SRCS
 		main.cpp

--- a/src/examples/segway/CMakeLists.txt
+++ b/src/examples/segway/CMakeLists.txt
@@ -33,8 +33,6 @@
 px4_add_module(
 	MODULE examples__segway
 	MAIN segway
-	STACK_MAIN 1400
-	STACK_MAX 1400
 	SRCS
 		blocks.cpp
 		segway_main.cpp

--- a/src/examples/uuv_example_app/CMakeLists.txt
+++ b/src/examples/uuv_example_app/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE examples__uuv_example_app
 	MAIN uuv_example_app
-	STACK_MAIN 2000
 	SRCS
 		uuv_example_app.cpp
 	DEPENDS

--- a/src/modules/attitude_estimator_q/CMakeLists.txt
+++ b/src/modules/attitude_estimator_q/CMakeLists.txt
@@ -35,7 +35,6 @@ px4_add_module(
 	MODULE modules__attitude_estimator_q
 	MAIN attitude_estimator_q
 	COMPILE_FLAGS
-	STACK_MAIN 1200
 	STACK_MAX 1600
 	SRCS
 		attitude_estimator_q_main.cpp

--- a/src/modules/commander/CMakeLists.txt
+++ b/src/modules/commander/CMakeLists.txt
@@ -36,8 +36,6 @@ add_subdirectory(failure_detector)
 px4_add_module(
 	MODULE modules__commander
 	MAIN commander
-	STACK_MAIN 4096
-	STACK_MAX 2450
 	COMPILE_FLAGS
 	SRCS
 		accelerometer_calibration.cpp

--- a/src/modules/dataman/CMakeLists.txt
+++ b/src/modules/dataman/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE modules__dataman
 	MAIN dataman
-	STACK_MAIN 1200
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/modules/ekf2/CMakeLists.txt
+++ b/src/modules/ekf2/CMakeLists.txt
@@ -34,8 +34,7 @@ px4_add_module(
 	MODULE modules__ekf2
 	MAIN ekf2
 	COMPILE_FLAGS
-	STACK_MAIN 2500
-	STACK_MAX 4000
+	STACK_MAX 2400
 	SRCS
 		ekf2_main.cpp
 	DEPENDS

--- a/src/modules/events/CMakeLists.txt
+++ b/src/modules/events/CMakeLists.txt
@@ -34,7 +34,6 @@
 px4_add_module(
 	MODULE modules__events
 	MAIN send_event
-	STACK_MAIN 2200
 	COMPILE_FLAGS
 	SRCS
 		rc_loss_alarm.cpp

--- a/src/modules/fw_pos_control_l1/CMakeLists.txt
+++ b/src/modules/fw_pos_control_l1/CMakeLists.txt
@@ -37,7 +37,6 @@ add_subdirectory(runway_takeoff)
 px4_add_module(
 	MODULE modules__fw_pos_control_l1
 	MAIN fw_pos_control_l1
-	STACK_MAIN 1200
 	SRCS
 		FixedwingPositionControl.cpp
 	DEPENDS

--- a/src/modules/land_detector/CMakeLists.txt
+++ b/src/modules/land_detector/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE modules__land_detector
 	MAIN land_detector
-	STACK_MAIN 1200
 	COMPILE_FLAGS
 	SRCS
 		land_detector_main.cpp

--- a/src/modules/landing_target_estimator/CMakeLists.txt
+++ b/src/modules/landing_target_estimator/CMakeLists.txt
@@ -34,7 +34,6 @@
 px4_add_module(
 	MODULE modules__landing_target_estimator
 	MAIN landing_target_estimator
-	STACK_MAIN 1200
 	COMPILE_FLAGS
 	SRCS
 		landing_target_estimator_main.cpp

--- a/src/modules/load_mon/CMakeLists.txt
+++ b/src/modules/load_mon/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE modules__load_mon
 	MAIN load_mon
-	STACK_MAIN 1200
 	COMPILE_FLAGS
 	SRCS
 		load_mon.cpp

--- a/src/modules/logger/CMakeLists.txt
+++ b/src/modules/logger/CMakeLists.txt
@@ -35,7 +35,6 @@ px4_add_module(
 	MODULE modules__logger
 	MAIN logger
 	PRIORITY "SCHED_PRIORITY_MAX-30"
-	STACK_MAIN 2200
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/modules/mavlink/CMakeLists.txt
+++ b/src/modules/mavlink/CMakeLists.txt
@@ -36,8 +36,6 @@ px4_add_git_submodule(TARGET git_mavlink_v2 PATH "${PX4_SOURCE_DIR}/mavlink/incl
 px4_add_module(
 	MODULE modules__mavlink
 	MAIN mavlink
-	STACK_MAIN 1600
-	STACK_MAX 1600
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 		-Wno-address-of-packed-member # TODO: fix in c_library_v2

--- a/src/modules/mc_att_control/CMakeLists.txt
+++ b/src/modules/mc_att_control/CMakeLists.txt
@@ -36,7 +36,6 @@ add_subdirectory(AttitudeControl)
 px4_add_module(
 	MODULE modules__mc_att_control
 	MAIN mc_att_control
-	STACK_MAIN 1200
 	STACK_MAX 3500
 	COMPILE_FLAGS
 	SRCS

--- a/src/modules/mc_pos_control/CMakeLists.txt
+++ b/src/modules/mc_pos_control/CMakeLists.txt
@@ -38,7 +38,6 @@ px4_add_module(
 	MAIN mc_pos_control
 	COMPILE_FLAGS
 		-Wno-implicit-fallthrough # TODO: fix and remove
-	STACK_MAIN 1500
 	SRCS
 		mc_pos_control_main.cpp
 		PositionControl.cpp

--- a/src/modules/navigator/CMakeLists.txt
+++ b/src/modules/navigator/CMakeLists.txt
@@ -34,8 +34,6 @@
 px4_add_module(
 	MODULE modules__navigator
 	MAIN navigator
-	STACK_MAIN 1300
-	COMPILE_FLAGS
 	SRCS
 		navigator_main.cpp
 		navigator_mode.cpp

--- a/src/modules/replay/CMakeLists.txt
+++ b/src/modules/replay/CMakeLists.txt
@@ -34,8 +34,6 @@ px4_add_module(
 	MODULE modules__replay
 	MAIN replay
 	COMPILE_FLAGS
-	STACK_MAIN 1000
-	STACK_MAX 4000
 	SRCS
 		replay_main.cpp
 	DEPENDS

--- a/src/modules/sensors/CMakeLists.txt
+++ b/src/modules/sensors/CMakeLists.txt
@@ -38,7 +38,6 @@ px4_add_module(
 	MODULE modules__sensors
 	MAIN sensors
 	PRIORITY "SCHED_PRIORITY_MAX-5"
-	STACK_MAIN 1500
 	SRCS
 		voted_sensors_update.cpp
 		rc_update.cpp

--- a/src/modules/sih/CMakeLists.txt
+++ b/src/modules/sih/CMakeLists.txt
@@ -34,7 +34,6 @@
 px4_add_module(
 	MODULE modules__sih
 	MAIN sih
-	STACK_MAIN 1200
 	STACK_MAX 1024
 	COMPILE_FLAGS
 	SRCS

--- a/src/modules/uORB/CMakeLists.txt
+++ b/src/modules/uORB/CMakeLists.txt
@@ -39,7 +39,6 @@ if(NOT "${PX4_BOARD}" MATCHES "px4_io") # TODO: fix this hack (move uORB to plat
 	px4_add_module(
 		MODULE modules__uORB
 		MAIN uorb
-		STACK_MAIN 2100
 		SRCS
 			ORBSet.hpp
 			Publication.hpp

--- a/src/modules/uORB/uORB_tests/CMakeLists.txt
+++ b/src/modules/uORB/uORB_tests/CMakeLists.txt
@@ -34,7 +34,6 @@
 px4_add_module(
 	MODULE modules__uORB__uORB_tests
 	MAIN uorb_tests
-	STACK_MAIN 2048
 	PRIORITY "SCHED_PRIORITY_MAX"
 	SRCS
 		uORB_tests_main.cpp

--- a/src/modules/vmount/CMakeLists.txt
+++ b/src/modules/vmount/CMakeLists.txt
@@ -34,7 +34,6 @@ px4_add_module(
 	MODULE drivers__vmount
 	MAIN vmount
 	COMPILE_FLAGS
-	STACK_MAIN 1024
 	SRCS
 		input.cpp
 		input_mavlink.cpp
@@ -48,4 +47,4 @@ px4_add_module(
 		git_ecl
 		ecl_geo
 	)
- 
+

--- a/src/modules/vtol_att_control/CMakeLists.txt
+++ b/src/modules/vtol_att_control/CMakeLists.txt
@@ -33,8 +33,6 @@
 px4_add_module(
 	MODULE modules__vtol_att_control
 	MAIN vtol_att_control
-	STACK_MAIN 1300
-	COMPILE_FLAGS
 	SRCS
 		vtol_att_control_main.cpp
 		tiltrotor.cpp

--- a/src/systemcmds/dmesg/CMakeLists.txt
+++ b/src/systemcmds/dmesg/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE systemcmds__dmesg
 	MAIN dmesg
-	STACK_MAIN 900
 	SRCS
 		dmesg.cpp
 	)

--- a/src/systemcmds/hardfault_log/CMakeLists.txt
+++ b/src/systemcmds/hardfault_log/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE systemcmds__hardfault_log
 	MAIN hardfault_log
-	STACK_MAIN 2100
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/systemcmds/led_control/CMakeLists.txt
+++ b/src/systemcmds/led_control/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE systemcmds__led_control
 	MAIN led_control
-	STACK_MAIN 2500
 	COMPILE_FLAGS
 	SRCS
 		led_control.cpp

--- a/src/systemcmds/motor_ramp/CMakeLists.txt
+++ b/src/systemcmds/motor_ramp/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
     MODULE systemcmds__motor_ramp
     MAIN motor_ramp
-    STACK_MAIN 1200
     COMPILE_FLAGS
         -Wno-write-strings
     SRCS

--- a/src/systemcmds/mtd/CMakeLists.txt
+++ b/src/systemcmds/mtd/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE systemcmds__mtd
 	MAIN mtd
-	STACK_MAIN 1500
 	COMPILE_FLAGS
 	SRCS
 		mtd.c

--- a/src/systemcmds/nshterm/CMakeLists.txt
+++ b/src/systemcmds/nshterm/CMakeLists.txt
@@ -34,7 +34,6 @@ px4_add_module(
 	MODULE systemcmds__nshterm
 	MAIN nshterm
 	PRIORITY "SCHED_PRIORITY_DEFAULT-30"
-	STACK_MAIN 1500
 	COMPILE_FLAGS
 	SRCS
 		nshterm.c

--- a/src/systemcmds/param/CMakeLists.txt
+++ b/src/systemcmds/param/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE systemcmds__param
 	MAIN param
-	STACK_MAIN 2500
 	COMPILE_FLAGS
 		-Wno-array-bounds
 	SRCS

--- a/src/systemcmds/perf/CMakeLists.txt
+++ b/src/systemcmds/perf/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE systemcmds__perf
 	MAIN perf
-	STACK_MAIN 1800
 	COMPILE_FLAGS
 	SRCS
 		perf.c

--- a/src/systemcmds/pwm/CMakeLists.txt
+++ b/src/systemcmds/pwm/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE systemcmds__pwm
 	MAIN pwm
-	STACK_MAIN 2500
 	COMPILE_FLAGS
 		-Wno-array-bounds
 	SRCS

--- a/src/systemcmds/reboot/CMakeLists.txt
+++ b/src/systemcmds/reboot/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE systemcmds__reboot
 	MAIN reboot
-	STACK_MAIN 800
 	COMPILE_FLAGS
 	SRCS
 		reboot.c

--- a/src/systemcmds/sd_bench/CMakeLists.txt
+++ b/src/systemcmds/sd_bench/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE systemcmds__sd_bench
 	MAIN sd_bench
-	STACK_MAIN 2500
 	COMPILE_FLAGS
 	SRCS
 		sd_bench.c

--- a/src/systemcmds/shutdown/CMakeLists.txt
+++ b/src/systemcmds/shutdown/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE systemcmds__shutdown
 	MAIN shutdown
-	STACK_MAIN 800
 	COMPILE_FLAGS
 	SRCS
 		shutdown.c

--- a/src/systemcmds/top/CMakeLists.txt
+++ b/src/systemcmds/top/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE systemcmds__top
 	MAIN top
-	STACK_MAIN 2000
 	PRIORITY "SCHED_PRIORITY_MAX"
 	COMPILE_FLAGS
 	SRCS

--- a/src/systemcmds/topic_listener/CMakeLists.txt
+++ b/src/systemcmds/topic_listener/CMakeLists.txt
@@ -46,7 +46,6 @@ add_custom_target(generate_topic_listener
 px4_add_module(
 	MODULE systemcmds__topic_listener
 	MAIN listener
-	STACK_MAIN 1800
 	COMPILE_FLAGS
 	INCLUDES
 		${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/systemcmds/tune_control/CMakeLists.txt
+++ b/src/systemcmds/tune_control/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE systemcmds__tune_control
 	MAIN tune_control
-	STACK_MAIN 2500 # TODO: choose an appropriate stack size
 	COMPILE_FLAGS
 	SRCS
 		tune_control.cpp

--- a/src/systemcmds/ver/CMakeLists.txt
+++ b/src/systemcmds/ver/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE systemcmds__ver
 	MAIN ver
-	STACK_MAIN 1224
 	COMPILE_FLAGS
 	SRCS
 		ver.c

--- a/src/templates/module/CMakeLists.txt
+++ b/src/templates/module/CMakeLists.txt
@@ -34,7 +34,6 @@
 px4_add_module(
 	MODULE templates__module
 	MAIN module
-	STACK_MAIN 1024
 	SRCS
 		module.cpp
 	DEPENDS


### PR DESCRIPTION
After https://github.com/PX4/Firmware/pull/12821 went in the px4_fmu-v5_stackcheck build was failing when starting `adc`. Rather than continuing to set this module by module only after we find a problem I propose we simply bump the default STACK_MAIN to something large enough to accommodate the majority of drivers and modules.

This only applies to the MAIN used to start drivers/modules, so doesn't require any additional memory past boot.

Once this build goes through jenkins hardware I'll review the memory (free and largest) before and after.  