### PR TITLE
PMW3901 improvements

### DIFF
--- a/src/drivers/optical_flow/pmw3901/PMW3901.cpp
+++ b/src/drivers/optical_flow/pmw3901/PMW3901.cpp
@@ -314,11 +314,11 @@ PMW3901::Run()
 
 	readMotionCount(delta_x_raw, delta_y_raw, qual);
 
-	if(qual > 0){
-	_flow_sum_x += delta_x_raw;
-	_flow_sum_y += delta_y_raw;
-	_flow_sample_counter ++;
-	_flow_quality_sum += qual;
+	if (qual > 0) {
+		_flow_sum_x += delta_x_raw;
+		_flow_sum_y += delta_y_raw;
+		_flow_sample_counter ++;
+		_flow_quality_sum += qual;
 	}
 
 	// returns if the collect time has not been reached
@@ -344,7 +344,7 @@ PMW3901::Run()
 	report.integration_timespan = _flow_dt_sum_usec; 	// microseconds
 
 	report.sensor_id = 0;
-	report.quality = _flow_sample_counter > 0 ?_flow_quality_sum / _flow_sample_counter : 0;
+	report.quality = _flow_sample_counter > 0 ? _flow_quality_sum / _flow_sample_counter : 0;
 
 
 	/* No gyro on this board */
@@ -388,9 +388,10 @@ PMW3901::readMotionCount(int16_t &deltaX, int16_t &deltaY, uint8_t &qual)
 	deltaY = ((int16_t)data[9] << 8) | data[7];
 
 	// If the reported flow is impossibly large, we just got garbage from the SPI
-	if (deltaX > 240 || deltaY > 240 || deltaX < -240 || deltaY < -240){
+	if (deltaX > 240 || deltaY > 240 || deltaX < -240 || deltaY < -240) {
 		qual = 0;
-	}else{
+
+	} else {
 		qual = data[11];
 	}
 

--- a/src/drivers/optical_flow/pmw3901/PMW3901.cpp
+++ b/src/drivers/optical_flow/pmw3901/PMW3901.cpp
@@ -386,7 +386,13 @@ PMW3901::readMotionCount(int16_t &deltaX, int16_t &deltaY, uint8_t &qual)
 
 	deltaX = ((int16_t)data[5] << 8) | data[3];
 	deltaY = ((int16_t)data[9] << 8) | data[7];
-	qual = data[11];
+
+	// If the reported flow is impossibly large, we just got garbage from the SPI
+	if (deltaX > 240 || deltaY > 240 || deltaX < -240 || deltaY < -240){
+		qual = 0;
+	}else{
+		qual = data[11];
+	}
 
 	ret = OK;
 

--- a/src/drivers/optical_flow/pmw3901/PMW3901.cpp
+++ b/src/drivers/optical_flow/pmw3901/PMW3901.cpp
@@ -314,8 +314,12 @@ PMW3901::Run()
 
 	readMotionCount(delta_x_raw, delta_y_raw, qual);
 
+	if(qual > 0){
 	_flow_sum_x += delta_x_raw;
 	_flow_sum_y += delta_y_raw;
+	_flow_sample_counter ++;
+	_flow_quality_sum += qual;
+	}
 
 	// returns if the collect time has not been reached
 	if (_flow_dt_sum_usec < _collect_time) {
@@ -336,19 +340,12 @@ PMW3901::Run()
 	rotate_3f(_yaw_rotation, report.pixel_flow_x_integral, report.pixel_flow_y_integral, zeroval);
 	rotate_3f(_yaw_rotation, report.gyro_x_rate_integral, report.gyro_y_rate_integral, report.gyro_z_rate_integral);
 
-	report.frame_count_since_last_readout = 4;		// microseconds
+	report.frame_count_since_last_readout = _flow_sample_counter;	// number of frames
 	report.integration_timespan = _flow_dt_sum_usec; 	// microseconds
 
 	report.sensor_id = 0;
+	report.quality = _flow_quality_sum / _flow_sample_counter;
 
-	// This sensor doesn't provide any quality metric. However if the sensor is unable to calculate the optical flow it will
-	// output 0 for the delta. Hence, we set the measurement to "invalid" (quality = 0) if the values are smaller than FLT_EPSILON
-	if (fabsf(report.pixel_flow_x_integral) < FLT_EPSILON && fabsf(report.pixel_flow_y_integral) < FLT_EPSILON) {
-		report.quality = 0;
-
-	} else {
-		report.quality = qual;
-	}
 
 	/* No gyro on this board */
 	report.gyro_x_rate_integral = NAN;
@@ -363,6 +360,8 @@ PMW3901::Run()
 	_flow_dt_sum_usec = 0;
 	_flow_sum_x = 0;
 	_flow_sum_y = 0;
+	_flow_sample_counter = 0;
+	_flow_quality_sum = 0;
 
 	_optical_flow_pub.publish(report);
 

--- a/src/drivers/optical_flow/pmw3901/PMW3901.cpp
+++ b/src/drivers/optical_flow/pmw3901/PMW3901.cpp
@@ -344,7 +344,7 @@ PMW3901::Run()
 	report.integration_timespan = _flow_dt_sum_usec; 	// microseconds
 
 	report.sensor_id = 0;
-	report.quality = _flow_quality_sum / _flow_sample_counter;
+	report.quality = _flow_sample_counter > 0 ?_flow_quality_sum / _flow_sample_counter : 0;
 
 
 	/* No gyro on this board */
@@ -378,6 +378,7 @@ PMW3901::readMotionCount(int16_t &deltaX, int16_t &deltaY, uint8_t &qual)
 	int ret = transfer(&data[0], &data[0], 12);
 
 	if (OK != ret) {
+		qual = 0;
 		perf_count(_comms_errors);
 		DEVICE_LOG("spi::transfer returned %d", ret);
 		return ret;

--- a/src/drivers/optical_flow/pmw3901/PMW3901.hpp
+++ b/src/drivers/optical_flow/pmw3901/PMW3901.hpp
@@ -117,6 +117,8 @@ private:
 	int _flow_sum_x{0};
 	int _flow_sum_y{0};
 	uint64_t _flow_dt_sum_usec{0};
+	uint16_t _flow_quality_sum{0};
+	uint8_t _flow_sample_counter{0};
 
 	/**
 	* Initialise the automatic measurement state machine and start it.

--- a/src/drivers/optical_flow/pmw3901/PMW3901.hpp
+++ b/src/drivers/optical_flow/pmw3901/PMW3901.hpp
@@ -103,7 +103,7 @@ protected:
 
 private:
 
-	const uint64_t _collect_time{15000}; // usecs, optical flow data publish rate
+	const uint64_t _collect_time{15000}; // usecs, ensures flow data is published every second iteration of Run() (100Hz -> 50Hz)
 
 	uORB::PublicationMulti<optical_flow_s> _optical_flow_pub{ORB_ID(optical_flow)};
 


### PR DESCRIPTION
This PR improves the PMW3901 driver a bit:
- If the SPI transfer fails, we are setting the quality specifically to zero. Previously SPI fails were ignored and we just used the data from the previous sample (or some garbage that may have accumulated in the buffer we passed to the SPI transfer function)
- When integrating the flow for several samples before publishing to uORB, we are now averaging the flow quality and only integrating valid samples.
- Sometimes the sensor reports huge readings that make no sense at all. This is now caught very low-level by setting the quality of those samples to zero.

Overall we can see a significant increase in performance this way, we no longer see the noisy spikes to 0.5, and much fewer invalid samples (quality drops to zero for one sample):

Before: [log](https://review.px4.io/plot_app?log=501dd971-20af-4a3f-95ea-683e650152ad)
![master](https://user-images.githubusercontent.com/14265408/65047111-29a1c200-d962-11e9-84ba-c64d45174488.png)

Now: [log](https://review.px4.io/plot_app?log=826edc55-1a8a-4927-94fc-93b18a12f2cb)
![pmw3901-changes](https://user-images.githubusercontent.com/14265408/65047122-2c9cb280-d962-11e9-9764-e75e73eb4d99.png)
