### PR TITLE
Add updated ccache for Ubuntu 16.04 dev scripts

### DIFF
--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -189,3 +189,8 @@ if [[ $INSTALL_SIM == "true" ]]; then
 		;
 
 fi
+
+if [[ $INSTALL_NUTTX == "true" ]]; then
+	echo
+	echo "Reboot computer before attempting to build NUTTX targets"
+fi

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -84,6 +84,12 @@ sudo apt-get -yy --quiet --no-install-recommends install \
 	;
 
 
+if [[ "${UBUNTU_RELEASE}" == "16.04" ]]; then
+	echo "Installing Ubuntu 16.04 PX4-compatible cmake"
+	wget -O /tmp/ccache_3.4.1-1_amd64.deb http://launchpadlibrarian.net/356662933/ccache_3.4.1-1_amd64.deb
+	sudo dpkg -i /tmp/ccache_3.4.1-1_amd64.deb
+fi
+
 # Python3 dependencies
 echo
 echo "Installing PX4 Python3 dependencies"


### PR DESCRIPTION
This adds the ccache update suggested by @jkflying https://github.com/PX4/Firmware/pull/12827#issuecomment-527953817 for Ubuntu 16.04 only.

Note this layers on top of the existing cmake installation, and only applies for Ubuntu 16.04. 