### PR TITLE
fmu-v5: add baro again in startup

### DIFF
--- a/boards/px4/fmu-v5/init/rc.board_sensors
+++ b/boards/px4/fmu-v5/init/rc.board_sensors
@@ -24,3 +24,6 @@ lis3mdl -X start
 
 # Possible internal compass
 ist8310 -C -b 5 start
+
+# Baro on internal SPI
+ms5611 -s start


### PR DESCRIPTION
With https://github.com/PX4/Firmware/pull/12848, the baro startup for fmu-v5 has been removed.

This PR reverts that.