### PR TITLE
mpu6000: remove factory test

### DIFF
--- a/cmake/px4_add_board.cmake
+++ b/cmake/px4_add_board.cmake
@@ -218,6 +218,7 @@ function(px4_add_board)
 
 	if(CONSTRAINED_FLASH)
 		set(px4_constrained_flash_build "1" CACHE INTERNAL "constrained flash build" FORCE)
+		add_definitions(-DCONSTRAINED_FLASH)
 	endif()
 
 	if(TESTING)

--- a/src/drivers/imu/mpu6000/MPU6000.cpp
+++ b/src/drivers/imu/mpu6000/MPU6000.cpp
@@ -383,6 +383,7 @@ MPU6000::_set_icm_acc_dlpf_filter(uint16_t frequency_hz)
 	write_checked_reg(ICMREG_ACCEL_CONFIG2, filter);
 }
 
+#ifndef CONSTRAINED_FLASH
 /*
   perform a self-test comparison to factory trim values. This takes
   about 200ms and will return OK if the current values are within 14%
@@ -526,6 +527,7 @@ MPU6000::factory_self_test()
 
 	return ret;
 }
+#endif
 
 /*
   deliberately trigger an error in the sensor to trigger recovery

--- a/src/drivers/imu/mpu6000/MPU6000.hpp
+++ b/src/drivers/imu/mpu6000/MPU6000.hpp
@@ -317,12 +317,14 @@ public:
 
 	void			print_registers();
 
+#ifndef CONSTRAINED_FLASH
 	/**
 	 * Test behaviour against factory offsets
 	 *
 	 * @return 0 on success, 1 on failure
 	 */
 	int 			factory_self_test();
+#endif
 
 	// deliberately cause a sensor error
 	void 			test_error();

--- a/src/drivers/imu/mpu6000/mpu6000_main.cpp
+++ b/src/drivers/imu/mpu6000/mpu6000_main.cpp
@@ -104,7 +104,9 @@ void	reset(enum MPU6000_BUS busid);
 void	info(enum MPU6000_BUS busid);
 void	regdump(enum MPU6000_BUS busid);
 void	testerror(enum MPU6000_BUS busid);
+#ifndef CONSTRAINED_FLASH
 void	factorytest(enum MPU6000_BUS busid);
+#endif
 void	usage();
 
 /**
@@ -293,6 +295,7 @@ testerror(enum MPU6000_BUS busid)
 	exit(0);
 }
 
+#ifndef CONSTRAINED_FLASH
 /**
  * Dump the register information
  */
@@ -310,11 +313,16 @@ factorytest(enum MPU6000_BUS busid)
 
 	exit(0);
 }
+#endif
 
 void
 usage()
 {
-	warnx("missing command: try 'start', 'info', 'stop',\n'reset', 'regdump', 'factorytest', 'testerror'");
+	warnx("missing command: try 'start', 'info', 'stop',\n'reset', 'regdump', 'testerror'"
+#ifndef CONSTRAINED_FLASH
+	      ", 'factorytest'"
+#endif
+	     );
 	warnx("options:");
 	warnx("    -X external I2C bus");
 	warnx("    -I internal I2C bus");
@@ -421,9 +429,13 @@ mpu6000_main(int argc, char *argv[])
 		mpu6000::regdump(busid);
 	}
 
+#ifndef CONSTRAINED_FLASH
+
 	if (!strcmp(verb, "factorytest")) {
 		mpu6000::factorytest(busid);
 	}
+
+#endif
 
 	if (!strcmp(verb, "testerror")) {
 		mpu6000::testerror(busid);


### PR DESCRIPTION
My assumption is that this is not used or needed and we can remove it to save some flash space.

```
     VM SIZE    
 -------------- 
  [ = ]       0    [Unmapped]
  [ = ]       0    [section .debug_abbrev]
  [ = ]       0    [section .debug_aranges]
  [ = ]       0    [section .debug_frame]
  [ = ]       0    [section .debug_info]
  [ = ]       0    [section .debug_line]
  [ = ]       0    [section .debug_loc]
  [ = ]       0    [section .debug_ranges]
  [ = ]       0    [section .debug_str]
  -6.0%     -20    mpu6000_main
  [DEL]     -44    mpu6000::factorytest()
  -0.1%     -64    [section .text]
  [DEL] -1.20Ki    MPU6000::factory_self_test()
  -0.1% -1.33Ki    TOTAL
```
