### PR TITLE
mavlink: disable sending RC override

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -3533,23 +3533,6 @@ protected:
 			msg.rssi = (rc.channel_count > 0) ? rc.rssi : 0;
 
 			mavlink_msg_rc_channels_send_struct(_mavlink->get_channel(), &msg);
-
-			/* send override message - harmless if connected to GCS, allows to connect a board to a Linux system */
-			/* http://mavlink.org/messages/common#RC_CHANNELS_OVERRIDE */
-			mavlink_rc_channels_override_t over = {};
-			over.target_system = mavlink_system.sysid;
-			over.target_component = 0;
-			over.chan1_raw = msg.chan1_raw;
-			over.chan2_raw = msg.chan2_raw;
-			over.chan3_raw = msg.chan3_raw;
-			over.chan4_raw = msg.chan4_raw;
-			over.chan5_raw = msg.chan5_raw;
-			over.chan6_raw = msg.chan6_raw;
-			over.chan7_raw = msg.chan7_raw;
-			over.chan8_raw = msg.chan8_raw;
-
-			mavlink_msg_rc_channels_override_send_struct(_mavlink->get_channel(), &over);
-
 			return true;
 		}
 


### PR DESCRIPTION
This was added to enable a Pixhawk to be used as an RC input for e.g. SITL. As far as we're aware of that's not really used. However, sending this can cause issues if multiple Pixhawks are in the same network.
Also, is uses up some of the MAVLink bandwidth.

Therefore, it's probably best to remove that feature for now.

As suggested by @LorenzMeier in https://github.com/PX4/Firmware/issues/11238#issuecomment-537809843.