### PR TITLE
controllib: fix for undefined sanitizer

### DIFF
--- a/src/lib/controllib/BlockLowPass.hpp
+++ b/src/lib/controllib/BlockLowPass.hpp
@@ -44,6 +44,7 @@
 #include <time.h>
 #include <stdlib.h>
 #include <math.h>
+#include <float.h>
 #include <mathlib/math/test/test.hpp>
 #include <mathlib/math/filter/LowPassFilter2p.hpp>
 
@@ -65,7 +66,7 @@ public:
 // methods
 	BlockLowPass(SuperBlock *parent, const char *name) :
 		Block(parent, name),
-		_state(0.0f / 0.0f /* initialize to invalid val, force into is_finite() check on first call */),
+		_state(NAN /* initialize to invalid val, force into is_finite() check on first call */),
 		_fCut(this, "") // only one parameter, no need to name
 	{}
 	virtual ~BlockLowPass() {}


### PR DESCRIPTION
This prevents the undefined sanitizer from complaining.