### PR TITLE
nxp/fmuk66-v3: readd uavcan

### DIFF
--- a/boards/nxp/fmuk66-v3/default.cmake
+++ b/boards/nxp/fmuk66-v3/default.cmake
@@ -48,6 +48,7 @@ px4_add_board(
 		telemetry # all available telemetry drivers
 		#test_ppm # NOT Portable YET
 		tone_alarm
+		uavcan
 
 	MODULES
 		attitude_estimator_q


### PR DESCRIPTION
This was accidentally dropped earlier this year.