### PR TITLE
vscode: restore editor.smoothScrolling to default

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -70,7 +70,6 @@
         "editor.minimap.maxColumn": 120,
         "editor.minimap.renderCharacters": false,
         "editor.minimap.showSlider": "always",
-        "editor.smoothScrolling": true,
         "editor.suggest.localityBonus": true,
         "editor.tabSize": 8,
         "editor.wordWrapColumn": 120,


### PR DESCRIPTION
Things seem slightly faster without smoothScrolling (the default).