### PR TITLE
MC rate control - Integrator fix for ideal PID form

### DIFF
--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -415,9 +415,9 @@ MulticopterAttitudeControl::control_attitude_rates(float dt, const Vector3f &rat
 	/* apply low-pass filtering to the rates for D-term */
 	Vector3f rates_filtered(_lp_filters_d.apply(rates));
 
-	_att_control = _rate_k.emult(rates_p_scaled.emult(rates_err) +
-				     _rates_int -
+	_att_control = _rate_k.emult(rates_p_scaled.emult(rates_err) -
 				     rates_d_scaled.emult(rates_filtered - _rates_prev_filtered) / dt) +
+		       _rates_int +
 		       _rate_ff.emult(_rates_sp);
 
 	_rates_prev = rates;
@@ -441,13 +441,11 @@ MulticopterAttitudeControl::control_attitude_rates(float dt, const Vector3f &rat
 			// prevent further positive control saturation
 			if (positive_saturation) {
 				rates_err(i) = math::min(rates_err(i), 0.0f);
-
 			}
 
 			// prevent further negative control saturation
 			if (negative_saturation) {
 				rates_err(i) = math::max(rates_err(i), 0.0f);
-
 			}
 
 			// I term factor: reduce the I gain with increasing rate error.
@@ -460,18 +458,12 @@ MulticopterAttitudeControl::control_attitude_rates(float dt, const Vector3f &rat
 			i_factor = math::max(0.0f, 1.f - i_factor * i_factor);
 
 			// Perform the integration using a first order method and do not propagate the result if out of range or invalid
-			float rate_i = _rates_int(i) + i_factor * rates_i_scaled(i) * rates_err(i) * dt;
+			float rate_i = _rates_int(i) + i_factor * _rate_k(i) * rates_i_scaled(i) * rates_err(i) * dt;
 
-			if (PX4_ISFINITE(rate_i) && rate_i > -_rate_int_lim(i) && rate_i < _rate_int_lim(i)) {
-				_rates_int(i) = rate_i;
-
+			if (PX4_ISFINITE(rate_i)) {
+				_rates_int(i) = math::constrain(rate_i, -_rate_int_lim(i), _rate_int_lim(i));
 			}
 		}
-	}
-
-	/* explicitly limit the integrator state */
-	for (int i = AXIS_INDEX_ROLL; i < AXIS_COUNT; i++) {
-		_rates_int(i) = math::constrain(_rates_int(i), -_rate_int_lim(i), _rate_int_lim(i));
 	}
 }
 


### PR DESCRIPTION
In the ideal form, the gain K scales the whole controller, however, since we want to constrain the contribution of the integrator the saturation needs to scale with K or the integrator has to be scaled with K before being constrained.

I decided to use the 2nd method since it then shows the exact contribution of the integrator to the whole output of the controller and it requires a multiplication instead of a division.

In summary, this has no effect on the parallel form and fixes the early saturation of the integrator in the ideal form.