### PR TITLE
Collision prevention: Option to enable flying outside FOV

### DIFF
--- a/src/lib/CollisionPrevention/CollisionPrevention.cpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.cpp
@@ -285,8 +285,8 @@ CollisionPrevention::_addDistanceSensorData(distance_sensor_s &distance_sensor, 
 void
 CollisionPrevention::_adaptSetpointDirection(Vector2f &setpoint_dir, int &setpoint_index, float vehicle_yaw_angle_rad)
 {
-	const float col_prev_d = _param_mpc_col_prev_d.get();
-	const int guidance_bins = floor(_param_mpc_col_prev_cng.get() / INTERNAL_MAP_INCREMENT_DEG);
+	const float col_prev_d = _param_mpc_cp_dist.get();
+	const int guidance_bins = floor(_param_mpc_cp_guide_ang.get() / INTERNAL_MAP_INCREMENT_DEG);
 	const int sp_index_original = setpoint_index;
 	float best_cost = 9999.f;
 
@@ -376,8 +376,8 @@ CollisionPrevention::_calculateConstrainedSetpoint(Vector2f &setpoint, const Vec
 	_updateObstacleMap();
 
 	// read parameters
-	const float col_prev_d = _param_mpc_col_prev_d.get();
-	const float col_prev_dly = _param_mpc_col_prev_dly.get();
+	const float col_prev_d = _param_mpc_cp_dist.get();
+	const float col_prev_dly = _param_mpc_cp_delay.get();
 	const float xy_p = _param_mpc_xy_p.get();
 	const float max_jerk = _param_mpc_jerk_max.get();
 	const float max_accel = _param_mpc_acc_hor.get();
@@ -400,7 +400,7 @@ CollisionPrevention::_calculateConstrainedSetpoint(Vector2f &setpoint, const Vec
 							       _obstacle_map_body_frame.angle_offset);
 			int sp_index = floor(sp_angle_with_offset_deg / INTERNAL_MAP_INCREMENT_DEG);
 
-			// change setpoint direction slightly (max by _param_mpc_col_prev_cng degrees) to help guide through narrow gaps
+			// change setpoint direction slightly (max by _param_mpc_cp_guide_ang degrees) to help guide through narrow gaps
 			_adaptSetpointDirection(setpoint_dir, sp_index, vehicle_yaw_angle_rad);
 
 			// limit speed for safe flight

--- a/src/lib/CollisionPrevention/CollisionPrevention.cpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.cpp
@@ -285,8 +285,8 @@ CollisionPrevention::_addDistanceSensorData(distance_sensor_s &distance_sensor, 
 void
 CollisionPrevention::_adaptSetpointDirection(Vector2f &setpoint_dir, int &setpoint_index, float vehicle_yaw_angle_rad)
 {
-	const float col_prev_d = _param_mpc_cp_dist.get();
-	const int guidance_bins = floor(_param_mpc_cp_guide_ang.get() / INTERNAL_MAP_INCREMENT_DEG);
+	const float col_prev_d = _param_cp_dist.get();
+	const int guidance_bins = floor(_param_cp_guide_ang.get() / INTERNAL_MAP_INCREMENT_DEG);
 	const int sp_index_original = setpoint_index;
 	float best_cost = 9999.f;
 
@@ -376,9 +376,9 @@ CollisionPrevention::_calculateConstrainedSetpoint(Vector2f &setpoint, const Vec
 	_updateObstacleMap();
 
 	// read parameters
-	const float col_prev_d = _param_mpc_cp_dist.get();
-	const float col_prev_dly = _param_mpc_cp_delay.get();
-	bool move_no_data = _param_mpc_cp_go_nodata.get() > 0;
+	const float col_prev_d = _param_cp_dist.get();
+	const float col_prev_dly = _param_cp_delay.get();
+	bool move_no_data = _param_cp_go_nodata.get() > 0;
 	const float xy_p = _param_mpc_xy_p.get();
 	const float max_jerk = _param_mpc_jerk_max.get();
 	const float max_accel = _param_mpc_acc_hor.get();
@@ -401,7 +401,7 @@ CollisionPrevention::_calculateConstrainedSetpoint(Vector2f &setpoint, const Vec
 							       _obstacle_map_body_frame.angle_offset);
 			int sp_index = floor(sp_angle_with_offset_deg / INTERNAL_MAP_INCREMENT_DEG);
 
-			// change setpoint direction slightly (max by _param_mpc_cp_guide_ang degrees) to help guide through narrow gaps
+			// change setpoint direction slightly (max by _param_cp_guide_ang degrees) to help guide through narrow gaps
 			_adaptSetpointDirection(setpoint_dir, sp_index, vehicle_yaw_angle_rad);
 
 			// limit speed for safe flight

--- a/src/lib/CollisionPrevention/CollisionPrevention.cpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.cpp
@@ -378,7 +378,7 @@ CollisionPrevention::_calculateConstrainedSetpoint(Vector2f &setpoint, const Vec
 	// read parameters
 	const float col_prev_d = _param_cp_dist.get();
 	const float col_prev_dly = _param_cp_delay.get();
-	bool move_no_data = _param_cp_go_nodata.get() > 0;
+	const bool move_no_data = _param_cp_go_nodata.get() > 0;
 	const float xy_p = _param_mpc_xy_p.get();
 	const float max_jerk = _param_mpc_jerk_max.get();
 	const float max_accel = _param_mpc_acc_hor.get();

--- a/src/lib/CollisionPrevention/CollisionPrevention.cpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.cpp
@@ -378,6 +378,7 @@ CollisionPrevention::_calculateConstrainedSetpoint(Vector2f &setpoint, const Vec
 	// read parameters
 	const float col_prev_d = _param_mpc_cp_dist.get();
 	const float col_prev_dly = _param_mpc_cp_delay.get();
+	bool move_no_data = _param_mpc_cp_go_nodata.get() > 0;
 	const float xy_p = _param_mpc_xy_p.get();
 	const float max_jerk = _param_mpc_jerk_max.get();
 	const float max_accel = _param_mpc_acc_hor.get();
@@ -452,7 +453,7 @@ CollisionPrevention::_calculateConstrainedSetpoint(Vector2f &setpoint, const Vec
 						}
 					}
 
-				} else if (_obstacle_map_body_frame.distances[i] == UINT16_MAX && i == sp_index) {
+				} else if (_obstacle_map_body_frame.distances[i] == UINT16_MAX && i == sp_index && (!move_no_data)) {
 					vel_max = 0.f;
 				}
 			}

--- a/src/lib/CollisionPrevention/CollisionPrevention.hpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.hpp
@@ -139,9 +139,10 @@ private:
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::MPC_CP_DIST>) _param_mpc_cp_dist, /**< collision prevention keep minimum distance */
-		(ParamFloat<px4::params::MPC_CP_GUIDE_ANG>) _param_mpc_cp_guide_ang, /**< collision prevention change setpoint angle */
-		(ParamFloat<px4::params::MPC_XY_P>) _param_mpc_xy_p, /**< p gain from position controller*/
 		(ParamFloat<px4::params::MPC_CP_DELAY>) _param_mpc_cp_delay, /**< delay of the range measurement data*/
+		(ParamFloat<px4::params::MPC_CP_GUIDE_ANG>) _param_mpc_cp_guide_ang, /**< collision prevention change setpoint angle */
+		(ParamFloat<px4::params::MPC_CP_GO_NODATA>) _param_mpc_cp_go_nodata, /**< movement allowed where no data*/
+		(ParamFloat<px4::params::MPC_XY_P>) _param_mpc_xy_p, /**< p gain from position controller*/
 		(ParamFloat<px4::params::MPC_JERK_MAX>) _param_mpc_jerk_max, /**< vehicle maximum jerk*/
 		(ParamFloat<px4::params::MPC_ACC_HOR>) _param_mpc_acc_hor /**< vehicle maximum horizontal acceleration*/
 	)

--- a/src/lib/CollisionPrevention/CollisionPrevention.hpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.hpp
@@ -70,7 +70,7 @@ public:
 	/**
 	 * Returs true if Collision Prevention is running
 	 */
-	bool is_active() { return _param_mpc_cp_dist.get() > 0; }
+	bool is_active() { return _param_cp_dist.get() > 0; }
 
 	/**
 	 * Computes collision free setpoints
@@ -138,10 +138,10 @@ private:
 	hrt_abstime	_last_collision_warning{0};
 
 	DEFINE_PARAMETERS(
-		(ParamFloat<px4::params::MPC_CP_DIST>) _param_mpc_cp_dist, /**< collision prevention keep minimum distance */
-		(ParamFloat<px4::params::MPC_CP_DELAY>) _param_mpc_cp_delay, /**< delay of the range measurement data*/
-		(ParamFloat<px4::params::MPC_CP_GUIDE_ANG>) _param_mpc_cp_guide_ang, /**< collision prevention change setpoint angle */
-		(ParamFloat<px4::params::MPC_CP_GO_NODATA>) _param_mpc_cp_go_nodata, /**< movement allowed where no data*/
+		(ParamFloat<px4::params::CP_DIST>) _param_cp_dist, /**< collision prevention keep minimum distance */
+		(ParamFloat<px4::params::CP_DELAY>) _param_cp_delay, /**< delay of the range measurement data*/
+		(ParamFloat<px4::params::CP_GUIDE_ANG>) _param_cp_guide_ang, /**< collision prevention change setpoint angle */
+		(ParamFloat<px4::params::CP_GO_NO_DATA>) _param_cp_go_nodata, /**< movement allowed where no data*/
 		(ParamFloat<px4::params::MPC_XY_P>) _param_mpc_xy_p, /**< p gain from position controller*/
 		(ParamFloat<px4::params::MPC_JERK_MAX>) _param_mpc_jerk_max, /**< vehicle maximum jerk*/
 		(ParamFloat<px4::params::MPC_ACC_HOR>) _param_mpc_acc_hor /**< vehicle maximum horizontal acceleration*/

--- a/src/lib/CollisionPrevention/CollisionPrevention.hpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.hpp
@@ -70,7 +70,7 @@ public:
 	/**
 	 * Returs true if Collision Prevention is running
 	 */
-	bool is_active() { return _param_mpc_col_prev_d.get() > 0; }
+	bool is_active() { return _param_mpc_cp_dist.get() > 0; }
 
 	/**
 	 * Computes collision free setpoints
@@ -138,10 +138,10 @@ private:
 	hrt_abstime	_last_collision_warning{0};
 
 	DEFINE_PARAMETERS(
-		(ParamFloat<px4::params::MPC_COL_PREV_D>) _param_mpc_col_prev_d, /**< collision prevention keep minimum distance */
-		(ParamFloat<px4::params::MPC_COL_PREV_CNG>) _param_mpc_col_prev_cng, /**< collision prevention change setpoint angle */
+		(ParamFloat<px4::params::MPC_CP_DIST>) _param_mpc_cp_dist, /**< collision prevention keep minimum distance */
+		(ParamFloat<px4::params::MPC_CP_GUIDE_ANG>) _param_mpc_cp_guide_ang, /**< collision prevention change setpoint angle */
 		(ParamFloat<px4::params::MPC_XY_P>) _param_mpc_xy_p, /**< p gain from position controller*/
-		(ParamFloat<px4::params::MPC_COL_PREV_DLY>) _param_mpc_col_prev_dly, /**< delay of the range measurement data*/
+		(ParamFloat<px4::params::MPC_CP_DELAY>) _param_mpc_cp_delay, /**< delay of the range measurement data*/
 		(ParamFloat<px4::params::MPC_JERK_MAX>) _param_mpc_jerk_max, /**< vehicle maximum jerk*/
 		(ParamFloat<px4::params::MPC_ACC_HOR>) _param_mpc_acc_hor /**< vehicle maximum horizontal acceleration*/
 	)

--- a/src/lib/CollisionPrevention/CollisionPreventionTest.cpp
+++ b/src/lib/CollisionPrevention/CollisionPreventionTest.cpp
@@ -108,7 +108,7 @@ TEST_F(CollisionPreventionTest, noSensorData)
 	matrix::Vector2f curr_vel(2, 0);
 
 	// AND: a parameter handle
-	param_t param = param_handle(px4::params::MPC_CP_DIST);
+	param_t param = param_handle(px4::params::CP_DIST);
 
 	// WHEN: we set the parameter check then apply the setpoint modification
 	float value = 10; // try to keep 10m away from obstacles
@@ -140,7 +140,7 @@ TEST_F(CollisionPreventionTest, testBehaviorOnWithObstacleMessage)
 	attitude.q[3] = 0.0f;
 
 	// AND: a parameter handle
-	param_t param = param_handle(px4::params::MPC_CP_DIST);
+	param_t param = param_handle(px4::params::CP_DIST);
 	float value = 10; // try to keep 10m distance
 	param_set(param, &value);
 	cp.paramsChanged();
@@ -205,7 +205,7 @@ TEST_F(CollisionPreventionTest, testBehaviorOnWithDistanceMessage)
 	attitude.q[3] = 0.0f;
 
 	// AND: a parameter handle
-	param_t param = param_handle(px4::params::MPC_CP_DIST);
+	param_t param = param_handle(px4::params::CP_DIST);
 	float value = 10; // try to keep 10m distance
 	param_set(param, &value);
 	cp.paramsChanged();
@@ -266,7 +266,7 @@ TEST_F(CollisionPreventionTest, testPurgeOldData)
 	attitude.q[3] = 0.0f;
 
 	// AND: a parameter handle
-	param_t param = param_handle(px4::params::MPC_CP_DIST);
+	param_t param = param_handle(px4::params::CP_DIST);
 	float value = 10; // try to keep 10m distance
 	param_set(param, &value);
 	cp.paramsChanged();
@@ -335,7 +335,7 @@ TEST_F(CollisionPreventionTest, noBias)
 	matrix::Vector2f curr_vel(2, 0);
 
 	// AND: a parameter handle
-	param_t param = param_handle(px4::params::MPC_CP_DIST);
+	param_t param = param_handle(px4::params::CP_DIST);
 	float value = 5; // try to keep 5m distance
 	param_set(param, &value);
 	cp.paramsChanged();
@@ -375,7 +375,7 @@ TEST_F(CollisionPreventionTest, outsideFOV)
 	matrix::Vector2f curr_vel(2, 0);
 
 	// AND: a parameter handle
-	param_t param = param_handle(px4::params::MPC_CP_DIST);
+	param_t param = param_handle(px4::params::CP_DIST);
 	float value = 5; // try to keep 5m distance
 	param_set(param, &value);
 	cp.paramsChanged();
@@ -439,7 +439,7 @@ TEST_F(CollisionPreventionTest, jerkLimit)
 	matrix::Vector2f curr_vel(2, 0);
 
 	// AND: distance set to 5m
-	param_t param = param_handle(px4::params::MPC_CP_DIST);
+	param_t param = param_handle(px4::params::CP_DIST);
 	float value = 5; // try to keep 5m distance
 	param_set(param, &value);
 	cp.paramsChanged();
@@ -847,7 +847,7 @@ TEST_F(CollisionPreventionTest, adaptSetpointDirection_distinct_minimum)
 	int sp_index = floor(sp_angle_with_offset_deg / cp.getObstacleMap().increment);
 
 	//set parameter
-	param_t param = param_handle(px4::params::MPC_CP_DIST);
+	param_t param = param_handle(px4::params::CP_DIST);
 	float value = 3; // try to keep 10m away from obstacles
 	param_set(param, &value);
 	cp.paramsChanged();
@@ -896,7 +896,7 @@ TEST_F(CollisionPreventionTest, adaptSetpointDirection_flat_minimum)
 	int sp_index = floor(sp_angle_with_offset_deg / cp.getObstacleMap().increment);
 
 	//set parameter
-	param_t param = param_handle(px4::params::MPC_CP_DIST);
+	param_t param = param_handle(px4::params::CP_DIST);
 	float value = 3; // try to keep 10m away from obstacles
 	param_set(param, &value);
 	cp.paramsChanged();
@@ -927,7 +927,7 @@ TEST_F(CollisionPreventionTest, overlappingSensors)
 	attitude.q[3] = 0.0f;
 
 	// AND: a parameter handle
-	param_t param = param_handle(px4::params::MPC_CP_DIST);
+	param_t param = param_handle(px4::params::CP_DIST);
 	float value = 10; // try to keep 10m distance
 	param_set(param, &value);
 	cp.paramsChanged();

--- a/src/lib/CollisionPrevention/CollisionPreventionTest.cpp
+++ b/src/lib/CollisionPrevention/CollisionPreventionTest.cpp
@@ -108,7 +108,7 @@ TEST_F(CollisionPreventionTest, noSensorData)
 	matrix::Vector2f curr_vel(2, 0);
 
 	// AND: a parameter handle
-	param_t param = param_handle(px4::params::MPC_COL_PREV_D);
+	param_t param = param_handle(px4::params::MPC_CP_DIST);
 
 	// WHEN: we set the parameter check then apply the setpoint modification
 	float value = 10; // try to keep 10m away from obstacles
@@ -140,7 +140,7 @@ TEST_F(CollisionPreventionTest, testBehaviorOnWithObstacleMessage)
 	attitude.q[3] = 0.0f;
 
 	// AND: a parameter handle
-	param_t param = param_handle(px4::params::MPC_COL_PREV_D);
+	param_t param = param_handle(px4::params::MPC_CP_DIST);
 	float value = 10; // try to keep 10m distance
 	param_set(param, &value);
 	cp.paramsChanged();
@@ -205,7 +205,7 @@ TEST_F(CollisionPreventionTest, testBehaviorOnWithDistanceMessage)
 	attitude.q[3] = 0.0f;
 
 	// AND: a parameter handle
-	param_t param = param_handle(px4::params::MPC_COL_PREV_D);
+	param_t param = param_handle(px4::params::MPC_CP_DIST);
 	float value = 10; // try to keep 10m distance
 	param_set(param, &value);
 	cp.paramsChanged();
@@ -266,7 +266,7 @@ TEST_F(CollisionPreventionTest, testPurgeOldData)
 	attitude.q[3] = 0.0f;
 
 	// AND: a parameter handle
-	param_t param = param_handle(px4::params::MPC_COL_PREV_D);
+	param_t param = param_handle(px4::params::MPC_CP_DIST);
 	float value = 10; // try to keep 10m distance
 	param_set(param, &value);
 	cp.paramsChanged();
@@ -335,7 +335,7 @@ TEST_F(CollisionPreventionTest, noBias)
 	matrix::Vector2f curr_vel(2, 0);
 
 	// AND: a parameter handle
-	param_t param = param_handle(px4::params::MPC_COL_PREV_D);
+	param_t param = param_handle(px4::params::MPC_CP_DIST);
 	float value = 5; // try to keep 5m distance
 	param_set(param, &value);
 	cp.paramsChanged();
@@ -375,7 +375,7 @@ TEST_F(CollisionPreventionTest, outsideFOV)
 	matrix::Vector2f curr_vel(2, 0);
 
 	// AND: a parameter handle
-	param_t param = param_handle(px4::params::MPC_COL_PREV_D);
+	param_t param = param_handle(px4::params::MPC_CP_DIST);
 	float value = 5; // try to keep 5m distance
 	param_set(param, &value);
 	cp.paramsChanged();
@@ -439,7 +439,7 @@ TEST_F(CollisionPreventionTest, jerkLimit)
 	matrix::Vector2f curr_vel(2, 0);
 
 	// AND: distance set to 5m
-	param_t param = param_handle(px4::params::MPC_COL_PREV_D);
+	param_t param = param_handle(px4::params::MPC_CP_DIST);
 	float value = 5; // try to keep 5m distance
 	param_set(param, &value);
 	cp.paramsChanged();
@@ -847,7 +847,7 @@ TEST_F(CollisionPreventionTest, adaptSetpointDirection_distinct_minimum)
 	int sp_index = floor(sp_angle_with_offset_deg / cp.getObstacleMap().increment);
 
 	//set parameter
-	param_t param = param_handle(px4::params::MPC_COL_PREV_D);
+	param_t param = param_handle(px4::params::MPC_CP_DIST);
 	float value = 3; // try to keep 10m away from obstacles
 	param_set(param, &value);
 	cp.paramsChanged();
@@ -896,7 +896,7 @@ TEST_F(CollisionPreventionTest, adaptSetpointDirection_flat_minimum)
 	int sp_index = floor(sp_angle_with_offset_deg / cp.getObstacleMap().increment);
 
 	//set parameter
-	param_t param = param_handle(px4::params::MPC_COL_PREV_D);
+	param_t param = param_handle(px4::params::MPC_CP_DIST);
 	float value = 3; // try to keep 10m away from obstacles
 	param_set(param, &value);
 	cp.paramsChanged();
@@ -927,7 +927,7 @@ TEST_F(CollisionPreventionTest, overlappingSensors)
 	attitude.q[3] = 0.0f;
 
 	// AND: a parameter handle
-	param_t param = param_handle(px4::params::MPC_COL_PREV_D);
+	param_t param = param_handle(px4::params::MPC_CP_DIST);
 	float value = 10; // try to keep 10m distance
 	param_set(param, &value);
 	cp.paramsChanged();

--- a/src/lib/CollisionPrevention/collisionprevention_params.c
+++ b/src/lib/CollisionPrevention/collisionprevention_params.c
@@ -49,7 +49,7 @@
  * @unit meters
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_CP_DIST, -1.0f);
+PARAM_DEFINE_FLOAT(CP_DIST, -1.0f);
 
 /**
  * Average delay of the range sensor message plus the tracking delay of the position controller in seconds
@@ -61,7 +61,7 @@ PARAM_DEFINE_FLOAT(MPC_CP_DIST, -1.0f);
  * @unit seconds
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_CP_DELAY, 0.4f);
+PARAM_DEFINE_FLOAT(CP_DELAY, 0.4f);
 
 /**
  * Angle left/right from the commanded setpoint by which the collision prevention algorithm can choose to change the setpoint direction
@@ -73,7 +73,7 @@ PARAM_DEFINE_FLOAT(MPC_CP_DELAY, 0.4f);
  * @unit [deg]
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_CP_GUIDE_ANG, 30.f);
+PARAM_DEFINE_FLOAT(CP_GUIDE_ANG, 30.f);
 
 /**
  * Boolean to allow moving into directions where there is no sensor data (outside FOV)
@@ -83,4 +83,4 @@ PARAM_DEFINE_FLOAT(MPC_CP_GUIDE_ANG, 30.f);
  * @boolean
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_CP_GO_NODATA, 0);
+PARAM_DEFINE_FLOAT(CP_GO_NO_DATA, 0);

--- a/src/lib/CollisionPrevention/collisionprevention_params.c
+++ b/src/lib/CollisionPrevention/collisionprevention_params.c
@@ -49,7 +49,7 @@
  * @unit meters
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_COL_PREV_D, -1.0f);
+PARAM_DEFINE_FLOAT(MPC_CP_DIST, -1.0f);
 
 /**
  * Average delay of the range sensor message plus the tracking delay of the position controller in seconds
@@ -61,7 +61,7 @@ PARAM_DEFINE_FLOAT(MPC_COL_PREV_D, -1.0f);
  * @unit seconds
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_COL_PREV_DLY, 0.4f);
+PARAM_DEFINE_FLOAT(MPC_CP_DELAY, 0.4f);
 
 /**
  * Angle left/right from the commanded setpoint by which the collision prevention algorithm can choose to change the setpoint direction
@@ -73,4 +73,4 @@ PARAM_DEFINE_FLOAT(MPC_COL_PREV_DLY, 0.4f);
  * @unit [deg]
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_COL_PREV_CNG, 30.f);
+PARAM_DEFINE_FLOAT(MPC_CP_GUIDE_ANG, 30.f);

--- a/src/lib/CollisionPrevention/collisionprevention_params.c
+++ b/src/lib/CollisionPrevention/collisionprevention_params.c
@@ -74,3 +74,13 @@ PARAM_DEFINE_FLOAT(MPC_CP_DELAY, 0.4f);
  * @group Multicopter Position Control
  */
 PARAM_DEFINE_FLOAT(MPC_CP_GUIDE_ANG, 30.f);
+
+/**
+ * Boolean to allow moving into directions where there is no sensor data (outside FOV)
+ *
+ * Only used in Position mode.
+ *
+ * @boolean
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_CP_GO_NODATA, 0);

--- a/src/lib/parameters/ParameterTest.cpp
+++ b/src/lib/parameters/ParameterTest.cpp
@@ -51,7 +51,7 @@ public:
 TEST_F(ParameterTest, testParamReadWrite)
 {
 	// GIVEN a parameter handle
-	param_t param = param_handle(px4::params::MPC_COL_PREV_D);
+	param_t param = param_handle(px4::params::MPC_CP_DIST);
 
 	// WHEN: we get the parameter
 	float value = -999.f;

--- a/src/lib/parameters/ParameterTest.cpp
+++ b/src/lib/parameters/ParameterTest.cpp
@@ -51,7 +51,7 @@ public:
 TEST_F(ParameterTest, testParamReadWrite)
 {
 	// GIVEN a parameter handle
-	param_t param = param_handle(px4::params::MPC_CP_DIST);
+	param_t param = param_handle(px4::params::CP_DIST);
 
 	// WHEN: we get the parameter
 	float value = -999.f;


### PR DESCRIPTION
This PR reacts to a feature request from the community. Since the latest changes in collision prevention it was not possible anymore to move into directions where there is no sensor coverage. Now I added a boolean MPC_CP_GO_NODATA which is per default set to false but enables people to explicitly allow such movements.

In the process I renamed the parameters of the collision prevention. Witch the naming before, we had only three letters available to actually describe the function of the parameter, which I thought was not enough. Open for discussions on the naming front if there are any better ideas/ objections to the proposed names.
