### PR TITLE
added vtol fixed wing preflight check

### DIFF
--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -921,6 +921,19 @@ bool preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status,
 		}
 	}
 
+	/* ---- VTOL ---- */
+	if (status.is_vtol) {
+
+		// prevent arming when not in rotary wing mode
+		if (!(status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING)) {
+			if (reportFailures) {
+				mavlink_log_critical(mavlink_log_pub, "Arming not allowed in fixed-wing mode");
+			}
+
+			failed = true;
+		}
+	}
+
 	/* ---- RC CALIBRATION ---- */
 	if (checkRC) {
 		if (rc_calibration_check(mavlink_log_pub, reportFailures && !failed, status.is_vtol) != OK) {


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
Some VTOLs do not have the ground clearance to allow arming of the aircraft in fixed wing mode.  This pull request creates a parameter COM_ARM_FW_VTOL that can be set to (1) allow arming in fixed wing mode or (2) not allow arming in fixed wing mode.  It adds a preflight

**Test data / coverage**
Tests on Cube (FMUv3) and it correctly prevents arming in fixed wing mode when the parameter is set to 0.

Addresses the following issue:
https://github.com/PX4/Firmware/issues/12931