### PR TITLE
VTOL standard: introduce scale for FW control surfaces in hover

### DIFF
--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -67,6 +67,9 @@ Standard::Standard(VtolAttitudeControl *attc) :
 	_params_handles_standard.pitch_setpoint_offset = param_find("FW_PSP_OFF");
 	_params_handles_standard.reverse_output = param_find("VT_B_REV_OUT");
 	_params_handles_standard.reverse_delay = param_find("VT_B_REV_DEL");
+
+	_params_handles_standard.mc_to_fw_gain_roll = param_find("VT_MC_AILE_GAIN");
+	_params_handles_standard.mc_to_fw_gain_pitch = param_find("VT_MC_ELEV_GAIN");
 }
 
 void
@@ -102,6 +105,12 @@ Standard::parameters_update()
 	/* reverse output */
 	param_get(_params_handles_standard.reverse_delay, &v);
 	_params_standard.reverse_delay = math::constrain(v, 0.0f, 10.0f);
+
+	param_get(_params_handles_standard.mc_to_fw_gain_roll, &v);
+	_params_standard.mc_to_fw_gain_roll = math::constrain(v, 0.0f, 10.0f);
+
+	param_get(_params_handles_standard.mc_to_fw_gain_pitch, &v);
+	_params_standard.mc_to_fw_gain_pitch = math::constrain(v, 0.0f, 10.0f);
 
 }
 
@@ -442,11 +451,11 @@ void Standard::fill_actuator_outputs()
 		} else {
 			// roll
 			_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] =
-				_actuators_fw_in->control[actuator_controls_s::INDEX_ROLL];
+				_actuators_fw_in->control[actuator_controls_s::INDEX_ROLL] * _params_standard.mc_to_fw_gain_roll;
 
 			// pitch
 			_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] =
-				_actuators_fw_in->control[actuator_controls_s::INDEX_PITCH];
+				_actuators_fw_in->control[actuator_controls_s::INDEX_PITCH] * _params_standard.mc_to_fw_gain_pitch;
 
 			_actuators_out_1->control[actuator_controls_s::INDEX_YAW] = 0.0f;
 			_actuators_out_1->control[actuator_controls_s::INDEX_AIRBRAKES] = 0.0f;

--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -74,6 +74,8 @@ private:
 		float pitch_setpoint_offset;
 		float reverse_output;
 		float reverse_delay;
+		float mc_to_fw_gain_roll;
+		float mc_to_fw_gain_pitch;
 	} _params_standard;
 
 	struct {
@@ -84,6 +86,8 @@ private:
 		param_t pitch_setpoint_offset;
 		param_t reverse_output;
 		param_t reverse_delay;
+		param_t mc_to_fw_gain_roll;
+		param_t mc_to_fw_gain_pitch;
 	} _params_handles_standard;
 
 	enum class vtol_mode {

--- a/src/modules/vtol_att_control/standard_params.c
+++ b/src/modules/vtol_att_control/standard_params.c
@@ -112,3 +112,25 @@ PARAM_DEFINE_FLOAT(VT_B_REV_DEL, 0.0f);
  * @group VTOL Attitude Control
  */
 PARAM_DEFINE_FLOAT(VT_PSHER_RMP_DT, 3.0f);
+
+/**
+ * Roll scale on fixed-wing actuators in hover.
+ *
+ * Determines how much the roll controlling surfaces (e.g. ailerons or elevons) are used to assist the multicopter motors in hover.
+ *
+ * @min 0
+ * @max 3
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_MC_AILE_GAIN, 1.0f);
+
+/**
+ * Pitch scale on fixed-wing actuators in hover.
+ *
+ * Determines how much the pitch controlling surfaces (e.g. elevator or elevons) are used to assist the multicopter motors in hover.
+ *
+ * @min 0
+ * @max 3
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_MC_ELEV_GAIN, 1.0f);


### PR DESCRIPTION
For VTOL in hover, if VT_ELEV_MC_LOCK is set to disabled, the FW control surfaces support the MC motors to control the rates/attitude. The FW control surfaces are controlled over the FW rate controller, which also runs in hover. The tuning of them is thus the same as in FW flight (except some scaling with airspeed, if available). 

This PR introduces additional tuning scales for the control surfaces in hover. Both pitch and roll have an additional gain to tune the allocation of FW rate controller output to FW control surface deflection.

Note: other than first planned this PR does not change the subscription of the control surfaces from FW to MC rate controller. This mainly to make the control loops less entangled/ make the architecture simpler. 


