### PR TITLE
Position Controller Failsafe Improvment

### DIFF
--- a/src/lib/FlightTasks/FlightTasks.cpp
+++ b/src/lib/FlightTasks/FlightTasks.cpp
@@ -63,7 +63,7 @@ FlightTaskError FlightTasks::switchTask(FlightTaskIndex new_task_index)
 		return FlightTaskError::NoError;
 	}
 
-	// Save current setpoints for the nex FlightTask
+	// Save current setpoints for the next FlightTask
 	vehicle_local_position_setpoint_s last_setpoint = getPositionSetpoint();
 
 	if (_initTask(new_task_index)) {


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
Presumably fixes #12307 
@julianoes @RyanHurst Can you please check if that produces the desired behavior?
In my quick SITL tests it worked fine.

**Test data / coverage**
SITL testing enabling disabling virtual joystick in QGC to simulate RC loss.

**Describe your preferred solution**
Since commander should still handle all failsafes we should only run into this case as last resort to not crash. If all failsafe actions are disabled but data is missing e.g. RC loss action disabled but flying in manual and no RC this can be tested. I'm not saying this will cover all cases but it's a step in the right direction and hopefully solves the current problem.

**Additional context**
#13125 is an alternative solution to #12307 but I don't consider it future proof since it just starts ignoring RC loss presuming the implementation using RC will do the right thing even without any useful data available.
