### PR TITLE
Treat UAVS diffrently from manned aviation 

### DIFF
--- a/msg/tools/uorb_rtps_message_ids.yaml
+++ b/msg/tools/uorb_rtps_message_ids.yaml
@@ -322,7 +322,7 @@ rtps:
   - msg: vehicle_angular_velocity_groundtruth
     id: 168
     alias: vehicle_angular_velocity
-    msg: vehicle_visual_odometry_aligned
+  - msg: vehicle_visual_odometry_aligned
     id: 169
     alias: vehicle_odometry
   ########## multi topics: end ##########

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -967,7 +967,7 @@ void Navigator::check_traffic()
 		
 		//TODO a better denomination if the other Vehicle is manned or an UAV
 		//Right now it decides on there being an ADSB emitter
-		if (tr.emitter_type) {
+		if (tr.emitter_type==14) {
 			float horizontal_separation = 10;
 			float vertical_separation = 10;
 		}

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -948,13 +948,6 @@ void Navigator::check_traffic()
 		
 
 
-	//TODO a better denomination if the other Vehicle is manned or an UAV
-	//Right now it decides on there being an ADSB emitter
-	if (NULL == transponder_report_s::emitter_type) {
-		float horizontal_separation = 10;
-		float vertical_separation = 10;
-	}
-
 
 	while (changed) {
 
@@ -969,10 +962,18 @@ void Navigator::check_traffic()
 			changed = _traffic_sub.updated();
 			continue;
 		}
+		
 
 		float d_hor, d_vert;
 		get_distance_to_point_global_wgs84(lat, lon, alt,
 						   tr.lat, tr.lon, tr.altitude, &d_hor, &d_vert);
+		
+		//TODO a better denomination if the other Vehicle is manned or an UAV
+		//Right now it decides on there being an ADSB emitter
+		if (tr.emitter_type) {
+			float horizontal_separation = 10;
+			float vertical_separation = 10;
+		}
 
 
 		// predict final altitude (positive is up) in prediction time frame

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -945,9 +945,6 @@ void Navigator::check_traffic()
 
 	float horizontal_separation = 500;
 	float vertical_separation = 500;
-		
-
-
 
 	while (changed) {
 


### PR DESCRIPTION
Using ADSB transmitter data existing or not.

A seperation distance of 10 Meters should suffice for D2D Collision avoidance.

This is needed to test the collision avoidance of UAVs. 500 Meters is an unnecessary Distance for UAVs.

Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by the proposed pull request**
500 Meters is an unnecessary Distance for UAV to UAV Collision avoidance


**Describe your preferred solution**
A Flag that decides if the encountered entity is Manned or an UAV



**Additional context**
Collision avoidance uses UTM_Global_Position as per this [PR](https://github.com/PX4/Firmware/pull/12452)
Testing Collision avoidance would mean a seperation distance of 500 meters.
