### PR TITLE
VTOL: fix front transition rate publication (enable FW attitude contr…

### DIFF
--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -526,10 +526,10 @@ void FixedwingAttitudeControl::Run()
 		const matrix::Eulerf euler_angles(R);
 
 		vehicle_attitude_setpoint_poll();
+		vehicle_status_poll(); // this poll has to be before the control_mode_poll, otherwise rate sp are not published during whole transition
 		vehicle_control_mode_poll();
 		vehicle_manual_poll();
 		_global_pos_sub.update(&_global_pos);
-		vehicle_status_poll();
 		vehicle_land_detected_poll();
 
 		// the position controller will not emit attitude setpoints in some modes


### PR DESCRIPTION
Fixes https://github.com/PX4/Firmware/issues/13030

With the changes in this PR the FW attitude controller is publishing rate sp also during first second of transition:
![image](https://user-images.githubusercontent.com/26798987/65676595-79624680-e050-11e9-9247-f0e7b59ead06.png)


