### PR TITLE
Appveyor: update to Windows Toolchain v0.6

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ install:
 # if the toolchain wasn't restored from build cache download and install it
 - ps: >-
     if (-not (Test-Path C:\PX4)) {
-        Invoke-WebRequest https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Windows+Cygwin+Toolchain+0.5.msi -OutFile C:\Toolchain.msi
+        Invoke-WebRequest https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Windows+Cygwin+Toolchain+0.6.msi -OutFile C:\Toolchain.msi
         Start-Process -Wait msiexec -ArgumentList '/I C:\Toolchain.msi /quiet /qn /norestart /log C:\install.log'
     }
 


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
Since @oneWayOut added gdb to the toolchain and tested it I thought it's a good time to build an up to date installer for the Windows Cygwin toolchain. When creating a new installer the scripts automatically take the latest Cygwin packets and I updated everything else to the latest working version. (ARM GCC 8 doesn't currently compile NuttX, see #11410.)

**Context**
- Add gdb to toolchain: https://github.com/PX4/windows-toolchain/pull/9
- Update components: https://github.com/PX4/windows-toolchain/pull/10
- Toolchain installer build: https://ci.appveyor.com/project/Dronecode/windows-toolchain/builds/27626982
- Update documentation when CI succeeds: https://github.com/PX4/Devguide/pull/870
