### PR TITLE
FlightTask - Move ekf reset counter monitoring logic in the base FlightTask

### DIFF
--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
@@ -56,7 +56,6 @@ bool FlightTaskAutoLineSmoothVel::activate(vehicle_local_position_setpoint_s las
 
 	_yaw_sp_prev = last_setpoint.yaw;
 	_updateTrajConstraints();
-	_initEkfResetCounters();
 
 	return ret;
 }
@@ -69,7 +68,6 @@ void FlightTaskAutoLineSmoothVel::reActivate()
 	}
 
 	_trajectory[2].reset(0.f, 0.7f, _position(2));
-	_initEkfResetCounters();
 }
 
 void FlightTaskAutoLineSmoothVel::checkSetpoints(vehicle_local_position_setpoint_s &setpoints)
@@ -96,6 +94,38 @@ void FlightTaskAutoLineSmoothVel::checkSetpoints(vehicle_local_position_setpoint
 	if (!PX4_ISFINITE(setpoints.acc_z)) { setpoints.acc_z = 0.f; }
 
 	if (!PX4_ISFINITE(setpoints.yaw)) { setpoints.yaw = _yaw; }
+}
+
+/**
+ * EKF reset handling functions
+ * Those functions are called by the base FlightTask in
+ * case of an EKF reset event
+ */
+void FlightTaskAutoLineSmoothVel::_ekfResetHandlerPositionXY()
+{
+	_trajectory[0].setCurrentPosition(_position(0));
+	_trajectory[1].setCurrentPosition(_position(1));
+}
+
+void FlightTaskAutoLineSmoothVel::_ekfResetHandlerVelocityXY()
+{
+	_trajectory[0].setCurrentVelocity(_velocity(0));
+	_trajectory[1].setCurrentVelocity(_velocity(1));
+}
+
+void FlightTaskAutoLineSmoothVel::_ekfResetHandlerPositionZ()
+{
+	_trajectory[2].setCurrentPosition(_position(2));
+}
+
+void FlightTaskAutoLineSmoothVel::_ekfResetHandlerVelocityZ()
+{
+	_trajectory[2].setCurrentVelocity(_velocity(2));
+}
+
+void FlightTaskAutoLineSmoothVel::_ekfResetHandlerHeading(float delta_psi)
+{
+	_yaw_sp_prev += delta_psi;
 }
 
 void FlightTaskAutoLineSmoothVel::_generateSetpoints()
@@ -149,40 +179,6 @@ inline float FlightTaskAutoLineSmoothVel::_constrainOneSide(float val, float con
 float FlightTaskAutoLineSmoothVel::_constrainAbs(float val, float min, float max)
 {
 	return math::sign(val) * math::constrain(fabsf(val), fabsf(min), fabsf(max));
-}
-
-void FlightTaskAutoLineSmoothVel::_initEkfResetCounters()
-{
-	_reset_counters.xy = _sub_vehicle_local_position->get().xy_reset_counter;
-	_reset_counters.vxy = _sub_vehicle_local_position->get().vxy_reset_counter;
-	_reset_counters.z = _sub_vehicle_local_position->get().z_reset_counter;
-	_reset_counters.vz = _sub_vehicle_local_position->get().vz_reset_counter;
-}
-
-void FlightTaskAutoLineSmoothVel::_checkEkfResetCounters()
-{
-	// Check if a reset event has happened.
-	if (_sub_vehicle_local_position->get().xy_reset_counter != _reset_counters.xy) {
-		_trajectory[0].setCurrentPosition(_position(0));
-		_trajectory[1].setCurrentPosition(_position(1));
-		_reset_counters.xy = _sub_vehicle_local_position->get().xy_reset_counter;
-	}
-
-	if (_sub_vehicle_local_position->get().vxy_reset_counter != _reset_counters.vxy) {
-		_trajectory[0].setCurrentVelocity(_velocity(0));
-		_trajectory[1].setCurrentVelocity(_velocity(1));
-		_reset_counters.vxy = _sub_vehicle_local_position->get().vxy_reset_counter;
-	}
-
-	if (_sub_vehicle_local_position->get().z_reset_counter != _reset_counters.z) {
-		_trajectory[2].setCurrentPosition(_position(2));
-		_reset_counters.z = _sub_vehicle_local_position->get().z_reset_counter;
-	}
-
-	if (_sub_vehicle_local_position->get().vz_reset_counter != _reset_counters.vz) {
-		_trajectory[2].setCurrentVelocity(_velocity(2));
-		_reset_counters.vz = _sub_vehicle_local_position->get().vz_reset_counter;
-	}
 }
 
 float FlightTaskAutoLineSmoothVel::_getSpeedAtTarget()
@@ -239,7 +235,6 @@ void FlightTaskAutoLineSmoothVel::_prepareSetpoints()
 	// that one is used as a velocity limit.
 	// If the position setpoints are set to NAN, the values in the velocity setpoints are used as velocity targets: nothing to do here.
 
-	_checkEkfResetCounters();
 	_want_takeoff = false;
 
 	if (_param_mpc_yaw_mode.get() == 4 && !_yaw_sp_aligned) {

--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
@@ -71,12 +71,16 @@ protected:
 
 	/** determines when to trigger a takeoff (ignored in flight) */
 	bool _checkTakeoff() override { return _want_takeoff; };
+	/** Reset position or velocity setpoints in case of EKF reset event */
+	void _ekfResetHandlerPositionXY() override;
+	void _ekfResetHandlerVelocityXY() override;
+	void _ekfResetHandlerPositionZ() override;
+	void _ekfResetHandlerVelocityZ() override;
+	void _ekfResetHandlerHeading(float delta_psi) override;
 
 	inline float _constrainOneSide(float val, float constraint); /**< Constrain val between INF and constraint */
 	inline float _constrainAbs(float val, float min, float max); /**< Constrain absolute value of val between min and max */
 
-	void _initEkfResetCounters();
-	void _checkEkfResetCounters(); /**< Reset the trajectories when the ekf resets velocity or position */
 	void _generateHeading();
 	bool _generateHeadingAlongTraj(); /**< Generates heading along trajectory. */
 	void _updateTrajConstraints();
@@ -86,11 +90,4 @@ protected:
 
 	bool _want_takeoff{false};
 
-	/* counters for estimator local position resets */
-	struct {
-		uint8_t xy;
-		uint8_t vxy;
-		uint8_t z;
-		uint8_t vz;
-	} _reset_counters{0, 0, 0, 0};
 };

--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
@@ -65,12 +65,7 @@ protected:
 				       );
 
 	void checkSetpoints(vehicle_local_position_setpoint_s &setpoints);
-	float _getSpeedAtTarget();
-	float _getMaxSpeedFromDistance(float braking_distance);
-	void _generateSetpoints() override; /**< Generate setpoints along line. */
 
-	/** determines when to trigger a takeoff (ignored in flight) */
-	bool _checkTakeoff() override { return _want_takeoff; };
 	/** Reset position or velocity setpoints in case of EKF reset event */
 	void _ekfResetHandlerPositionXY() override;
 	void _ekfResetHandlerVelocityXY() override;
@@ -78,16 +73,23 @@ protected:
 	void _ekfResetHandlerVelocityZ() override;
 	void _ekfResetHandlerHeading(float delta_psi) override;
 
+	void _generateSetpoints() override; /**< Generate setpoints along line. */
+	void _generateHeading();
+	bool _generateHeadingAlongTraj(); /**< Generates heading along trajectory. */
+
 	inline float _constrainOneSide(float val, float constraint); /**< Constrain val between INF and constraint */
 	inline float _constrainAbs(float val, float min, float max); /**< Constrain absolute value of val between min and max */
 
-	void _generateHeading();
-	bool _generateHeadingAlongTraj(); /**< Generates heading along trajectory. */
-	void _updateTrajConstraints();
-	void _prepareSetpoints(); /**< Generate velocity target points for the trajectory generator. */
-	void _generateTrajectory();
-	VelocitySmoothing _trajectory[3]; ///< Trajectories in x, y and z directions
+	float _getSpeedAtTarget();
+	float _getMaxSpeedFromDistance(float braking_distance);
 
+	void _prepareSetpoints(); /**< Generate velocity target points for the trajectory generator. */
+	void _updateTrajConstraints();
+	void _generateTrajectory();
+
+	/** determines when to trigger a takeoff (ignored in flight) */
+	bool _checkTakeoff() override { return _want_takeoff; };
 	bool _want_takeoff{false};
 
+	VelocitySmoothing _trajectory[3]; ///< Trajectories in x, y and z directions
 };

--- a/src/lib/FlightTasks/tasks/FlightTask/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask/FlightTask.hpp
@@ -178,7 +178,6 @@ protected:
 
 	uORB::SubscriptionPollable<vehicle_local_position_s> *_sub_vehicle_local_position{nullptr};
 	uORB::SubscriptionPollable<vehicle_attitude_s> *_sub_attitude{nullptr};
-	uint8_t _heading_reset_counter{0}; /**< estimator heading reset */
 
 	/** Reset all setpoints to NAN */
 	void _resetSetpoints();
@@ -189,8 +188,20 @@ protected:
 	/** Set constraints to default values */
 	virtual void _setDefaultConstraints();
 
-	/** determines when to trigger a takeoff (ignored in flight) */
+	/** Determine when to trigger a takeoff (ignored in flight) */
 	virtual bool _checkTakeoff();
+
+	/**
+	 * Monitor the EKF reset counters and
+	 * call the appropriate handling functions in case of a reset event
+	 */
+	void _initEkfResetCounters();
+	void _checkEkfResetCounters();
+	virtual void _ekfResetHandlerPositionXY() {};
+	virtual void _ekfResetHandlerVelocityXY() {};
+	virtual void _ekfResetHandlerPositionZ() {};
+	virtual void _ekfResetHandlerVelocityZ() {};
+	virtual void _ekfResetHandlerHeading(float delta_psi) {};
 
 	/* Time abstraction */
 	static constexpr uint64_t _timeout = 500000; /**< maximal time in us before a loop or data times out */
@@ -224,6 +235,15 @@ protected:
 
 	matrix::Vector3f _velocity_setpoint_feedback;
 	matrix::Vector3f _thrust_setpoint_feedback;
+
+	/* Counters for estimator local position resets */
+	struct {
+		uint8_t xy;
+		uint8_t vxy;
+		uint8_t z;
+		uint8_t vz;
+		uint8_t quat;
+	} _reset_counters{0, 0, 0, 0, 0};
 
 	/**
 	 * Vehicle constraints.

--- a/src/lib/FlightTasks/tasks/FlightTask/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask/FlightTask.hpp
@@ -238,12 +238,12 @@ protected:
 
 	/* Counters for estimator local position resets */
 	struct {
-		uint8_t xy;
-		uint8_t vxy;
-		uint8_t z;
-		uint8_t vz;
-		uint8_t quat;
-	} _reset_counters{0, 0, 0, 0, 0};
+		uint8_t xy = 0;
+		uint8_t vxy = 0;
+		uint8_t z = 0;
+		uint8_t vz = 0;
+		uint8_t quat = 0;
+	} _reset_counters;
 
 	/**
 	 * Vehicle constraints.

--- a/src/lib/FlightTasks/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
+++ b/src/lib/FlightTasks/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
@@ -310,14 +310,15 @@ void FlightTaskManualAltitude::_updateHeadingSetpoints()
 		// hold the current heading when no more rotation commanded
 		if (!PX4_ISFINITE(_yaw_setpoint)) {
 			_yaw_setpoint = _yaw;
-
-		} else {
-			// check reset counter and update yaw setpoint if necessary
-			if (_sub_attitude->get().quat_reset_counter != _heading_reset_counter) {
-				_yaw_setpoint += matrix::Eulerf(matrix::Quatf(_sub_attitude->get().delta_q_reset)).psi();
-				_heading_reset_counter = _sub_attitude->get().quat_reset_counter;
-			}
 		}
+	}
+}
+
+void FlightTaskManualAltitude::_ekfResetHandlerHeading(float delta_psi)
+{
+	// Only reset the yaw setpoint when the heading is locked
+	if (PX4_ISFINITE(_yaw_setpoint)) {
+		_yaw_setpoint += delta_psi;
 	}
 }
 

--- a/src/lib/FlightTasks/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
+++ b/src/lib/FlightTasks/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
@@ -54,6 +54,7 @@ public:
 
 protected:
 	void _updateHeadingSetpoints(); /**< sets yaw or yaw speed */
+	void _ekfResetHandlerHeading(float delta_psi) override; /**< adjust heading setpoint in case of EKF reset event */
 	virtual void _updateSetpoints(); /**< updates all setpoints */
 	virtual void _scaleSticks(); /**< scales sticks to velocity in z */
 	bool _checkTakeoff() override;

--- a/src/lib/FlightTasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.hpp
+++ b/src/lib/FlightTasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.hpp
@@ -55,6 +55,10 @@ protected:
 
 	virtual void _updateSetpoints() override;
 
+	/** Reset position or velocity setpoints in case of EKF reset event */
+	void _ekfResetHandlerPositionZ() override;
+	void _ekfResetHandlerVelocityZ() override;
+
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::MPC_JERK_MAX>) _param_mpc_jerk_max,
 		(ParamFloat<px4::params::MPC_ACC_UP_MAX>) _param_mpc_acc_up_max,
@@ -65,16 +69,8 @@ private:
 
 	void checkSetpoints(vehicle_local_position_setpoint_s &setpoints);
 
-	void _initEkfResetCounters();
-	void _checkEkfResetCounters(); /**< Reset the trajectories when the ekf resets velocity or position */
 	void _updateTrajConstraints();
 	void _setOutputState();
 
 	ManualVelocitySmoothingZ _smoothing; ///< Smoothing in z direction
-
-	/* counters for estimator local position resets */
-	struct {
-		uint8_t z;
-		uint8_t vz;
-	} _reset_counters{0, 0};
 };

--- a/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.hpp
+++ b/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.hpp
@@ -60,6 +60,12 @@ protected:
 
 	virtual void _updateSetpoints() override;
 
+	/** Reset position or velocity setpoints in case of EKF reset event */
+	void _ekfResetHandlerPositionXY() override;
+	void _ekfResetHandlerVelocityXY() override;
+	void _ekfResetHandlerPositionZ() override;
+	void _ekfResetHandlerVelocityZ() override;
+
 	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTaskManualPosition,
 					(ParamFloat<px4::params::MPC_JERK_MAX>) _param_mpc_jerk_max,
 					(ParamFloat<px4::params::MPC_ACC_UP_MAX>) _param_mpc_acc_up_max,
@@ -68,14 +74,6 @@ protected:
 
 private:
 	void checkSetpoints(vehicle_local_position_setpoint_s &setpoints);
-
-	void _initEkfResetCounters();
-	void _initEkfResetCountersXY();
-	void _initEkfResetCountersZ();
-
-	void _checkEkfResetCounters(); /**< Reset the trajectories when the ekf resets velocity or position */
-	void _checkEkfResetCountersXY();
-	void _checkEkfResetCountersZ();
 
 	void _updateTrajConstraints();
 	void _updateTrajConstraintsXY();
@@ -92,12 +90,4 @@ private:
 
 	ManualVelocitySmoothingXY _smoothing_xy; ///< Smoothing in x and y directions
 	ManualVelocitySmoothingZ _smoothing_z; ///< Smoothing in z direction
-
-	/* counters for estimator local position resets */
-	struct {
-		uint8_t xy;
-		uint8_t vxy;
-		uint8_t z;
-		uint8_t vz;
-	} _reset_counters{0, 0, 0, 0};
 };


### PR DESCRIPTION
Until now, the FlightTask altitude was checking for the EKF quaternion reset, and the AutoLineSmoothVel & PositionSmoothVel were checking for position and velocity estimate resets; the code was simply duplicated.

To make it more scalable and to avoid further copy/paste, the logic for checking the reset counters has been moved to the base FlightTask that calls EKF reset handler functions.
Each child FlightTask can simply implement what it wants to do in case
of an EKF reset event by overriding one of the `_ekfResetHandler...` functions:
- void _ekfResetHandlerPositionXY()
- void _ekfResetHandlerVelocityXY()
- void _ekfResetHandlerPositionZ()
- void _ekfResetHandlerVelocityZ()
- void _ekfResetHandlerHeading(float delta_psi)

Changes made in
- [x] ManualAltitude
- [x] ManualPositionSmoothVel
- [x] AutoLineSmoothVel
- [x] AltitudeSmoothVel

Next step is to send the `delta_position` and `delta_velocity` as well, but this is more than a simple refactoring (see issue #12966)