### PR TITLE
ubuntu.sh - remove modemmanager

### DIFF
--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -148,7 +148,9 @@ if [[ $INSTALL_NUTTX == "true" ]]; then
 
 	# add user to dialout group (serial port access)
 	sudo usermod -a -G dialout $USER
-
+	
+	# Remove modem manager (interferes with PX4 serial port/USB serial usage). 
+	sudo apt-get remove modemmanager -y
 
 	# arm-none-eabi-gcc
 	NUTTX_GCC_VERSION="7-2017-q4-major"


### PR DESCRIPTION
This just automates one more step for people setting up environment on Ubuntu. From guide:

> Ubuntu comes with a serial modem manager which interferes heavily with any robotics related use of a serial port (or USB serial). It can removed/deinstalled without side effects: