### PR TITLE
Takeoff: add back implicit fallthrough warning (testing where CI might fail)

### DIFF
--- a/src/modules/mc_pos_control/CMakeLists.txt
+++ b/src/modules/mc_pos_control/CMakeLists.txt
@@ -36,8 +36,6 @@ add_subdirectory(Takeoff)
 px4_add_module(
 	MODULE modules__mc_pos_control
 	MAIN mc_pos_control
-	COMPILE_FLAGS
-		-Wno-implicit-fallthrough # TODO: fix and remove
 	SRCS
 		mc_pos_control_main.cpp
 		PositionControl.cpp


### PR DESCRIPTION
Since I don't exactly understand what #13084 tries to achieve or if there's no simpler solution I'm removing the line that ignores the warning to see if CI actually fails on some platform because my setup does not fail to compile it.