### PR TITLE
cmake: show sitl_gazebo build output and improve rebuild

### DIFF
--- a/boards/px4/sitl/default.cmake
+++ b/boards/px4/sitl/default.cmake
@@ -91,10 +91,10 @@ set_property(CACHE config_sitl_debugger PROPERTY STRINGS "disable;gdb;lldb")
 # support. In this case, we enable the orb publisher rules.
 set(REPLAY_FILE "$ENV{replay}")
 if(REPLAY_FILE)
-	message("Building with uorb publisher rules support")
+	message(STATUS "Building with uorb publisher rules support")
 	add_definitions(-DORB_USE_PUBLISHER_RULES)
 
-	message("Building without lockstep for replay")
+	message(STATUS "Building without lockstep for replay")
 	set(ENABLE_LOCKSTEP_SCHEDULER no)
 else()
 	set(ENABLE_LOCKSTEP_SCHEDULER yes)

--- a/boards/px4/sitl/rtps.cmake
+++ b/boards/px4/sitl/rtps.cmake
@@ -95,7 +95,7 @@ if(REPLAY_FILE)
 	message("Building with uorb publisher rules support")
 	add_definitions(-DORB_USE_PUBLISHER_RULES)
 
-	message("Building without lockstep for replay")
+	message(STATUS "Building without lockstep for replay")
 	set(ENABLE_LOCKSTEP_SCHEDULER no)
 else()
 	set(ENABLE_LOCKSTEP_SCHEDULER yes)

--- a/boards/px4/sitl/test.cmake
+++ b/boards/px4/sitl/test.cmake
@@ -91,9 +91,9 @@ set_property(CACHE config_sitl_debugger PROPERTY STRINGS "disable;gdb;lldb")
 # support. In this case, we enable the orb publisher rules.
 set(REPLAY_FILE "$ENV{replay}")
 if(REPLAY_FILE)
-	message("Building with uorb publisher rules support")
+	message(STATUS "Building with uorb publisher rules support")
 	add_definitions(-DORB_USE_PUBLISHER_RULES)
 endif()
 
-message("Building without lockstep for test")
+message(STATUS "Building without lockstep for test")
 set(ENABLE_LOCKSTEP_SCHEDULER no)

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -39,14 +39,11 @@ ExternalProject_Add(sitl_gazebo
 	INSTALL_COMMAND ""
 	DEPENDS
 		git_gazebo
-	)
-set_target_properties(sitl_gazebo PROPERTIES EXCLUDE_FROM_ALL TRUE)
-
-ExternalProject_Add_Step(sitl_gazebo forceconfigure
-	DEPENDEES update
-	DEPENDERS configure
-	ALWAYS 1
-	)
+	USES_TERMINAL_CONFIGURE true
+	USES_TERMINAL_BUILD true
+	EXCLUDE_FROM_ALL true
+	BUILD_ALWAYS 1
+)
 
 # create targets for each viewer/model/debugger combination
 set(viewers none jmavsim gazebo)


### PR DESCRIPTION
This removes the unnecessary reconfigure & rebuild every time sitl_gazebo is used from PX4/Firmware. It also shows the build output so you know what's happening. This significantly improves the rebuild time when using sitl_gazebo during development. Any build dependency issues will be fixed on the sitl_gazebo side.