### PR TITLE
microRTPS bridge: templates: do not change naming of topics based on the fasrtpsgen version

### DIFF
--- a/msg/templates/urtps/Publisher.cpp.em
+++ b/msg/templates/urtps/Publisher.cpp.em
@@ -98,28 +98,15 @@ bool @(topic)_Publisher::init()
     PublisherAttributes Wparam;
     Wparam.topic.topicKind = NO_KEY;
     Wparam.topic.topicDataType = myType.getName();  //This type MUST be registered
-@[if 1.5 <= fastrtpsgen_version <= 1.7]@
-@[    if ros2_distro]@
-@[        if ros2_distro == "ardent"]@
+@[if ros2_distro]@
+@[    if ros2_distro == "ardent"]@
     Wparam.qos.m_partition.push_back("rt");
     Wparam.topic.topicName = "@(topic)_PubSubTopic";
-@[        else]@
-    Wparam.topic.topicName = "rt/@(topic)_PubSubTopic";
-@[        end if]@
 @[    else]@
-    Wparam.topic.topicName = "@(topic)_PubSubTopic";
+    Wparam.topic.topicName = "rt/@(topic)_PubSubTopic";
 @[    end if]@
 @[else]@
-@[    if ros2_distro]@
-@[        if ros2_distro == "ardent"]@
-    Wparam.qos.m_partition.push_back("rt");
-    Wparam.topic.topicName = "@(topic)PubSubTopic";
-@[        else]@
-    Wparam.topic.topicName = "rt/@(topic)PubSubTopic";
-@[        end if]@
-@[    else]@
-    Wparam.topic.topicName = "@(topic)PubSubTopic";
-@[    end if]@
+    Wparam.topic.topicName = "@(topic)_PubSubTopic";
 @[end if]@
     mp_publisher = Domain::createPublisher(mp_participant, Wparam, static_cast<PublisherListener*>(&m_listener));
     if(mp_publisher == nullptr)

--- a/msg/templates/urtps/Subscriber.cpp.em
+++ b/msg/templates/urtps/Subscriber.cpp.em
@@ -93,28 +93,15 @@ bool @(topic)_Subscriber::init()
     SubscriberAttributes Rparam;
     Rparam.topic.topicKind = NO_KEY;
     Rparam.topic.topicDataType = myType.getName(); //Must be registered before the creation of the subscriber
-@[if 1.5 <= fastrtpsgen_version <= 1.7]@
-@[    if ros2_distro]@
-@[        if ros2_distro == "ardent"]@
+@[if ros2_distro]@
+@[    if ros2_distro == "ardent"]@
     Rparam.qos.m_partition.push_back("rt");
     Rparam.topic.topicName = "@(topic)_PubSubTopic";
-@[        else]@
-    Rparam.topic.topicName = "rt/@(topic)_PubSubTopic";
-@[        end if]@
 @[    else]@
-    Rparam.topic.topicName = "@(topic)_PubSubTopic";
+    Rparam.topic.topicName = "rt/@(topic)_PubSubTopic";
 @[    end if]@
 @[else]@
-@[    if ros2_distro]@
-@[        if ros2_distro == "ardent"]@
-    Rparam.qos.m_partition.push_back("rt");
-    Rparam.topic.topicName = "@(topic)PubSubTopic";
-@[        else]@
-    Rparam.topic.topicName = "rt/@(topic)PubSubTopic";
-@[        end if]@
-@[    else]@
-    Rparam.topic.topicName = "@(topic)PubSubTopic";
-@[    end if]@
+    Rparam.topic.topicName = "@(topic)_PubSubTopic";
 @[end if]@
     mp_subscriber = Domain::createSubscriber(mp_participant, Rparam, static_cast<SubscriberListener*>(&m_listener));
     if(mp_subscriber == nullptr)


### PR DESCRIPTION
This makes sure that all topics are consistent between all Pub/Subs in the different Fast-RTPS and ROS2 versions.
