### PR TITLE
Multicopter mission guidance improvements

### DIFF
--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
@@ -147,15 +147,9 @@ inline float FlightTaskAutoLineSmoothVel::_constrainOneSide(float val, float con
 	return math::constrain(val, min, max);
 }
 
-float FlightTaskAutoLineSmoothVel::_constrainAbs(float val, float constraint)
+float FlightTaskAutoLineSmoothVel::_constrainAbs(float val, float min, float max)
 {
-	float constraint_abs = fabsf(constraint);
-	return math::constrain(val, -constraint_abs, constraint_abs);
-}
-
-float FlightTaskAutoLineSmoothVel::_maxAbs(float val, float constraint)
-{
-	return math::sign(val) * math::max(fabsf(val), fabsf(constraint));
+	return math::sign(val) * math::constrain(fabsf(val), fabsf(min), fabsf(max));
 }
 
 void FlightTaskAutoLineSmoothVel::_initEkfResetCounters()
@@ -280,8 +274,6 @@ void FlightTaskAutoLineSmoothVel::_prepareSetpoints()
 				// to force the drone to pass the waypoint with a desired speed
 				Vector2f u_prev_to_target_xy((_target - _prev_wp).unit_or_zero());
 				vel_min_xy = u_prev_to_target_xy * _getSpeedAtTarget();
-				vel_min_xy(0) = fabsf(vel_min_xy(0));
-				vel_min_xy(1) = fabsf(vel_min_xy(1));
 
 			} else {
 				// The drone has to change altitude, stop at the waypoint
@@ -290,8 +282,8 @@ void FlightTaskAutoLineSmoothVel::_prepareSetpoints()
 
 			// Constrain the norm of each component using min and max values
 			Vector2f vel_sp_constrained_xy;
-			vel_sp_constrained_xy(0) = _maxAbs(_constrainAbs(vel_sp_xy(0), vel_max_xy(0)), vel_min_xy(0));
-			vel_sp_constrained_xy(1) = _maxAbs(_constrainAbs(vel_sp_xy(1), vel_max_xy(1)), vel_min_xy(1));
+			vel_sp_constrained_xy(0) = _constrainAbs(vel_sp_xy(0), vel_min_xy(0), vel_max_xy(0));
+			vel_sp_constrained_xy(1) = _constrainAbs(vel_sp_xy(1), vel_min_xy(1), vel_max_xy(1));
 
 			for (int i = 0; i < 2; i++) {
 				// If available, constrain the velocity using _velocity_setpoint(.)

--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
@@ -73,8 +73,7 @@ protected:
 	bool _checkTakeoff() override { return _want_takeoff; };
 
 	inline float _constrainOneSide(float val, float constraint); /**< Constrain val between INF and constraint */
-	inline float _constrainAbs(float val, float constraint); /**< Constrain the absolute value of val */
-	inline float _maxAbs(float val, float constraint); /**< Maximum of val and constraint with the sign of val */
+	inline float _constrainAbs(float val, float min, float max); /**< Constrain the absolute value of val to be at least min and at most max */
 
 	void _initEkfResetCounters();
 	void _checkEkfResetCounters(); /**< Reset the trajectories when the ekf resets velocity or position */

--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
@@ -72,7 +72,10 @@ protected:
 	/** determines when to trigger a takeoff (ignored in flight) */
 	bool _checkTakeoff() override { return _want_takeoff; };
 
-	inline float _constrainOneSide(float val, float constrain);
+	inline float _constrainOneSide(float val, float constraint); /**< Constrain val between INF and constraint */
+	inline float _constrainAbs(float val, float constraint); /**< Constrain the absolute value of val */
+	inline float _maxAbs(float val, float constraint); /**< Maximum of val and constraint with the sign of val */
+
 	void _initEkfResetCounters();
 	void _checkEkfResetCounters(); /**< Reset the trajectories when the ekf resets velocity or position */
 	void _generateHeading();

--- a/src/lib/mathlib/math/Functions.hpp
+++ b/src/lib/mathlib/math/Functions.hpp
@@ -48,7 +48,7 @@ namespace math
 template<typename T>
 int sign(T val)
 {
-	return (T(0) < val) - (val < T(0));
+	return (T(FLT_EPSILON) < val) - (val < T(FLT_EPSILON));
 }
 
 // Type-safe signum function with zero treated as positive


### PR DESCRIPTION
A recent modification (#12505 ) allows the drone to pass through a waypoint without completely stopping depending on the previous-current-next waypoints and the maximum centripetal acceleration. The implementation had visible corner cases when the path is parallel to the north or east axis as shown on the picture below:
![bokeh_plot(23)](https://user-images.githubusercontent.com/14822839/64342552-0df5fd80-cfeb-11e9-90d4-f74d47ee66a3.png)
(log: https://logs.px4.io/plot_app?log=d4a1d4ef-48ae-4e80-847c-ddd69d2d95dd )
The problem is that the velocity the drone is allowed to fly in a waypoint was directly applied to the norm of the velocity vector instead of each axis independently.

This PR fixes that behavior by applying properly the constraints to each component of the velocity vector:
![bokeh_plot(24)](https://user-images.githubusercontent.com/14822839/64342728-6d540d80-cfeb-11e9-8358-ce9c826e25cb.png)
(log: https://logs.px4.io/plot_app?log=85680273-9b06-44e7-b7a4-918b79581d05 )

**Additional change** the signum function now compares the number against `FLT_EPSILON` instead of 0 in case of a floating point number. 

FYI @Stifael 