### PR TITLE
microRTPS: make the templates generic to work on ROS2 as well

### DIFF
--- a/msg/templates/urtps/Publisher.cpp.em
+++ b/msg/templates/urtps/Publisher.cpp.em
@@ -102,8 +102,12 @@ bool @(topic)_Publisher::init()
 @[else]@
     Wparam.topic.topicName = "@(topic)PubSubTopic";
 @[end if]@
-@[if ros2_distro and ros2_distro != "ardent"]@
+@[if ros2_distro]@
+@[    if ros2_distro == "ardent"]@
+    Wparam.qos.m_partition.push_back("rt");
+@[    else]@
     Wparam.topic.topicName = "rt/" + Wparam.topic.topicName;
+@[    end if]@
 @[end if]@
     mp_publisher = Domain::createPublisher(mp_participant, Wparam, static_cast<PublisherListener*>(&m_listener));
     if(mp_publisher == nullptr)
@@ -139,9 +143,17 @@ void @(topic)_Publisher::run()
 
     // Publication code
 @[if 1.5 <= fastrtpsgen_version <= 1.7]@
+@[    if ros2_distro]@
+    @(package)::msg::dds_::@(topic)_ st;
+@[    else]@
     @(topic)_ st;
+@[    end if]@
 @[else]@
+@[    if ros2_distro]@
+    @(package)::msg::@(topic) st;
+@[    else]@
     @(topic) st;
+@[    end if]@
 @[end if]@
 
     /* Initialize your structure here */
@@ -168,9 +180,17 @@ void @(topic)_Publisher::run()
 }
 
 @[if 1.5 <= fastrtpsgen_version <= 1.7]@
-void @(topic)_Publisher::publish(@(topic)_* st)
+@[    if ros2_distro]@
+    void @(topic)_Publisher::publish(@(package)::msg::dds_::@(topic)_* st)
+@[    else]@
+    void @(topic)_Publisher::publish(@(topic)_* st)
+@[    end if]@
 @[else]@
-void @(topic)_Publisher::publish(@(topic)* st)
+@[    if ros2_distro]@
+    void @(topic)_Publisher::publish(@(package)::msg::@(topic)* st)
+@[    else]@
+    void @(topic)_Publisher::publish(@(topic)* st)
+@[    end if]@
 @[end if]@
 {
     mp_publisher->write(st);

--- a/msg/templates/urtps/Publisher.h.em
+++ b/msg/templates/urtps/Publisher.h.em
@@ -81,9 +81,17 @@ public:
     bool init();
     void run();
 @[if 1.5 <= fastrtpsgen_version <= 1.7]@
+@[    if ros2_distro]@
+    void publish(@(package)::msg::dds_::@(topic)_* st);
+@[    else]@
     void publish(@(topic)_* st);
+@[    end if]@
 @[else]@
+@[    if ros2_distro]@
+    void publish(@(package)::msg::@(topic)* st);
+@[    else]@
     void publish(@(topic)* st);
+@[    end if]@
 @[end if]@
 private:
     Participant *mp_participant;
@@ -98,9 +106,17 @@ private:
         int n_matched;
     } m_listener;
 @[if 1.5 <= fastrtpsgen_version <= 1.7]@
+@[    if ros2_distro]@
+    @(package)::msg::dds_::@(topic)_PubSubType myType;
+@[    else]@
     @(topic)_PubSubType myType;
+@[    end if]@
 @[else]@
+@[    if ros2_distro]@
+    @(package)::msg::@(topic)PubSubType myType;
+@[    else]@
     @(topic)PubSubType myType;
+@[    end if]@
 @[end if]@
 };
 

--- a/msg/templates/urtps/RtpsTopics.cpp.em
+++ b/msg/templates/urtps/RtpsTopics.cpp.em
@@ -93,9 +93,17 @@ void RtpsTopics::publish(uint8_t topic_ID, char data_buffer[], size_t len)
         case @(rtps_message_id(ids, topic)): // @(topic)
         {
 @[    if 1.5 <= fastrtpsgen_version[0] <= 1.7]@
+@[        if ros2_distro[0]]@
+            @(package[0])::msg::dds_::@(topic)_ st;
+@[        else]@
             @(topic)_ st;
+@[        end if]@
 @[    else]@
+@[        if ros2_distro[0]]@
+            @(package[0])::msg::@(topic) st;
+@[        else]@
             @(topic) st;
+@[        end if]@
 @[    end if]@
             eprosima::fastcdr::FastBuffer cdrbuffer(data_buffer, len);
             eprosima::fastcdr::Cdr cdr_des(cdrbuffer);
@@ -150,9 +158,17 @@ bool RtpsTopics::getMsg(const uint8_t topic_ID, eprosima::fastcdr::Cdr &scdr)
             if (_@(topic)_sub.hasMsg())
             {
 @[    if 1.5 <= fastrtpsgen_version[0] <= 1.7]@
+@[        if ros2_distro[0]]@
+                @(package[0])::msg::dds_::@(topic)_ msg = _@(topic)_sub.getMsg();
+@[        else]@
                 @(topic)_ msg = _@(topic)_sub.getMsg();
+@[        end if]@
 @[    else]@
+@[        if ros2_distro[0]]@
+                @(package[0])::msg::@(topic) msg = _@(topic)_sub.getMsg();
+@[        else]@
                 @(topic) msg = _@(topic)_sub.getMsg();
+@[        end if]@
 @[    end if]@
                 msg.serialize(scdr);
                 ret = true;

--- a/msg/templates/urtps/Subscriber.cpp.em
+++ b/msg/templates/urtps/Subscriber.cpp.em
@@ -97,8 +97,12 @@ bool @(topic)_Subscriber::init()
 @[else]@
     Rparam.topic.topicName = "@(topic)PubSubTopic";
 @[end if]@
-@[if ros2_distro and ros2_distro != "ardent"]@
-    Rparam.topic.topicName = "rt/" + Wparam.topic.topicName;
+@[if ros2_distro]@
+@[    if ros2_distro == "ardent"]@
+    Rparam.qos.m_partition.push_back("rt");
+@[    else]@
+    Rparam.topic.topicName = "rt/" + Rparam.topic.topicName;
+@[    end if]@
 @[end if]@
     mp_subscriber = Domain::createSubscriber(mp_participant, Rparam, static_cast<SubscriberListener*>(&m_listener));
     if(mp_subscriber == nullptr)
@@ -126,9 +130,17 @@ void @(topic)_Subscriber::SubListener::onNewDataMessage(Subscriber* sub)
 {
         // Take data
 @[if 1.5 <= fastrtpsgen_version <= 1.7]@
+@[    if ros2_distro]@
+        @(package)::msg::dds_::@(topic)_ st;
+@[    else]@
         @(topic)_ st;
+@[    end if]@
 @[else]@
+@[    if ros2_distro]@
+        @(package)::msg::@(topic) st;
+@[    else]@
         @(topic) st;
+@[    end if]@
 @[end if]@
 
         if(sub->takeNextData(&st, &m_info))
@@ -157,9 +169,17 @@ bool @(topic)_Subscriber::hasMsg()
 }
 
 @[if 1.5 <= fastrtpsgen_version <= 1.7]@
+@[    if ros2_distro]@
+@(package)::msg::dds_::@(topic)_ @(topic)_Subscriber::getMsg()
+@[    else]@
 @(topic)_ @(topic)_Subscriber::getMsg()
+@[    end if]@
 @[else]@
+@[    if ros2_distro]@
+@(package)::msg::@(topic) @(topic)_Subscriber::getMsg()
+@[    else]@
 @(topic) @(topic)_Subscriber::getMsg()
+@[    end if]@
 @[end if]@
 {
     m_listener.has_msg = false;

--- a/msg/templates/urtps/Subscriber.h.em
+++ b/msg/templates/urtps/Subscriber.h.em
@@ -82,9 +82,17 @@ public:
     void run();
     bool hasMsg();
 @[if 1.5 <= fastrtpsgen_version <= 1.7]@
+@[    if ros2_distro]@
+    @(package)::msg::dds_::@(topic)_ getMsg();
+@[    else]@
     @(topic)_ getMsg();
+@[    end if]@
 @[else]@
+@[    if ros2_distro]@
+    @(package)::msg::@(topic) getMsg();
+@[    else]@
     @(topic) getMsg();
+@[    end if]@
 @[end if]@
 private:
     Participant *mp_participant;
@@ -101,17 +109,33 @@ private:
         int n_matched;
         int n_msg;
 @[if 1.5 <= fastrtpsgen_version <= 1.7]@
+@[    if ros2_distro]@
+        @(package)::msg::dds_::@(topic)_ msg;
+@[    else]@
         @(topic)_ msg;
+@[    end if]@
 @[else]@
+@[    if ros2_distro]@
+        @(package)::msg::@(topic) msg;
+@[    else]@
         @(topic) msg;
+@[    end if]@
 @[end if]@
         bool has_msg = false;
 
     } m_listener;
 @[if 1.5 <= fastrtpsgen_version <= 1.7]@
+@[    if ros2_distro]@
+    @(package)::msg::dds_::@(topic)_PubSubType myType;
+@[    else]@
     @(topic)_PubSubType myType;
+@[    end if]@
 @[else]@
+@[    if ros2_distro]@
+    @(package)::msg::@(topic)PubSubType myType;
+@[    else]@
     @(topic)PubSubType myType;
+@[    end if]@
 @[end if]@
 };
 

--- a/msg/ulog_stream.msg
+++ b/msg/ulog_stream.msg
@@ -12,7 +12,7 @@ uint8 FLAGS_NEED_ACK = 1	# if set, this message requires to be acked.
 uint8 length			# length of data
 uint8 first_message_offset	# offset into data where first message starts. This
 				# can be used for recovery, when a previous message got lost
-uint16 sequence		# allows determine drops
+uint16 msg_sequence		# allows determine drops
 uint8 flags			# see FLAGS_*
 uint8[249] data		# ulog data
 

--- a/msg/ulog_stream_ack.msg
+++ b/msg/ulog_stream_ack.msg
@@ -5,4 +5,4 @@ uint64 timestamp		# time since system start (microseconds)
 int32 ACK_TIMEOUT = 50		# timeout waiting for an ack until we retry to send the message [ms]
 int32 ACK_MAX_TRIES = 50	# maximum amount of tries to (re-)send a message, each time waiting ACK_TIMEOUT ms
 
-uint16 sequence
+uint16 msg_sequence

--- a/src/modules/logger/log_writer_mavlink.cpp
+++ b/src/modules/logger/log_writer_mavlink.cpp
@@ -72,7 +72,7 @@ void LogWriterMavlink::start_log()
 	ulog_stream_ack_s ack;
 	orb_copy(ORB_ID(ulog_stream_ack), _ulog_stream_ack_sub, &ack);
 
-	_ulog_stream_data.sequence = 0;
+	_ulog_stream_data.msg_sequence = 0;
 	_ulog_stream_data.length = 0;
 	_ulog_stream_data.first_message_offset = 0;
 
@@ -160,7 +160,7 @@ int LogWriterMavlink::publish_message()
 				ulog_stream_ack_s ack;
 				orb_copy(ORB_ID(ulog_stream_ack), _ulog_stream_ack_sub, &ack);
 
-				if (ack.sequence == _ulog_stream_data.sequence) {
+				if (ack.msg_sequence == _ulog_stream_data.msg_sequence) {
 					got_ack = true;
 				}
 
@@ -178,7 +178,7 @@ int LogWriterMavlink::publish_message()
 		PX4_DEBUG("got ack in %i ms", (int)(hrt_elapsed_time(&started) / 1000));
 	}
 
-	_ulog_stream_data.sequence++;
+	_ulog_stream_data.msg_sequence++;
 	_ulog_stream_data.length = 0;
 	_ulog_stream_data.first_message_offset = 255;
 	return 0;

--- a/src/modules/mavlink/mavlink_ulog.cpp
+++ b/src/modules/mavlink/mavlink_ulog.cpp
@@ -116,7 +116,7 @@ int MavlinkULog::handle_update(mavlink_channel_t channel)
 					const ulog_stream_s &ulog_data = _ulog_stream_sub.get();
 
 					mavlink_logging_data_acked_t msg;
-					msg.sequence = ulog_data.sequence;
+					msg.sequence = ulog_data.msg_sequence;
 					msg.length = ulog_data.length;
 					msg.first_message_offset = ulog_data.first_message_offset;
 					msg.target_system = _target_system;
@@ -140,12 +140,12 @@ int MavlinkULog::handle_update(mavlink_channel_t channel)
 				_sent_tries = 1;
 				_last_sent_time = hrt_absolute_time();
 				lock();
-				_wait_for_ack_sequence = ulog_data.sequence;
+				_wait_for_ack_sequence = ulog_data.msg_sequence;
 				_ack_received = false;
 				unlock();
 
 				mavlink_logging_data_acked_t msg;
-				msg.sequence = ulog_data.sequence;
+				msg.sequence = ulog_data.msg_sequence;
 				msg.length = ulog_data.length;
 				msg.first_message_offset = ulog_data.first_message_offset;
 				msg.target_system = _target_system;
@@ -155,7 +155,7 @@ int MavlinkULog::handle_update(mavlink_channel_t channel)
 
 			} else {
 				mavlink_logging_data_t msg;
-				msg.sequence = ulog_data.sequence;
+				msg.sequence = ulog_data.msg_sequence;
 				msg.length = ulog_data.length;
 				msg.first_message_offset = ulog_data.first_message_offset;
 				msg.target_system = _target_system;
@@ -252,7 +252,7 @@ void MavlinkULog::publish_ack(uint16_t sequence)
 {
 	ulog_stream_ack_s ack;
 	ack.timestamp = hrt_absolute_time();
-	ack.sequence = sequence;
+	ack.msg_sequence = sequence;
 
 	_ulog_stream_ack_pub.publish(ack);
 }


### PR DESCRIPTION
Also renames the `sequence` fields of the ulog stream msgs as `sequence` is a protected name on the IDL definitions (`fastrtpsgen` does this verification *a priori*).