### PR TITLE
[WIP] added control modes concept

### DIFF
--- a/boards/px4/fmu-v5/critmonitor.cmake
+++ b/boards/px4/fmu-v5/critmonitor.cmake
@@ -11,6 +11,12 @@ px4_add_board(
 	TESTING
 	UAVCAN_INTERFACES 2
 
+	CONTROL_MODES
+		fixed_wing
+		vtol
+		multicopter
+		rover
+
 	SERIAL_PORTS
 		GPS1:/dev/ttyS0
 		TEL1:/dev/ttyS1

--- a/boards/px4/fmu-v5/default.cmake
+++ b/boards/px4/fmu-v5/default.cmake
@@ -11,6 +11,12 @@ px4_add_board(
 	TESTING
 	UAVCAN_INTERFACES 2
 
+	CONTROL_MODES
+		fixed_wing
+		vtol
+		multicopter
+		rover
+
 	SERIAL_PORTS
 		GPS1:/dev/ttyS0
 		TEL1:/dev/ttyS1

--- a/boards/px4/fmu-v5/fixedwing.cmake
+++ b/boards/px4/fmu-v5/fixedwing.cmake
@@ -10,6 +10,9 @@ px4_add_board(
 	IO px4_io-v2_default
 	UAVCAN_INTERFACES 2
 
+	CONTROL_MODES
+		fixed_wing
+
 	SERIAL_PORTS
 		GPS1:/dev/ttyS0
 		TEL1:/dev/ttyS1

--- a/boards/px4/fmu-v5/irqmonitor.cmake
+++ b/boards/px4/fmu-v5/irqmonitor.cmake
@@ -11,6 +11,12 @@ px4_add_board(
 	TESTING
 	UAVCAN_INTERFACES 2
 
+	CONTROL_MODES
+		fixed_wing
+		vtol
+		multicopter
+		rover
+
 	SERIAL_PORTS
 		GPS1:/dev/ttyS0
 		TEL1:/dev/ttyS1

--- a/boards/px4/fmu-v5/multicopter.cmake
+++ b/boards/px4/fmu-v5/multicopter.cmake
@@ -11,6 +11,9 @@ px4_add_board(
 	TESTING
 	UAVCAN_INTERFACES 2
 
+	CONTROL_MODES
+		multicopter
+
 	SERIAL_PORTS
 		GPS1:/dev/ttyS0
 		TEL1:/dev/ttyS1

--- a/boards/px4/fmu-v5/rover.cmake
+++ b/boards/px4/fmu-v5/rover.cmake
@@ -10,6 +10,9 @@ px4_add_board(
 	IO px4_io-v2_default
 	UAVCAN_INTERFACES 2
 
+	CONTROL_MODES
+		rover
+
 	SERIAL_PORTS
 		GPS1:/dev/ttyS0
 		TEL1:/dev/ttyS1

--- a/boards/px4/fmu-v5/rtps.cmake
+++ b/boards/px4/fmu-v5/rtps.cmake
@@ -11,6 +11,12 @@ px4_add_board(
 	TESTING
 	UAVCAN_INTERFACES 2
 
+	CONTROL_MODES
+		fixed_wing
+		vtol
+		multicopter
+		rover
+
 	SERIAL_PORTS
 		GPS1:/dev/ttyS0
 		TEL1:/dev/ttyS1

--- a/boards/px4/fmu-v5/stackcheck.cmake
+++ b/boards/px4/fmu-v5/stackcheck.cmake
@@ -11,6 +11,12 @@ px4_add_board(
 	TESTING
 	#UAVCAN_INTERFACES 2
 
+	CONTROL_MODES
+		fixed_wing
+		vtol
+		multicopter
+		rover
+
 	SERIAL_PORTS
 		GPS1:/dev/ttyS0
 		TEL1:/dev/ttyS1

--- a/boards/px4/sitl/default.cmake
+++ b/boards/px4/sitl/default.cmake
@@ -6,6 +6,12 @@ px4_add_board(
 	LABEL default
 	TESTING
 
+	CONTROL_MODES
+		fixed_wing
+		vtol
+		multicopter
+		rover
+
 	DRIVERS
 		#barometer # all available barometer drivers
 		#batt_smbus

--- a/boards/px4/sitl/rtps.cmake
+++ b/boards/px4/sitl/rtps.cmake
@@ -6,6 +6,12 @@ px4_add_board(
 	LABEL rtps
 	TESTING
 
+	CONTROL_MODES
+		fixed_wing
+		vtol
+		multicopter
+		rover
+
 	DRIVERS
 		#barometer # all available barometer drivers
 		#batt_smbus

--- a/boards/px4/sitl/test.cmake
+++ b/boards/px4/sitl/test.cmake
@@ -6,6 +6,12 @@ px4_add_board(
 	LABEL test
 	TESTING
 
+	CONTROL_MODES
+		fixed_wing
+		vtol
+		multicopter
+		rover
+
 	DRIVERS
 		#barometer # all available barometer drivers
 		#batt_smbus

--- a/cmake/px4_add_board.cmake
+++ b/cmake/px4_add_board.cmake
@@ -146,6 +146,7 @@ function(px4_add_board)
 			SYSTEMCMDS
 			EXAMPLES
 			SERIAL_PORTS
+			CONTROL_MODES
 			DF_DRIVERS
 		OPTIONS
 			CONSTRAINED_FLASH
@@ -198,6 +199,10 @@ function(px4_add_board)
 
 	if(SERIAL_PORTS)
 		set(board_serial_ports ${SERIAL_PORTS} PARENT_SCOPE)
+	endif()
+
+	if(CONTROL_MODES)
+		set(control_modes ${CONTROL_MODES} PARENT_SCOPE)
 	endif()
 
 	# ROMFS

--- a/cmake/px4_add_common_flags.cmake
+++ b/cmake/px4_add_common_flags.cmake
@@ -191,4 +191,33 @@ function(px4_add_common_flags)
 		-D__STDC_FORMAT_MACROS
 		)
 
+	list(FIND control_modes "fixed_wing" control_mode_index)
+	if(${control_mode_index} GREATER -1)
+		add_definitions(
+			-DCONTROL_MODES_FW
+		)
+	endif()
+
+	list(FIND control_modes "multicopter" control_mode_index)
+	if(${control_mode_index} GREATER -1)
+		add_definitions(
+			-DCONTROL_MODES_MC
+			)
+	endif()
+
+	list(FIND control_modes "vtol" control_mode_index)
+	if(${control_mode_index} GREATER -1)
+		add_definitions(
+			-DCONTROL_MODES_VTOL
+		)
+	endif()
+
+	list(FIND control_modes "rover" control_mode_index)
+	if(${control_mode_index} GREATER -1)
+		add_definitions(
+			-DCONTROL_MODES_ROVER
+		)
+	endif()
+
+
 endfunction()

--- a/src/modules/land_detector/CMakeLists.txt
+++ b/src/modules/land_detector/CMakeLists.txt
@@ -30,6 +30,28 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 ############################################################################
+
+set(CONTROL_MODES_SRCS)
+list(FIND control_modes "fixed_wing" control_mode_index)
+if(${control_mode_index} GREATER -1)
+	list(APPEND CONTROL_MODES_SRCS FixedwingLandDetector.cpp)
+endif()
+
+list(FIND control_modes "multicopter" control_mode_index)
+if(${control_mode_index} GREATER -1)
+	list(APPEND CONTROL_MODES_SRCS MulticopterLandDetector.cpp)
+endif()
+
+list(FIND control_modes "vtol" control_mode_index)
+if(${control_mode_index} GREATER -1)
+	list(APPEND CONTROL_MODES_SRCS VtolLandDetector.cpp)
+endif()
+
+list(FIND control_modes "rover" control_mode_index)
+if(${control_mode_index} GREATER -1)
+	list(APPEND CONTROL_MODES_SRCS RoverLandDetector.cpp)
+endif()
+
 px4_add_module(
 	MODULE modules__land_detector
 	MAIN land_detector
@@ -37,10 +59,8 @@ px4_add_module(
 	SRCS
 		land_detector_main.cpp
 		LandDetector.cpp
-		MulticopterLandDetector.cpp
-		FixedwingLandDetector.cpp
-		VtolLandDetector.cpp
-		RoverLandDetector.cpp
+		${CONTROL_MODES_SRCS}
+
 	DEPENDS
 		hysteresis
 	)

--- a/src/modules/land_detector/land_detector_main.cpp
+++ b/src/modules/land_detector/land_detector_main.cpp
@@ -67,22 +67,35 @@ int LandDetector::task_spawn(int argc, char *argv[])
 
 	LandDetector *obj = nullptr;
 
+#ifdef CONTROL_MODE_FW
+
 	if (strcmp(argv[1], "fixedwing") == 0) {
 		obj = new FixedwingLandDetector();
 
-	} else if (strcmp(argv[1], "multicopter") == 0) {
-		obj = new MulticopterLandDetector();
+	} else
+#endif
+#ifdef CONTROL_MODE_MC
+		if (strcmp(argv[1], "multicopter") == 0) {
+			obj = new MulticopterLandDetector();
 
-	} else if (strcmp(argv[1], "vtol") == 0) {
-		obj = new VtolLandDetector();
+		} else
+#endif
+#ifdef CONTROL_MODE_VT
+			if (strcmp(argv[1], "vtol") == 0) {
+				obj = new VtolLandDetector();
 
-	} else if (strcmp(argv[1], "rover") == 0) {
-		obj = new RoverLandDetector();
+			} else
+#endif
+#ifdef CONTROL_MODE_ROVER
+				if (strcmp(argv[1], "rover") == 0) {
+					obj = new RoverLandDetector();
 
-	} else {
-		print_usage("unknown mode");
-		return PX4_ERROR;
-	}
+				} else
+#endif
+				{
+					print_usage("unknown mode");
+					return PX4_ERROR;
+				}
 
 	if (obj == nullptr) {
 		PX4_ERR("alloc failed");

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -159,11 +159,16 @@ MulticopterAttitudeControl::vehicle_status_poll()
 				_actuators_id = ORB_ID(actuator_controls_virtual_mc);
 				_attitude_sp_id = ORB_ID(mc_virtual_attitude_setpoint);
 
+#ifdef CONTROL_MODE_VTOL
 				int32_t vt_type = -1;
 
 				if (param_get(param_find("VT_TYPE"), &vt_type) == PX4_OK) {
 					_is_tailsitter = (static_cast<vtol_type>(vt_type) == vtol_type::TAILSITTER);
 				}
+
+#else
+				_is_tailsitter = false;
+#endif
 
 			} else {
 				_actuators_id = ORB_ID(actuator_controls_0);


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
there are many places of dead code on firmware that related to control mode (fw/mc/vtol/rover) . for example, landing detector of fixed-wing on multicopter only compilations.
also, calling to non-exists parameters of VTOL, on many different places on the code.

**Test data / coverage**
none for now...

**Describe your preferred solution**
added new concept of control modes which allows to separate different vehicles modes in the compile time.
current control modes are: fixed wing, multicopter, vtol, rover.

**Additional context**
note: this is wip, and waiting for responses. after the concept is added many other placed on the code can use that in order to reduce and improve code.
in current examples, i showed that only relevant land detectors modes can now be compiled.
later, places that search for non-relevant parameters can be optimized. for example, look at VT_MODE that spereded in many places.
