### PR TITLE
Add camera models for VTOL models for sitl

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/1043_standard_vtol_cam
+++ b/ROMFS/px4fmu_common/init.d-posix/1043_standard_vtol_cam
@@ -1,0 +1,6 @@
+#!/bin/sh
+#
+# @name Plane SITL with camera
+#
+
+sh /etc/init.d-posix/1040_standard_vtol

--- a/ROMFS/px4fmu_common/init.d-posix/1044_tailsitter_cam
+++ b/ROMFS/px4fmu_common/init.d-posix/1044_tailsitter_cam
@@ -1,0 +1,6 @@
+#!/bin/sh
+#
+# @name Tailsitter SITL with camera
+#
+
+sh /etc/init.d-posix/1041_tailsitter


### PR DESCRIPTION
**Describe problem solved by this pull request**
This is a follow up of https://github.com/PX4/sitl_gazebo/pull/360 which adds a sitl models for VTOLS that have camera attached in order to simulate survey missions.