### PR TITLE
Refactor jerk-limited trajectory generator

### DIFF
--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
@@ -349,13 +349,13 @@ void FlightTaskAutoLineSmoothVel::_generateTrajectory()
 	Vector2f position_xy(_position);
 	Vector2f vel_traj_xy(_trajectory[0].getCurrentVelocity(), _trajectory[1].getCurrentVelocity());
 	Vector2f drone_to_trajectory_xy(position_trajectory_xy - position_xy);
-	//float position_error = drone_to_trajectory_xy.length();
+	float position_error = drone_to_trajectory_xy.length();
 
-	//float time_stretch = 1.f - math::constrain(position_error * 0.5f, 0.f, 1.f);
+	float time_stretch = 1.f - math::constrain(position_error * 0.5f, 0.f, 1.f);
 
 	// Don't stretch time if the drone is ahead of the position setpoint
 	if (drone_to_trajectory_xy.dot(vel_traj_xy) < 0.f) {
-		//time_stretch = 1.f;
+		time_stretch = 1.f;
 	}
 
 	Vector3f jerk_sp_smooth;
@@ -364,16 +364,17 @@ void FlightTaskAutoLineSmoothVel::_generateTrajectory()
 	Vector3f pos_sp_smooth;
 
 	for (int i = 0; i < 3; ++i) {
-		// TODO: fix time stretch
-		//_trajectory[i].updateTraj(_time_stamp_current, time_stretch, accel_sp_smooth(i), vel_sp_smooth(i), pos_sp_smooth(i));
-		_trajectory[i].updateTraj(_time, accel_sp_smooth(i), vel_sp_smooth(i), pos_sp_smooth(i));
+		_trajectory[i].updateTraj(_deltatime, time_stretch);
 		jerk_sp_smooth(i) = _trajectory[i].getCurrentJerk();
+		accel_sp_smooth(i) = _trajectory[i].getCurrentAcceleration();
+		vel_sp_smooth(i) = _trajectory[i].getCurrentVelocity();
+		pos_sp_smooth(i) = _trajectory[i].getCurrentPosition();
 	}
 
 	_updateTrajConstraints();
 
 	for (int i = 0; i < 3; ++i) {
-		_trajectory[i].updateDurations(_time, _velocity_setpoint(i));
+		_trajectory[i].updateDurations(_velocity_setpoint(i));
 	}
 
 	VelocitySmoothing::timeSynchronization(_trajectory, 2); // Synchronize x and y only

--- a/src/lib/FlightTasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.cpp
@@ -155,7 +155,8 @@ void FlightTaskManualAltitudeSmoothVel::_updateSetpoints()
 
 	float pos_sp_smooth;
 
-	_smoothing.integrate(_acceleration_setpoint(2), _vel_sp_smooth, pos_sp_smooth);
+	// TODO: move before updateDurations
+	_smoothing.updateTraj(_time_stamp_current, _acceleration_setpoint(2), _vel_sp_smooth, pos_sp_smooth);
 	_velocity_setpoint(2) = _vel_sp_smooth; // Feedforward
 	_jerk_setpoint(2) = _smoothing.getCurrentJerk();
 

--- a/src/lib/FlightTasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.cpp
@@ -106,6 +106,15 @@ void FlightTaskManualAltitudeSmoothVel::_checkEkfResetCounters()
 
 void FlightTaskManualAltitudeSmoothVel::_updateSetpoints()
 {
+	float pos_sp_smooth;
+
+	_smoothing.updateTraj(_deltatime);
+
+	_jerk_setpoint(2) = _smoothing.getCurrentJerk();
+	_acceleration_setpoint(2) = _smoothing.getCurrentAcceleration();
+	_vel_sp_smooth = _smoothing.getCurrentVelocity();
+	pos_sp_smooth = _smoothing.getCurrentPosition();
+
 	/* Get yaw setpont, un-smoothed position setpoints.*/
 	FlightTaskManualAltitude::_updateSetpoints();
 
@@ -142,26 +151,12 @@ void FlightTaskManualAltitudeSmoothVel::_updateSetpoints()
 		_position_lock_z_active = false;
 	}
 
-	// During position lock, lower jerk to help the optimizer
-	// to converge to 0 acceleration and velocity
-	jerk = _position_lock_z_active ? 1.f : _param_mpc_jerk_max.get();
-
 	_smoothing.setMaxJerk(jerk);
 	_smoothing.updateDurations(_velocity_setpoint(2));
 
 	if (!_position_lock_z_active) {
 		_smoothing.setCurrentPosition(_position(2));
 	}
-
-	float pos_sp_smooth;
-
-	// TODO: move before updateDurations
-	_smoothing.updateTraj(_deltatime);
-
-	_jerk_setpoint(2) = _smoothing.getCurrentJerk();
-	_acceleration_setpoint(2) = _smoothing.getCurrentAcceleration();
-	_vel_sp_smooth = _smoothing.getCurrentVelocity();
-	pos_sp_smooth = _smoothing.getCurrentPosition();
 
 	_velocity_setpoint(2) = _vel_sp_smooth; // Feedforward
 

--- a/src/lib/FlightTasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.cpp
@@ -147,7 +147,7 @@ void FlightTaskManualAltitudeSmoothVel::_updateSetpoints()
 	jerk = _position_lock_z_active ? 1.f : _param_mpc_jerk_max.get();
 
 	_smoothing.setMaxJerk(jerk);
-	_smoothing.updateDurations(_deltatime, _velocity_setpoint(2));
+	_smoothing.updateDurations(_velocity_setpoint(2));
 
 	if (!_position_lock_z_active) {
 		_smoothing.setCurrentPosition(_position(2));
@@ -156,9 +156,14 @@ void FlightTaskManualAltitudeSmoothVel::_updateSetpoints()
 	float pos_sp_smooth;
 
 	// TODO: move before updateDurations
-	_smoothing.updateTraj(_time_stamp_current, _acceleration_setpoint(2), _vel_sp_smooth, pos_sp_smooth);
-	_velocity_setpoint(2) = _vel_sp_smooth; // Feedforward
+	_smoothing.updateTraj(_deltatime);
+
 	_jerk_setpoint(2) = _smoothing.getCurrentJerk();
+	_acceleration_setpoint(2) = _smoothing.getCurrentAcceleration();
+	_vel_sp_smooth = _smoothing.getCurrentVelocity();
+	pos_sp_smooth = _smoothing.getCurrentPosition();
+
+	_velocity_setpoint(2) = _vel_sp_smooth; // Feedforward
 
 	if (fabsf(_vel_sp_smooth) < 0.1f &&
 	    fabsf(_acceleration_setpoint(2)) < .2f &&

--- a/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
@@ -141,6 +141,13 @@ void FlightTaskManualPositionSmoothVel::_checkEkfResetCounters()
 
 void FlightTaskManualPositionSmoothVel::_updateSetpoints()
 {
+	Vector3f pos_sp_smooth;
+
+	for (int i = 0; i < 3; ++i) {
+		_smoothing[i].updateTraj(_time_stamp_current, _acceleration_setpoint(i), _vel_sp_smooth(i), pos_sp_smooth(i));
+		_jerk_setpoint(i) = _smoothing[i].getCurrentJerk();
+	}
+
 	/* Get yaw setpont, un-smoothed position setpoints.*/
 	FlightTaskManualPosition::_updateSetpoints();
 
@@ -194,22 +201,9 @@ void FlightTaskManualPositionSmoothVel::_updateSetpoints()
 		_position_lock_z_active = false;
 	}
 
-	// During position lock, lower jerk to help the optimizer
-	// to converge to 0 acceleration and velocity
-	if (_position_lock_xy_active) {
-		jerk[0] = 1.f;
-		jerk[1] = 1.f;
-
-	} else {
-		jerk[0] = _param_mpc_jerk_max.get();
-		jerk[1] = _param_mpc_jerk_max.get();
-	}
-
-	jerk[2] = _position_lock_z_active ? 1.f : _param_mpc_jerk_max.get();
-
 	for (int i = 0; i < 3; ++i) {
 		_smoothing[i].setMaxJerk(jerk[i]);
-		_smoothing[i].updateDurations(_deltatime, _velocity_setpoint(i));
+		_smoothing[i].updateDurations(_time_stamp_current, _velocity_setpoint(i));
 	}
 
 	VelocitySmoothing::timeSynchronization(_smoothing, 2); // Synchronize x and y only
@@ -221,14 +215,6 @@ void FlightTaskManualPositionSmoothVel::_updateSetpoints()
 
 	if (!_position_lock_z_active) {
 		_smoothing[2].setCurrentPosition(_position(2));
-	}
-
-	Vector3f pos_sp_smooth;
-
-	for (int i = 0; i < 3; ++i) {
-		_smoothing[i].integrate(_acceleration_setpoint(i), _vel_sp_smooth(i), pos_sp_smooth(i));
-		_velocity_setpoint(i) = _vel_sp_smooth(i); // Feedforward
-		_jerk_setpoint(i) = _smoothing[i].getCurrentJerk();
 	}
 
 	// Check for position lock transition
@@ -276,6 +262,7 @@ void FlightTaskManualPositionSmoothVel::_updateSetpoints()
 		}
 	}
 
+	_velocity_setpoint = _vel_sp_smooth; // Feedforward
 	_position_setpoint(0) = _position_setpoint_xy_locked(0);
 	_position_setpoint(1) = _position_setpoint_xy_locked(1);
 	_position_setpoint(2) = _position_setpoint_z_locked;

--- a/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
@@ -144,8 +144,12 @@ void FlightTaskManualPositionSmoothVel::_updateSetpoints()
 	Vector3f pos_sp_smooth;
 
 	for (int i = 0; i < 3; ++i) {
-		_smoothing[i].updateTraj(_time_stamp_current, _acceleration_setpoint(i), _vel_sp_smooth(i), pos_sp_smooth(i));
+		_smoothing[i].updateTraj(_deltatime);
+
 		_jerk_setpoint(i) = _smoothing[i].getCurrentJerk();
+		_acceleration_setpoint(i) = _smoothing[i].getCurrentAcceleration();
+		_vel_sp_smooth(i) = _smoothing[i].getCurrentVelocity();
+		pos_sp_smooth(i) = _smoothing[i].getCurrentPosition();
 	}
 
 	/* Get yaw setpont, un-smoothed position setpoints.*/
@@ -203,7 +207,7 @@ void FlightTaskManualPositionSmoothVel::_updateSetpoints()
 
 	for (int i = 0; i < 3; ++i) {
 		_smoothing[i].setMaxJerk(jerk[i]);
-		_smoothing[i].updateDurations(_time_stamp_current, _velocity_setpoint(i));
+		_smoothing[i].updateDurations(_velocity_setpoint(i));
 	}
 
 	VelocitySmoothing::timeSynchronization(_smoothing, 2); // Synchronize x and y only

--- a/src/lib/FlightTasks/tasks/Utility/VelocitySmoothing.cpp
+++ b/src/lib/FlightTasks/tasks/Utility/VelocitySmoothing.cpp
@@ -35,7 +35,6 @@
 
 #include <cstdio>
 #include <float.h>
-
 #include <mathlib/mathlib.h>
 
 VelocitySmoothing::VelocitySmoothing(float initial_accel, float initial_vel, float initial_pos)
@@ -238,12 +237,7 @@ Trajectory VelocitySmoothing::evaluatePoly(float j, float a0, float v0, float x0
 
 void VelocitySmoothing::updateTraj(float dt, float time_stretch)
 {
-	updateTraj(dt * time_stretch);
-}
-
-void VelocitySmoothing::updateTraj(float dt)
-{
-	_local_time += dt;
+	_local_time += dt * time_stretch;
 	const float t = _local_time;
 	float t1 = 0.f;
 	float t2 = 0.f;

--- a/src/lib/FlightTasks/tasks/Utility/VelocitySmoothing.cpp
+++ b/src/lib/FlightTasks/tasks/Utility/VelocitySmoothing.cpp
@@ -241,22 +241,21 @@ void VelocitySmoothing::updateTraj(float dt, float time_stretch)
 {
 	_local_time += dt * time_stretch;
 	float t_remain = _local_time;
-	float t[3];
 
-	t[0] = math::min(t_remain, _T1);
-	_state = evaluatePoly(_max_jerk, _state_init.a, _state_init.v, _state_init.x, t[0], _direction);
-	t_remain -= t[0];
+	float t1 = math::min(t_remain, _T1);
+	_state = evaluatePoly(_max_jerk, _state_init.a, _state_init.v, _state_init.x, t1, _direction);
+	t_remain -= t1;
 
 	if (t_remain > 0.f) {
-		t[1] = math::min(t_remain, _T2);
-		_state = evaluatePoly(0.f, _state.a, _state.v, _state.x, t[1], 0.f);
-		t_remain -= t[1];
+		float t2 = math::min(t_remain, _T2);
+		_state = evaluatePoly(0.f, _state.a, _state.v, _state.x, t2, 0.f);
+		t_remain -= t2;
 	}
 
 	if (t_remain > 0.f) {
-		t[2] = math::min(t_remain, _T3);
-		_state = evaluatePoly(_max_jerk, _state.a, _state.v, _state.x, t[2], -_direction);
-		t_remain -= t[2];
+		float t3 = math::min(t_remain, _T3);
+		_state = evaluatePoly(_max_jerk, _state.a, _state.v, _state.x, t3, -_direction);
+		t_remain -= t3;
 	}
 
 	if (t_remain > 0.f) {

--- a/src/lib/FlightTasks/tasks/Utility/VelocitySmoothing.cpp
+++ b/src/lib/FlightTasks/tasks/Utility/VelocitySmoothing.cpp
@@ -48,6 +48,8 @@ void VelocitySmoothing::reset(float accel, float vel, float pos)
 	_state.a = accel;
 	_state.v = vel;
 	_state.x = pos;
+
+	_state_init = _state;
 }
 
 float VelocitySmoothing::saturateT1ForAccel(float a0, float j_max, float T1, float a_max)

--- a/src/lib/FlightTasks/tasks/Utility/VelocitySmoothing.cpp
+++ b/src/lib/FlightTasks/tasks/Utility/VelocitySmoothing.cpp
@@ -188,7 +188,7 @@ int VelocitySmoothing::computeDirection()
 	if (direction == 0) {
 		// If by braking immediately the velocity is exactly
 		// the require one with zero acceleration, then brake
-		direction = -math::sign(_state.a);
+		direction = math::sign(_state.a);
 	}
 
 	return direction;

--- a/src/lib/FlightTasks/tasks/Utility/VelocitySmoothing.hpp
+++ b/src/lib/FlightTasks/tasks/Utility/VelocitySmoothing.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018-2019 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -81,17 +81,17 @@ public:
 
 	/**
 	 * Generate the trajectory (acceleration, velocity and position) by integrating the current jerk
-	 * @param dt optional integration period. If not given, the integration period provided during updateDuration call is used.
-	 * 	A dt different from the one given during the computation of T1-T3 can be used to fast-forward or slow-down the trajectory.
+	 * @param dt integration period
+	 * @param time_stretch (optional) used to scale the integration period. This can be used to slow down
+	 * or fast-forward the trajectory
 	 */
-	void updateTraj(float dt, float time_stretch);
-	void updateTraj(float dt);
+	void updateTraj(float dt, float time_stretch = 1.f);
 
-	/* Get / Set constraints (constraints can be updated at any time) */
+	/**
+	 * Getters and setters
+	 */
 	float getMaxJerk() const { return _max_jerk; }
 	void setMaxJerk(float max_jerk) { _max_jerk = max_jerk; }
-
-
 
 	float getMaxAccel() const { return _max_accel; }
 	void setMaxAccel(float max_accel) { _max_accel = max_accel; }
@@ -107,6 +107,13 @@ public:
 	void setCurrentPosition(const float pos) { _state.x = pos; }
 	float getCurrentPosition() const { return _state.x; }
 
+	float getVelSp() const { return _vel_sp; }
+
+	float getT1() const { return _T1; }
+	float getT2() const { return _T2; }
+	float getT3() const { return _T3; }
+	float getTotalTime() const { return _T1 + _T2 + _T3; }
+
 	/**
 	 * Synchronize several trajectories to have the same total time. This is required to generate
 	 * straight lines.
@@ -115,12 +122,6 @@ public:
 	 * @param n_traj the number of trajectories to be synchronized
 	 */
 	static void timeSynchronization(VelocitySmoothing *traj, int n_traj);
-
-	float getTotalTime() const { return _T1 + _T2 + _T3; }
-	float getT1() const { return _T1; }
-	float getT2() const { return _T2; }
-	float getT3() const { return _T3; }
-	float getVelSp() const { return _vel_sp; }
 
 private:
 
@@ -152,19 +153,27 @@ private:
 	 * Compute increasing acceleration time
 	 */
 	inline float computeT1(float a0, float v3, float j_max, float a_max);
+
 	/**
 	 * Compute increasing acceleration time using total time constraint
 	 */
 	inline float computeT1(float T123, float a0, float v3, float j_max, float a_max);
+
+	/**
+	 * Saturate T1 in order to respect the maximum acceleration constraint
+	 */
 	inline float saturateT1ForAccel(float a0, float j_max, float T1, float a_max);
+
 	/**
 	 * Compute constant acceleration time
 	 */
 	inline float computeT2(float T1, float T3, float a0, float v3, float j_max);
+
 	/**
 	 * Compute constant acceleration time using total time constraint
 	 */
 	inline float computeT2(float T123, float T1, float T3);
+
 	/**
 	 * Compute decreasing acceleration time
 	 */

--- a/src/lib/FlightTasks/tasks/Utility/VelocitySmoothing.hpp
+++ b/src/lib/FlightTasks/tasks/Utility/VelocitySmoothing.hpp
@@ -100,11 +100,11 @@ public:
 	void setMaxVel(float max_vel) { _max_vel = max_vel; }
 
 	float getCurrentJerk() const { return _state.j; }
-	void setCurrentAcceleration(const float accel) { _state.a = accel; }
+	void setCurrentAcceleration(const float accel) { _state.a = _state_init.a = accel; }
 	float getCurrentAcceleration() const { return _state.a; }
-	void setCurrentVelocity(const float vel) { _state.v = vel; }
+	void setCurrentVelocity(const float vel) { _state.v = _state_init.v = vel; }
 	float getCurrentVelocity() const { return _state.v; }
-	void setCurrentPosition(const float pos) { _state.x = pos; }
+	void setCurrentPosition(const float pos) { _state.x = _state_init.x = pos; }
 	float getCurrentPosition() const { return _state.x; }
 
 	float getVelSp() const { return _vel_sp; }

--- a/src/lib/FlightTasks/tasks/Utility/VelocitySmoothingTest.cpp
+++ b/src/lib/FlightTasks/tasks/Utility/VelocitySmoothingTest.cpp
@@ -48,7 +48,7 @@ class VelocitySmoothingTest : public ::testing::Test
 public:
 	void setConstraints(float j_max, float a_max, float v_max);
 	void setInitialConditions(Vector3f acc, Vector3f vel, Vector3f pos);
-	void updateTrajectories(Vector3f velocity_setpoints, float dt);
+	void updateTrajectories(Vector3f velocity_setpoints, float t);
 
 	VelocitySmoothing _trajectories[3];
 };
@@ -71,19 +71,19 @@ void VelocitySmoothingTest::setInitialConditions(Vector3f a0, Vector3f v0, Vecto
 	}
 }
 
-void VelocitySmoothingTest::updateTrajectories(Vector3f velocity_setpoints, float dt)
+void VelocitySmoothingTest::updateTrajectories(Vector3f velocity_setpoints, float t)
 {
-	for (int i = 0; i < 3; i++) {
-		_trajectories[i].updateDurations(dt, velocity_setpoints(i));
-	}
-
-	VelocitySmoothing::timeSynchronization(_trajectories, 2);
-
 	float dummy; // We don't care about the immediate result
 
 	for (int i = 0; i < 3; i++) {
-		_trajectories[i].integrate(dummy, dummy, dummy);
+		_trajectories[i].updateTraj(t, dummy, dummy, dummy);
 	}
+
+	for (int i = 0; i < 3; i++) {
+		_trajectories[i].updateDurations(t, velocity_setpoints(i));
+	}
+
+	VelocitySmoothing::timeSynchronization(_trajectories, 2);
 }
 
 TEST_F(VelocitySmoothingTest, testTimeSynchronization)
@@ -96,16 +96,16 @@ TEST_F(VelocitySmoothingTest, testTimeSynchronization)
 	setConstraints(j_max, a_max, v_max);
 
 	// AND: A set of initial conditions
-	Vector3f a0(0.f, 0.f, 0.f);
-	Vector3f v0(0.f, 0.f, 0.f);
+	Vector3f a0(0.22f, 0.f, 0.22f);
+	Vector3f v0(2.47f, -5.59e-6f, 2.47f);
 	Vector3f x0(0.f, 0.f, 0.f);
 
 	setInitialConditions(a0, v0, x0);
 
 	// WHEN: We generate trajectories (time synchronized in XY) with constant setpoints and dt
-	Vector3f velocity_setpoints(0.f, 1.f, 0.f);
-	float dt = 0.01f;
-	updateTrajectories(velocity_setpoints, dt);
+	Vector3f velocity_setpoints(-3.f, 1.f, 0.f);
+	updateTrajectories(velocity_setpoints, 0.f);
+
 
 	// THEN: The X and Y trajectories should have the same total time (= time sunchronized)
 	EXPECT_LE(fabsf(_trajectories[0].getTotalTime() - _trajectories[1].getTotalTime()), 0.0001);
@@ -114,27 +114,29 @@ TEST_F(VelocitySmoothingTest, testTimeSynchronization)
 TEST_F(VelocitySmoothingTest, testConstantSetpoint)
 {
 	// GIVEN: A set of initial conditions (same constraints as before)
-	Vector3f a0(0.22f, 0.f, 0.22f);
-	Vector3f v0(2.47f, -5.59e-6f, 2.47f);
+	Vector3f a0(0.f, 0.f, 0.f);
+	Vector3f v0(0.f, 0.f, 0.f);
 	Vector3f x0(0.f, 0.f, 0.f);
 
 	setInitialConditions(a0, v0, x0);
 
 	// WHEN: We generate trajectories with constant setpoints and dt
-	Vector3f velocity_setpoints(0.f, 1.f, 0.f);
-	float dt = 0.01f;
+	Vector3f velocity_setpoints(-3.f, 0.f, -1.f);
 
 	// Compute the number of steps required to reach desired value
 	// because of known numerical issues, the actual trajectory takes a
 	// bit more time than the predicted one, this is why we have to add 14 steps
 	// to the theoretical value.
 	// The updateTrajectories is fist called once to compute the total time
-	updateTrajectories(velocity_setpoints, dt);
+	float t = 0.f;
+	const float dt = 0.01;
+	updateTrajectories(velocity_setpoints, t);
 	float t123 = _trajectories[0].getTotalTime();
-	int nb_steps = ceil(t123 / dt) + 14;
+	int nb_steps = ceil(t123 / dt);
 
 	for (int i = 0; i < nb_steps; i++) {
-		updateTrajectories(velocity_setpoints, dt);
+		t += dt;
+		updateTrajectories(velocity_setpoints, t);
 	}
 
 	// THEN: All the trajectories should have reach their
@@ -156,11 +158,13 @@ TEST_F(VelocitySmoothingTest, testZeroSetpoint)
 
 	// AND: Null setpoints
 	Vector3f velocity_setpoints(0.f, 0.f, 0.f);
-	float dt = 0.01f;
+	float t = 0.f;
+	const float dt = 0.01f;
 
 	// WHEN: We run a few times the algorithm
 	for (int i = 0; i < 60; i++) {
-		updateTrajectories(velocity_setpoints, dt);
+		updateTrajectories(velocity_setpoints, t);
+		t += dt;
 	}
 
 	// THEN: All the trajectories should still be null

--- a/src/lib/FlightTasks/tasks/Utility/VelocitySmoothingTest.cpp
+++ b/src/lib/FlightTasks/tasks/Utility/VelocitySmoothingTest.cpp
@@ -75,6 +75,9 @@ void VelocitySmoothingTest::updateTrajectories(float dt, Vector3f velocity_setpo
 {
 	for (int i = 0; i < 3; i++) {
 		_trajectories[i].updateTraj(dt);
+		EXPECT_LE(fabsf(_trajectories[i].getCurrentJerk()), _trajectories[i].getMaxJerk());
+		EXPECT_LE(fabsf(_trajectories[i].getCurrentAcceleration()), _trajectories[i].getMaxAccel());
+		EXPECT_LE(fabsf(_trajectories[i].getCurrentVelocity()), _trajectories[i].getMaxVel());
 	}
 
 	for (int i = 0; i < 3; i++) {

--- a/src/lib/FlightTasks/tasks/Utility/VelocitySmoothingTest.cpp
+++ b/src/lib/FlightTasks/tasks/Utility/VelocitySmoothingTest.cpp
@@ -48,7 +48,7 @@ class VelocitySmoothingTest : public ::testing::Test
 public:
 	void setConstraints(float j_max, float a_max, float v_max);
 	void setInitialConditions(Vector3f acc, Vector3f vel, Vector3f pos);
-	void updateTrajectories(float t, Vector3f velocity_setpoints);
+	void updateTrajectories(float dt, Vector3f velocity_setpoints);
 
 	VelocitySmoothing _trajectories[3];
 };
@@ -71,16 +71,14 @@ void VelocitySmoothingTest::setInitialConditions(Vector3f a0, Vector3f v0, Vecto
 	}
 }
 
-void VelocitySmoothingTest::updateTrajectories(float t, Vector3f velocity_setpoints)
+void VelocitySmoothingTest::updateTrajectories(float dt, Vector3f velocity_setpoints)
 {
-	float dummy; // We don't care about the immediate result
-
 	for (int i = 0; i < 3; i++) {
-		_trajectories[i].updateTraj(t, dummy, dummy, dummy);
+		_trajectories[i].updateTraj(dt);
 	}
 
 	for (int i = 0; i < 3; i++) {
-		_trajectories[i].updateDurations(t, velocity_setpoints(i));
+		_trajectories[i].updateDurations(velocity_setpoints(i));
 	}
 
 	VelocitySmoothing::timeSynchronization(_trajectories, 2);
@@ -132,15 +130,13 @@ TEST_F(VelocitySmoothingTest, testConstantSetpoint)
 
 	// Compute the number of steps required to reach desired value
 	// The updateTrajectories is fist called once to compute the total time
-	float t = 0.f;
 	const float dt = 0.01;
-	updateTrajectories(t, velocity_setpoints);
+	updateTrajectories(0.f, velocity_setpoints);
 	float t123 = _trajectories[0].getTotalTime();
 	int nb_steps = ceil(t123 / dt);
 
 	for (int i = 0; i < nb_steps; i++) {
-		t += dt;
-		updateTrajectories(t, velocity_setpoints);
+		updateTrajectories(dt, velocity_setpoints);
 	}
 
 	// THEN: All the trajectories should have reach their
@@ -167,7 +163,7 @@ TEST_F(VelocitySmoothingTest, testZeroSetpoint)
 
 	// WHEN: We run a few times the algorithm
 	for (int i = 0; i < 60; i++) {
-		updateTrajectories(t, velocity_setpoints);
+		updateTrajectories(dt, velocity_setpoints);
 		t += dt;
 	}
 

--- a/src/lib/FlightTasks/tasks/Utility/VelocitySmoothingTest.cpp
+++ b/src/lib/FlightTasks/tasks/Utility/VelocitySmoothingTest.cpp
@@ -132,7 +132,7 @@ TEST_F(VelocitySmoothingTest, testConstantSetpoint)
 	Vector3f velocity_setpoints(-3.f, 0.f, -1.f);
 
 	// Compute the number of steps required to reach desired value
-	// The updateTrajectories is fist called once to compute the total time
+	// The updateTrajectories is first called once to compute the total time
 	const float dt = 0.01;
 	updateTrajectories(0.f, velocity_setpoints);
 	float t123 = _trajectories[0].getTotalTime();
@@ -159,7 +159,7 @@ TEST_F(VelocitySmoothingTest, testZeroSetpoint)
 
 	setInitialConditions(a0, v0, x0);
 
-	// AND: Null setpoints
+	// AND: Zero setpoints
 	Vector3f velocity_setpoints(0.f, 0.f, 0.f);
 	float t = 0.f;
 	const float dt = 0.01f;
@@ -170,7 +170,7 @@ TEST_F(VelocitySmoothingTest, testZeroSetpoint)
 		t += dt;
 	}
 
-	// THEN: All the trajectories should still be null
+	// THEN: All the trajectories should still be zero
 	for (int i = 0; i < 3; i++) {
 		EXPECT_EQ(_trajectories[i].getCurrentJerk(), 0.f);
 		EXPECT_EQ(_trajectories[i].getCurrentAcceleration(), 0.f);

--- a/src/lib/FlightTasks/tasks/Utility/test_velocity_smoothing.cpp
+++ b/src/lib/FlightTasks/tasks/Utility/test_velocity_smoothing.cpp
@@ -43,8 +43,8 @@ int main(int argc, char *argv[])
 {
 	VelocitySmoothing trajectory[3];
 
-	float a0[3] = {0.22, 0.f, 0.22f};
-	float v0[3] = {2.47f, -5.59e-6f, 2.47f};
+	float a0[3] = {0.f, 0.f, 0.f};
+	float v0[3] = {0.f, 0.f, 0.f};
 	float x0[3] = {0.f, 0.f, 0.f};
 
 	float j_max = 55.2f;
@@ -59,18 +59,20 @@ int main(int argc, char *argv[])
 		trajectory[i].setCurrentVelocity(v0[i]);
 	}
 
-	float dt = 0.01f;
+	float t = 0.f;
+	const float dt = 0.01f;
 
-	float velocity_setpoint[3] = {0.f, 1.f, 0.f};
+	float velocity_setpoint[3] = {0.f, -1.f, 0.f};
 
 	for (int i = 0; i < 3; i++) {
-		trajectory[i].updateDurations(dt, velocity_setpoint[i]);
+		trajectory[i].updateDurations(velocity_setpoint[i], t);
 	}
 
-	VelocitySmoothing::timeSynchronization(trajectory, 2);
+	//VelocitySmoothing::timeSynchronization(trajectory, 2);
 
+	t += dt;
 	for (int i = 0; i < 3; i++) {
-		trajectory[i].integrate(a0[i], v0[i], x0[i]);
+		trajectory[i].updateTraj(t, a0[i], v0[i], x0[i]);
 	}
 
 	for (int i = 0; i < 3; i++) {

--- a/src/lib/FlightTasks/tasks/Utility/test_velocity_smoothing.cpp
+++ b/src/lib/FlightTasks/tasks/Utility/test_velocity_smoothing.cpp
@@ -38,6 +38,7 @@
 
 #include "VelocitySmoothing.hpp"
 #include <cstdio>
+#include <matrix/matrix/math.hpp>
 
 int main(int argc, char *argv[])
 {
@@ -62,25 +63,35 @@ int main(int argc, char *argv[])
 	float t = 0.f;
 	const float dt = 0.01f;
 
-	float velocity_setpoint[3] = {0.f, -1.f, 0.f};
+	float velocity_setpoint[3] = {1.f, 0.f, -1.f};
 
 	for (int i = 0; i < 3; i++) {
-		trajectory[i].updateDurations(velocity_setpoint[i], t);
+		trajectory[i].updateDurations(t, velocity_setpoint[i]);
 	}
 
-	//VelocitySmoothing::timeSynchronization(trajectory, 2);
+	float t123 = trajectory[2].getTotalTime();
+	int nb_steps = ceil(t123 / dt);
+	printf("Nb steps = %d\n", nb_steps);
 
-	t += dt;
-	for (int i = 0; i < 3; i++) {
-		trajectory[i].updateTraj(t, a0[i], v0[i], x0[i]);
-	}
+	for (int i = 0; i < nb_steps; i++) {
+		t += dt;
+		for (int i = 0; i < 3; i++) {
+			trajectory[i].updateTraj(t, a0[i], v0[i], x0[i]);
+		}
 
-	for (int i = 0; i < 3; i++) {
-		printf("Traj[%d]\n", i);
-		printf("jerk = %.3f\taccel = %.3f\tvel = %.3f\n", trajectory[i].getCurrentJerk(),
-		       trajectory[i].getCurrentAcceleration(), trajectory[i].getCurrentVelocity());
-		printf("T1 = %.3f\tT2 = %.3f\tT3 = %.3f\n", trajectory[i].getT1(), trajectory[i].getT2(), trajectory[i].getT3());
-		printf("\n");
+		for (int i = 0; i < 3; i++) {
+			trajectory[i].updateDurations(t, velocity_setpoint[i]);
+		}
+
+		VelocitySmoothing::timeSynchronization(trajectory, 2);
+
+		for (int i = 0; i < 3; i++) {
+			printf("Traj[%d]\n", i);
+			printf("jerk = %.3f\taccel = %.3f\tvel = %.3f\tpos = %.3f\n", trajectory[i].getCurrentJerk(),
+			       a0[i], v0[i], x0[i]);
+			printf("T1 = %.3f\tT2 = %.3f\tT3 = %.3f\n", trajectory[i].getT1(), trajectory[i].getT2(), trajectory[i].getT3());
+			printf("\n");
+		}
 	}
 
 	return 0;

--- a/src/lib/FlightTasks/tasks/Utility/test_velocity_smoothing.cpp
+++ b/src/lib/FlightTasks/tasks/Utility/test_velocity_smoothing.cpp
@@ -60,35 +60,36 @@ int main(int argc, char *argv[])
 		trajectory[i].setCurrentVelocity(v0[i]);
 	}
 
-	float t = 0.f;
 	const float dt = 0.01f;
 
 	float velocity_setpoint[3] = {1.f, 0.f, -1.f};
 
 	for (int i = 0; i < 3; i++) {
-		trajectory[i].updateDurations(t, velocity_setpoint[i]);
+		trajectory[i].updateDurations(velocity_setpoint[i]);
 	}
 
-	float t123 = trajectory[2].getTotalTime();
+	float t123 = trajectory[0].getTotalTime();
 	int nb_steps = ceil(t123 / dt);
 	printf("Nb steps = %d\n", nb_steps);
 
 	for (int i = 0; i < nb_steps; i++) {
-		t += dt;
 		for (int i = 0; i < 3; i++) {
-			trajectory[i].updateTraj(t, a0[i], v0[i], x0[i]);
+			trajectory[i].updateTraj(dt);
 		}
 
 		for (int i = 0; i < 3; i++) {
-			trajectory[i].updateDurations(t, velocity_setpoint[i]);
+			trajectory[i].updateDurations(velocity_setpoint[i]);
 		}
 
 		VelocitySmoothing::timeSynchronization(trajectory, 2);
 
-		for (int i = 0; i < 3; i++) {
+		for (int i = 0; i < 1; i++) {
 			printf("Traj[%d]\n", i);
-			printf("jerk = %.3f\taccel = %.3f\tvel = %.3f\tpos = %.3f\n", trajectory[i].getCurrentJerk(),
-			       a0[i], v0[i], x0[i]);
+			printf("jerk = %.3f\taccel = %.3f\tvel = %.3f\tpos = %.3f\n",
+			       trajectory[i].getCurrentJerk(),
+			       trajectory[i].getCurrentAcceleration(),
+			       trajectory[i].getCurrentVelocity(),
+			       trajectory[i].getCurrentPosition());
 			printf("T1 = %.3f\tT2 = %.3f\tT3 = %.3f\n", trajectory[i].getT1(), trajectory[i].getT2(), trajectory[i].getT3());
 			printf("\n");
 		}


### PR DESCRIPTION
### Context
Currently, algorithm generates the trajectory by performing a numerical integration of the current jerk. This is relatively fast to compute but has a few drawbacks:
- requires small dt to be accurate: slowing down the algorithm creates nasty numerical issues
- limits the maximum jerk: if the desired jerk is too large, the time where the jerk is active can be smaller than dt, this can freeze the trajectory
- sensitive to dt jitter: if the integration uses a different dt than the one used to predict the timings, slight imperfections will occur and destabilize the algorithm
- fails to compute accurate results around zero: the algorithm struggles to reach exactly zero speed

All those "corner cases" are handled to make the algorithm viable but the benefit of this light weight numerical integration with all those fixes isn't really relevant anymore.

### New implementation
Evaluating the piecewise polynomials for the current time instead of the numerical integration gives the exact result regardless time jitter, jerk amplitude and converges properly to small values without the need of tricks.
- It is now possible to set large jerk and accelerations without any numerical issues
- The overall implementation is simpler, no corner case handling
- The result is exact

### Comparison
**Current algorithm**
![vel_traj_graph](https://user-images.githubusercontent.com/14822839/64353375-f2e0b900-cffd-11e9-855b-2eb35267ce28.png)

**New proposed algorithm**
![New_traj_gen](https://user-images.githubusercontent.com/14822839/64353413-01c76b80-cffe-11e9-8d9b-f458c869fb0d.png)

The unit test has also been updated to verify the time synchronization between two trajectories, the exactness of the predicted time and a few trivial cases.

TODO:
- [x] test auto mode
- [x] reintroduce time stretching in auto mode
- [x] test altitude mode
- [x] test manual mode