### PR TITLE
fixed total flight time counting bug

### DIFF
--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -104,7 +104,7 @@ void LandDetector::Run()
 	    (_land_detected.in_ground_effect != in_ground_effect) ||
 	    (fabsf(_land_detected.alt_max - alt_max) > FLT_EPSILON)) {
 
-		if (!landDetected && _land_detected.landed) {
+		if (!landDetected && _land_detected.landed && _takeoff_time == 0) { /* only set take off time once, until disarming */
 			// We did take off
 			_takeoff_time = now;
 		}


### PR DESCRIPTION
After landing it can happen that a second take off is detected and then the _takeoff_time is rest, resulting in a wrong total flight time counter after disarming.

When checking for _takeoff_time == 0 the flight time is reliably counted from the _first_ take off until the vehicle is disarmed. 
Normally the vehicle will not spend much time armed after landing, if it does the flight time will be off but this is the same as before this fix. Without this additional check the flight time will be counted from the last detected take off until disarming.

This fix was tested in several flight experiments.
