### PR TITLE
ROMFS: rc.vtol_defaults limit inner loop rate

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
@@ -9,6 +9,10 @@ set VEHICLE_TYPE vtol
 
 if [ $AUTOCNF = yes ]
 then
+
+	# to minimize cpu usage on older boards limit inner loop to 400 Hz
+	param set IMU_GYRO_RATEMAX 400
+
 	param set MIS_TAKEOFF_ALT 20
 	param set MIS_YAW_TMT 10
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
On VTOL all multicopter and fixedwing controllers are running plus a vtol module that provides simple control allocation and transition handling. By default in PX4 the rate controller runs synchronized with the primary gyro (typically 1 kHz), so the cpu load on other boards can be quite high depending on configuration. https://github.com/PX4/Firmware/issues/13149

**Describe your solution**
As a precaution we can limit the inner loop to 400 Hz. To replicate historic PX4 behaviour it would be 250 Hz.

**Describe possible alternatives**
 - Optimize drivers (SPI DMA), mavlink (minimize streams, TX DMA), and other controllers to minimize cpu usage (smoothing flight tasks are quite expensive).
 - better overall system understanding so that the rate can be automatically limited based on the output module (eg IMU_GYRO_RATEMAX set to PWM_MAX)

