### PR TITLE
commander increase cpu overload threshold

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2485,7 +2485,7 @@ control_status_leds(vehicle_status_s *status_local, const actuator_armed_s *actu
 {
 	static hrt_abstime overload_start = 0;
 
-	bool overload = (cpuload_local->load > 0.80f) || (cpuload_local->ram_usage > 0.98f);
+	bool overload = (cpuload_local->load > 0.95f) || (cpuload_local->ram_usage > 0.98f);
 
 	if (overload_start == 0 && overload) {
 		overload_start = hrt_absolute_time();


### PR DESCRIPTION
 * the large 20% margin is no longer appropriate now that nearly all work in the system is
scheduled (out of ISRs) and represented in the load percentage
 * closes https://github.com/PX4/Firmware/issues/12753