### PR TITLE
Add generic quad airframes for 250, 450, and 650 size quadrotors and set PWM_OUT in rc.mc_defaults.

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4001_quad_x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4001_quad_x
@@ -23,5 +23,3 @@
 sh /etc/init.d/rc.mc_defaults
 
 set MIXER quad_x
-
-set PWM_OUT 1234

--- a/ROMFS/px4fmu_common/init.d/airframes/4002_quad_x_mount
+++ b/ROMFS/px4fmu_common/init.d/airframes/4002_quad_x_mount
@@ -28,7 +28,5 @@ then
 fi
 
 set MIXER quad_x
-set PWM_OUT 1234
-
 set MIXER_AUX mount
 set PWM_AUX_OUT 123456

--- a/ROMFS/px4fmu_common/init.d/airframes/4003_qavr5
+++ b/ROMFS/px4fmu_common/init.d/airframes/4003_qavr5
@@ -12,9 +12,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	param set MC_ROLL_P 8
@@ -37,3 +34,5 @@ then
 
 	param set PWM_MIN 1075
 fi
+
+set MIXER quad_x

--- a/ROMFS/px4fmu_common/init.d/airframes/4004_H4_680mm
+++ b/ROMFS/px4fmu_common/init.d/airframes/4004_H4_680mm
@@ -12,12 +12,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
-
-set MIXER_AUX mount
-set PWM_AUX_OUT 123456
-
 # The Z1 Tiny2 can handle up to 400Hz
 # and works with min 1020us, middle 1520us, max 2020us
 # see http://www.zhiyun-tech.com/uploadfile/datedown/instruction/Tiny2_English_instructionV1.03.pdf
@@ -30,6 +24,10 @@ then
 	param set PWM_AUX_MAX 2020
 	param set PWM_AUX_RATE 400
 fi
+
+set MIXER quad_x
+set MIXER_AUX mount
+set PWM_AUX_OUT 123456
 
 # Start FrSky telemetry on SERIAL4 (ttyS6, designated "SERIAL4/5" on the case)
 frsky_telemetry start -d /dev/ttyS6

--- a/ROMFS/px4fmu_common/init.d/airframes/4009_qav250
+++ b/ROMFS/px4fmu_common/init.d/airframes/4009_qav250
@@ -10,9 +10,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	param set ATT_BIAS_MAX 0
@@ -39,3 +36,5 @@ then
 
 	param set PWM_MIN 1075
 fi
+
+set MIXER quad_x

--- a/ROMFS/px4fmu_common/init.d/airframes/4010_dji_f330
+++ b/ROMFS/px4fmu_common/init.d/airframes/4010_dji_f330
@@ -10,9 +10,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	param set MC_ROLL_P 7
@@ -31,3 +28,5 @@ then
 	# DJI ESCs do not support calibration and need a higher min
 	param set PWM_MIN 1230
 fi
+
+set MIXER quad_x

--- a/ROMFS/px4fmu_common/init.d/airframes/4011_dji_f450
+++ b/ROMFS/px4fmu_common/init.d/airframes/4011_dji_f450
@@ -12,19 +12,6 @@ sh /etc/init.d/rc.mc_defaults
 
 if [ $AUTOCNF = yes ]
 then
-	param set MC_ROLL_P 7
-	param set MC_ROLLRATE_P 0.15
-	param set MC_ROLLRATE_I 0.05
-	param set MC_ROLLRATE_D 0.003
-	param set MC_PITCH_P 7
-	param set MC_PITCHRATE_P 0.15
-	param set MC_PITCHRATE_I 0.05
-	param set MC_PITCHRATE_D 0.003
-	param set MC_YAW_P 2.8
-	param set MC_YAWRATE_P 0.3
-	param set MC_YAWRATE_I 0.1
-	param set MC_YAWRATE_D 0
-
 	# DJI ESCs do not support calibration and need a higher min
 	param set PWM_MIN 1230
 fi

--- a/ROMFS/px4fmu_common/init.d/airframes/4011_dji_f450
+++ b/ROMFS/px4fmu_common/init.d/airframes/4011_dji_f450
@@ -10,9 +10,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	param set MC_ROLL_P 7
@@ -31,3 +28,5 @@ then
 	# DJI ESCs do not support calibration and need a higher min
 	param set PWM_MIN 1230
 fi
+
+set MIXER quad_x

--- a/ROMFS/px4fmu_common/init.d/airframes/4014_s500
+++ b/ROMFS/px4fmu_common/init.d/airframes/4014_s500
@@ -10,9 +10,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	param set MC_ROLLRATE_P 0.18
@@ -22,3 +19,5 @@ then
 	param set MC_ROLLRATE_D 0.003
 	param set MC_PITCHRATE_D 0.003
 fi
+
+set MIXER quad_x

--- a/ROMFS/px4fmu_common/init.d/airframes/4015_holybro_s500
+++ b/ROMFS/px4fmu_common/init.d/airframes/4015_holybro_s500
@@ -10,9 +10,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	param set IMU_GYRO_CUTOFF 80
@@ -24,3 +21,5 @@ then
 	param set MC_ROLLRATE_D 0.004
 	param set MC_PITCHRATE_D 0.004
 fi
+
+set MIXER quad_x

--- a/ROMFS/px4fmu_common/init.d/airframes/4020_hk_micro_pcb
+++ b/ROMFS/px4fmu_common/init.d/airframes/4020_hk_micro_pcb
@@ -18,9 +18,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	param set MC_ROLL_P 7
@@ -38,3 +35,5 @@ then
 
 	param set PWM_MIN 1200
 fi
+
+set MIXER quad_x

--- a/ROMFS/px4fmu_common/init.d/airframes/4030_3dr_solo
+++ b/ROMFS/px4fmu_common/init.d/airframes/4030_3dr_solo
@@ -88,7 +88,4 @@ then
 fi
 
 set MIXER quad_x
-
-set PWM_OUT 1234
 set MIXER_AUX none
-

--- a/ROMFS/px4fmu_common/init.d/airframes/4031_3dr_quad
+++ b/ROMFS/px4fmu_common/init.d/airframes/4031_3dr_quad
@@ -10,8 +10,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
 
 if [ $AUTOCNF = yes ]
 then
@@ -25,3 +23,5 @@ then
 	param set MC_PITCHRATE_D 0.004
 	param set MC_YAW_P 4
 fi
+
+set MIXER quad_x

--- a/ROMFS/px4fmu_common/init.d/airframes/4040_reaper
+++ b/ROMFS/px4fmu_common/init.d/airframes/4040_reaper
@@ -42,9 +42,3 @@ then
 fi
 
 set MIXER quad_h
-
-set PWM_OUT 1234
-
-set MIXER_AUX pass
-
-set PWM_AUX_OUT 1234

--- a/ROMFS/px4fmu_common/init.d/airframes/4041_beta75x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4041_beta75x
@@ -62,5 +62,3 @@ fi
 
 # The Whoop uses reversed props
 set MIXER quad_h
-set PWM_OUT 1234
-

--- a/ROMFS/px4fmu_common/init.d/airframes/4051_s250aq
+++ b/ROMFS/px4fmu_common/init.d/airframes/4051_s250aq
@@ -21,11 +21,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_s250aq
-set MAV_TYPE 2
-
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	param set ATT_BIAS_MAX 0
@@ -61,3 +56,6 @@ then
 
 	param set PWM_MIN 1075
 fi
+
+set MAV_TYPE 2
+set MIXER quad_s250aq

--- a/ROMFS/px4fmu_common/init.d/airframes/4052_holybro_qav250
+++ b/ROMFS/px4fmu_common/init.d/airframes/4052_holybro_qav250
@@ -13,9 +13,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	# The set does not include a battery, but most people will probably use 4S
@@ -55,3 +52,4 @@ then
 	param set THR_MDL_FAC 0.3
 fi
 
+set MIXER quad_x

--- a/ROMFS/px4fmu_common/init.d/airframes/4053_holybro_kopis2
+++ b/ROMFS/px4fmu_common/init.d/airframes/4053_holybro_kopis2
@@ -12,9 +12,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	param set BAT_N_CELLS 4
@@ -59,3 +56,4 @@ then
 	param set EV_TSK_RC_LOSS 1
 fi
 
+set MIXER quad_x

--- a/ROMFS/px4fmu_common/init.d/airframes/4071_ifo
+++ b/ROMFS/px4fmu_common/init.d/airframes/4071_ifo
@@ -20,10 +20,6 @@
 # @maintainer Hyon Lim <lim@uvify.com>
 #
 
-set VEHICLE_TYPE mc
-set MIXER quad_x
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	# Attitude & rate gains
@@ -124,3 +120,6 @@ then
 	param set MAV_1_MODE 0	# normal
 	param set SER_TEL2_BAUD 57600
 fi
+
+set MIXER quad_x
+set VEHICLE_TYPE mc

--- a/ROMFS/px4fmu_common/init.d/airframes/4072_draco
+++ b/ROMFS/px4fmu_common/init.d/airframes/4072_draco
@@ -22,9 +22,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	# use the Q attitude estimator, it works w/o mag or GPS.
@@ -101,3 +98,5 @@ then
 	# TELEM2 ttyS2
 	#param set MAV_1_CONFIG 0
 fi
+
+set MIXER quad_x

--- a/ROMFS/px4fmu_common/init.d/airframes/4080_zmr250
+++ b/ROMFS/px4fmu_common/init.d/airframes/4080_zmr250
@@ -13,9 +13,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER zmr250
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	param set CBRK_IO_SAFETY 22027
@@ -52,3 +49,5 @@ then
 	param set PWM_RATE 400
 	param set PWM_DISARMED 900
 fi
+
+set MIXER zmr250

--- a/ROMFS/px4fmu_common/init.d/airframes/4090_nanomind
+++ b/ROMFS/px4fmu_common/init.d/airframes/4090_nanomind
@@ -17,9 +17,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	param set BAT_N_CELLS 1
@@ -41,3 +38,5 @@ then
 	param set PWM_MIN 500
 	param set PWM_MAX 2200
 fi
+
+set MIXER quad_x

--- a/ROMFS/px4fmu_common/init.d/airframes/4100_tiltquadrotor
+++ b/ROMFS/px4fmu_common/init.d/airframes/4100_tiltquadrotor
@@ -31,5 +31,3 @@ param set LED_RGB_MAXBRT 8
 # Set mixer
 set MIXER tilt_quad
 set MIXER_AUX tilt_quad
-
-set PWM_OUT 1234

--- a/ROMFS/px4fmu_common/init.d/airframes/4250_generic_quad_250
+++ b/ROMFS/px4fmu_common/init.d/airframes/4250_generic_quad_250
@@ -44,7 +44,7 @@ then
 	# enable high-rate logging profile (helps with tuning)
 	param set SDLOG_PROFILE 19
 
-	# use thrust curve factor (instead of TPA)
+	# use thrust curve factor
 	param set THR_MDL_FAC 0.3
 fi
 

--- a/ROMFS/px4fmu_common/init.d/airframes/4250_generic_quad_250
+++ b/ROMFS/px4fmu_common/init.d/airframes/4250_generic_quad_250
@@ -1,32 +1,32 @@
 #!/bin/sh
 #
-# @name Generic 250 Racer
+# @name Generic Quadcopter (250mm racer)
 #
 # @type Quadrotor x
 # @class Copter
 #
-# @maintainer Lorenz Meier <lorenz@px4.io>
-#
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
-	param set MC_ROLL_P 8
+	param set CBRK_IO_SAFETY 22027
+
+	param set MC_ROLL_P 8.0
 	param set MC_ROLLRATE_P 0.08
 	param set MC_ROLLRATE_I 0.25
 	param set MC_ROLLRATE_D 0.001
-	param set MC_PITCH_P 8
+
+	param set MC_PITCH_P 8.0
 	param set MC_PITCHRATE_P 0.08
 	param set MC_PITCHRATE_I 0.25
 	param set MC_PITCHRATE_D 0.001
+
 	param set MC_YAW_P 4
 	param set MC_YAWRATE_P 0.2
 	param set MC_YAWRATE_I 0.1
-	param set MC_YAWRATE_D 0
+	param set MC_YAWRATE_D 0.0
+	param set MC_YAW_FF 0.5
 
 	param set MC_ROLLRATE_MAX 1600
 	param set MC_PITCHRATE_MAX 1600
@@ -35,18 +35,17 @@ then
 	param set MPC_MANTHR_MIN 0
 	param set MPC_MAN_TILT_MAX 60
 
-	# use thrust curve factor (instead of TPA)
-	param set THR_MDL_FAC 0.3
-
-	param set PWM_MIN 1075
 	# enable one-shot
 	param set PWM_RATE 0
-
-	# enable high-rate logging profile (helps with tuning)
-	param set SDLOG_PROFILE 19
 
 	# disable RC filtering
 	param set RC_FLT_CUTOFF 0
 
-	param set CBRK_IO_SAFETY 22027
+	# enable high-rate logging profile (helps with tuning)
+	param set SDLOG_PROFILE 19
+
+	# use thrust curve factor (instead of TPA)
+	param set THR_MDL_FAC 0.3
 fi
+
+set MIXER quad_x

--- a/ROMFS/px4fmu_common/init.d/airframes/4250_teal
+++ b/ROMFS/px4fmu_common/init.d/airframes/4250_teal
@@ -18,12 +18,7 @@
 # @maintainer Matt McFadden <matt.mcfadden@tealdrones.com>
 #
 
-echo "Executing 4250_teal script."
-
 sh /etc/init.d/rc.mc_defaults
-
-set MIXER quad_x
-set PWM_OUT 1234
 
 if [ $AUTOCNF = yes ]
 then
@@ -199,6 +194,8 @@ then
 	param set CAL_MAG_PRIME 265738
 
 fi
+
+set MIXER quad_x
 
 # Logger mode. Default(1) + estimator replay(2) + thermal calibration(4)
 param set SDLOG_PROFILE 6

--- a/ROMFS/px4fmu_common/init.d/airframes/4450_generic_quad_450
+++ b/ROMFS/px4fmu_common/init.d/airframes/4450_generic_quad_450
@@ -10,20 +10,10 @@ sh /etc/init.d/rc.mc_defaults
 
 if [ $AUTOCNF = yes ]
 then
-	param set MC_ROLL_P 7.0
-	param set MC_ROLLRATE_P 0.15
-	param set MC_ROLLRATE_I 0.05
-	param set MC_ROLLRATE_D 0.003
 
-	param set MC_PITCH_P 7.0
-	param set MC_PITCHRATE_P 0.15
-	param set MC_PITCHRATE_I 0.05
-	param set MC_PITCHRATE_D 0.003
+	# This file is currently a placeholder to be populated with
+	# appropritate values for this size airframe.
 
-	param set MC_YAW_P 2.8
-	param set MC_YAWRATE_P 0.3
-	param set MC_YAWRATE_I 0.1
-	param set MC_YAWRATE_D 0.0
 fi
 
 set MIXER quad_x

--- a/ROMFS/px4fmu_common/init.d/airframes/4450_generic_quad_450
+++ b/ROMFS/px4fmu_common/init.d/airframes/4450_generic_quad_450
@@ -1,32 +1,29 @@
 #!/bin/sh
 #
-# @name F450-sized quadrotor with CAN
+# @name Generic Quadcopter (450mm)
 #
 # @type Quadrotor x
 # @class Copter
-#
-# @board px4_fmu-v2 exclude
-#
-# @maintainer Pavel Kirienko <pavel.kirienko@gmail.com>
 #
 
 sh /etc/init.d/rc.mc_defaults
 
 if [ $AUTOCNF = yes ]
 then
-	param set MC_ROLL_P 7
-	param set MC_ROLLRATE_P 0.16
+	param set MC_ROLL_P 7.0
+	param set MC_ROLLRATE_P 0.15
 	param set MC_ROLLRATE_I 0.05
 	param set MC_ROLLRATE_D 0.003
-	param set MC_PITCH_P 7
-	param set MC_PITCHRATE_P 0.16
+
+	param set MC_PITCH_P 7.0
+	param set MC_PITCHRATE_P 0.15
 	param set MC_PITCHRATE_I 0.05
 	param set MC_PITCHRATE_D 0.003
+
 	param set MC_YAW_P 2.8
 	param set MC_YAWRATE_P 0.3
 	param set MC_YAWRATE_I 0.1
-	param set MC_YAWRATE_D 0
+	param set MC_YAWRATE_D 0.0
 fi
 
-set MIXER quad_x_can
-set OUTPUT_MODE uavcan_esc
+set MIXER quad_x

--- a/ROMFS/px4fmu_common/init.d/airframes/4650_generic_quad_650
+++ b/ROMFS/px4fmu_common/init.d/airframes/4650_generic_quad_650
@@ -1,32 +1,28 @@
 #!/bin/sh
 #
-# @name DJI Matrice 100
+# @name Generic Quadcopter (650mm)
 #
 # @type Quadrotor x
 # @class Copter
-#
-# @maintainer James Goppert <james.goppert@gmail.com>
 #
 
 sh /etc/init.d/rc.mc_defaults
 
 if [ $AUTOCNF = yes ]
 then
-	param set BAT_N_CELLS 6
-
 	param set MC_ROLL_P 6.5
 	param set MC_ROLLRATE_P 0.05
 	param set MC_ROLLRATE_I 0.05
 	param set MC_ROLLRATE_D 0.001
+
 	param set MC_PITCH_P 6.5
 	param set MC_PITCHRATE_P 0.05
 	param set MC_PITCHRATE_I 0.05
 	param set MC_PITCHRATE_D 0.001
-	param set MC_YAWRATE_P 0.2
-	param set MC_YAWRATE_I 0
-	param set MC_YAWRATE_D 0
 
-	param set PWM_MIN 1200
+	param set MC_YAWRATE_P 0.2
+	param set MC_YAWRATE_I 0.0
+	param set MC_YAWRATE_D 0.0
 fi
 
 set MIXER quad_x

--- a/ROMFS/px4fmu_common/init.d/airframes/4900_crazyflie
+++ b/ROMFS/px4fmu_common/init.d/airframes/4900_crazyflie
@@ -17,8 +17,6 @@
 #
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
 if [ $AUTOCNF = yes ]
 then
 	param set BAT_N_CELLS 1
@@ -73,10 +71,11 @@ then
 
 fi
 
+set MIXER quad_x
+
 set PWM_DISARMED none
 set PWM_MAX none
 set PWM_MIN none
 
 syslink start
 mavlink start -d /dev/bridge0 -b 57600 -m osd -r 40000
-

--- a/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
@@ -75,7 +75,6 @@ px4_add_romfs_files(
 	4031_3dr_quad
 	4040_reaper
 	4041_beta75x
-	4050_generic_250
 	4051_s250aq
 	4052_holybro_qav250
 	4053_holybro_kopis2
@@ -86,8 +85,11 @@ px4_add_romfs_files(
 	4080_zmr250
 	4090_nanomind
 	4100_tiltquadrotor
+	4250_generic_quad_250
 	4250_teal
+	4450_generic_quad_450
 	4500_clover4
+	4650_generic_quad_650
 	4900_crazyflie
 
 	# [5000, 5999] Quadrotor +"

--- a/ROMFS/px4fmu_common/init.d/rc.mc_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.mc_defaults
@@ -25,4 +25,5 @@ fi
 #
 set MIXER_AUX pass
 
+set PWM_OUT 1234
 set PWM_AUX_OUT 1234


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This PR adds a range of generic quadrotor airframes to advance PR #9849.

**Additional context**
See PR #9849 and PR #12506.

@dagar , would you let me know if you'd like to see anything different in this PR or if it is no longer of interest?  Thanks!