### PR TITLE
[WIP] VTOL Transition Task: Control Z and Yaw Velocity to 0

### DIFF
--- a/src/lib/FlightTasks/tasks/Transition/FlightTaskTransition.cpp
+++ b/src/lib/FlightTasks/tasks/Transition/FlightTaskTransition.cpp
@@ -45,8 +45,6 @@ bool FlightTaskTransition::updateInitialize()
 bool FlightTaskTransition::activate(vehicle_local_position_setpoint_s last_setpoint)
 {
 	checkSetpoints(last_setpoint);
-	_transition_altitude = last_setpoint.z;
-	_transition_yaw = last_setpoint.yaw;
 	_acceleration_setpoint.setAll(0.f);
 	_velocity_prev = _velocity;
 	return FlightTask::activate(last_setpoint);
@@ -77,15 +75,12 @@ void FlightTaskTransition::updateAccelerationEstimate()
 
 bool FlightTaskTransition::update()
 {
-	// level wings during the transition, altitude should be controlled
-	_thrust_setpoint(0) = _thrust_setpoint(1) = 0.0f;
-	_thrust_setpoint(2) = NAN;
-	_position_setpoint *= NAN;
-	_velocity_setpoint *= NAN;
-	_position_setpoint(2) = _transition_altitude;
+	// level wings during the transition
+	_thrust_setpoint = matrix::Vector3f(0.f, 0.f, NAN);
+	// altitude and yaw should be controlled to slow down/stop
+	_velocity_setpoint = matrix::Vector3f(NAN, NAN, 0.f);
+	_yawspeed_setpoint = 0.f;
 
 	updateAccelerationEstimate();
-
-	_yaw_setpoint = _transition_yaw;
 	return true;
 }

--- a/src/lib/FlightTasks/tasks/Transition/FlightTaskTransition.hpp
+++ b/src/lib/FlightTasks/tasks/Transition/FlightTaskTransition.hpp
@@ -55,7 +55,5 @@ private:
 	void checkSetpoints(vehicle_local_position_setpoint_s &setpoints);
 	void updateAccelerationEstimate();
 
-	float _transition_altitude = 0.0f;
-	float _transition_yaw = 0.0f;
 	matrix::Vector3f _velocity_prev{};
 };


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
Hopefully fixes #13068

**Describe your preferred solution**
@sfuhrer showed and explained problems during transition to me and once thing I clearly saw in the logs he analyzed was that if you have any vertical speed the concept of just giving a fixed altitude setpoint to the multicopter position controller results in very high thrust fluctuations. This is because the controller goes full effort to that exact altitude and almost always overshoots, similar problem like breaking down when switching to hold mode from fast forward multicopter flight. Since the transition task is only ran for seconds during the transition to stabilize the vehicle from the multicopter side I think setting zero velocity is the best solution since it accounts for eventual initial overshoot in altitude. I applied the same concept to yaw since it can also result in strong actuation especially on VTOL.

**Test data / coverage**
Totally untested @sfuhrer please verify.
