### PR TITLE
[WIP]: Mavlink stream check available buffer before doing any work

### DIFF
--- a/src/modules/mavlink/mavlink_stream.cpp
+++ b/src/modules/mavlink/mavlink_stream.cpp
@@ -56,66 +56,70 @@ MavlinkStream::MavlinkStream(Mavlink *mavlink) :
 int
 MavlinkStream::update(const hrt_abstime &t)
 {
+	// collect data for streams that requirre it independent of actual stream rate.
 	update_data();
 
-	// If the message has never been sent before we want
-	// to send it immediately and can return right away
-	if (_last_sent == 0) {
-		// this will give different messages on the same run a different
-		// initial timestamp which will help spacing them out
-		// on the link scheduling
-		if (send(t)) {
-			_last_sent = hrt_absolute_time();
+	// check TX buffer before doing anything
+	const size_t send_size = get_size();
 
-			if (!_first_message_sent) {
-				_first_message_sent = true;
-			}
-		}
+	if (send_size > 0 && _mavlink->get_free_tx_buf() >= send_size) {
 
-		return 0;
-	}
+		// If the message has never been sent before we want
+		// to send it immediately and can return right away
+		if (_last_sent == 0) {
+			// this will give different messages on the same run a different
+			// initial timestamp which will help spacing them out
+			// on the link scheduling
+			if (send(t)) {
+				_last_sent = hrt_absolute_time();
 
-	// One of the previous iterations sent the update
-	// already before the deadline
-	if (_last_sent > t) {
-		return -1;
-	}
-
-	int64_t dt = t - _last_sent;
-	int interval = (_interval > 0) ? _interval : 0;
-
-	if (!const_rate()) {
-		interval /= _mavlink->get_rate_mult();
-	}
-
-	// Send the message if it is due or
-	// if it will overrun the next scheduled send interval
-	// by 30% of the interval time. This helps to avoid
-	// sending a scheduled message on average slower than
-	// scheduled. Doing this at 50% would risk sending
-	// the message too often as the loop runtime of the app
-	// needs to be accounted for as well.
-	// This method is not theoretically optimal but a suitable
-	// stopgap as it hits its deadlines well (0.5 Hz, 50 Hz and 250 Hz)
-
-	if (interval == 0 || (dt > (interval - (_mavlink->get_main_loop_delay() / 10) * 3))) {
-		// interval expired, send message
-
-		// If the interval is non-zero and dt is smaller than 1.5 times the interval
-		// do not use the actual time but increment at a fixed rate, so that processing delays do not
-		// distort the average rate. The check of the maximum interval is done to ensure that after a
-		// long time not sending anything, sending multiple messages in a short time is avoided.
-		if (send(t)) {
-			_last_sent = ((interval > 0) && ((int64_t)(1.5f * interval) > dt)) ? _last_sent + interval : t;
-
-			if (!_first_message_sent) {
-				_first_message_sent = true;
+				if (!_first_message_sent) {
+					_first_message_sent = true;
+				}
 			}
 
 			return 0;
+		}
 
-		} else {
+		// One of the previous iterations sent the update
+		// already before the deadline
+		if (_last_sent > t) {
 			return -1;
+		}
+
+		const int64_t dt = t - _last_sent;
+		int interval = (_interval > 0) ? _interval : 0;
+
+		if (!const_rate()) {
+			interval /= _mavlink->get_rate_mult();
+		}
+
+		// Send the message if it is due or
+		// if it will overrun the next scheduled send interval
+		// by 30% of the interval time. This helps to avoid
+		// sending a scheduled message on average slower than
+		// scheduled. Doing this at 50% would risk sending
+		// the message too often as the loop runtime of the app
+		// needs to be accounted for as well.
+		// This method is not theoretically optimal but a suitable
+		// stopgap as it hits its deadlines well (0.5 Hz, 50 Hz and 250 Hz)
+
+		if (interval == 0 || (dt > (interval - (_mavlink->get_main_loop_delay() / 10) * 3))) {
+			// interval expired, send message
+
+			// If the interval is non-zero and dt is smaller than 1.5 times the interval
+			// do not use the actual time but increment at a fixed rate, so that processing delays do not
+			// distort the average rate. The check of the maximum interval is done to ensure that after a
+			// long time not sending anything, sending multiple messages in a short time is avoided.
+			if (send(t)) {
+				_last_sent = ((interval > 0) && ((int64_t)(1.5f * interval) > dt)) ? _last_sent + interval : t;
+
+				if (!_first_message_sent) {
+					_first_message_sent = true;
+				}
+
+				return 0;
+			}
 		}
 	}
 


### PR DESCRIPTION
Partially related to https://github.com/PX4/Firmware/pull/12967 and https://github.com/PX4/Firmware/issues/12957, but we need to be careful with this one because it will change the behavior of the existing mavlink throttling mechanisms.

Overall the goal is to be lazy. Don't gather up orb data to build the mavlink message or even compute if it's time to send if there isn't sufficient buffer.