### PR TITLE
lib/led: temporarily ignore implicit fallthrough warning

### DIFF
--- a/src/lib/led/CMakeLists.txt
+++ b/src/lib/led/CMakeLists.txt
@@ -32,3 +32,6 @@
 ############################################################################
 
 px4_add_library(led led.cpp)
+target_compile_options(led
+	PRIVATE -Wno-implicit-fallthrough # TODO: fix and remove
+)


### PR DESCRIPTION
I'm seeing the build failure in a few other random places. Let's just silence it for now per library and push on switching to c++17 ([[fallthrough]]) as soon as possible post v1.10.

http://ci.px4.io:8080/job/PX4_misc/job/Firmware_memory_map/283/console