### PR TITLE
CI: bump container tags to 2019-10-04

### DIFF
--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -8,7 +8,7 @@ pipeline {
     stage('Build') {
       agent {
         docker {
-          image 'px4io/px4-dev-ros-kinetic:2019-07-29'
+          image 'px4io/px4-dev-ros-kinetic:2019-10-04'
           args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
         }
       }
@@ -130,7 +130,7 @@ def createTestNode(Map test_def) {
   return {
     node {
       cleanWs()
-      docker.image("px4io/px4-dev-ros-kinetic:2019-07-29").inside('-e HOME=${WORKSPACE}') {
+      docker.image("px4io/px4-dev-ros-kinetic:2019-10-04").inside('-e HOME=${WORKSPACE}') {
         stage(test_def.name) {
           def run_script = test_def.get('run_script', 'rostest_px4_run.sh')
           def test_ok = true

--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -86,20 +86,20 @@ pipeline {
             //   mission: "VTOL_mission_1",
             //   vehicle: "tiltrotor"
             // ],
-            [
-              name: "MC_avoidance",
-              test: "mavros_posix_test_avoidance.test",
-              mission: "avoidance",
-              vehicle: "iris_obs_avoid",
-              run_script: "rostest_avoidance_run.sh"
-            ],
-            [
-              name: "MC_safe_landing",
-              test: "mavros_posix_test_safe_landing.test",
-              mission: "MC_safe_landing",
-              vehicle: "iris_obs_avoid",
-              run_script: "rostest_avoidance_run.sh"
-            ],
+            // [
+            //   name: "MC_avoidance",
+            //   test: "mavros_posix_test_avoidance.test",
+            //   mission: "avoidance",
+            //   vehicle: "iris_obs_avoid",
+            //   run_script: "rostest_avoidance_run.sh"
+            // ],
+            // [
+            //   name: "MC_safe_landing",
+            //   test: "mavros_posix_test_safe_landing.test",
+            //   mission: "MC_safe_landing",
+            //   vehicle: "iris_obs_avoid",
+            //   run_script: "rostest_avoidance_run.sh"
+            // ],
 
           ]
 

--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -80,12 +80,12 @@ pipeline {
               mission: "VTOL_mission_1",
               vehicle: "tailsitter"
             ],
-            // [
-            //   name: "VTOL_tiltrotor",
-            //   test: "mavros_posix_test_mission.test",
-            //   mission: "VTOL_mission_1",
-            //   vehicle: "tiltrotor"
-            // ],
+            [
+              name: "VTOL_tiltrotor",
+              test: "mavros_posix_test_mission.test",
+              mission: "VTOL_mission_1",
+              vehicle: "tiltrotor"
+            ],
             // [
             //   name: "MC_avoidance",
             //   test: "mavros_posix_test_avoidance.test",

--- a/.ci/Jenkinsfile-SITL_tests_ASan
+++ b/.ci/Jenkinsfile-SITL_tests_ASan
@@ -8,7 +8,7 @@ pipeline {
     stage('Build') {
       agent {
         docker {
-          image 'px4io/px4-dev-ros-kinetic:2019-07-29'
+          image 'px4io/px4-dev-ros-kinetic:2019-10-04'
           args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
         }
       }
@@ -117,7 +117,7 @@ def createTestNode(Map test_def) {
   return {
     node {
       cleanWs()
-      docker.image("px4io/px4-dev-ros-kinetic:2019-07-29").inside('-e HOME=${WORKSPACE}') {
+      docker.image("px4io/px4-dev-ros-kinetic:2019-10-04").inside('-e HOME=${WORKSPACE}') {
         stage(test_def.name) {
           def test_ok = true
           sh('export')

--- a/.ci/Jenkinsfile-SITL_tests_coverage
+++ b/.ci/Jenkinsfile-SITL_tests_coverage
@@ -79,7 +79,7 @@ pipeline {
         stage('code coverage (python)') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2019-07-29'
+              image 'px4io/px4-dev-base-bionic:2019-10-04'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -99,7 +99,7 @@ pipeline {
         stage('unit tests') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2019-07-29'
+              image 'px4io/px4-dev-base-bionic:2019-10-04'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -137,7 +137,7 @@ def createTestNode(Map test_def) {
   return {
     node {
       cleanWs()
-      docker.image("px4io/px4-dev-ros-kinetic:2019-07-29").inside('-e HOME=${WORKSPACE}') {
+      docker.image("px4io/px4-dev-ros-kinetic:2019-10-04").inside('-e HOME=${WORKSPACE}') {
         stage(test_def.name) {
           def test_ok = true
           sh('export')

--- a/.ci/Jenkinsfile-compile
+++ b/.ci/Jenkinsfile-compile
@@ -9,10 +9,10 @@ pipeline {
         script {
           def build_nodes = [:]
           def docker_images = [
-            armhf: "px4io/px4-dev-armhf:2019-07-29",
-            base: "px4io/px4-dev-base-bionic:2019-07-29",
-            nuttx: "px4io/px4-dev-nuttx:2019-07-29",
-            rpi: "px4io/px4-dev-raspi:2019-07-29",
+            armhf: "px4io/px4-dev-armhf:2019-10-04",
+            base: "px4io/px4-dev-base-bionic:2019-10-04",
+            nuttx: "px4io/px4-dev-nuttx:2019-10-04",
+            rpi: "px4io/px4-dev-raspi:2019-10-04",
             snapdragon: "lorenzmeier/px4-dev-snapdragon:2018-09-12"
           ]
 
@@ -81,7 +81,7 @@ pipeline {
     // TODO: actually upload artifacts to S3
     // stage('S3 Upload') {
     //   agent {
-    //     docker { image 'px4io/px4-dev-base-bionic:2019-07-29' }
+    //     docker { image 'px4io/px4-dev-base-bionic:2019-10-04' }
     //   }
     //   options {
     //         skipDefaultCheckout()

--- a/.ci/Jenkinsfile-hardware
+++ b/.ci/Jenkinsfile-hardware
@@ -11,7 +11,7 @@ pipeline {
         stage('px4_fmu-v2_test') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-07-29'
+              image 'px4io/px4-dev-nuttx:2019-10-04'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -35,7 +35,7 @@ pipeline {
         stage('px4_fmu-v3_default') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-07-29'
+              image 'px4io/px4-dev-nuttx:2019-10-04'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -59,7 +59,7 @@ pipeline {
         stage('px4_fmu-v4_default') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-07-29'
+              image 'px4io/px4-dev-nuttx:2019-10-04'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -83,7 +83,7 @@ pipeline {
         stage('px4_fmu-v4pro_default') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-07-29'
+              image 'px4io/px4-dev-nuttx:2019-10-04'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -107,7 +107,7 @@ pipeline {
         stage('px4_fmu-v5_default') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-07-29'
+              image 'px4io/px4-dev-nuttx:2019-10-04'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -131,7 +131,7 @@ pipeline {
         stage('px4_fmu-v5_critmonitor') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-07-29'
+              image 'px4io/px4-dev-nuttx:2019-10-04'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -155,7 +155,7 @@ pipeline {
         stage('px4_fmu-v5_irqmonitor') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-07-29'
+              image 'px4io/px4-dev-nuttx:2019-10-04'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -179,7 +179,7 @@ pipeline {
         stage('px4_fmu-v5_stackcheck') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-07-29'
+              image 'px4io/px4-dev-nuttx:2019-10-04'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -203,7 +203,7 @@ pipeline {
         stage('px4_fmu-v5x_default') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-07-29'
+              image 'px4io/px4-dev-nuttx:2019-10-04'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -227,7 +227,7 @@ pipeline {
         stage('nxp_fmuk66-v3_default') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-07-29'
+              image 'px4io/px4-dev-nuttx:2019-10-04'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
         // stage('Catkin build on ROS workspace') {
         //   agent {
         //     docker {
-        //       image 'px4io/px4-dev-ros-melodic:2019-07-29'
+        //       image 'px4io/px4-dev-ros-melodic:2019-10-04'
         //       args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
         //     }
         //   }
@@ -51,7 +51,7 @@ pipeline {
         stage('Colcon build on ROS2 workspace') {
           agent {
             docker {
-              image 'px4io/px4-dev-ros2-bouncy:2019-07-29'
+              image 'px4io/px4-dev-ros2-bouncy:2019-10-04'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
             }
           }
@@ -82,7 +82,7 @@ pipeline {
 
         stage('Style check') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-07-29' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-10-04' }
           }
           steps {
             sh 'make check_format'
@@ -97,7 +97,7 @@ pipeline {
         stage('px4_fmu-v2 (bloaty)') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-07-29'
+              image 'px4io/px4-dev-nuttx:2019-10-04'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -130,7 +130,7 @@ pipeline {
         stage('px4_fmu-v5 (bloaty)') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-07-29'
+              image 'px4io/px4-dev-nuttx:2019-10-04'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -163,7 +163,7 @@ pipeline {
         stage('px4_sitl (bloaty)') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-07-29'
+              image 'px4io/px4-dev-nuttx:2019-10-04'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -196,7 +196,7 @@ pipeline {
         stage('px4_fmu-v5 (no ninja)') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-07-29'
+              image 'px4io/px4-dev-nuttx:2019-10-04'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -222,7 +222,7 @@ pipeline {
         stage('px4_sitl (no ninja)') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-07-29'
+              image 'px4io/px4-dev-nuttx:2019-10-04'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -248,7 +248,7 @@ pipeline {
         stage('SITL unit tests') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2019-07-29'
+              image 'px4io/px4-dev-base-bionic:2019-10-04'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -270,7 +270,7 @@ pipeline {
         stage('Clang analyzer') {
           agent {
             docker {
-              image 'px4io/px4-dev-clang:2019-07-29'
+              image 'px4io/px4-dev-clang:2019-10-04'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -308,7 +308,7 @@ pipeline {
         // stage('Clang tidy') {
         //   agent {
         //     docker {
-        //       image 'px4io/px4-dev-clang:2019-07-29'
+        //       image 'px4io/px4-dev-clang:2019-10-04'
         //       args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
         //     }
         //   }
@@ -329,7 +329,7 @@ pipeline {
         stage('Cppcheck') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2019-07-29'
+              image 'px4io/px4-dev-base-bionic:2019-10-04'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -367,7 +367,7 @@ pipeline {
         stage('Check stack') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-07-29'
+              image 'px4io/px4-dev-nuttx:2019-10-04'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -387,7 +387,7 @@ pipeline {
         stage('ShellCheck') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-07-29'
+              image 'px4io/px4-dev-nuttx:2019-10-04'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -406,7 +406,7 @@ pipeline {
         stage('Module config validation') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2019-07-29'
+              image 'px4io/px4-dev-base-bionic:2019-10-04'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -431,7 +431,7 @@ pipeline {
 
         stage('Airframe') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-07-29' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-10-04' }
           }
           steps {
             sh 'make distclean'
@@ -450,7 +450,7 @@ pipeline {
 
         stage('Parameter') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-07-29' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-10-04' }
           }
           steps {
             sh 'make distclean'
@@ -469,7 +469,7 @@ pipeline {
 
         stage('Module') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-07-29' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-10-04' }
           }
           steps {
             sh 'make distclean'
@@ -489,7 +489,7 @@ pipeline {
         stage('uORB graphs') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-07-29'
+              image 'px4io/px4-dev-nuttx:2019-10-04'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -518,7 +518,7 @@ pipeline {
 
         stage('Devguide') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-07-29' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-10-04' }
           }
           steps {
             sh('export')
@@ -548,7 +548,7 @@ pipeline {
 
         stage('Userguide') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-07-29' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-10-04' }
           }
           steps {
             sh('export')
@@ -576,7 +576,7 @@ pipeline {
 
         stage('QGroundControl') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-07-29' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-10-04' }
           }
           steps {
             sh('export')
@@ -604,7 +604,7 @@ pipeline {
 
         stage('PX4 ROS msgs') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-07-29' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-10-04' }
           }
           steps {
             sh('export')
@@ -633,7 +633,7 @@ pipeline {
 
         stage('PX4 ROS2 bridge') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-07-29' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-10-04' }
           }
           steps {
             sh('export')
@@ -674,7 +674,7 @@ pipeline {
 
         stage('S3') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2019-07-29' }
+            docker { image 'px4io/px4-dev-base-bionic:2019-10-04' }
           }
           steps {
             sh('export')

--- a/Tools/docker_run.sh
+++ b/Tools/docker_run.sh
@@ -19,7 +19,7 @@ if [ -z ${PX4_DOCKER_REPO+x} ]; then
 		PX4_DOCKER_REPO="px4io/px4-dev-clang:2019-07-29"
 	elif [[ $@ =~ .*tests* ]]; then
 		# run all tests with simulation
-		PX4_DOCKER_REPO="px4io/px4-dev-simulation:2019-07-29"
+		PX4_DOCKER_REPO="px4io/px4-dev-simulation-xenial:2019-10-04"
 	fi
 else
 	echo "PX4_DOCKER_REPO is set to '$PX4_DOCKER_REPO'";

--- a/msg/tools/generate_microRTPS_bridge.py
+++ b/msg/tools/generate_microRTPS_bridge.py
@@ -251,8 +251,10 @@ if(os.path.exists(fastrtpsgen_path)):
     except OSError:
         raise
 
-    if fastrtpsgen_version_out:
+    if fastrtpsgen_version_out.isdigit():
         fastrtpsgen_version = float(fastrtpsgen_version_out)
+    else:
+        fastrtpsgen_version = 1.0
 else:
     raise Exception(
         "FastRTPSGen not found. Specify the location of fastrtpsgen with the -f flag")


### PR DESCRIPTION
These bring updated containers with upgraded Fast-RTPS versions and also a new simulation container dependency (ROS Kinetic based from a simulation container with Gazebo 7).