### PR TITLE
mavlink: fix boot complete without lockstep

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -159,6 +159,8 @@ mavlink_message_t *mavlink_get_channel_buffer(uint8_t channel)
 
 static void usage();
 
+hrt_abstime Mavlink::_first_start_time = {0};
+
 bool Mavlink::_boot_complete = false;
 
 Mavlink::Mavlink() :
@@ -178,6 +180,10 @@ Mavlink::Mavlink() :
 
 	if (comp_id > 0 && comp_id < 255) {
 		mavlink_system.compid = comp_id;
+	}
+
+	if (_first_start_time == 0) {
+		_first_start_time = hrt_absolute_time();
 	}
 }
 

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -532,6 +532,8 @@ public:
 	 */
 	struct ping_statistics_s &get_ping_statistics() { return _ping_stats; }
 
+	static hrt_abstime &get_first_start_time() { return _first_start_time; }
+
 protected:
 	Mavlink			*next{nullptr};
 
@@ -687,6 +689,8 @@ private:
 	static constexpr unsigned RADIO_BUFFER_CRITICAL_LOW_PERCENTAGE = 25;
 	static constexpr unsigned RADIO_BUFFER_LOW_PERCENTAGE = 35;
 	static constexpr unsigned RADIO_BUFFER_HALF_PERCENTAGE = 50;
+
+	static hrt_abstime _first_start_time;
 
 	/**
 	 * Configure a single stream.

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2529,7 +2529,7 @@ MavlinkReceiver::Run()
 
 	// make sure mavlink app has booted before we start processing anything (parameter sync, etc)
 	while (!_mavlink->boot_complete()) {
-		if (hrt_absolute_time() > 20_s) {
+		if (hrt_elapsed_time(&_mavlink->get_first_start_time()) > 20_s) {
 			PX4_ERR("system boot did not complete in 20 seconds");
 			_mavlink->set_boot_complete();
 		}


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**

Without lockstep the actual monotonic clock of the host computer is used. Therefore, this time is likely much more than 20 seconds and the check if the boot complete happened in time will fail immediately.

Therefore, it probably makes more sense to count the time from the first mavlink creation.

**Test data / coverage**

Tested in SITL with and without lockstep.
