### PR TITLE
Multicopter land detector: do not update parameters every cycle

### DIFF
--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -57,7 +57,7 @@ LandDetector::~LandDetector()
 
 void LandDetector::start()
 {
-	_update_params(true);
+	_update_params();
 	ScheduleOnInterval(LAND_DETECTOR_UPDATE_INTERVAL);
 }
 
@@ -65,7 +65,10 @@ void LandDetector::Run()
 {
 	perf_begin(_cycle_perf);
 
-	_update_params();
+	if (_parameter_update_sub.updated()) {
+		_update_params();
+	}
+
 	_actuator_armed_sub.update(&_actuator_armed);
 	_update_topics();
 	_update_state();
@@ -131,16 +134,12 @@ void LandDetector::Run()
 	}
 }
 
-void LandDetector::_update_params(const bool force)
+void LandDetector::_update_params()
 {
-	// check for parameter updates
-	if (_parameter_update_sub.updated() || force) {
-		// clear update
-		parameter_update_s param_update;
-		_parameter_update_sub.copy(&param_update);
+	parameter_update_s param_update;
+	_parameter_update_sub.copy(&param_update);
 
-		_update_total_flight_time();
-	}
+	_update_total_flight_time();
 }
 
 void LandDetector::_update_state()

--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -139,6 +139,7 @@ void LandDetector::_update_params()
 	parameter_update_s param_update;
 	_parameter_update_sub.copy(&param_update);
 
+	updateParams();
 	_update_total_flight_time();
 }
 

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -97,10 +97,9 @@ public:
 protected:
 
 	/**
-	 * Updates parameters if changes have occurred or if forced.
-	 * @var force Forces a parameter update.
+	 * Updates parameters.
 	 */
-	virtual void _update_params(const bool force = false);
+	virtual void _update_params();
 
 	/**
 	 * Updates subscribed uORB topics.
@@ -162,11 +161,6 @@ protected:
 
 	uORB::Publication<vehicle_land_detected_s> _vehicle_land_detected_pub{ORB_ID(vehicle_land_detected)};
 
-	uORB::Subscription _actuator_armed_sub{ORB_ID(actuator_armed)};
-	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
-	uORB::Subscription _vehicle_acceleration_sub{ORB_ID(vehicle_acceleration)};
-	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
-
 private:
 
 	void Run() override;
@@ -181,6 +175,11 @@ private:
 	hrt_abstime _total_flight_time{0};	///< total vehicle flight time in microseconds
 
 	perf_counter_t _cycle_perf{perf_alloc(PC_ELAPSED, "land_detector_cycle")};
+
+	uORB::Subscription _actuator_armed_sub{ORB_ID(actuator_armed)};
+	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
+	uORB::Subscription _vehicle_acceleration_sub{ORB_ID(vehicle_acceleration)};
+	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(
 		ModuleParams,

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -148,6 +148,7 @@ protected:
 
 	actuator_armed_s         _actuator_armed{};
 	vehicle_acceleration_s   _vehicle_acceleration{};
+
 	vehicle_land_detected_s _land_detected = {
 		.timestamp = 0,
 		.alt_max = -1.0f,
@@ -156,11 +157,13 @@ protected:
 		.maybe_landed = true,
 		.landed = true,
 	};
+
 	vehicle_local_position_s _vehicle_local_position{};
 
 	uORB::Publication<vehicle_land_detected_s> _vehicle_land_detected_pub{ORB_ID(vehicle_land_detected)};
 
 	uORB::Subscription _actuator_armed_sub{ORB_ID(actuator_armed)};
+	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
 	uORB::Subscription _vehicle_acceleration_sub{ORB_ID(vehicle_acceleration)};
 	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
 
@@ -178,8 +181,6 @@ private:
 	hrt_abstime _total_flight_time{0};	///< total vehicle flight time in microseconds
 
 	perf_counter_t _cycle_perf{perf_alloc(PC_ELAPSED, "land_detector_cycle")};
-
-	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(
 		ModuleParams,

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -99,12 +99,13 @@ void MulticopterLandDetector::_update_params(const bool force)
 {
 	LandDetector::_update_params(force);
 
-	_freefall_hysteresis.set_hysteresis_time_from(false, (hrt_abstime)(1e6f * _param_lndmc_ffall_ttri.get()));
-
-	param_get(_paramHandle.minThrottle, &_params.minThrottle);
-	param_get(_paramHandle.hoverThrottle, &_params.hoverThrottle);
-	param_get(_paramHandle.minManThrottle, &_params.minManThrottle);
-	param_get(_paramHandle.landSpeed, &_params.landSpeed);
+	if (_parameter_update_sub.updated() || force) {
+		_freefall_hysteresis.set_hysteresis_time_from(false, (hrt_abstime)(1e6f * _param_lndmc_ffall_ttri.get()));
+		param_get(_paramHandle.minThrottle, &_params.minThrottle);
+		param_get(_paramHandle.hoverThrottle, &_params.hoverThrottle);
+		param_get(_paramHandle.minManThrottle, &_params.minManThrottle);
+		param_get(_paramHandle.landSpeed, &_params.landSpeed);
+	}
 }
 
 bool MulticopterLandDetector::_get_freefall_state()

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -95,17 +95,16 @@ void MulticopterLandDetector::_update_topics()
 	_vehicle_local_position_setpoint_sub.update(&_vehicle_local_position_setpoint);
 }
 
-void MulticopterLandDetector::_update_params(const bool force)
+void MulticopterLandDetector::_update_params()
 {
-	LandDetector::_update_params(force);
+	LandDetector::_update_params();
 
-	if (_parameter_update_sub.updated() || force) {
-		_freefall_hysteresis.set_hysteresis_time_from(false, (hrt_abstime)(1e6f * _param_lndmc_ffall_ttri.get()));
-		param_get(_paramHandle.minThrottle, &_params.minThrottle);
-		param_get(_paramHandle.hoverThrottle, &_params.hoverThrottle);
-		param_get(_paramHandle.minManThrottle, &_params.minManThrottle);
-		param_get(_paramHandle.landSpeed, &_params.landSpeed);
-	}
+	_freefall_hysteresis.set_hysteresis_time_from(false, (hrt_abstime)(1e6f * _param_lndmc_ffall_ttri.get()));
+
+	param_get(_paramHandle.minThrottle, &_params.minThrottle);
+	param_get(_paramHandle.hoverThrottle, &_params.hoverThrottle);
+	param_get(_paramHandle.minManThrottle, &_params.minManThrottle);
+	param_get(_paramHandle.landSpeed, &_params.landSpeed);
 }
 
 bool MulticopterLandDetector::_get_freefall_state()

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -62,7 +62,7 @@ public:
 	MulticopterLandDetector();
 
 protected:
-	void _update_params(const bool force = false) override;
+	void _update_params() override;
 	void _update_topics() override;
 
 	bool _get_landed_state() override;


### PR DESCRIPTION
**Describe problem solved by this pull request**
In PR #11874 I inadvertently introduced updating multicopter throttle and landspeed parameters every cycle.  This PR corrects that error. I think this PR also simplifies the logic a bit as well.

**Test data / coverage**
Test flown on a 250 quad with pixhawk 4 mini: https://review.px4.io/plot_app?log=f71fb16d-69c1-4ef7-93cd-40783eee96f8

**Additional context**
See feedback in PR #11874 for background.

Hi @bkueng , I think your suggestion to move the `if (_parameter_update_sub.updated())` check up into the `LandDetector::Run()` method works nicely.  Let me know if you prefer the first commit instead or if you have any other feedback.  Thanks for your review!

@MaEtUgR , @julianoes , let me know if you'd like to see anything different as well.

Thanks!