### PR TITLE
Multiply degrees in vmount/DO_MOUNT_CONTROL

### DIFF
--- a/src/modules/vmount/output.h
+++ b/src/modules/vmount/output.h
@@ -66,6 +66,7 @@ struct OutputConfig {
 
 	uint32_t mavlink_sys_id;	/**< Mavlink target system id for mavlink output */
 	uint32_t mavlink_comp_id;
+	uint32_t custom_gimbal;		/**< Custom gimbal device */
 };
 
 

--- a/src/modules/vmount/output_mavlink.cpp
+++ b/src/modules/vmount/output_mavlink.cpp
@@ -97,7 +97,7 @@ int OutputMavlink::update(const ControlData *control_data)
 		break;
 
 	case 1: // Gremsy Pixy F - need to multiply the degrees by 100
-		vehicle_command.param1 = math::degrees(_angle_outputs[1] + _config.pitch_offset) * 1e2f;
+		vehicle_command.param1 = math::degrees(_angle_outputs[1] + _config.pitch_offset) * -1e2f;
 		vehicle_command.param2 = math::degrees(_angle_outputs[0] + _config.roll_offset) * 1e2f;
 		vehicle_command.param3 = math::degrees(_angle_outputs[2] + _config.yaw_offset) * 1e2f;
 		break;

--- a/src/modules/vmount/vmount.cpp
+++ b/src/modules/vmount/vmount.cpp
@@ -99,6 +99,7 @@ struct Parameters {
 	float mnt_off_pitch;
 	float mnt_off_roll;
 	float mnt_off_yaw;
+	int32_t mnt_out_custom;
 
 	bool operator!=(const Parameters &p)
 	{
@@ -119,7 +120,8 @@ struct Parameters {
 		       mnt_range_yaw != p.mnt_range_yaw ||
 		       mnt_off_pitch != p.mnt_off_pitch ||
 		       mnt_off_roll != p.mnt_off_roll ||
-		       mnt_off_yaw != p.mnt_off_yaw;
+		       mnt_off_yaw != p.mnt_off_yaw ||
+		       mnt_out_custom != p.mnt_out_custom;
 #pragma GCC diagnostic pop
 
 	}
@@ -142,6 +144,7 @@ struct ParameterHandles {
 	param_t mnt_off_pitch;
 	param_t mnt_off_roll;
 	param_t mnt_off_yaw;
+	param_t mnt_out_custom;
 };
 
 
@@ -233,6 +236,7 @@ static int vmount_thread_main(int argc, char *argv[])
 			output_config.pitch_offset = params.mnt_off_pitch * M_DEG_TO_RAD_F;
 			output_config.roll_offset = params.mnt_off_roll * M_DEG_TO_RAD_F;
 			output_config.yaw_offset = params.mnt_off_yaw * M_DEG_TO_RAD_F;
+			output_config.custom_gimbal = params.mnt_out_custom;
 			output_config.mavlink_sys_id = params.mnt_mav_sysid;
 			output_config.mavlink_comp_id = params.mnt_mav_compid;
 
@@ -531,6 +535,7 @@ void update_params(ParameterHandles &param_handles, Parameters &params, bool &go
 	param_get(param_handles.mnt_off_pitch, &params.mnt_off_pitch);
 	param_get(param_handles.mnt_off_roll, &params.mnt_off_roll);
 	param_get(param_handles.mnt_off_yaw, &params.mnt_off_yaw);
+	param_get(param_handles.mnt_out_custom, &params.mnt_out_custom);
 
 	got_changes = prev_params != params;
 }
@@ -553,6 +558,7 @@ bool get_params(ParameterHandles &param_handles, Parameters &params)
 	param_handles.mnt_off_pitch = param_find("MNT_OFF_PITCH");
 	param_handles.mnt_off_roll = param_find("MNT_OFF_ROLL");
 	param_handles.mnt_off_yaw = param_find("MNT_OFF_YAW");
+	param_handles.mnt_out_custom = param_find("MNT_OUT_CUSTOM");
 
 	if (param_handles.mnt_mode_in == PARAM_INVALID ||
 	    param_handles.mnt_mode_out == PARAM_INVALID ||
@@ -569,7 +575,8 @@ bool get_params(ParameterHandles &param_handles, Parameters &params)
 	    param_handles.mnt_range_yaw == PARAM_INVALID ||
 	    param_handles.mnt_off_pitch == PARAM_INVALID ||
 	    param_handles.mnt_off_roll == PARAM_INVALID ||
-	    param_handles.mnt_off_yaw == PARAM_INVALID) {
+	    param_handles.mnt_off_yaw == PARAM_INVALID ||
+	    param_handles.mnt_out_custom == PARAM_INVALID) {
 		return false;
 	}
 

--- a/src/modules/vmount/vmount_params.c
+++ b/src/modules/vmount/vmount_params.c
@@ -228,3 +228,14 @@ PARAM_DEFINE_FLOAT(MNT_OFF_ROLL, 0.0f);
 * @group Mount
 */
 PARAM_DEFINE_FLOAT(MNT_OFF_YAW, 0.0f);
+
+/**
+* Custom mount settings for specific gimbal devices.
+*
+* @value 0 DEFAULT
+* @value 1 Gremsy Pixy F
+* @min 0
+* @max 1
+* @group Mount
+*/
+PARAM_DEFINE_INT32(MNT_OUT_CUSTOM, 0);


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
Gimbals from Gremsy expect DO_MOUNT_CONTROL messages with the degrees multiplied by 100. This pull request adds the possibility to specify this multiplier, which defaults to 1.

**Test data / coverage**
Tested with Gremsy Pixy F gimbal. Responds correctly to /mavros/mount_control/command (see https://github.com/mavlink/mavros/pull/1257) with mode 2 (DO_MOUNT_CONTROL).

**Describe your preferred solution**
Some gimbals vary a bit from the standard MAVLink messages. Even though I think it's bad to deviate from the MAVLink standard, this was the only feasible solution in one of our drones as we had no UART ports left.

**Describe possible alternatives**
For this type of gimbal, create a UART connection to the gimbal from a companion computer and send those custom MAVLink commands not from Pixhawk. This requires a companion computer though.