### PR TITLE
@value will be printed with Whitespace  in start of line for serial_c…

### DIFF
--- a/Tools/serial/serial_params.c.jinja
+++ b/Tools/serial/serial_params.c.jinja
@@ -55,9 +55,9 @@ PARAM_DEFINE_INT32(SER_{{ serial_device.tag }}_BAUD, {{ serial_device.default_ba
  * {{ command.description_extended | replace("\n", " ") }}
  *
  * @value 0 Disabled
-{% for serial_device in serial_devices -%}
+{%- for serial_device in serial_devices %}
  * @value {{ serial_device.index }} {{ serial_device.label }}
-{% endfor -%}
+{%- endfor %}
  * @group {{ command.param_group }}
  * @reboot_required true
  */


### PR DESCRIPTION
…onfig parameters

**Describe problem solved by the proposed pull request**
no whitespace in the start of a new line in jinja template
