### PR TITLE
Remove references to pow(x,0.5), use sqrt instead

### DIFF
--- a/src/lib/controllib/BlockStats.hpp
+++ b/src/lib/controllib/BlockStats.hpp
@@ -89,7 +89,7 @@ public:
 	}
 	matrix::Vector<Type, M> getStdDev()
 	{
-		return getVar().pow(0.5f);
+		return getVar().sqrt();
 	}
 private:
 // attributes

--- a/src/systemcmds/tests/test_matrix.cpp
+++ b/src/systemcmds/tests/test_matrix.cpp
@@ -644,7 +644,7 @@ bool MatrixTest::vectorTests()
 	ut_test(isEqual(v2, v3));
 	float data1_sq[] = {1, 4, 9, 16, 25};
 	Vector<float, 5> v4(data1_sq);
-	ut_test(isEqual(v1, v4.pow(0.5)));
+	ut_test(isEqual(v1, v4.sqrt()));
 
 	return true;
 }


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
`pow` does not have a native arm instruction, and GCC does not inline it for non-integer arguments. Since we only use pow in Matrix with argument 0.5 to get sqrt, we should instead use sqrt directly, which compiles down to a single instruction.

**Test data / coverage**
See godbolt linked at https://github.com/PX4/Matrix/pull/86

NB!! DO NOT MERGE UNTIL MATRIX PR IS MERGED