### PR TITLE
VFR_HUD: add attitude for user display

### DIFF
--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -71,6 +71,7 @@ uint8 vehicle_type          # Type of vehicle (fixed-wing, rotary wing, ground)
                             # and VEHICLE_TYPE_FIXED_WING when flying as a fixed-wing
 
 bool is_vtol				# True if the system is VTOL capable
+bool is_vtol_tailsitter                 # True if the system performs a 90° pitch down rotation during transition from MC to FW
 bool vtol_fw_permanent_stab		# True if VTOL should stabilize attitude for fw in manual mode
 bool in_transition_mode			# True if VTOL is doing a transition
 bool in_transition_to_fw		# True if VTOL is doing a transition from MC to FW

--- a/src/lib/conversion/rotation.cpp
+++ b/src/lib/conversion/rotation.cpp
@@ -50,6 +50,15 @@ get_rot_matrix(enum Rotation rot)
 			math::radians((float)rot_lookup[rot].yaw)}};
 }
 
+__EXPORT matrix::Quatf
+get_rot_quaternion(enum Rotation rot)
+{
+	return matrix::Quatf{matrix::Eulerf{
+			math::radians((float)rot_lookup[rot].roll),
+			math::radians((float)rot_lookup[rot].pitch),
+			math::radians((float)rot_lookup[rot].yaw)}};
+}
+
 __EXPORT void
 rotate_3f(enum Rotation rot, float &x, float &y, float &z)
 {

--- a/src/lib/conversion/rotation.h
+++ b/src/lib/conversion/rotation.h
@@ -136,8 +136,14 @@ const rot_lookup_t rot_lookup[] = {
 /**
  * Get the rotation matrix
  */
+__EXPORT matrix::Dcmf
+get_rot_matrix(enum Rotation rot);
 
-__EXPORT matrix::Dcmf get_rot_matrix(enum Rotation rot);
+/**
+ * Get the rotation quaternion
+ */
+__EXPORT matrix::Quatf
+get_rot_quaternion(enum Rotation rot);
 
 /**
  * rotate a 3 element float vector in-place

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1332,6 +1332,7 @@ Commander::run()
 	}
 
 	status.is_vtol = is_vtol(&status);
+	status.is_vtol_tailsitter = is_vtol_tailsitter(&status);
 
 	commander_boot_timestamp = hrt_absolute_time();
 
@@ -1452,6 +1453,7 @@ Commander::run()
 
 				/* set vehicle_status.is_vtol flag */
 				status.is_vtol = is_vtol(&status);
+				status.is_vtol_tailsitter = is_vtol_tailsitter(&status);
 
 				/* check and update system / component ID */
 				int32_t sys_id = 0;

--- a/src/modules/commander/commander_helper.cpp
+++ b/src/modules/commander/commander_helper.cpp
@@ -110,6 +110,12 @@ bool is_vtol(const struct vehicle_status_s *current_status)
 		current_status->system_type == VEHICLE_TYPE_VTOL_RESERVED5);
 }
 
+bool is_vtol_tailsitter(const struct vehicle_status_s *current_status)
+{
+	return (current_status->system_type == VEHICLE_TYPE_VTOL_DUOROTOR ||
+		current_status->system_type == VEHICLE_TYPE_VTOL_QUADROTOR);
+}
+
 bool is_fixed_wing(const struct vehicle_status_s *current_status)
 {
 	return current_status->system_type == VEHICLE_TYPE_FIXED_WING;

--- a/src/modules/commander/commander_helper.h
+++ b/src/modules/commander/commander_helper.h
@@ -53,6 +53,7 @@
 bool is_multirotor(const struct vehicle_status_s *current_status);
 bool is_rotary_wing(const struct vehicle_status_s *current_status);
 bool is_vtol(const struct vehicle_status_s *current_status);
+bool is_vtol_tailsitter(const struct vehicle_status_s *current_status);
 bool is_fixed_wing(const struct vehicle_status_s *current_status);
 bool is_ground_rover(const struct vehicle_status_s *current_status);
 

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1608,7 +1608,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 	case MAVLINK_MODE_NORMAL:
 		configure_stream_local("ADSB_VEHICLE", unlimited_rate);
 		configure_stream_local("ALTITUDE", 1.0f);
-		configure_stream_local("ATTITUDE", 15.0f);
+		configure_stream_local("ATTITUDE", 5.0f);
 		configure_stream_local("ATTITUDE_TARGET", 2.0f);
 		configure_stream_local("BATTERY_STATUS", 0.5f);
 		configure_stream_local("CAMERA_IMAGE_CAPTURED", unlimited_rate);
@@ -1635,7 +1635,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("SERVO_OUTPUT_RAW_0", 1.0f);
 		configure_stream_local("SYS_STATUS", 1.0f);
 		configure_stream_local("UTM_GLOBAL_POSITION", 0.5f);
-		configure_stream_local("VFR_HUD", 4.0f);
+		configure_stream_local("VFR_HUD", 15.0f);
 		configure_stream_local("WIND_COV", 0.5f);
 		break;
 
@@ -1678,7 +1678,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("TIMESYNC", 10.0f);
 		configure_stream_local("TRAJECTORY_REPRESENTATION_WAYPOINTS", 5.0f);
 		configure_stream_local("UTM_GLOBAL_POSITION", 1.0f);
-		configure_stream_local("VFR_HUD", 10.0f);
+		configure_stream_local("VFR_HUD", 50.0f);
 		configure_stream_local("WIND_COV", 10.0f);
 		break;
 
@@ -1792,7 +1792,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("SYSTEM_TIME", 1.0f);
 		configure_stream_local("TIMESYNC", 10.0f);
 		configure_stream_local("UTM_GLOBAL_POSITION", 1.0f);
-		configure_stream_local("VFR_HUD", 20.0f);
+		configure_stream_local("VFR_HUD", 50.0f);
 		configure_stream_local("WIND_COV", 10.0f);
 		break;
 


### PR DESCRIPTION
( Requires MAVLink PR https://github.com/mavlink/mavlink/pull/1247 )

This PR handles the extension of VFR_HUD with attitude fields meant for user display.

See MAVLink PR for details.

fixes https://github.com/PX4/Firmware/issues/5291 https://github.com/PX4/Firmware/issues/10405