### PR TITLE
arch.sh: use nproc instead of grepping /proc/cpuinfo

### DIFF
--- a/Tools/setup/arch.sh
+++ b/Tools/setup/arch.sh
@@ -138,7 +138,7 @@ if [[ $INSTALL_SIM == "true" ]]; then
 			;
 
 		# enable multicore gazebo compilation
-		sudo sed -i '/MAKEFLAGS=/c\MAKEFLAGS="-j'$(($(grep -c processor /proc/cpuinfo)+2))'"' /etc/makepkg.conf
+		sudo sed -i '/MAKEFLAGS=/c\MAKEFLAGS="-j'$(($(nproc)+2))'"' /etc/makepkg.conf
 
 		# install gazebo from AUR
 		yay -S gazebo --noconfirm


### PR DESCRIPTION
**Describe problem solved by this pull request**
Cleanup

**Describe your solution**
Someone at the AUR where I posted the gazebo issue corrected my script: https://aur.archlinux.org/packages/gazebo/#comment-711953

**Test data / coverage**
Tested, works exactly like it should.

**Additional context**
#13160 
