### PR TITLE
FlightTasks: disable failsafe descend on RC loss

### DIFF
--- a/src/lib/FlightTasks/tasks/Manual/FlightTaskManual.cpp
+++ b/src/lib/FlightTasks/tasks/Manual/FlightTaskManual.cpp
@@ -96,11 +96,12 @@ bool FlightTaskManual::_evaluateSticks()
 		return valid_sticks;
 
 	} else {
-		/* Timeout: set all sticks to zero */
+		// Timeout: set all sticks to zero
 		_sticks.zero();
 		_sticks_expo.zero();
 		_gear.landing_gear = landing_gear_s::GEAR_KEEP;
-		return false;
+		// We still return true because it's up to commander to figure out the failsafe.
+		return true;
 	}
 }
 


### PR DESCRIPTION
The problem with returning false and therefore causing a FlightTask failsafe is that it does not follow the configuration that one might set using the commander params.

Specifically if the RC failsafe behaviour is set to "Disabled" (0), then the FlightTasks failsafe causes the drone to descend even though it supposedly should not react at all.

With this change the behaviour is as follows with NAV_RCL_ACT = 0:

* POSCLT: stays in POSCTL but with all sticks 0, so it stays still.
* ALTCTL: stays in ALTCTL but with all sticks 0, so it stays horizontal and keeps altitude.
* MANUAL: stays in MANUAL but with all sticks 0, so it stays horizontal but throttle will be half-way which either leads to a descent or fly away. This case is clearly not optimal.
Alternatives could be:
  1. 0 throttle, basically drop from the sky
  1. hover throttle
  1. automatic switch to either DESCEND or ALTCTL
  1. ~Remove the DISABLED option because it doesn't make any sense.~ It does make sense for non-manual modes.

Tested in SITL only so far.

Fixes #12307.

