### PR TITLE
PULL_REQUEST_TEMPLATE: change order of titles

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,17 @@
 Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.
 
-**Describe problem solved by the proposed pull request**
-A clear and concise description of the problem this proposed change will solve. E.g. For this use case I ran into...
+**Describe problem solved by this pull request**
+A clear and concise description of the problem this proposed change will solve.
+E.g. For this use case I ran into...
 
-**Test data / coverage**
-How was it tested? What cases were covered? Logs uploaded to https://review.px4.io/ and screenshots of the important plot parts.
-
-**Describe your preferred solution**
+**Describe your solution**
 A clear and concise description of what you have implemented.
 
 **Describe possible alternatives**
 A clear and concise description of alternative solutions or features you've considered.
+
+**Test data / coverage**
+How was it tested? What cases were covered? Logs uploaded to https://review.px4.io/ and screenshots of the important plot parts.
 
 **Additional context**
 Add any other related context or media.


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
I like the pull request template a lot but every time I'm changing the order of the titles in the same way because first I want to describe what it contains and then how it was tested.

**Describe your preferred solution**
I changed the order of the titles to be IMHO more intuitive.

**Additional context**
Last such reorder: https://github.com/PX4/Firmware/commit/bff93685a50e58964743857e671ff35d36f3ca4a#diff-7240be7a02d8789cae2c0970f0260dfe which I accidentally commited directly because of a GitHub web UI bug.
