### PR TITLE
uorb_rtps_message_ids.yaml: fix typo

### DIFF
--- a/msg/tools/uorb_rtps_message_ids.yaml
+++ b/msg/tools/uorb_rtps_message_ids.yaml
@@ -322,7 +322,7 @@ rtps:
   - msg: vehicle_angular_velocity_groundtruth
     id: 168
     alias: vehicle_angular_velocity
-    msg: vehicle_visual_odometry_aligned
+  - msg: vehicle_visual_odometry_aligned
     id: 169
     alias: vehicle_odometry
   ########## multi topics: end ##########


### PR DESCRIPTION
Fixes a typo on the yaml file that was causing `vehicle_angular_velocity_groundtruth` IDL not being generated.