### PR TITLE
Arch setup script

### DIFF
--- a/Tools/setup/arch.sh
+++ b/Tools/setup/arch.sh
@@ -1,0 +1,120 @@
+#! /usr/bin/env bash
+
+## Bash script to setup PX4 development environment on Arch Linux.
+## Tested on Manjaro 18.0.1.
+##
+## Installs:
+## - Common dependencies and tools for nuttx, jMAVSim
+## - NuttX toolchain (omit with arg: --no-nuttx)
+## - jMAVSim simulator (omit with arg: --no-sim-tools)
+##
+## Not Installs:
+## - Gazebo simulation
+## - FastRTPS and FastCDR
+
+INSTALL_NUTTX="true"
+INSTALL_SIM="true"
+
+# Parse arguments
+for arg in "$@"
+do
+	if [[ $arg == "--no-nuttx" ]]; then
+		INSTALL_NUTTX="false"
+	fi
+
+	if [[ $arg == "--no-sim-tools" ]]; then
+		INSTALL_SIM="false"
+	fi
+
+done
+
+# script directory
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+# check requirements.txt exists (script not run in source tree)
+REQUIREMENTS_FILE="requirements.txt"
+if [[ ! -f "${DIR}/${REQUIREMENTS_FILE}" ]]; then
+	echo "FAILED: ${REQUIREMENTS_FILE} needed in same directory as ubuntu.sh (${DIR})."
+	return 1
+fi
+
+echo
+echo "Installing PX4 general dependencies"
+
+sudo pacman -Sy
+sudo pacman -S \
+	astyle \
+	base-devel \
+	ccache \
+	clang \
+	cmake \
+	cppcheck \
+	doxygen \
+	gdb \
+	ninja \
+	rsync \
+	shellcheck \
+	;
+
+# Python dependencies
+echo "Installing PX4 Python3 dependencies"
+sudo pip install --upgrade pip setuptools wheel
+sudo pip install -r ${DIR}/requirements.txt
+
+
+# NuttX toolchain (arm-none-eabi-gcc)
+if [[ $INSTALL_NUTTX == "true" ]]; then
+	echo
+	echo "Installing NuttX dependencies"
+
+	sudo pacman -S \
+		gperf \
+		vim \
+		;
+
+	# add user to dialout group (serial port access)
+	sudo usermod -aG uucp $USER
+
+	# Remove modem manager (interferes with PX4 serial port/USB serial usage).
+	sudo pacman -R modemmanager
+
+	# arm-none-eabi-gcc
+	NUTTX_GCC_VERSION="7-2017-q4-major"
+	GCC_VER_STR=$(arm-none-eabi-gcc --version)
+	STATUSRETVAL=$(echo $GCC_VER_STR | grep -c "${NUTTX_GCC_VERSION}")
+
+	if [ $STATUSRETVAL -eq "1" ]; then
+		echo "arm-none-eabi-gcc-${NUTTX_GCC_VERSION} found, skipping installation"
+	else
+		echo "Installing arm-none-eabi-gcc-${NUTTX_GCC_VERSION}";
+		wget -O /tmp/gcc-arm-none-eabi-${NUTTX_GCC_VERSION}-linux.tar.bz2 https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/7-2017q4/gcc-arm-none-eabi-${NUTTX_GCC_VERSION}-linux.tar.bz2 && \
+			sudo tar -jxf /tmp/gcc-arm-none-eabi-${NUTTX_GCC_VERSION}-linux.tar.bz2 -C /opt/;
+
+		# add arm-none-eabi-gcc to user's PATH
+		exportline="export PATH=/opt/gcc-arm-none-eabi-${NUTTX_GCC_VERSION}/bin:\$PATH"
+
+		if grep -Fxq "$exportline" $HOME/.profile;
+		then
+			echo "${NUTTX_GCC_VERSION} path already set.";
+		else
+			echo $exportline >> $HOME/.profile;
+		fi
+	fi
+fi
+
+# Simulation tools
+if [[ $INSTALL_SIM == "true" ]]; then
+	echo
+	echo "Installing PX4 simulation dependencies"
+
+	# java (jmavsim or fastrtps)
+	sudo pacman -S \
+		ant \
+		jdk8-openjdk \
+		;
+fi
+
+if [[ $INSTALL_NUTTX == "true" ]]; then
+	echo
+	echo "Reboot computer before attempting to build NuttX targets"
+fi

--- a/Tools/setup/arch.sh
+++ b/Tools/setup/arch.sh
@@ -41,8 +41,7 @@ fi
 echo
 echo "Installing PX4 general dependencies"
 
-sudo pacman -Sy
-sudo pacman -S \
+sudo pacman -Sy --noconfirm --needed \
 	astyle \
 	base-devel \
 	ccache \
@@ -51,9 +50,17 @@ sudo pacman -S \
 	cppcheck \
 	doxygen \
 	gdb \
+	git \
+	gnutls \
+	nettle \
 	ninja \
+	python-pip \
 	rsync \
 	shellcheck \
+	tar \
+	unzip \
+	wget \
+	zip \
 	;
 
 # Python dependencies
@@ -67,7 +74,7 @@ if [[ $INSTALL_NUTTX == "true" ]]; then
 	echo
 	echo "Installing NuttX dependencies"
 
-	sudo pacman -S \
+	sudo pacman -S --noconfirm --needed \
 		gperf \
 		vim \
 		;
@@ -76,7 +83,7 @@ if [[ $INSTALL_NUTTX == "true" ]]; then
 	sudo usermod -aG uucp $USER
 
 	# Remove modem manager (interferes with PX4 serial port/USB serial usage).
-	sudo pacman -R modemmanager
+	sudo pacman -R modemmanager --noconfirm
 
 	# arm-none-eabi-gcc
 	NUTTX_GCC_VERSION="7-2017-q4-major"
@@ -108,7 +115,7 @@ if [[ $INSTALL_SIM == "true" ]]; then
 	echo "Installing PX4 simulation dependencies"
 
 	# java (jmavsim or fastrtps)
-	sudo pacman -S \
+	sudo pacman -S --noconfirm --needed \
 		ant \
 		jdk8-openjdk \
 		;

--- a/Tools/setup/arch.sh
+++ b/Tools/setup/arch.sh
@@ -34,7 +34,7 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 # check requirements.txt exists (script not run in source tree)
 REQUIREMENTS_FILE="requirements.txt"
 if [[ ! -f "${DIR}/${REQUIREMENTS_FILE}" ]]; then
-	echo "FAILED: ${REQUIREMENTS_FILE} needed in same directory as ubuntu.sh (${DIR})."
+	echo "FAILED: ${REQUIREMENTS_FILE} needed in same directory as arch.sh (${DIR})."
 	return 1
 fi
 
@@ -123,5 +123,5 @@ fi
 
 if [[ $INSTALL_NUTTX == "true" ]]; then
 	echo
-	echo "Reboot computer before attempting to build NuttX targets"
+	echo "Reboot or logout, login computer before attempting to build NuttX targets"
 fi

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -49,7 +49,7 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 REQUIREMENTS_FILE="requirements.txt"
 if [[ ! -f "${DIR}/${REQUIREMENTS_FILE}" ]]; then
 	echo "FAILED: ${REQUIREMENTS_FILE} needed in same directory as ubuntu.sh (${DIR})."
-        return 1
+	return 1
 fi
 
 
@@ -216,5 +216,5 @@ fi
 
 if [[ $INSTALL_NUTTX == "true" ]]; then
 	echo
-	echo "Reboot computer before attempting to build NUTTX targets"
+	echo "Reboot computer before attempting to build NuttX targets"
 fi

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -216,5 +216,5 @@ fi
 
 if [[ $INSTALL_NUTTX == "true" ]]; then
 	echo
-	echo "Reboot computer before attempting to build NuttX targets"
+	echo "Reboot or logout, login computer before attempting to build NuttX targets"
 fi


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
A lot of new hardware doesn't work properly on Ubuntu out of the box. We should support Arch and Arch based distributions like Manjaro with a setup script.

**Describe your preferred solution**
 I followed the clean ubuntu script in this repository and adopted it to the requirements on Arch.

**Test data / coverage**
I tested the script on a Vanialla Manjaro 18.0.1 (latest). Everything but gazebo works and is super quick to set up compared to Ubuntu. The step that takes longest is to load the downgraded arm-gcc which we are hopefully able to get rid of at some point.

Test on pure Arch is still missing, if someone has a quick way to check it I would appreciate.

**Describe possible alternatives**
I saw https://github.com/PX4/containers/blob/master/docker/px4-dev/Dockerfile_base-archlinux but e.g. it downloads `arm-gcc` using pacman which is super nice but PX4 doesn't compile on GCC 9 yet.
