### PR TITLE
FW pos C: fix altitude control for VTOL/FW by also publishing attitud…

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1746,7 +1746,8 @@ FixedwingPositionControl::Run()
 			if (_control_mode.flag_control_offboard_enabled ||
 			    _control_mode.flag_control_position_enabled ||
 			    _control_mode.flag_control_velocity_enabled ||
-			    _control_mode.flag_control_acceleration_enabled) {
+			    _control_mode.flag_control_acceleration_enabled ||
+			    _control_mode.flag_control_altitude_enabled) {
 
 				/* lazily publish the setpoint only once available */
 				if (_attitude_sp_pub != nullptr) {


### PR DESCRIPTION
Fixes https://github.com/PX4/Firmware/issues/12910.

The VTOL altitude control in FW mode was broken with https://github.com/PX4/Firmware/pull/12532. Before the attitude sp was always published if not on offboard control or in position/velocity control. This PR adds Altitude control support there (thus not relying on the "not offboard" flag as before. 

Probably also applies for FW flown in ALT control.