### PR TITLE
arch.sh: switch permissions of pip install (again)

### DIFF
--- a/Tools/setup/arch.sh
+++ b/Tools/setup/arch.sh
@@ -69,9 +69,7 @@ sudo pacman -Sy --noconfirm --needed \
 
 # Python dependencies
 echo "Installing PX4 Python3 dependencies"
-pip install --upgrade pip setuptools wheel
-pip install -r ${DIR}/requirements.txt
-
+pip install --user -r ${DIR}/requirements.txt
 
 # NuttX toolchain (arm-none-eabi-gcc)
 if [[ $INSTALL_NUTTX == "true" ]]; then
@@ -83,10 +81,10 @@ if [[ $INSTALL_NUTTX == "true" ]]; then
 		vim \
 		;
 
-	# add user to dialout group (serial port access)
+	# add user to uucp group (to get serial port access)
 	sudo usermod -aG uucp $USER
 
-	# remove modem manager (interferes with PX4 serial port/USB serial usage).
+	# remove modem manager (interferes with PX4 serial port usage)
 	sudo pacman -R modemmanager --noconfirm
 
 	# arm-none-eabi-gcc


### PR DESCRIPTION
after testing the right solution on a fresh installation

**Describe problem solved by the proposed pull request**
I tested it again on a fresh system and before https://github.com/PX4/Firmware/commit/c09ea2a9b0b644a949a5010de6edf2abb3ad9613 there was the problem that python packages were installed under root and the normal user didn't have it in his path. After that the user doesn't have permissions to update binaries like `pip`, `easy_install` and `wheel`.

**Describe your preferred solution**
Now I fixed all these cases updating the binaries with sudo and installing the package requirements under the user (see https://dev.to/elabftw/stop-using-sudo-pip-install-52mn). 

**Test data / coverage**
Tested on the go on a fresh install.

**Additional context**
#13111
#13160
