### PR TITLE
Arch Linux Setup: optionally install gazebo from AUR and fix pip Call

### DIFF
--- a/Tools/setup/arch.sh
+++ b/Tools/setup/arch.sh
@@ -139,6 +139,8 @@ if [[ $INSTALL_SIM == "true" ]]; then
 			yay \
 			;
 
+		sudo sed -i '/MAKEFLAGS=/c\MAKEFLAGS="-j'$(($(grep -c processor /proc/cpuinfo)+2))'"' /etc/makepkg.conf
+
 		yay -S gazebo --noconfirm
 
 		if sudo dmidecode -t system | grep -q "Manufacturer: VMware, Inc." ; then

--- a/Tools/setup/arch.sh
+++ b/Tools/setup/arch.sh
@@ -7,13 +7,14 @@
 ## - Common dependencies and tools for nuttx, jMAVSim
 ## - NuttX toolchain (omit with arg: --no-nuttx)
 ## - jMAVSim simulator (omit with arg: --no-sim-tools)
+## - Gazebo simulator (not by default, use --gazebo)
 ##
 ## Not Installs:
-## - Gazebo simulation
 ## - FastRTPS and FastCDR
 
 INSTALL_NUTTX="true"
 INSTALL_SIM="true"
+INSTALL_GAZEBO="false"
 
 # Parse arguments
 for arg in "$@"
@@ -26,6 +27,9 @@ do
 		INSTALL_SIM="false"
 	fi
 
+	if [[ $arg == "--gazebo" ]]; then
+		INSTALL_GAZEBO="true"
+	fi
 done
 
 # script directory
@@ -119,6 +123,29 @@ if [[ $INSTALL_SIM == "true" ]]; then
 		ant \
 		jdk8-openjdk \
 		;
+
+	# Simulation tools
+	if [[ $INSTALL_GAZEBO == "true" ]]; then
+		echo
+		echo "Installing gazebo and dependencies for PX4 simulation"
+
+		# java (jmavsim or fastrtps)
+		sudo pacman -S --noconfirm --needed \
+			eigen3 \
+			hdf5 \
+			opencv \
+			protobuf \
+			vtk \
+			yay \
+			;
+
+		yay -S gazebo --noconfirm
+
+		if sudo dmidecode -t system | grep -q "Manufacturer: VMware, Inc." ; then
+			# fix VMWare 3D graphics acceleration for gazebo
+			echo "export SVGA_VGPU10=0" >> ~/.profile
+		fi
+	fi
 fi
 
 if [[ $INSTALL_NUTTX == "true" ]]; then

--- a/Tools/setup/arch.sh
+++ b/Tools/setup/arch.sh
@@ -69,8 +69,8 @@ sudo pacman -Sy --noconfirm --needed \
 
 # Python dependencies
 echo "Installing PX4 Python3 dependencies"
-sudo pip install --upgrade pip setuptools wheel
-sudo pip install -r ${DIR}/requirements.txt
+pip install --upgrade pip setuptools wheel
+pip install -r ${DIR}/requirements.txt
 
 
 # NuttX toolchain (arm-none-eabi-gcc)


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
Gazebo is not an official package for Arch Linux but there's a community driven AUR https://aur.archlinux.org/packages/gazebo/ that can be installed with a helper program yay https://github.com/Jguer/yay which is an officially supported package.

**Describe your preferred solution**
I notices that running pip as sudo on Arch is not a good idea. It installs the python modules in a different location `/root/.local/lib/python3.7/site-packages` which depending on your environment can be inaccessible later on.

I made an `--gazebo` option to the arch setup script that is disabled by default. If it's passed as parameter I install all the official libraries that PX4 needs to simulate with gazebo e.g. protobug, eigen... also yay which automatically builds gazebo from source using the AUR description. There's a small workaround necessary because apparently the AUR description contains one single error.

**Test data / coverage**
Tested on fresh install Manjaro VM:
![gazebo_arch](https://user-images.githubusercontent.com/4668506/66650636-5ed3c400-ec31-11e9-9d5e-40d6200d1d29.PNG)
Disadvantage: It takes a couple of minutes to compile gazebo and all its dependencies.

**Additional context**
#13111
