### PR TITLE
Misc resource leaks found with cppcheck. 

### DIFF
--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -673,6 +673,7 @@ void Simulator::poll_for_MAVLink_messages()
 
 		if (bind(_fd, (struct sockaddr *)&_myaddr, sizeof(_myaddr)) < 0) {
 			PX4_ERR("bind for UDP port %i failed (%i)", _port, errno);
+			::close(_fd);
 			return;
 		}
 

--- a/src/systemcmds/dumpfile/dumpfile.c
+++ b/src/systemcmds/dumpfile/dumpfile.c
@@ -99,6 +99,7 @@ dumpfile_main(int argc, char *argv[])
 
 	if (tcsetattr(out, TCSANOW, &tc) < 0) {
 		PX4_ERR("failed setting stdout attributes");
+		fclose(f);
 		return 1;
 	}
 


### PR DESCRIPTION
Certain conditional branches returned before closing a file handle.

**Describe problem solved by the proposed pull request**
Running cppcheck over this project highlighted several areas where functions returned without close a file handle.

**Test data / coverage**
No tests warranted as functionality hasn't changed.

**Describe your preferred solution**
Explicitly close file handles before returning on problematic conditional branches. 

**Describe possible alternatives**
N/A

**Additional context**
N/A
