### PR TITLE
Handle MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN 'Do nothing for autopilot'

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3406,6 +3406,12 @@ void *commander_low_prio_loop(void *arg)
 			switch (cmd.command) {
 
 			case vehicle_command_s::VEHICLE_CMD_PREFLIGHT_REBOOT_SHUTDOWN:
+				if (((int)(cmd.param1)) == 0) {
+					answer_command(cmd, vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED, command_ack_pub);
+					/* do nothing for autopilot */
+					break;
+				}
+
 				if (is_safe(safety, armed)) {
 
 					if (((int)(cmd.param1)) == 1) {


### PR DESCRIPTION
**Describe problem solved by this pull request**
I was using MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN to signal an onboard computer to shutdown and for the PX4 autopilot to "do nothing." This is specified by setting param1=0 and param2=2 in the command, but PX4 does not explicitly handle the case of param1=0, which causes PX4 to incorrectly respond with DENIED. My changes cause PX4 to respond with ACCEPTED instead.

**Describe your solution**
When param1=0, respond with ACCEPTED and do nothing else.

**Test data / coverage**
The problem is reproducible using a custom QGC widget. I used a widget which includes the following:

```
QGCButton {
text: "Shutdown Onboard Computer"
// Arguments to CustomCommandWidgetController::sendCommand (MAVLink COMMAND_LONG)
// command id MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN (246) https://mavlink.io/en/messages/common.html#MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN
// target_component id = 0 (MAV_COMP_ID_ALL)
// confirmation
// param 1 - 7
onClicked: controller.sendCommand(246, 0, 0, 0, 2, 0, 0, 0, 0, 0)
}
```

Here is a screenshot of what would happen before the changes:

![Screenshot from 2019-10-18 09-55-21](https://user-images.githubusercontent.com/1399452/67100382-8d035780-f18d-11e9-84cb-67ade3972570.png)

Notice the critical notification near the top of the QGC window. With the code changes, the critical notification no longer appears at the top of the QGC window.

