### PR TITLE
CollisionPrevention: limit collision warning to every 3 seconds

### DIFF
--- a/src/lib/CollisionPrevention/CollisionPrevention.hpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.hpp
@@ -59,6 +59,8 @@
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/vehicle_command.h>
 
+using namespace time_literals;
+
 class CollisionPrevention : public ModuleParams
 {
 public:
@@ -131,7 +133,9 @@ private:
 	uORB::Subscription _sub_distance_sensor[ORB_MULTI_MAX_INSTANCES] {{ORB_ID(distance_sensor), 0}, {ORB_ID(distance_sensor), 1}, {ORB_ID(distance_sensor), 2}, {ORB_ID(distance_sensor), 3}}; /**< distance data received from onboard rangefinders */
 	uORB::SubscriptionData<vehicle_attitude_s> _sub_vehicle_attitude{ORB_ID(vehicle_attitude)};
 
-	static constexpr uint64_t RANGE_STREAM_TIMEOUT_US{500000};
+	static constexpr uint64_t RANGE_STREAM_TIMEOUT_US{500_ms};
+
+	hrt_abstime	_last_collision_warning{0};
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::MPC_COL_PREV_D>) _param_mpc_col_prev_d, /**< collision prevention keep minimum distance */


### PR DESCRIPTION
The only real change here is to limit the "Collision Warning" mavlink message to once every 3 seconds. I also found a few more instances of double promotion and cleaned up the whitespace along the way.