### PR TITLE
PMW3901: use quality metric

### DIFF
--- a/src/drivers/optical_flow/pmw3901/PMW3901.cpp
+++ b/src/drivers/optical_flow/pmw3901/PMW3901.cpp
@@ -302,6 +302,7 @@ PMW3901::Run()
 
 	int16_t delta_x_raw = 0;
 	int16_t delta_y_raw = 0;
+	uint8_t qual = 0;
 	float delta_x = 0.0f;
 	float delta_y = 0.0f;
 
@@ -311,7 +312,7 @@ PMW3901::Run()
 
 	_flow_dt_sum_usec += dt_flow;
 
-	readMotionCount(delta_x_raw, delta_y_raw);
+	readMotionCount(delta_x_raw, delta_y_raw, qual);
 
 	_flow_sum_x += delta_x_raw;
 	_flow_sum_y += delta_y_raw;
@@ -346,7 +347,7 @@ PMW3901::Run()
 		report.quality = 0;
 
 	} else {
-		report.quality = 255;
+		report.quality = qual;
 	}
 
 	/* No gyro on this board */
@@ -369,13 +370,13 @@ PMW3901::Run()
 }
 
 int
-PMW3901::readMotionCount(int16_t &deltaX, int16_t &deltaY)
+PMW3901::readMotionCount(int16_t &deltaX, int16_t &deltaY, uint8_t &qual)
 {
-	uint8_t data[10] = { DIR_READ(0x02), 0, DIR_READ(0x03), 0, DIR_READ(0x04), 0,
-			     DIR_READ(0x05), 0, DIR_READ(0x06), 0
+	uint8_t data[12] = { DIR_READ(0x02), 0, DIR_READ(0x03), 0, DIR_READ(0x04), 0,
+			     DIR_READ(0x05), 0, DIR_READ(0x06), 0, DIR_READ(0x07), 0
 			   };
 
-	int ret = transfer(&data[0], &data[0], 10);
+	int ret = transfer(&data[0], &data[0], 12);
 
 	if (OK != ret) {
 		perf_count(_comms_errors);
@@ -385,6 +386,7 @@ PMW3901::readMotionCount(int16_t &deltaX, int16_t &deltaY)
 
 	deltaX = ((int16_t)data[5] << 8) | data[3];
 	deltaY = ((int16_t)data[9] << 8) | data[7];
+	qual = data[11];
 
 	ret = OK;
 

--- a/src/drivers/optical_flow/pmw3901/PMW3901.hpp
+++ b/src/drivers/optical_flow/pmw3901/PMW3901.hpp
@@ -141,5 +141,5 @@ private:
 	int writeRegister(unsigned reg, uint8_t data);
 
 	int sensorInit();
-	int readMotionCount(int16_t &deltaX, int16_t &deltaY);
+	int readMotionCount(int16_t &deltaX, int16_t &deltaY, uint8_t &qual);
 };


### PR DESCRIPTION
This PR adds support for the quality metric of the flow data of the PMW3901 optical flow sensor.

Previously, the quality field of the `distance_sensor` message was populated in a binary way, either 0 for infinitesimally small motion or 255 in any other case.

![image](https://user-images.githubusercontent.com/14265408/64251276-7031fe00-cf18-11e9-8dcf-4c26f3a460c5.png)

However, the data inherently computes a flow metric which can be read from register 7. (See [here](https://wiki.bitcraze.io/_media/projects:crazyflie2:expansionboards:pot0189-pmw3901mb-txqt-ds-r1.00-200317_20170331160807_public.pdf))

![image](https://user-images.githubusercontent.com/14265408/64250786-488e6600-cf17-11e9-922a-29d64852decb.png)

Sadly, I was unable to find any documentation about what the values really mean. But I've done a good amount of testing and must say that it correlates exceptionally well with what I would expect to influence the flow quality:
- It goes very low (<60, with long spans of constant 0) in complete darkness
- It goes very low if there is no texture
- It's around 80-100 in normal office lighting
- It's around 120-150 on a sunny day outside

I'm not familiar with the exact way how this data is fused by EKF2, but I believe that it scales the variance linearly between `EKF2_OF_QMIN`  and 255. Based on my tests I would recommend that parameter to be set to 60.

** Handheld flow-tests **
I started the logger and took my quad for a little walk. Obviously the two "walks" are not very similar. This is just to get an idea of how often EKF2 resets, how much it drifts etc. I can not see a difference in performance between the two, to be honest. But I can't imagine things would be worse
Master: https://review.px4.io/plot_app?log=348f5982-94b0-4d92-8ed7-1f506576eef4
This PR: https://review.px4.io/plot_app?log=baf10d57-5b5d-4de5-b596-c6b9b0d9873e