### PR TITLE
Land Detector Properties instead of one State

### DIFF
--- a/msg/vehicle_land_detected.msg
+++ b/msg/vehicle_land_detected.msg
@@ -1,7 +1,7 @@
 uint64 timestamp	# time since system start (microseconds)
-bool landed		# true if vehicle is currently landed on the ground
-bool freefall		# true if vehicle is currently in free-fall
-bool ground_contact	# true if vehicle has ground contact but is not landed
-bool maybe_landed	# true if the vehicle might have landed
 float32 alt_max 	# maximum altitude in [m] that can be reached
+bool freefall		# true if vehicle is currently in free-fall
+bool ground_contact	# true if vehicle has ground contact but is not landed (1. stage)
+bool maybe_landed	# true if the vehicle might have landed (2. stage)
+bool landed		# true if vehicle is currently landed on the ground (3. stage)
 bool in_ground_effect # indicates if from the perspective of the landing detector the vehicle might be in ground effect (baro). This flag will become true if the vehicle is not moving horizontally and is descending (crude assumption that user is landing).

--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -81,7 +81,6 @@ void LandDetector::Run()
 
 	// publish at 1 Hz, very first time, or when the result has changed
 	if ((hrt_elapsed_time(&_land_detected.timestamp) >= 1_s) ||
-	    (_land_detected_pub == nullptr) ||
 	    (_land_detected.landed != landDetected) ||
 	    (_land_detected.freefall != freefallDetected) ||
 	    (_land_detected.maybe_landed != maybe_landedDetected) ||
@@ -102,9 +101,7 @@ void LandDetector::Run()
 		_land_detected.alt_max = alt_max;
 		_land_detected.in_ground_effect = in_ground_effect;
 
-		int instance;
-		orb_publish_auto(ORB_ID(vehicle_land_detected), &_land_detected_pub, &_land_detected,
-				 &instance, ORB_PRIO_DEFAULT);
+		_vehicle_land_detected_pub.publish(_land_detected);
 	}
 
 	// set the flight time when disarming (not necessarily when landed, because all param changes should

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -70,13 +70,6 @@ namespace land_detector
 class LandDetector : public ModuleBase<LandDetector>, ModuleParams, px4::ScheduledWorkItem
 {
 public:
-	enum class LandDetectionState {
-		FLYING = 0,
-		LANDED = 1,
-		FREEFALL = 2,
-		GROUND_CONTACT = 3,
-		MAYBE_LANDED = 4
-	};
 
 	LandDetector();
 	virtual ~LandDetector();
@@ -93,11 +86,6 @@ public:
 
 	/** @see ModuleBase::print_status() */
 	int print_status() override;
-
-	/**
-	 * @return current state.
-	 */
-	LandDetectionState get_state() const { return _state; }
 
 	/**
 	 * Get the work queue going.
@@ -152,8 +140,6 @@ protected:
 	/** Run main land detector loop at this interval. */
 	static constexpr uint32_t LAND_DETECTOR_UPDATE_INTERVAL = 20_ms;
 
-	LandDetectionState _state{LandDetectionState::LANDED};
-
 	systemlib::Hysteresis _freefall_hysteresis{false};
 	systemlib::Hysteresis _landed_hysteresis{true};
 	systemlib::Hysteresis _maybe_landed_hysteresis{true};
@@ -162,7 +148,14 @@ protected:
 
 	actuator_armed_s         _actuator_armed{};
 	vehicle_acceleration_s   _vehicle_acceleration{};
-	vehicle_land_detected_s  _land_detected{};
+	vehicle_land_detected_s _land_detected = {
+		.timestamp = 0,
+		.alt_max = -1.0f,
+		.freefall = false,
+		.ground_contact = true,
+		.maybe_landed = true,
+		.landed = true,
+	};
 	vehicle_local_position_s _vehicle_local_position{};
 
 	orb_advert_t _land_detected_pub{nullptr};

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -54,6 +54,7 @@
 #include <px4_module_params.h>
 #include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
 #include <uORB/Subscription.hpp>
+#include <uORB/Publication.hpp>
 #include <uORB/topics/actuator_armed.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/sensor_bias.h>
@@ -158,7 +159,7 @@ protected:
 	};
 	vehicle_local_position_s _vehicle_local_position{};
 
-	orb_advert_t _land_detected_pub{nullptr};
+	uORB::Publication<vehicle_land_detected_s> _vehicle_land_detected_pub{ORB_ID(vehicle_land_detected)};
 
 	uORB::Subscription _actuator_armed_sub{ORB_ID(actuator_armed)};
 	uORB::Subscription _vehicle_acceleration_sub{ORB_ID(vehicle_acceleration)};

--- a/src/modules/land_detector/land_detector_main.cpp
+++ b/src/modules/land_detector/land_detector_main.cpp
@@ -104,29 +104,8 @@ int LandDetector::task_spawn(int argc, char *argv[])
 int LandDetector::print_status()
 {
 	PX4_INFO("running (%s)", _currentMode);
-	LandDetector::LandDetectionState state = get_state();
-
-	switch (state) {
-	case LandDetector::LandDetectionState::FLYING:
-		PX4_INFO("State: Flying");
-		break;
-
-	case LandDetector::LandDetectionState::LANDED:
-		PX4_INFO("State: Landed");
-		break;
-
-	case LandDetector::LandDetectionState::FREEFALL:
-		PX4_INFO("State: Freefall");
-		break;
-
-	default:
-		PX4_ERR("State: unknown");
-		break;
-	}
-
 	return 0;
 }
-
 int LandDetector::print_usage(const char *reason)
 {
 	if (reason != nullptr) {

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -135,10 +135,10 @@ private:
 	vehicle_land_detected_s _vehicle_land_detected = {
 		.timestamp = 0,
 		.alt_max = -1.0f,
-		.landed = true,
 		.freefall = false,
-		.ground_contact = false,
-		.maybe_landed = false,
+		.ground_contact = true,
+		.maybe_landed = true,
+		.landed = true,
 	};
 
 	vehicle_attitude_setpoint_s	_att_sp{};			/**< vehicle attitude setpoint */


### PR DESCRIPTION
~**Only look at the last commit: https://github.com/PX4/Firmware/commit/3d3a57f7b6ef9097c97afa368adbd78f06214d1e**
I based this pr on a rebased version of #11874 since I don't want to generate any conflicts. It's mergable after #11874.~ ✔️ 

**Describe problem solved by the proposed pull request**
Internally the land detector determines certain properties of the vehicle and some depend on each other e.g. if the vehicle is landed it ia also maybe landed but others don't e.g. there can be ground contact but there's still ground effect distorting the barometer. Until now there was one single state determined from all these properties using prioritization and then all the original flags were published but because there the state was in between only one could be true at once. As a result:
- people had to log or print the state of all the other flags to understand what's going on even though the flags were always there in the uORB message but not filled
- when you wanted to check e.g. if you are in stage 1 or further in land detection you had to check for `land_detected.ground_contact || land_detected.maybe_landed || land_detected.landed` even though the first property always holds when the others hold
- certain combinations like having ground contact but still having additional lift by ground effect were not possible at all

**Describe your preferred solution**
All properties are published like they are determined. Multiple properties can hold at the same time. Interdependencies of properties are covered by their respective detection functions.

**Test data / coverage**
I SITL tested and multicopter land detection still works fine:
![land_detection_properties](https://user-images.githubusercontent.com/4668506/66707152-82cffc00-ed3c-11e9-8f17-9f8311e310e6.PNG)
You can see well that the flags turn on one after the other instead of switching on and off again one after the other.
