### PR TITLE
Deprecate RoverLandDetector virtual methods that are redundant.

### DIFF
--- a/src/modules/land_detector/RoverLandDetector.cpp
+++ b/src/modules/land_detector/RoverLandDetector.cpp
@@ -39,8 +39,6 @@
  * @author Julian Oes <julian@oes.ch>
  */
 
-#include <drivers/drv_hrt.h>
-
 #include "RoverLandDetector.h"
 
 namespace land_detector
@@ -59,23 +57,12 @@ bool RoverLandDetector::_get_ground_contact_state()
 	return true;
 }
 
-bool RoverLandDetector::_get_maybe_landed_state()
-{
-	return false;
-}
-
-
 bool RoverLandDetector::_get_landed_state()
 {
 	if (!_actuator_armed.armed) {
 		return true;
 	}
 
-	return false;
-}
-
-bool RoverLandDetector::_get_freefall_state()
-{
 	return false;
 }
 

--- a/src/modules/land_detector/RoverLandDetector.h
+++ b/src/modules/land_detector/RoverLandDetector.h
@@ -62,10 +62,6 @@ protected:
 
 	virtual bool  _get_ground_contact_state() override;
 
-	virtual bool _get_maybe_landed_state() override;
-
-	virtual bool _get_freefall_state() override;
-
 	virtual float _get_max_altitude() override;
 
 private:


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
The RoverLandDetector class contains a few inherited methods that already have the same return value as default in the LandDetector base class.  This PR simply deprecates the methods that are redundant.

For convenience, you can see the [base class implementations returning the same values here](https://github.com/PX4/Firmware/blob/5842c0c2fbd1e540a8bf847fdb348e4611b03221/src/modules/land_detector/LandDetector.h#L120).

**Additional context**
See also PR's #9756 and #11874.

Let me know if you have any questions on this PR!  Thanks!