### PR TITLE
ubuntu.sh: No automatic removal of modemmanager

### DIFF
--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -149,9 +149,6 @@ if [[ $INSTALL_NUTTX == "true" ]]; then
 	# add user to dialout group (serial port access)
 	sudo usermod -a -G dialout $USER
 
-	# Remove modem manager (interferes with PX4 serial port/USB serial usage).
-	sudo apt-get remove modemmanager -y
-
 	# arm-none-eabi-gcc
 	NUTTX_GCC_VERSION="7-2017-q4-major"
 


### PR DESCRIPTION
Removing the modemmanager was done to allow firmware upload on any board. However this not needed when working with many boards because they are registered with the manager, and it is not good practice to just remove a feature someone might be using.

So removing this, and will add a note in the docs. If we run into specific boards that aren't covered we'll request they be registered.

As discussed in https://github.com/PX4/Firmware/pull/13111 