### PR TITLE
Deprecate vehicle_attitude_sub from MulticopterLandDetector as it is no longer utilized.

### DIFF
--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -90,7 +90,6 @@ void MulticopterLandDetector::_update_topics()
 	_battery_sub.update(&_battery_status);
 	_vehicle_acceleration_sub.update(&_vehicle_acceleration);
 	_vehicle_angular_velocity_sub.update(&_vehicle_angular_velocity);
-	_vehicle_attitude_sub.update(&_vehicle_attitude);
 	_vehicle_control_mode_sub.update(&_vehicle_control_mode);
 	_vehicle_local_position_sub.update(&_vehicle_local_position);
 	_vehicle_local_position_setpoint_sub.update(&_vehicle_local_position_setpoint);

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -121,7 +121,6 @@ private:
 	uORB::Subscription _battery_sub{ORB_ID(battery_status)};
 	uORB::Subscription _vehicle_acceleration_sub{ORB_ID(vehicle_acceleration)};
 	uORB::Subscription _vehicle_angular_velocity_sub{ORB_ID(vehicle_angular_velocity)};
-	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
 	uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};
 	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
 	uORB::Subscription _vehicle_local_position_setpoint_sub{ORB_ID(vehicle_local_position_setpoint)};
@@ -130,7 +129,6 @@ private:
 	battery_status_s                  _battery_status {};
 	vehicle_acceleration_s            _vehicle_acceleration{};
 	vehicle_angular_velocity_s        _vehicle_angular_velocity{};
-	vehicle_attitude_s                _vehicle_attitude {};
 	vehicle_control_mode_s            _vehicle_control_mode {};
 	vehicle_local_position_s          _vehicle_local_position {};
 	vehicle_local_position_setpoint_s _vehicle_local_position_setpoint {};


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This PR finishes off work in PR #13072, 

> `_vehicle_attitude` is now unused and can be removed completely

**Additional context**
See also PR #13072

@bkueng , thank you for your diligent review!

Please let me know if you have any concerns about this PR!  Thanks!

-Mark
