### PR TITLE
FlightTaskAutoLineSmoothVel: generate trajectory does not override th…

### DIFF
--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
@@ -363,7 +363,7 @@ void FlightTaskAutoLineSmoothVel::_generateTrajectory()
 		jerk_sp_smooth(i) = _trajectory[i].getCurrentJerk();
 		accel_sp_smooth(i) = _trajectory[i].getCurrentAcceleration();
 		vel_sp_smooth(i) = _trajectory[i].getCurrentVelocity();
-		pos_sp_smooth(i) = _trajectory[i].getCurrentPosition();
+		pos_sp_smooth(i) = PX4_ISFINITE(_position_setpoint(i)) ? _trajectory[i].getCurrentPosition() : NAN;
 	}
 
 	_updateTrajConstraints();


### PR DESCRIPTION
…e NAN position setpoints

In case we want to control the drone by setting the velocities, we set the position setpoint to NAN.
FlightTaskAutoLineSmoothVel::_generateTrajectory() overrides this NAN setpoints which causes the position controller to control position rather than the velocity directly.

I noticed this when I checked for the landing velocity setpoints. The setpoint was set to be the one set by the parameter, and the position sp was set to NAN, but this was overridden with an another value, and the drone didn't land with the desired velocity but hit the ground very hard.

This pr simply fixes the problem by checking if the position sp is NAN before overriding it.
I tested the landing case, and the z velocity setpoint was set properly to match the landing speed defined with the parameter.