### PR TITLE
Mavlink receiver SET_ATTITUDE_TARGET filling for VTOLs

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1397,6 +1397,10 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
 						case MAV_TYPE_OCTOROTOR:
 						case MAV_TYPE_TRICOPTER:
 						case MAV_TYPE_HELICOPTER:
+						case MAV_TYPE_VTOL_DUOROTOR:
+						case MAV_TYPE_VTOL_QUADROTOR:
+						case MAV_TYPE_VTOL_TILTROTOR:
+						case MAV_TYPE_VTOL_RESERVED2:
 							att_sp.thrust_body[2] = -set_attitude_target.thrust;
 							break;
 


### PR DESCRIPTION
 Add MAV_TYPE_VTOL_* to thrust filling

**Describe problem solved by the proposed pull request**
Thrust received from SET_ATTITUDE_TARGET does not filled for VTOL airframe types.

**Test data / coverage**
Tested on real UAV and MAVSDK.

**Describe your preferred solution**
Add VTOL types to thrust filling.