### PR TITLE
github: tone stalebot down

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,18 +1,15 @@
 # Number of days of inactivity before an issue becomes stale
 daysUntilStale: 90
-# Number of days of inactivity before a stale issue is closed
-daysUntilClose: 14
+# Number of days of inactivity before a stale issue is closed, or `false` to disable
+daysUntilClose: false
 # Issues with these labels will never be considered stale
 exemptLabels:
   - pinned
-  - security
 # Label to use when marking an issue as stale
-staleLabel: wontfix
+staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
+  recent activity. Thank you for your contributions.
 # Comment to post when closing a stale issue. Set to `false` to disable
-closeComment: >
-  Closing as stale.
+closeComment: false


### PR DESCRIPTION
My suggestion is to re-configure stale bot so it just adds the label
stale but does not close the issue/PR.

This enables us to look for outdated issues using the stale label and
close them.

This brings these advantages:
- No more endless re-opening of PRs and issues which is not fun (and I  will eventually give up on).
- Less stalebot comment noise. (Because it is handy to look for all issues/PRs without any comments to see what is unanswered).
- I'm not listed as "participating" in all the issues/PRs just because I was just fighting the stalebot.
- Less notifications meaning we can see anything in the noise.
