### PR TITLE
microRTPS: templates: only decode ros2_distro when possible and nedeed

### DIFF
--- a/msg/templates/urtps/Publisher.cpp.em
+++ b/msg/templates/urtps/Publisher.cpp.em
@@ -16,7 +16,10 @@ import gencpp
 from px_generate_uorb_topic_helper import * # this is in Tools/
 
 topic = alias if alias else spec.short_name
-ros2_distro = ros2_distro.decode("utf-8")
+try:
+    ros2_distro = ros2_distro.decode("utf-8")
+except AttributeError:
+    pass
 }@
 /****************************************************************************
  *
@@ -57,6 +60,7 @@ ros2_distro = ros2_distro.decode("utf-8")
  *
  * This file was adapted from the fastcdrgen tool.
  */
+
 
 #include <fastrtps/participant/Participant.h>
 #include <fastrtps/attributes/ParticipantAttributes.h>

--- a/msg/templates/urtps/Publisher.h.em
+++ b/msg/templates/urtps/Publisher.h.em
@@ -16,7 +16,10 @@ import gencpp
 from px_generate_uorb_topic_helper import * # this is in Tools/
 
 topic = alias if alias else spec.short_name
-ros2_distro = ros2_distro.decode("utf-8")
+try:
+    ros2_distro = ros2_distro.decode("utf-8")
+except AttributeError:
+    pass
 }@
 /****************************************************************************
  *

--- a/msg/templates/urtps/RtpsTopics.cpp.em
+++ b/msg/templates/urtps/RtpsTopics.cpp.em
@@ -21,7 +21,10 @@ send_topics = [(alias[idx] if alias[idx] else s.short_name) for idx, s in enumer
 recv_topics = [(alias[idx] if alias[idx] else s.short_name) for idx, s in enumerate(spec) if scope[idx] == MsgScope.RECEIVE]
 package = package[0]
 fastrtpsgen_version = fastrtpsgen_version[0]
-ros2_distro = ros2_distro[0].decode("utf-8")
+try:
+    ros2_distro = ros2_distro[0].decode("utf-8")
+except AttributeError:
+    ros2_distro = ros2_distro[0]
 }@
 /****************************************************************************
  *

--- a/msg/templates/urtps/Subscriber.cpp.em
+++ b/msg/templates/urtps/Subscriber.cpp.em
@@ -16,7 +16,10 @@ import gencpp
 from px_generate_uorb_topic_helper import * # this is in Tools/
 
 topic = alias if alias else spec.short_name
-ros2_distro = ros2_distro.decode("utf-8")
+try:
+    ros2_distro = ros2_distro.decode("utf-8")
+except AttributeError:
+    pass
 }@
 /****************************************************************************
  *

--- a/msg/templates/urtps/Subscriber.h.em
+++ b/msg/templates/urtps/Subscriber.h.em
@@ -16,7 +16,10 @@ import gencpp
 from px_generate_uorb_topic_helper import * # this is in Tools/
 
 topic = alias if alias else spec.short_name
-ros2_distro = ros2_distro.decode("utf-8")
+try:
+    ros2_distro = ros2_distro.decode("utf-8")
+except AttributeError:
+    pass
 }@
 /****************************************************************************
  *


### PR DESCRIPTION
Aims to fix http://ci.px4.io:8080/blue/organizations/jenkins/PX4%2Fcontainers/detail/PR-205/2/pipeline/#step-78-log-252. Seems to be something only present in Python 3.7.