### PR TITLE
mavlink: always check stream subscriptions

### DIFF
--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -720,6 +720,8 @@ private:
 
 	void publish_telemetry_status();
 
+	void check_requested_subscriptions();
+
 	/**
 	 * Check the configuration of a connected radio
 	 *


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This fixes the regression where we saw this in SITL:
```
ERROR [mavlink] system boot did not complete in 20 seconds
```

The reason was that the stream subscription requests were not checked because the while loop was not running yet because mavlink was not booted completely.
By moving the stream subscription requests into a function we can run them even if we don't run the rest of the loop.

**Test data / coverage**
Tested in SITL.

Fixes #13001.