### PR TITLE
Don't implement print_message for fmu-v2

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -177,6 +177,10 @@ foreach(msg_file ${msg_files})
 	list(APPEND uorb_sources ${msg_source_out_path}/${msg}.cpp)
 endforeach()
 
+if (px4_constrained_flash_build)
+	set(added_arguments --constrained-flash)
+endif()
+
 # Generate uORB headers
 add_custom_command(OUTPUT ${uorb_headers}
 	COMMAND ${PYTHON_EXECUTABLE} tools/px_generate_uorb_topic_files.py
@@ -187,6 +191,7 @@ add_custom_command(OUTPUT ${uorb_headers}
 		-e templates/uorb
 		-t ${CMAKE_CURRENT_BINARY_DIR}/tmp/headers
 		-q
+		${added_arguments}
 	DEPENDS
 		${msg_files}
 		templates/uorb/msg.h.em
@@ -207,6 +212,7 @@ add_custom_command(OUTPUT ${uorb_sources}
 		-e templates/uorb
 		-t ${CMAKE_CURRENT_BINARY_DIR}/tmp/sources
 		-q
+		${added_arguments}
 	DEPENDS
 		${msg_files}
 		templates/uorb/msg.cpp.em

--- a/msg/templates/uorb/msg.cpp.em
+++ b/msg/templates/uorb/msg.cpp.em
@@ -15,6 +15,7 @@
 @#  - md5sum (String) MD5Sum of the .msg specification
 @#  - search_path (dict) search paths for genmsg
 @#  - topics (List of String) multi-topic names
+@#  - constrained_flash set to true if flash is constrained
 @#  - ids (List) list of all RTPS msg ids
 @###############################################
 /****************************************************************************
@@ -82,9 +83,14 @@ ORB_DEFINE(@multi_topic, struct @uorb_struct, @(struct_size-padding_end_size), _
 
 void print_message(const @uorb_struct& message)
 {
+@[if constrained_flash]
+	(void)message;
+	PX4_INFO_RAW("Not implemented on flash constrained hardware\n");
+@[else]
 	PX4_INFO_RAW(" @(uorb_struct)\n");
 @[for field in sorted_fields]@
 	@( print_field(field) )@
 @[end for]@
+@[end if]@
 
 }

--- a/msg/tools/px_generate_uorb_topic_files.py
+++ b/msg/tools/px_generate_uorb_topic_files.py
@@ -33,7 +33,7 @@
 #############################################################################
 
 """
-px_generate_uorb_topics.py
+px_generate_uorb_topic_files.py
 Generates c/cpp header/source files for uorb topics from .msg (ROS syntax)
 message files
 """
@@ -84,6 +84,8 @@ INCL_DEFAULT = ['std_msgs:./msg/std_msgs']
 PACKAGE = 'px4'
 TOPICS_TOKEN = '# TOPICS '
 IDL_TEMPLATE_FILE = 'msg.idl.em'
+
+CONSTRAINED_FLASH = False
 
 
 class MsgScope:
@@ -156,7 +158,8 @@ def generate_output_from_file(format_idx, filename, outputdir, package, template
         "search_path": search_path,
         "msg_context": msg_context,
         "spec": spec,
-        "topics": topics
+        "topics": topics,
+        "constrained_flash": CONSTRAINED_FLASH
     }
 
     # Make sure output directory exists:
@@ -511,10 +514,14 @@ if __name__ == "__main__":
     parser.add_argument('-q', dest='quiet', default=False, action='store_true',
                         help='string added as prefix to the output file '
                         ' name when converting directories')
+    parser.add_argument('--constrained-flash', dest='constrained_flash', default=False, action='store_true',
+                        help='set to save flash space')
     args = parser.parse_args()
 
     if args.include_paths:
         append_to_include_path(args.include_paths, INCL_DEFAULT, args.package)
+
+    CONSTRAINED_FLASH = args.constrained_flash
 
     if args.headers:
         generate_idx = 0


### PR DESCRIPTION
This saves about 3.4k of flash for fmu-v2.

```
     VM SIZE    
 -------------- 
  [ = ]       0    [Unmapped]
  [ = ]       0    [section .debug_abbrev]
  [ = ]       0    [section .debug_frame]
  [ = ]       0    [section .debug_info]
  [ = ]       0    [section .debug_line]
  [ = ]       0    [section .debug_loc]
  [ = ]       0    [section .debug_ranges]
  [ = ]       0    [section .debug_str]
  [ = ]       0    [section .symtab]
  [DEL]     -16    CSWTCH.5
  [DEL]     -64    CSWTCH.4
  -1.0%    -900    [section .text]
 -96.7% -2.44Ki    print_message()
  -0.3% -3.40Ki    TOTAL
```