### PR TITLE
pwm_out_sim: refactor to work queue and use the MixingOutput library

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.interface
+++ b/ROMFS/px4fmu_common/init.d/rc.interface
@@ -84,7 +84,7 @@ then
 
 	if [ $OUTPUT_MODE = hil -o $OUTPUT_MODE = sim ]
 	then
-		if ! pwm_out_sim start
+		if ! pwm_out_sim start -m $OUTPUT_MODE
 		then
 			# Error tune.
 			tune_control play -t 2

--- a/Tools/uorb_graph/create.py
+++ b/Tools/uorb_graph/create.py
@@ -227,7 +227,6 @@ class Graph(object):
 
     ('uavcan', r'uavcan_main\.cpp$', r'\b_control_topics\[[0-9]\]=([^,)]+)', r'^_control_topics\[i\]$'),
     ('tap_esc', r'.*', r'\b_control_topics\[[0-9]\]=([^,)]+)', r'^_control_topics\[i\]$'),
-    ('pwm_out_sim', r'.*', r'\b_control_topics\[[0-9]\]=([^,)]+)', r'^_control_topics\[i\]$'),
     ('snapdragon_pwm_out', r'.*', r'\b_controls_topics\[[0-9]\]=([^,)]+)', r'^_controls_topics\[i\]$'),
     ('linux_pwm_out', r'.*', r'\b_controls_topics\[[0-9]\]=([^,)]+)', r'^_controls_topics\[i\]$'),
     ]

--- a/boards/px4/sitl/default.cmake
+++ b/boards/px4/sitl/default.cmake
@@ -56,6 +56,7 @@ px4_add_board(
 		led_control
 		mixer
 		motor_ramp
+		motor_test
 		#mtd
 		#nshterm
 		param

--- a/msg/test_motor.msg
+++ b/msg/test_motor.msg
@@ -1,7 +1,13 @@
 uint64 timestamp				# time since system start (microseconds)
 uint8 NUM_MOTOR_OUTPUTS = 8
 
+uint8 ACTION_STOP = 0				# stop motors (disable motor test mode)
+uint8 ACTION_RUN = 1				# run motors (enable motor test mode)
+
+uint8 action					# one of ACTION_* (applies to all motors)
 uint32 motor_number				# number of motor to spin
 float32 value					# output power, range [0..1]
+
+uint8 driver_instance				# select output driver (for boards with multiple outputs, like IO+FMU)
 
 uint8 ORB_QUEUE_LENGTH = 4

--- a/src/drivers/drv_pwm_output.h
+++ b/src/drivers/drv_pwm_output.h
@@ -66,13 +66,8 @@ __BEGIN_DECLS
 
 struct pwm_output_values {
 	uint32_t channel_count;
-	uint16_t values[16];
+	uint16_t values[PWM_OUTPUT_MAX_CHANNELS];
 };
-
-/**
- * Maximum number of PWM output channels supported by the device.
- */
-//#define PWM_OUTPUT_MAX_CHANNELS	16
 
 /* Use defaults unless the board override the defaults by providing
  * PX4_PWM_ALTERNATE_RANGES and a replacement set of

--- a/src/drivers/dshot/dshot.cpp
+++ b/src/drivers/dshot/dshot.cpp
@@ -122,9 +122,6 @@ public:
 	static int task_spawn(int argc, char *argv[]);
 
 	/** @see ModuleBase */
-	static DShotOutput *instantiate(int argc, char *argv[]);
-
-	/** @see ModuleBase */
 	static int custom_command(int argc, char *argv[]);
 
 	/** @see ModuleBase */
@@ -197,7 +194,7 @@ private:
 
 	int requestESCInfo();
 
-	MixingOutput _mixing_output{*this, MixingOutput::SchedulingPolicy::Auto, false, false};
+	MixingOutput _mixing_output{DIRECT_PWM_OUTPUT_CHANNELS, *this, MixingOutput::SchedulingPolicy::Auto, false, false};
 
 	Telemetry *_telemetry{nullptr};
 	static char _telemetry_device[20];

--- a/src/drivers/dshot/dshot.cpp
+++ b/src/drivers/dshot/dshot.cpp
@@ -146,7 +146,7 @@ public:
 					   hrt_abstime edge_time, uint32_t edge_state,
 					   uint32_t overflow);
 
-	void updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 	void mixerChanged() override;
@@ -686,11 +686,11 @@ void DShotOutput::mixerChanged()
 	updateTelemetryNumMotors();
 }
 
-void DShotOutput::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+bool DShotOutput::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
 				unsigned num_outputs, unsigned num_control_groups_updated)
 {
 	if (!_outputs_on) {
-		return;
+		return false;
 	}
 
 	int requested_telemetry_index = -1;
@@ -740,6 +740,8 @@ void DShotOutput::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS
 	if (stop_motors || num_control_groups_updated > 0) {
 		up_dshot_trigger();
 	}
+
+	return true;
 }
 
 void

--- a/src/drivers/dshot/dshot.cpp
+++ b/src/drivers/dshot/dshot.cpp
@@ -1070,7 +1070,7 @@ DShotOutput::pwm_ioctl(file *filp, int cmd, unsigned long arg)
 
 	case MIXERIOCLOADBUF: {
 			const char *buf = (const char *)arg;
-			unsigned buflen = strnlen(buf, 1024);
+			unsigned buflen = strlen(buf);
 			ret = _mixing_output.loadMixerThreadSafe(buf, buflen);
 
 			break;

--- a/src/drivers/mkblctrl/mkblctrl.cpp
+++ b/src/drivers/mkblctrl/mkblctrl.cpp
@@ -1052,7 +1052,7 @@ MK::pwm_ioctl(file *filp, int cmd, unsigned long arg)
 
 	case MIXERIOCLOADBUF: {
 			const char *buf = (const char *)arg;
-			unsigned buflen = strnlen(buf, 1024);
+			unsigned buflen = strlen(buf);
 
 			if (_mixers == nullptr) {
 				_mixers = new MixerGroup(control_callback, (uintptr_t)&_controls);

--- a/src/drivers/pwm_out_sim/CMakeLists.txt
+++ b/src/drivers/pwm_out_sim/CMakeLists.txt
@@ -37,4 +37,6 @@ px4_add_module(
 		PWMSim.cpp
 	DEPENDS
 		mixer
+		mixer_module
+		output_limit
 	)

--- a/src/drivers/pwm_out_sim/PWMSim.cpp
+++ b/src/drivers/pwm_out_sim/PWMSim.cpp
@@ -79,11 +79,13 @@ PWMSim::Run()
 	_mixing_output.updateSubscriptions(true);
 }
 
-void
+bool
 PWMSim::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
 		      unsigned num_control_groups_updated)
 {
-	// nothing to do, as we are only interested in the actuator_outputs topic publication
+	// Nothing to do, as we are only interested in the actuator_outputs topic publication.
+	// That should only be published once we receive actuator_controls (important for lock-step to work correctly)
+	return num_control_groups_updated > 0;
 }
 
 int

--- a/src/drivers/pwm_out_sim/PWMSim.cpp
+++ b/src/drivers/pwm_out_sim/PWMSim.cpp
@@ -219,7 +219,7 @@ PWMSim::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 
 	case MIXERIOCLOADBUF: {
 			const char *buf = (const char *)arg;
-			unsigned buflen = strnlen(buf, 1024);
+			unsigned buflen = strlen(buf);
 			ret = _mixing_output.loadMixerThreadSafe(buf, buflen);
 			break;
 		}

--- a/src/drivers/pwm_out_sim/PWMSim.cpp
+++ b/src/drivers/pwm_out_sim/PWMSim.cpp
@@ -33,326 +33,57 @@
 
 #include "PWMSim.hpp"
 
-#include <px4_time.h>
 #include <mathlib/mathlib.h>
+#include <px4_getopt.h>
 
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/parameter_update.h>
-#include <uORB/topics/multirotor_motor_limits.h>
 
-PWMSim::PWMSim() :
+extern "C" __EXPORT int pwm_out_sim_main(int argc, char *argv[]);
+
+PWMSim::PWMSim(bool hil_mode_enabled) :
 	CDev(PWM_OUTPUT0_DEVICE_PATH),
-	_perf_control_latency(perf_alloc(PC_ELAPSED, "pwm_out_sim control latency"))
+	OutputModuleInterface(MODULE_NAME, px4::wq_configurations::hp_default)
 {
-	for (unsigned i = 0; i < MAX_ACTUATORS; i++) {
-		_pwm_min[i] = PWM_SIM_PWM_MIN_MAGIC;
-		_pwm_max[i] = PWM_SIM_PWM_MAX_MAGIC;
-	}
+	_mixing_output.setAllDisarmedValues(PWM_SIM_DISARMED_MAGIC);
+	_mixing_output.setAllFailsafeValues(PWM_SIM_FAILSAFE_MAGIC);
+	_mixing_output.setAllMinValues(PWM_SIM_PWM_MIN_MAGIC);
+	_mixing_output.setAllMaxValues(PWM_SIM_PWM_MAX_MAGIC);
 
-	_control_topics[0] = ORB_ID(actuator_controls_0);
-	_control_topics[1] = ORB_ID(actuator_controls_1);
-	_control_topics[2] = ORB_ID(actuator_controls_2);
-	_control_topics[3] = ORB_ID(actuator_controls_3);
-
-	for (unsigned i = 0; i < actuator_controls_s::NUM_ACTUATOR_CONTROL_GROUPS; i++) {
-		_control_subs[i] = -1;
-	}
+	_mixing_output.setIgnoreLockdown(hil_mode_enabled);
 
 	CDev::init();
-
-	// default to MODE_16PWM
-	set_mode(MODE_16PWM);
-}
-
-PWMSim::~PWMSim()
-{
-	perf_free(_perf_control_latency);
-}
-
-int
-PWMSim::set_mode(Mode mode)
-{
-	/*
-	 * Configure for PWM output.
-	 *
-	 * Note that regardless of the configured mode, the task is always
-	 * listening and mixing; the mode just selects which of the channels
-	 * are presented on the output pins.
-	 */
-	switch (mode) {
-	case MODE_8PWM:
-		/* multi-port as 8 PWM outs */
-		_update_rate = 400;	/* default output rate */
-		_num_outputs = 8;
-		break;
-
-	case MODE_16PWM:
-		/* multi-port as 16 PWM outs */
-		_update_rate = 400;	/* default output rate */
-		_num_outputs = 16;
-		break;
-
-	case MODE_NONE:
-		/* disable servo outputs and set a very low update rate */
-		_update_rate = 10;
-		_num_outputs = 0;
-		break;
-
-	default:
-		return -EINVAL;
-	}
-
-	_mode = mode;
-	return OK;
-}
-
-int
-PWMSim::set_pwm_rate(unsigned rate)
-{
-	if ((rate > 500) || (rate < 10)) {
-		return -EINVAL;
-	}
-
-	_update_rate = rate;
-	return OK;
 }
 
 void
-PWMSim::subscribe()
+PWMSim::Run()
 {
-	/* subscribe/unsubscribe to required actuator control groups */
-	uint32_t sub_groups = _groups_required & ~_groups_subscribed;
-	uint32_t unsub_groups = _groups_subscribed & ~_groups_required;
-	_poll_fds_num = 0;
+	if (should_exit()) {
+		ScheduleClear();
+		_mixing_output.unregister();
 
-	for (unsigned i = 0; i < actuator_controls_s::NUM_ACTUATOR_CONTROL_GROUPS; i++) {
-		if (sub_groups & (1 << i)) {
-			PX4_DEBUG("subscribe to actuator_controls_%d", i);
-			_control_subs[i] = orb_subscribe(_control_topics[i]);
-		}
-
-		if (unsub_groups & (1 << i)) {
-			PX4_DEBUG("unsubscribe from actuator_controls_%d", i);
-			orb_unsubscribe(_control_subs[i]);
-			_control_subs[i] = -1;
-		}
-
-		if (_control_subs[i] >= 0) {
-			_poll_fds[_poll_fds_num].fd = _control_subs[i];
-			_poll_fds[_poll_fds_num].events = POLLIN;
-			_poll_fds_num++;
-		}
+		exit_and_cleanup();
+		return;
 	}
-}
 
-void PWMSim::update_params()
-{
-	// multicopter air-mode
-	param_t param_handle = param_find("MC_AIRMODE");
+	_mixing_output.update();
 
-	if (param_handle != PARAM_INVALID) {
-		param_get(param_handle, &_airmode);
+	// check for parameter updates
+	if (_parameter_update_sub.updated()) {
+		parameter_update_s pupdate;
+		_parameter_update_sub.copy(&pupdate);
+		updateParams();
 	}
+
+	// check at end of cycle (updateSubscriptions() can potentially change to a different WorkQueue thread)
+	_mixing_output.updateSubscriptions(true);
 }
 
 void
-PWMSim::run()
+PWMSim::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
+		      unsigned num_control_groups_updated)
 {
-	/* force a reset of the update rate */
-	_current_update_rate = 0;
-
-	_armed_sub = orb_subscribe(ORB_ID(actuator_armed));
-
-	update_params();
-	uORB::Subscription parameter_update_sub{ORB_ID(parameter_update)};
-
-	/* loop until killed */
-	while (!should_exit()) {
-
-		if (_groups_subscribed != _groups_required) {
-			subscribe();
-			_groups_subscribed = _groups_required;
-		}
-
-		/* handle update rate changes */
-		if (_current_update_rate != _update_rate) {
-			int update_rate_in_ms = int(1000 / _update_rate);
-
-			if (update_rate_in_ms < 2) {
-				update_rate_in_ms = 2;
-			}
-
-			for (unsigned i = 0; i < actuator_controls_s::NUM_ACTUATOR_CONTROL_GROUPS; i++) {
-				if (_control_subs[i] >= 0) {
-					orb_set_interval(_control_subs[i], update_rate_in_ms);
-				}
-			}
-
-			// up_pwm_servo_set_rate(_update_rate);
-			_current_update_rate = _update_rate;
-		}
-
-		if (_mixers) {
-			_mixers->set_airmode(_airmode);
-		}
-
-		/* this can happen during boot, but after the sleep its likely resolved */
-		if (_poll_fds_num == 0) {
-			px4_sleep(1);
-
-			PX4_DEBUG("no valid fds");
-			continue;
-		}
-
-		/* sleep waiting for data, but no more than a second */
-		int ret = px4_poll(&_poll_fds[0], _poll_fds_num, 1000);
-
-		/* this would be bad... */
-		if (ret < 0) {
-			PX4_ERR("poll error %d", errno);
-			continue;
-		}
-
-		if (ret == 0) {
-			// timeout
-			continue;
-		}
-
-		/* get controls for required topics */
-		unsigned poll_id = 0;
-
-		for (unsigned i = 0; i < actuator_controls_s::NUM_ACTUATOR_CONTROL_GROUPS; i++) {
-			if (_control_subs[i] >= 0) {
-				if (_poll_fds[poll_id].revents & POLLIN) {
-					orb_copy(_control_topics[i], _control_subs[i], &_controls[i]);
-				}
-
-				poll_id++;
-			}
-		}
-
-		/* can we mix? */
-		/* We also publish if not armed, this way we make sure SITL gets feedback. */
-		if (_mixers != nullptr) {
-
-			/* do mixing */
-			_actuator_outputs.noutputs = _mixers->mix(&_actuator_outputs.output[0], _num_outputs);
-
-			/* disable unused ports by setting their output to NaN */
-			const size_t actuator_outputs_size = sizeof(_actuator_outputs.output) / sizeof(_actuator_outputs.output[0]);
-
-			for (size_t i = _actuator_outputs.noutputs; i < actuator_outputs_size; i++) {
-				_actuator_outputs.output[i] = NAN;
-			}
-
-			/* iterate actuators */
-			for (unsigned i = 0; i < _actuator_outputs.noutputs; i++) {
-				/* last resort: catch NaN, INF and out-of-band errors */
-				const bool sane_mixer_output = PX4_ISFINITE(_actuator_outputs.output[i]) &&
-							       _actuator_outputs.output[i] >= -1.0f &&
-							       _actuator_outputs.output[i] <= 1.0f;
-
-				if (_armed && sane_mixer_output) {
-					/* scale for PWM output 1000 - 2000us */
-					_actuator_outputs.output[i] = 1500 + (500 * _actuator_outputs.output[i]);
-					_actuator_outputs.output[i] = math::constrain(_actuator_outputs.output[i], (float)_pwm_min[i], (float)_pwm_max[i]);
-
-				} else {
-					/* Disarmed or insane value - set disarmed pwm value
-					 * This will be clearly visible on the servo status and will limit the risk of accidentally
-					 * spinning motors. It would be deadly in flight. */
-					_actuator_outputs.output[i] = PWM_SIM_DISARMED_MAGIC;
-				}
-			}
-
-			/* overwrite outputs in case of force_failsafe */
-			if (_failsafe) {
-				for (size_t i = 0; i < _actuator_outputs.noutputs; i++) {
-					_actuator_outputs.output[i] = PWM_SIM_FAILSAFE_MAGIC;
-				}
-			}
-
-			/* overwrite outputs in case of lockdown */
-			if (_lockdown) {
-				for (size_t i = 0; i < _actuator_outputs.noutputs; i++) {
-					_actuator_outputs.output[i] = 0.0;
-				}
-			}
-
-			/* publish mixer status */
-			MultirotorMixer::saturation_status saturation_status;
-			saturation_status.value = _mixers->get_saturation_status();
-
-			if (saturation_status.flags.valid) {
-				multirotor_motor_limits_s motor_limits;
-				motor_limits.timestamp = hrt_absolute_time();
-				motor_limits.saturation_status = saturation_status.value;
-
-				int instance;
-				orb_publish_auto(ORB_ID(multirotor_motor_limits), &_mixer_status, &motor_limits, &instance, ORB_PRIO_DEFAULT);
-			}
-
-			_actuator_outputs.timestamp = hrt_absolute_time();
-
-			_outputs_pub.publish(_actuator_outputs);
-
-
-			// use first valid timestamp_sample for latency tracking
-			for (int i = 0; i < actuator_controls_s::NUM_ACTUATOR_CONTROL_GROUPS; i++) {
-				const bool required = _groups_required & (1 << i);
-				const hrt_abstime &timestamp_sample = _controls[i].timestamp_sample;
-
-				if (required && (timestamp_sample > 0)) {
-					perf_set_elapsed(_perf_control_latency, _actuator_outputs.timestamp - timestamp_sample);
-					break;
-				}
-			}
-		}
-
-		/* how about an arming update? */
-		bool updated;
-
-		orb_check(_armed_sub, &updated);
-
-		if (updated) {
-			actuator_armed_s aa = {};
-
-			if (orb_copy(ORB_ID(actuator_armed), _armed_sub, &aa) == PX4_OK) {
-				/* do not obey the lockdown value, as lockdown is for PWMSim. Only obey manual lockdown */
-				_armed = aa.armed;
-				_failsafe = aa.force_failsafe;
-				_lockdown = aa.manual_lockdown;
-			}
-		}
-
-		// check for parameter updates
-		if (parameter_update_sub.updated()) {
-			// clear update
-			parameter_update_s pupdate;
-			parameter_update_sub.copy(&pupdate);
-
-			// update parameters from storage
-			update_params();
-		}
-	}
-
-	for (unsigned i = 0; i < actuator_controls_s::NUM_ACTUATOR_CONTROL_GROUPS; i++) {
-		if (_control_subs[i] >= 0) {
-			orb_unsubscribe(_control_subs[i]);
-		}
-	}
-
-	orb_unsubscribe(_armed_sub);
-}
-
-int
-PWMSim::control_callback(uintptr_t handle, uint8_t control_group, uint8_t control_index, float &input)
-{
-	const actuator_controls_s *controls = (actuator_controls_s *)handle;
-
-	input = controls[control_group].control[control_index];
-
-	return 0;
+	// nothing to do, as we are only interested in the actuator_outputs topic publication
 }
 
 int
@@ -364,20 +95,17 @@ PWMSim::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 
 	switch (cmd) {
 	case PWM_SERVO_ARM:
-		// up_pwm_servo_arm(true);
 		break;
 
 	case PWM_SERVO_DISARM:
-		// up_pwm_servo_arm(false);
 		break;
 
 	case PWM_SERVO_SET_MIN_PWM: {
 			struct pwm_output_values *pwm = (struct pwm_output_values *)arg;
 
 			for (unsigned i = 0; i < pwm->channel_count; i++) {
-
-				if (i < MAX_ACTUATORS) {
-					_pwm_min[i] = pwm->values[i];
+				if (i < OutputModuleInterface::MAX_ACTUATORS) {
+					_mixing_output.minValue(i) = pwm->values[i];
 				}
 			}
 
@@ -388,8 +116,8 @@ PWMSim::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 			struct pwm_output_values *pwm = (struct pwm_output_values *)arg;
 
 			for (unsigned i = 0; i < pwm->channel_count; i++) {
-				if (i < MAX_ACTUATORS) {
-					_pwm_max[i] = pwm->values[i];
+				if (i < OutputModuleInterface::MAX_ACTUATORS) {
+					_mixing_output.maxValue(i) = pwm->values[i];
 				}
 			}
 
@@ -397,20 +125,18 @@ PWMSim::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 		}
 
 	case PWM_SERVO_SET_UPDATE_RATE:
-		// PWMSim always outputs at the alternate (usually faster) rate
-		set_pwm_rate(arg);
+		// PWMSim does not limit the update rate
 		break;
 
 	case PWM_SERVO_SET_SELECT_UPDATE_RATE:
-		// PWMSim always outputs at the alternate (usually faster) rate
 		break;
 
 	case PWM_SERVO_GET_DEFAULT_UPDATE_RATE:
-		*(uint32_t *)arg = 400;
+		*(uint32_t *)arg = 9999;
 		break;
 
 	case PWM_SERVO_GET_UPDATE_RATE:
-		*(uint32_t *)arg = _current_update_rate;
+		*(uint32_t *)arg = 9999;
 		break;
 
 	case PWM_SERVO_GET_SELECT_UPDATE_RATE:
@@ -420,70 +146,55 @@ PWMSim::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 	case PWM_SERVO_GET_FAILSAFE_PWM: {
 			struct pwm_output_values *pwm = (struct pwm_output_values *)arg;
 
-			for (unsigned i = 0; i < _num_outputs; i++) {
-				pwm->values[i] = PWM_SIM_FAILSAFE_MAGIC;
+			for (unsigned i = 0; i < OutputModuleInterface::MAX_ACTUATORS; i++) {
+				pwm->values[i] = _mixing_output.failsafeValue(i);
 			}
 
-			pwm->channel_count = _num_outputs;
+			pwm->channel_count = OutputModuleInterface::MAX_ACTUATORS;
 			break;
 		}
 
 	case PWM_SERVO_GET_DISARMED_PWM: {
 			struct pwm_output_values *pwm = (struct pwm_output_values *)arg;
 
-			for (unsigned i = 0; i < _num_outputs; i++) {
-				pwm->values[i] = PWM_SIM_DISARMED_MAGIC;
+			for (unsigned i = 0; i < OutputModuleInterface::MAX_ACTUATORS; i++) {
+				pwm->values[i] = _mixing_output.disarmedValue(i);
 			}
 
-			pwm->channel_count = _num_outputs;
+			pwm->channel_count = OutputModuleInterface::MAX_ACTUATORS;
 			break;
 		}
 
 	case PWM_SERVO_GET_MIN_PWM: {
 			struct pwm_output_values *pwm = (struct pwm_output_values *)arg;
 
-			for (unsigned i = 0; i < _num_outputs; i++) {
-				pwm->values[i] = PWM_SIM_PWM_MIN_MAGIC;
+			for (unsigned i = 0; i < OutputModuleInterface::MAX_ACTUATORS; i++) {
+				pwm->values[i] = _mixing_output.minValue(i);
 			}
 
-			pwm->channel_count = _num_outputs;
+			pwm->channel_count = OutputModuleInterface::MAX_ACTUATORS;
 			break;
 		}
 
 	case PWM_SERVO_GET_TRIM_PWM: {
 			struct pwm_output_values *pwm = (struct pwm_output_values *)arg;
 
-			for (unsigned i = 0; i < _num_outputs; i++) {
-				pwm->values[i] = (PWM_SIM_PWM_MAX_MAGIC + PWM_SIM_PWM_MIN_MAGIC) / 2;
+			for (unsigned i = 0; i < OutputModuleInterface::MAX_ACTUATORS; i++) {
+				pwm->values[i] = (_mixing_output.maxValue(i) + _mixing_output.minValue(i)) / 2;
 			}
 
-			pwm->channel_count = _num_outputs;
+			pwm->channel_count = OutputModuleInterface::MAX_ACTUATORS;
 			break;
 		}
 
 	case PWM_SERVO_GET_MAX_PWM: {
 			struct pwm_output_values *pwm = (struct pwm_output_values *)arg;
 
-			for (unsigned i = 0; i < _num_outputs; i++) {
-				pwm->values[i] = PWM_SIM_PWM_MAX_MAGIC;
+			for (unsigned i = 0; i < OutputModuleInterface::MAX_ACTUATORS; i++) {
+				pwm->values[i] = _mixing_output.maxValue(i);
 			}
 
-			pwm->channel_count = _num_outputs;
-			break;
-		}
-
-	case PWM_SERVO_GET(0) ... PWM_SERVO_GET(PWM_OUTPUT_MAX_CHANNELS - 1): {
-
-			unsigned channel = cmd - PWM_SERVO_GET(0);
-
-			if (channel >= _num_outputs) {
-				ret = -EINVAL;
-
-			} else {
-				/* fetch a current PWM value */
-				*(servo_position_t *)arg = _actuator_outputs.output[channel];
-			}
-
+			pwm->channel_count = OutputModuleInterface::MAX_ACTUATORS;
 			break;
 		}
 
@@ -497,53 +208,17 @@ PWMSim::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 
 	case PWM_SERVO_GET_COUNT:
 	case MIXERIOCGETOUTPUTCOUNT:
-		if (_mode == MODE_16PWM) {
-			*(unsigned *)arg = 16;
-
-		} else if (_mode == MODE_8PWM) {
-
-			*(unsigned *)arg = 8;
-		}
-
+		*(unsigned *)arg = OutputModuleInterface::MAX_ACTUATORS;
 		break;
 
 	case MIXERIOCRESET:
-		if (_mixers != nullptr) {
-			delete _mixers;
-			_mixers = nullptr;
-			_groups_required = 0;
-		}
-
+		_mixing_output.resetMixerThreadSafe();
 		break;
 
 	case MIXERIOCLOADBUF: {
 			const char *buf = (const char *)arg;
 			unsigned buflen = strnlen(buf, 1024);
-
-			if (_mixers == nullptr) {
-				_mixers = new MixerGroup(control_callback, (uintptr_t)&_controls);
-			}
-
-			if (_mixers == nullptr) {
-				_groups_required = 0;
-				ret = -ENOMEM;
-
-			} else {
-
-				ret = _mixers->load_from_buf(buf, buflen);
-
-				if (ret != 0) {
-					PX4_ERR("mixer load failed with %d", ret);
-					delete _mixers;
-					_mixers = nullptr;
-					_groups_required = 0;
-					ret = -EINVAL;
-
-				} else {
-					_mixers->groups_required(_groups_required);
-				}
-			}
-
+			ret = _mixing_output.loadMixerThreadSafe(buf, buflen);
 			break;
 		}
 
@@ -561,67 +236,38 @@ PWMSim::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 int
 PWMSim::task_spawn(int argc, char *argv[])
 {
-	_task_id = px4_task_spawn_cmd("pwm_out_sim",
-				      SCHED_DEFAULT,
-				      SCHED_PRIORITY_ACTUATOR_OUTPUTS,
-				      1100,
-				      (px4_main_t)&run_trampoline,
-				      nullptr);
+	bool hil_mode = false;
 
-	if (_task_id < 0) {
-		_task_id = -1;
-		return -errno;
+	int myoptind = 1;
+	int ch;
+	const char *myoptarg = nullptr;
+
+	while ((ch = px4_getopt(argc, argv, "m:", &myoptind, &myoptarg)) != EOF) {
+		switch (ch) {
+		case 'm':
+			hil_mode = strcmp(myoptarg, "hil") == 0;
+			break;
+
+		default:
+			return print_usage("unrecognized flag");
+		}
 	}
 
-	// wait until task is up & running (the mode_* commands depend on it)
-	if (wait_until_running() < 0) {
-		_task_id = -1;
+	PWMSim *instance = new PWMSim(hil_mode);
+
+	if (!instance) {
+		PX4_ERR("alloc failed");
 		return -1;
 	}
 
-	return PX4_OK;
-}
-
-PWMSim *PWMSim::instantiate(int argc, char *argv[])
-{
-	return new PWMSim();
+	_object.store(instance);
+	_task_id = task_id_is_work_queue;
+	instance->ScheduleNow();
+	return 0;
 }
 
 int PWMSim::custom_command(int argc, char *argv[])
 {
-	const char *verb = argv[0];
-
-	/* start the task if not running */
-	if (!is_running()) {
-		int ret = PWMSim::task_spawn(argc, argv);
-
-		if (ret) {
-			return ret;
-		}
-	}
-
-	Mode servo_mode = MODE_NONE;
-
-	if (!strcmp(verb, "mode_pwm")) {
-		servo_mode = PWMSim::MODE_8PWM;
-
-	} else if (!strcmp(verb, "mode_pwm16")) {
-		servo_mode = PWMSim::MODE_16PWM;
-	}
-
-	/* was a new mode set? */
-	if (servo_mode != MODE_NONE) {
-		/* switch modes */
-		PWMSim *object = get_instance();
-
-		if (servo_mode != object->get_mode()) {
-			/* (re)set the PWM output mode */
-			return object->set_mode(servo_mode);
-		}
-
-		return 0;
-	}
-
 	return print_usage("unknown command");
 }
 
@@ -645,13 +291,8 @@ It is used in SITL and HITL.
 )DESCR_STR");
 
 	PRINT_MODULE_USAGE_NAME("pwm_out_sim", "driver");
-	PRINT_MODULE_USAGE_COMMAND_DESCR("start", "Start the task in mode_pwm16");
-
-	PRINT_MODULE_USAGE_PARAM_COMMENT("All of the mode_* commands will start the pwm sim if not running already");
-
-	PRINT_MODULE_USAGE_COMMAND_DESCR("mode_pwm", "use 8 PWM outputs");
-	PRINT_MODULE_USAGE_COMMAND_DESCR("mode_pwm16", "use 16 PWM outputs");
-
+	PRINT_MODULE_USAGE_COMMAND_DESCR("start", "Start the module");
+	PRINT_MODULE_USAGE_PARAM_STRING('m', "sim", "hil|sim", "Mode", true);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 
 	return 0;
@@ -659,29 +300,9 @@ It is used in SITL and HITL.
 
 int PWMSim::print_status()
 {
-	PX4_INFO("Running max update rate: %i Hz", _current_update_rate);
-	PX4_INFO("Polling %i actuator controls", _poll_fds_num);
-
-	const char *mode_str = nullptr;
-
-	switch (_mode) {
-	case MODE_8PWM: mode_str = "pwm8"; break;
-	case MODE_16PWM: mode_str = "pwm16"; break;
-
-	case MODE_NONE: mode_str = "no pwm"; break;
-
-	default:
-		break;
-	}
-
-	if (mode_str) {
-		PX4_INFO("PWM Mode: %s", mode_str);
-	}
-
+	_mixing_output.printStatus();
 	return 0;
 }
-
-extern "C" __EXPORT int pwm_out_sim_main(int argc, char *argv[]);
 
 int
 pwm_out_sim_main(int argc, char *argv[])

--- a/src/drivers/pwm_out_sim/PWMSim.hpp
+++ b/src/drivers/pwm_out_sim/PWMSim.hpp
@@ -33,47 +33,25 @@
 
 #pragma once
 
-#include <string.h>
-
 #include <drivers/device/device.h>
 #include <drivers/drv_hrt.h>
 #include <drivers/drv_mixer.h>
 #include <drivers/drv_pwm_output.h>
 #include <lib/mixer/mixer.h>
-#include <perf/perf_counter.h>
+#include <lib/mixer_module/mixer_module.hpp>
 #include <px4_config.h>
 #include <px4_module.h>
 #include <px4_tasks.h>
 #include <px4_time.h>
-#include <uORB/Publication.hpp>
-#include <uORB/topics/actuator_armed.h>
-#include <uORB/topics/actuator_controls.h>
-#include <uORB/topics/actuator_outputs.h>
 #include <uORB/topics/parameter_update.h>
 
-class PWMSim : public cdev::CDev, public ModuleBase<PWMSim>
+class PWMSim : public cdev::CDev, public ModuleBase<PWMSim>, public OutputModuleInterface
 {
-	static constexpr uint32_t PWM_SIM_DISARMED_MAGIC = 900;
-	static constexpr uint32_t PWM_SIM_FAILSAFE_MAGIC = 600;
-	static constexpr uint32_t PWM_SIM_PWM_MIN_MAGIC = 1000;
-	static constexpr uint32_t PWM_SIM_PWM_MAX_MAGIC = 2000;
-
 public:
-
-	enum Mode {
-		MODE_8PWM,
-		MODE_16PWM,
-		MODE_NONE
-	};
-
-	PWMSim();
-	virtual ~PWMSim();
+	PWMSim(bool hil_mode_enabled);
 
 	/** @see ModuleBase */
 	static int task_spawn(int argc, char *argv[]);
-
-	/** @see ModuleBase */
-	static PWMSim *instantiate(int argc, char *argv[]);
 
 	/** @see ModuleBase */
 	static int custom_command(int argc, char *argv[]);
@@ -81,64 +59,24 @@ public:
 	/** @see ModuleBase */
 	static int print_usage(const char *reason = nullptr);
 
-	/** @see ModuleBase::run() */
-	void run() override;
-
 	/** @see ModuleBase::print_status() */
 	int print_status() override;
 
+	void Run() override;
 
-	int		ioctl(device::file_t *filp, int cmd, unsigned long arg) override;
+	int ioctl(device::file_t *filp, int cmd, unsigned long arg) override;
 
-	int		set_pwm_rate(unsigned rate);
-
-	int		set_mode(Mode mode);
-	Mode	get_mode() { return _mode; }
+	void updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 private:
-	static constexpr unsigned MAX_ACTUATORS = 16;
+	static constexpr uint16_t PWM_SIM_DISARMED_MAGIC = 900;
+	static constexpr uint16_t PWM_SIM_FAILSAFE_MAGIC = 600;
+	static constexpr uint16_t PWM_SIM_PWM_MIN_MAGIC = 1000;
+	static constexpr uint16_t PWM_SIM_PWM_MAX_MAGIC = 2000;
 
-	Mode		_mode{MODE_NONE};
+	MixingOutput _mixing_output{MAX_ACTUATORS, *this, MixingOutput::SchedulingPolicy::Auto, false, false};
+	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
 
-	int 		_update_rate{400};
-	int 		_current_update_rate{0};
-
-	int			_control_subs[actuator_controls_s::NUM_ACTUATOR_CONTROL_GROUPS];
-
-	px4_pollfd_struct_t	_poll_fds[actuator_controls_s::NUM_ACTUATOR_CONTROL_GROUPS] {};
-	unsigned	_poll_fds_num{0};
-
-	int		_armed_sub{-1};
-
-	actuator_outputs_s _actuator_outputs {};
-	uORB::Publication<actuator_outputs_s> _outputs_pub{ORB_ID(actuator_outputs)};
-	orb_advert_t	_mixer_status{nullptr};
-
-	unsigned	_num_outputs{0};
-
-	unsigned 	_pwm_min[MAX_ACTUATORS] {};
-	unsigned 	_pwm_max[MAX_ACTUATORS] {};
-
-	uint32_t	_groups_required{0};
-	uint32_t	_groups_subscribed{0};
-
-	bool	_armed{false};
-	bool	_lockdown{false};
-	bool	_failsafe{false};
-
-	MixerGroup	*_mixers{nullptr};
-
-	actuator_controls_s _controls[actuator_controls_s::NUM_ACTUATOR_CONTROL_GROUPS] {};
-	orb_id_t	_control_topics[actuator_controls_s::NUM_ACTUATOR_CONTROL_GROUPS] {};
-
-	Mixer::Airmode 	_airmode{Mixer::Airmode::disabled}; 	///< multicopter air-mode
-
-	perf_counter_t	_perf_control_latency;
-
-	static int	control_callback(uintptr_t handle, uint8_t control_group, uint8_t control_index, float &input);
-
-	void 	subscribe();
-
-	void 	update_params();
 };
 

--- a/src/drivers/pwm_out_sim/PWMSim.hpp
+++ b/src/drivers/pwm_out_sim/PWMSim.hpp
@@ -66,7 +66,7 @@ public:
 
 	int ioctl(device::file_t *filp, int cmd, unsigned long arg) override;
 
-	void updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 private:

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -1470,7 +1470,7 @@ PX4FMU::pwm_ioctl(file *filp, int cmd, unsigned long arg)
 
 	case MIXERIOCLOADBUF: {
 			const char *buf = (const char *)arg;
-			unsigned buflen = strnlen(buf, 1024);
+			unsigned buflen = strlen(buf);
 			ret = _mixing_output.loadMixerThreadSafe(buf, buflen);
 			update_pwm_trims();
 

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -156,7 +156,7 @@ public:
 
 	void update_pwm_trims();
 
-	void updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 private:
@@ -719,11 +719,11 @@ PX4FMU::update_pwm_out_state(bool on)
 }
 
 
-void PX4FMU::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+bool PX4FMU::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated)
 {
 	if (_test_mode) {
-		return;
+		return false;
 	}
 
 	/* output to the servos */
@@ -739,6 +739,8 @@ void PX4FMU::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
 	if (num_control_groups_updated > 0) {
 		up_pwm_update();
 	}
+
+	return true;
 }
 
 void

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -253,6 +253,8 @@ PX4FMU::init()
 		PX4_ERR("FAILED registering class device");
 	}
 
+	_mixing_output.setDriverInstance(_class_instance);
+
 	/* force a reset of the update rate */
 	_current_update_rate = 0;
 

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -2704,7 +2704,7 @@ PX4IO::ioctl(file *filep, int cmd, unsigned long arg)
 
 	case MIXERIOCLOADBUF: {
 			const char *buf = (const char *)arg;
-			ret = mixer_send(buf, strnlen(buf, 2048));
+			ret = mixer_send(buf, strlen(buf));
 			break;
 		}
 

--- a/src/drivers/tap_esc/tap_esc.cpp
+++ b/src/drivers/tap_esc/tap_esc.cpp
@@ -496,7 +496,14 @@ void TAP_ESC::cycle()
 			if (test_motor_updated) {
 				struct test_motor_s test_motor;
 				orb_copy(ORB_ID(test_motor), _test_motor_sub, &test_motor);
-				_outputs.output[test_motor.motor_number] = RPMSTOPPED + ((RPMMAX - RPMSTOPPED) * test_motor.value);
+
+				if (test_motor.action == test_motor_s::ACTION_STOP) {
+					_outputs.output[test_motor.motor_number] = RPMSTOPPED;
+
+				} else {
+					_outputs.output[test_motor.motor_number] = RPMSTOPPED + ((RPMMAX - RPMSTOPPED) * test_motor.value);
+				}
+
 				PX4_INFO("setting motor %i to %.1lf", test_motor.motor_number,
 					 (double)_outputs.output[test_motor.motor_number]);
 			}

--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -1099,7 +1099,7 @@ UavcanNode::ioctl(file *filp, int cmd, unsigned long arg)
 
 	case MIXERIOCLOADBUF: {
 			const char *buf = (const char *)arg;
-			unsigned buflen = strnlen(buf, 1024);
+			unsigned buflen = strlen(buf);
 
 			if (_mixers == nullptr) {
 				_mixers = new MixerGroup(control_callback, (uintptr_t)_controls);

--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -971,7 +971,7 @@ int UavcanNode::run()
 			orb_copy(ORB_ID(test_motor), _test_motor_sub, &_test_motor);
 
 			// Update the test status and check that we're not locked down
-			_test_in_progress = (_test_motor.value > 0);
+			_test_in_progress = (_test_motor.action == test_motor_s::ACTION_RUN);
 			_esc_controller.arm_single_esc(_test_motor.motor_number, _test_in_progress);
 		}
 

--- a/src/lib/mixer_module/mixer_module.cpp
+++ b/src/lib/mixer_module/mixer_module.cpp
@@ -285,18 +285,15 @@ bool MixingOutput::update()
 		}
 	}
 
+	bool stop_motors = mixed_num_outputs == 0 || !_throttle_armed;
+
 	/* overwrite outputs in case of lockdown or parachute triggering with disarmed values */
 	if (_armed.lockdown || _armed.manual_lockdown) {
 		for (size_t i = 0; i < mixed_num_outputs; i++) {
 			output_limited[i] = _disarmed_value[i];
 		}
-	}
 
-	bool stop_motors = true;
-
-	if (mixed_num_outputs > 0) {
-		/* assume if one (here the 1.) motor is disarmed, all of them should be stopped */
-		stop_motors = (output_limited[0] == _disarmed_value[0]);
+		stop_motors = true;
 	}
 
 	/* apply _param_mot_ordering */

--- a/src/lib/mixer_module/mixer_module.cpp
+++ b/src/lib/mixer_module/mixer_module.cpp
@@ -571,11 +571,11 @@ int MixingOutput::loadMixer(const char *buf, unsigned len)
 
 void MixingOutput::handleCommands()
 {
-	if (_command.command.load() == Command::Type::None) {
+	if ((Command::Type)_command.command.load() == Command::Type::None) {
 		return;
 	}
 
-	switch (_command.command.load()) {
+	switch ((Command::Type)_command.command.load()) {
 	case Command::Type::loadMixer:
 		_command.result = loadMixer(_command.mixer_buf, _command.mixer_buf_length);
 		break;
@@ -590,12 +590,12 @@ void MixingOutput::handleCommands()
 	}
 
 	// mark as done
-	_command.command.store(Command::Type::None);
+	_command.command.store((int)Command::Type::None);
 }
 
 void MixingOutput::resetMixerThreadSafe()
 {
-	if (_command.command.load() != Command::Type::None) {
+	if ((Command::Type)_command.command.load() != Command::Type::None) {
 		// Cannot happen, because we expect only one other thread to call this.
 		// But as a safety precaution we return here.
 		PX4_ERR("Command not None");
@@ -604,14 +604,14 @@ void MixingOutput::resetMixerThreadSafe()
 
 	lock();
 
-	_command.command.store(Command::Type::resetMixer);
+	_command.command.store((int)Command::Type::resetMixer);
 
 	_interface.ScheduleNow();
 
 	unlock();
 
 	// wait until processed
-	while (_command.command.load() != Command::Type::None) {
+	while ((Command::Type)_command.command.load() != Command::Type::None) {
 		usleep(1000);
 	}
 
@@ -619,7 +619,7 @@ void MixingOutput::resetMixerThreadSafe()
 
 int MixingOutput::loadMixerThreadSafe(const char *buf, unsigned len)
 {
-	if (_command.command.load() != Command::Type::None) {
+	if ((Command::Type)_command.command.load() != Command::Type::None) {
 		// Cannot happen, because we expect only one other thread to call this.
 		// But as a safety precaution we return here.
 		PX4_ERR("Command not None");
@@ -630,14 +630,14 @@ int MixingOutput::loadMixerThreadSafe(const char *buf, unsigned len)
 
 	_command.mixer_buf = buf;
 	_command.mixer_buf_length = len;
-	_command.command.store(Command::Type::loadMixer);
+	_command.command.store((int)Command::Type::loadMixer);
 
 	_interface.ScheduleNow();
 
 	unlock();
 
 	// wait until processed
-	while (_command.command.load() != Command::Type::None) {
+	while ((Command::Type)_command.command.load() != Command::Type::None) {
 		usleep(1000);
 	}
 

--- a/src/lib/mixer_module/mixer_module.cpp
+++ b/src/lib/mixer_module/mixer_module.cpp
@@ -308,9 +308,11 @@ bool MixingOutput::update()
 		unsigned num_motor_test = motorTest();
 
 		if (num_motor_test > 0) {
-			_interface.updateOutputs(false, _current_output_value, num_motor_test, 1);
-			actuator_outputs_s actuator_outputs{};
-			setAndPublishActuatorOutputs(num_motor_test, actuator_outputs);
+			if (_interface.updateOutputs(false, _current_output_value, num_motor_test, 1)) {
+				actuator_outputs_s actuator_outputs{};
+				setAndPublishActuatorOutputs(num_motor_test, actuator_outputs);
+			}
+
 			checkSafetyButton();
 			handleCommands();
 			return true;
@@ -375,14 +377,13 @@ bool MixingOutput::update()
 	reorderOutputs(_current_output_value);
 
 	/* now return the outputs to the driver */
-	_interface.updateOutputs(stop_motors, _current_output_value, mixed_num_outputs, n_updates);
+	if (_interface.updateOutputs(stop_motors, _current_output_value, mixed_num_outputs, n_updates)) {
+		actuator_outputs_s actuator_outputs{};
+		setAndPublishActuatorOutputs(mixed_num_outputs, actuator_outputs);
 
-
-	actuator_outputs_s actuator_outputs{};
-	setAndPublishActuatorOutputs(mixed_num_outputs, actuator_outputs);
-
-	publishMixerStatus(actuator_outputs);
-	updateLatencyPerfCounter(actuator_outputs);
+		publishMixerStatus(actuator_outputs);
+		updateLatencyPerfCounter(actuator_outputs);
+	}
 
 	checkSafetyButton();
 	handleCommands();

--- a/src/lib/mixer_module/mixer_module.hpp
+++ b/src/lib/mixer_module/mixer_module.hpp
@@ -202,7 +202,7 @@ private:
 			resetMixer,
 			loadMixer
 		};
-		px4::atomic<Type> command{Type::None};
+		px4::atomic<int> command{(int)Type::None};
 		const char *mixer_buf;
 		unsigned mixer_buf_length;
 		int result;

--- a/src/lib/mixer_module/mixer_module.hpp
+++ b/src/lib/mixer_module/mixer_module.hpp
@@ -173,6 +173,12 @@ private:
 	{
 		return (_armed.prearmed && !_armed.armed) || _armed.in_esc_calibration_mode;
 	}
+
+	void updateOutputSlewrate();
+	void checkSafetyButton();
+	void publishMixerStatus(const actuator_outputs_s &actuator_outputs);
+	void updateLatencyPerfCounter(const actuator_outputs_s &actuator_outputs);
+
 	static int controlCallback(uintptr_t handle, uint8_t control_group, uint8_t control_index, float &input);
 
 	enum class MotorOrdering : int32_t {

--- a/src/lib/mixer_module/mixer_module.hpp
+++ b/src/lib/mixer_module/mixer_module.hpp
@@ -50,7 +50,6 @@
 #include <uORB/topics/actuator_outputs.h>
 #include <uORB/topics/multirotor_motor_limits.h>
 #include <uORB/topics/parameter_update.h>
-#include <uORB/topics/safety.h>
 #include <uORB/topics/test_motor.h>
 
 
@@ -193,7 +192,6 @@ private:
 	unsigned motorTest();
 
 	void updateOutputSlewrate();
-	void checkSafetyButton();
 	void setAndPublishActuatorOutputs(unsigned num_outputs, actuator_outputs_s &actuator_outputs);
 	void publishMixerStatus(const actuator_outputs_s &actuator_outputs);
 	void updateLatencyPerfCounter(const actuator_outputs_s &actuator_outputs);
@@ -238,7 +236,6 @@ private:
 	output_limit_t _output_limit;
 
 	uORB::Subscription _armed_sub{ORB_ID(actuator_armed)};
-	uORB::Subscription _safety_sub{ORB_ID(safety)};
 	uORB::SubscriptionCallbackWorkItem _control_subs[actuator_controls_s::NUM_ACTUATOR_CONTROL_GROUPS];
 
 	uORB::PublicationMulti<actuator_outputs_s> _outputs_pub{ORB_ID(actuator_outputs), ORB_PRIO_DEFAULT};
@@ -250,7 +247,6 @@ private:
 	hrt_abstime _time_last_mix{0};
 	unsigned _max_topic_update_interval_us{0}; ///< max _control_subs topic update interval (0=unlimited)
 
-	bool _safety_off{false}; ///< State of the safety button from the subscribed _safety_sub topic
 	bool _throttle_armed{false};
 	bool _ignore_lockdown{false}; ///< if true, ignore the _armed.lockdown flag (for HIL outputs)
 
@@ -279,8 +275,7 @@ private:
 		(ParamInt<px4::params::MC_AIRMODE>) _param_mc_airmode,   ///< multicopter air-mode
 		(ParamFloat<px4::params::MOT_SLEW_MAX>) _param_mot_slew_max,
 		(ParamFloat<px4::params::THR_MDL_FAC>) _param_thr_mdl_fac, ///< thrust to motor control signal modelling factor
-		(ParamInt<px4::params::MOT_ORDERING>) _param_mot_ordering,
-		(ParamInt<px4::params::CBRK_IO_SAFETY>) _param_cbrk_io_safety
+		(ParamInt<px4::params::MOT_ORDERING>) _param_mot_ordering
 
 	)
 };

--- a/src/lib/mixer_module/mixer_module.hpp
+++ b/src/lib/mixer_module/mixer_module.hpp
@@ -66,7 +66,16 @@ public:
 	OutputModuleInterface(const char *name, const px4::wq_config_t &config)
 		: px4::ScheduledWorkItem(name, config), ModuleParams(nullptr) {}
 
-	virtual void updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	/**
+	 * Callback to update the (physical) actuator outputs in the driver
+	 * @param stop_motors if true, all motors must be stopped (if false, individual motors
+	 *                    might still be stopped via outputs[i] == disarmed_value)
+	 * @param outputs individual actuator outputs in range [min, max] or failsafe/disarmed value
+	 * @param num_outputs number of outputs (<= max_num_outputs)
+	 * @param num_control_groups_updated number of actuator_control groups updated
+	 * @return if true, the update got handled, and actuator_outputs can be published
+	 */
+	virtual bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
 				   unsigned num_outputs, unsigned num_control_groups_updated) = 0;
 
 	/** called whenever the mixer gets updated/reset */

--- a/src/systemcmds/motor_test/motor_test.cpp
+++ b/src/systemcmds/motor_test/motor_test.cpp
@@ -48,20 +48,27 @@
 
 extern "C" __EXPORT int motor_test_main(int argc, char *argv[]);
 
-static void motor_test(unsigned channel, float value);
+static void motor_test(unsigned channel, float value, uint8_t driver_instance);
 static void usage(const char *reason);
 
-void motor_test(unsigned channel, float value)
+void motor_test(unsigned channel, float value, uint8_t driver_instance)
 {
 	test_motor_s test_motor{};
 	test_motor.timestamp = hrt_absolute_time();
 	test_motor.motor_number = channel;
 	test_motor.value = value;
+	test_motor.action = value >= 0.f ? test_motor_s::ACTION_RUN : test_motor_s::ACTION_STOP;
+	test_motor.driver_instance = driver_instance;
 
 	uORB::PublicationQueued<test_motor_s> test_motor_pub{ORB_ID(test_motor)};
 	test_motor_pub.publish(test_motor);
 
-	PX4_INFO("motor %d set to %.2f", channel, (double)value);
+	if (test_motor.action == test_motor_s::ACTION_STOP) {
+		PX4_INFO("motors stop command sent");
+
+	} else {
+		PX4_INFO("motor %d set to %.2f", channel, (double)value);
+	}
 }
 
 static void usage(const char *reason)
@@ -70,15 +77,20 @@ static void usage(const char *reason)
 		PX4_WARN("%s", reason);
 	}
 
-	PRINT_MODULE_DESCRIPTION("Utility to test motors.\n"
-				 "\n"
-				 "Note: this can only be used for drivers which support the motor_test uorb topic (currently uavcan and tap_esc)\n"
-				);
+	PRINT_MODULE_DESCRIPTION(
+		R"DESCR_STR(
+Utility to test motors.
+
+WARNING: remove all props before using this command.
+
+Note: this can only be used for drivers which support the motor_test uorb topic (not px4io).
+)DESCR_STR");
 
 	PRINT_MODULE_USAGE_NAME("motor_test", "command");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("test", "Set motor(s) to a specific output value");
 	PRINT_MODULE_USAGE_PARAM_INT('m', -1, 0, 7, "Motor to test (0...7, all if not specified)", true);
 	PRINT_MODULE_USAGE_PARAM_INT('p', 0, 0, 100, "Power (0...100)", true);
+	PRINT_MODULE_USAGE_PARAM_INT('i', 0, 0, 4, "driver instance", true);
 	PRINT_MODULE_USAGE_COMMAND_DESCR("stop", "Stop all motors");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("iterate", "Iterate all motors starting and stopping one after the other");
 
@@ -89,13 +101,18 @@ int motor_test_main(int argc, char *argv[])
 	int channel = -1; //default to all channels
 	unsigned long lval;
 	float value = 0.0f;
+	uint8_t driver_instance = 0;
 	int ch;
 
 	int myoptind = 1;
 	const char *myoptarg = NULL;
 
-	while ((ch = px4_getopt(argc, argv, "m:p:", &myoptind, &myoptarg)) != EOF) {
+	while ((ch = px4_getopt(argc, argv, "i:m:p:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
+
+		case 'i':
+			driver_instance = (uint8_t)strtol(myoptarg, NULL, 0);
+			break;
 
 		case 'm':
 			/* Read in motor number */
@@ -124,17 +141,17 @@ int motor_test_main(int argc, char *argv[])
 
 	if (myoptind >= 0 && myoptind < argc) {
 		if (strcmp("stop", argv[myoptind]) == 0) {
-			channel = -1;
-			value = 0.f;
+			channel = 0;
+			value = -1.f;
 
 		} else if (strcmp("iterate", argv[myoptind]) == 0) {
-			value = 0.3f;
+			value = 0.15f;
 
 			for (int i = 0; i < 8; ++i) {
-				motor_test(i, value);
-				usleep(500000);
-				motor_test(i, 0.f);
-				usleep(10000);
+				motor_test(i, value, driver_instance);
+				px4_usleep(500000);
+				motor_test(i, -1.f, driver_instance);
+				px4_usleep(10000);
 			}
 
 			run_test = false;
@@ -154,12 +171,12 @@ int motor_test_main(int argc, char *argv[])
 	if (run_test) {
 		if (channel < 0) {
 			for (int i = 0; i < 8; ++i) {
-				motor_test(i, value);
-				usleep(10000);
+				motor_test(i, value, driver_instance);
+				px4_usleep(10000);
 			}
 
 		} else {
-			motor_test(channel, value);
+			motor_test(channel, value, driver_instance);
 		}
 	}
 


### PR DESCRIPTION
This refactors `pwm_out_sim` to use the MixingOutput library so that SITL uses the same code as on HW.
It also adds support for the `test_motor` uORB topic (`motor_test` CLI command) to MixingOutput (it works in SITL as well).
Next we can interface that to MAVLink, which possibly requires more changes to the uORB topic.

Tested with DShot + FMU PWM, SITL and HITL.