### PR TITLE
Add board orientation ROLL_90_YAW_270

### DIFF
--- a/src/lib/conversion/rotation.cpp
+++ b/src/lib/conversion/rotation.cpp
@@ -277,5 +277,13 @@ rotate_3f(enum Rotation rot, float &x, float &y, float &z)
 			x = tmp;
 			return;
 		}
+
+	case ROTATION_ROLL_90_YAW_270: {
+			tmp = x;
+			x = -z;
+			z = y;
+			y = -tmp;
+			return;
+		}
 	}
 }

--- a/src/lib/conversion/rotation.h
+++ b/src/lib/conversion/rotation.h
@@ -84,6 +84,7 @@ enum Rotation {
 	ROTATION_PITCH_9_YAW_180 = 32,
 	ROTATION_PITCH_45 = 33,
 	ROTATION_PITCH_315 = 34,
+	ROTATION_ROLL_90_YAW_270 = 35,
 	ROTATION_MAX
 };
 
@@ -129,6 +130,7 @@ const rot_lookup_t rot_lookup[] = {
 	{  0,   9, 180 },
 	{ 0,   45,   0 },
 	{ 0,  315,   0 },
+	{ 90,   0, 270 },
 };
 
 /**

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -161,6 +161,7 @@ PARAM_DEFINE_FLOAT(SENS_BARO_QNH, 1013.25f);
  * @value 32 Pitch 9°, Yaw 180°
  * @value 33 Pitch 45°
  * @value 34 Pitch 315°
+ * @value 35 Roll 90°, Yaw 270°
  *
  * @reboot_required true
  *


### PR DESCRIPTION
Adds support for board orientation Roll = 90 ° and Yaw = 270°.

Note: the PX4 rotation enum has diverged from the MAVLink rotation enum, I opened a separate issue https://github.com/PX4/Firmware/issues/12906 .
