### PR TITLE
Comment out the ll40ls (LidarLite) driver from the fmu-v2 build to save flash.

### DIFF
--- a/boards/px4/fmu-v2/default.cmake
+++ b/boards/px4/fmu-v2/default.cmake
@@ -29,7 +29,7 @@ px4_add_board(
 		#differential_pressure # all available differential pressure drivers
 		differential_pressure/ms4525
 		#distance_sensor # all available distance sensor drivers
-		distance_sensor/ll40ls
+		#distance_sensor/ll40ls
 		#distance_sensor/sf0x
 		gps
 		#heater


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This is one of the last drivers that can be commented out of the fmu-v2 build to meet flash constraints.

**Test data / coverage**
No need to test.

**Additional context**
fmu-v2 is out of space and causing most PR builds to fail CI.  This is the last easy option.

Please close this PR if this is not a good option!

-Mark
