### PR TITLE
px4_tasks: reduce POSITION_CONTROL priority

### DIFF
--- a/src/platforms/px4_tasks.h
+++ b/src/platforms/px4_tasks.h
@@ -101,27 +101,21 @@ typedef struct {
 #endif
 
 // PX4 work queue starting high priority
-#define PX4_WQ_HP_BASE (SCHED_PRIORITY_MAX - 11)
+#define PX4_WQ_HP_BASE (SCHED_PRIORITY_MAX - 12)
 
 // Fast drivers - they need to run as quickly as possible to minimize control
 // latency.
 #define SCHED_PRIORITY_FAST_DRIVER		(SCHED_PRIORITY_MAX - 0)
+
+// Actuator outputs should run as soon as the rate controller publishes
+// the actuator controls topic
+#define SCHED_PRIORITY_ACTUATOR_OUTPUTS		(PX4_WQ_HP_BASE - 3)
 
 // Attitude controllers typically are in a blocking wait on driver data
 // they should be the first to run on an update, using the current sensor
 // data and the *previous* attitude reference from the position controller
 // which typically runs at a slower rate
 #define SCHED_PRIORITY_ATTITUDE_CONTROL		(PX4_WQ_HP_BASE - 4)
-
-// Actuator outputs should run as soon as the rate controller publishes
-// the actuator controls topic
-#define SCHED_PRIORITY_ACTUATOR_OUTPUTS		(PX4_WQ_HP_BASE - 3)
-
-// Position controllers typically are in a blocking wait on estimator data
-// so when new sensor data is available they will run last. Keeping them
-// on a high priority ensures that they are the first process to be run
-// when the estimator updates.
-#define SCHED_PRIORITY_POSITION_CONTROL		(PX4_WQ_HP_BASE - 5)
 
 // Estimators should run after the attitude controller but before anything
 // else in the system. They wait on sensor data which is either coming
@@ -134,6 +128,12 @@ typedef struct {
 // in the controller chain, but provides easy-to-use data to the more
 // complex downstream consumers
 #define SCHED_PRIORITY_SENSOR_HUB		(PX4_WQ_HP_BASE - 6)
+
+// Position controllers typically are in a blocking wait on estimator data
+// so when new sensor data is available they will run last. Keeping them
+// on a high priority ensures that they are the first process to be run
+// when the estimator updates.
+#define SCHED_PRIORITY_POSITION_CONTROL		(PX4_WQ_HP_BASE - 7)
 
 // The log capture (which stores log data into RAM) should run faster
 // than other components, but should not run before the control pipeline


### PR DESCRIPTION
This is a precaution to prevent the multicopter position controller (and/or any FlightTask) from starving the estimator.

From cpu spikes in logs (both periodic and significant changes on arming) I would guess we have some performance work to do in mc_pos_ctrl/FlightTasks, but we need more instrumentation to see what's actually happening.

https://review.px4.io/plot_app?log=98b0867a-1db3-4082-8b7e-2902cc53f7d8

![image](https://user-images.githubusercontent.com/84712/65055764-c2721680-d93d-11e9-9a69-307a30f6b54b.png)
