### PR TITLE
mavlink send helpers refactor to prevent writing partial messages

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -187,11 +187,6 @@ Mavlink::Mavlink() :
 
 Mavlink::~Mavlink()
 {
-	perf_free(_loop_perf);
-	perf_free(_loop_interval_perf);
-	perf_free(_send_byte_error_perf);
-	perf_free(_send_start_tx_buf_low);
-
 	if (_task_running) {
 		/* task wakes up every 10ms or so at the longest */
 		_task_should_exit = true;
@@ -214,6 +209,8 @@ Mavlink::~Mavlink()
 
 	perf_free(_loop_perf);
 	perf_free(_loop_interval_perf);
+	perf_free(_send_byte_error_perf);
+	perf_free(_send_start_tx_buf_low);
 }
 
 void

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -665,10 +665,10 @@ private:
 		(ParamInt<px4::params::SYS_HITL>) _param_sys_hitl
 	)
 
-	perf_counter_t		_loop_perf{perf_alloc(PC_ELAPSED, "mavlink_el")};		/**< loop performance counter */
-	perf_counter_t		_loop_interval_perf{perf_alloc(PC_INTERVAL, "mavlink_int")};	/**< loop interval performance counter */
-	perf_counter_t		_send_byte_error_perf{perf_alloc(PC_COUNT, "mavlink_send_bytes_error")};	/**< send bytes error count */
-	perf_counter_t		_send_start_tx_buf_low{perf_alloc(PC_COUNT, "mavlink_tx_buf_low")};	/**< available tx buffer smaller than message */
+	perf_counter_t _loop_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": tx run elapsed")};                      /**< loop performance counter */
+	perf_counter_t _loop_interval_perf{perf_alloc(PC_INTERVAL, MODULE_NAME": tx run interval")};           /**< loop interval performance counter */
+	perf_counter_t _send_byte_error_perf{perf_alloc(PC_COUNT, MODULE_NAME": send_bytes error")};           /**< send bytes error count */
+	perf_counter_t _send_start_tx_buf_low{perf_alloc(PC_COUNT, MODULE_NAME": send_start tx buffer full")}; /**< available tx buffer smaller than message */
 
 	void			mavlink_update_parameters();
 


### PR DESCRIPTION
Possible quick work around for https://github.com/PX4/Firmware/issues/12957.

This pull request rearranges the mavlink helpers slightly to shift the the buffer, should_transmit, error count updates into the single final mavlink `mavlink_end_uart_send` call rather than each `mavlink_send_uart_bytes` (called 3 times per mavlink message send).

This is accomplished by unifying some of the uart/udp logic differences. Each write (`mavlink_send_uart_bytes`) goes into a buffer, then that buffer is written out once (`mavlink_end_uart_send`). This should prevent broken mavlink messages from going out over the wire, and will also be slightly more efficient by minimizing work for each send.


TODO:
 - [ ] move the get_free_tx_buf() check to mavlink_start_uart_send, store the result and skip mavlink_send_uart_bytes if there's not enough buffer space left.