### PR TITLE
Sensors enabled flag fixes

### DIFF
--- a/src/modules/sensors/voted_sensors_update.cpp
+++ b/src/modules/sensors/voted_sensors_update.cpp
@@ -264,17 +264,29 @@ void VotedSensorsUpdate::parametersUpdate()
 				if (!_gyro.enabled[driver_index]) { _gyro.priority[driver_index] = 0; }
 
 				struct gyro_calibration_s gscale = {};
+
 				(void)sprintf(str, "CAL_GYRO%u_XOFF", i);
+
 				failed = failed || (OK != param_get(param_find(str), &gscale.x_offset));
+
 				(void)sprintf(str, "CAL_GYRO%u_YOFF", i);
+
 				failed = failed || (OK != param_get(param_find(str), &gscale.y_offset));
+
 				(void)sprintf(str, "CAL_GYRO%u_ZOFF", i);
+
 				failed = failed || (OK != param_get(param_find(str), &gscale.z_offset));
+
 				(void)sprintf(str, "CAL_GYRO%u_XSCALE", i);
+
 				failed = failed || (OK != param_get(param_find(str), &gscale.x_scale));
+
 				(void)sprintf(str, "CAL_GYRO%u_YSCALE", i);
+
 				failed = failed || (OK != param_get(param_find(str), &gscale.y_scale));
+
 				(void)sprintf(str, "CAL_GYRO%u_ZSCALE", i);
+
 				failed = failed || (OK != param_get(param_find(str), &gscale.z_scale));
 
 				if (failed) {
@@ -355,17 +367,29 @@ void VotedSensorsUpdate::parametersUpdate()
 				if (!_accel.enabled[driver_index]) { _accel.priority[driver_index] = 0; }
 
 				struct accel_calibration_s ascale = {};
+
 				(void)sprintf(str, "CAL_ACC%u_XOFF", i);
+
 				failed = failed || (OK != param_get(param_find(str), &ascale.x_offset));
+
 				(void)sprintf(str, "CAL_ACC%u_YOFF", i);
+
 				failed = failed || (OK != param_get(param_find(str), &ascale.y_offset));
+
 				(void)sprintf(str, "CAL_ACC%u_ZOFF", i);
+
 				failed = failed || (OK != param_get(param_find(str), &ascale.z_offset));
+
 				(void)sprintf(str, "CAL_ACC%u_XSCALE", i);
+
 				failed = failed || (OK != param_get(param_find(str), &ascale.x_scale));
+
 				(void)sprintf(str, "CAL_ACC%u_YSCALE", i);
+
 				failed = failed || (OK != param_get(param_find(str), &ascale.y_scale));
+
 				(void)sprintf(str, "CAL_ACC%u_ZSCALE", i);
+
 				failed = failed || (OK != param_get(param_find(str), &ascale.z_scale));
 
 				if (failed) {
@@ -479,22 +503,35 @@ void VotedSensorsUpdate::parametersUpdate()
 				if (!_mag.enabled[topic_instance]) { _mag.priority[topic_instance] = 0; }
 
 				struct mag_calibration_s mscale = {};
+
 				(void)sprintf(str, "CAL_MAG%u_XOFF", i);
+
 				failed = failed || (OK != param_get(param_find(str), &mscale.x_offset));
+
 				(void)sprintf(str, "CAL_MAG%u_YOFF", i);
+
 				failed = failed || (OK != param_get(param_find(str), &mscale.y_offset));
+
 				(void)sprintf(str, "CAL_MAG%u_ZOFF", i);
+
 				failed = failed || (OK != param_get(param_find(str), &mscale.z_offset));
+
 				(void)sprintf(str, "CAL_MAG%u_XSCALE", i);
+
 				failed = failed || (OK != param_get(param_find(str), &mscale.x_scale));
+
 				(void)sprintf(str, "CAL_MAG%u_YSCALE", i);
+
 				failed = failed || (OK != param_get(param_find(str), &mscale.y_scale));
+
 				(void)sprintf(str, "CAL_MAG%u_ZSCALE", i);
+
 				failed = failed || (OK != param_get(param_find(str), &mscale.z_scale));
 
 				(void)sprintf(str, "CAL_MAG%u_ROT", i);
 
 				int32_t mag_rot;
+
 				param_get(param_find(str), &mag_rot);
 
 				if (is_external) {


### PR DESCRIPTION
This is a partial fix from the https://github.com/PX4/Firmware/pull/13025

Bugs:
1) Mag inconsistency check fail when there is only one mag enabled, due to a late publishing of a disabled mag
2) Disabled mag flagged as used in ecl data validator due to not skipping a late published disabled mag
3) CAL_*_EN and CAL_*_ID parameters are handled inconsistently

Description:

1) I encountered a bug where I had 1 mag enabled but got mag sensors inconsistency failure. This happened because mag 2 was disabled but still had priority set to 100 instead of zero and was used in the inconsistency checks. This happens when the mag data is published after the parameter update in the voted_senors_update has already finished, and the enabled flag was not set to false for this sensor. When the data is available on the topic for the first time the mag is given the priority and after that the enabled flag is set to false, but the data is still pushed to the ecl data validator.

- Solution: when the parameter update is run after the first publication of the late mag, set the priority to 0 when setting the enabled flag to false, and skip pushing the data to the validator so the validator doesn't set the used flag to true for this mag

2) voted_sensors_update::parameters_update() sets the enabled flags for each sensor using the CAL_*i_EN parameter.
CAL_*_EN and CAL_*_ID params are handled inconsistently in parameters_update(). Enabled parameters are handled such that CAL_MAGi_EN refers to the sensor on uorb instance i.
The ID param is searched for, which means that if uorb instance i has the same id as param CAL_MAGj_ID then CAL_MAGj calibration will be set for driver i. But still CAL_MAGi_EN will enable driver i.

- Fix is made such that enabled is set for the driver with the ID that's set with CAL_*_ID param.

Note: the problems that occur due to late mag publishing are caused by looping through the mag uORB instances instead of the drivers as it is the case for imu sensors. This is introduced in commit: ba3d66abba5e93c00b112b324ed2b751cc1ba3d8 which did this to fix the mag issues in posix. If the fix can be made outside of the sensors module than the mag looping and identifying logic in sensors module should change to be consistent with other imu sensors.