### PR TITLE
generate_listener.py don't use message length

### DIFF
--- a/src/systemcmds/topic_listener/generate_listener.py
+++ b/src/systemcmds/topic_listener/generate_listener.py
@@ -119,9 +119,9 @@ print("""
 
 for index, (m, t) in enumerate(zip(messages, topics)):
 	if index == 0:
-		print("\tif (strncmp(topic_name,\"%s\", %d) == 0) {" % (t, len(t)))
+		print("\tif (strcmp(topic_name,\"%s\") == 0) {" % (t))
 	else:
-		print("\t} else if (strncmp(topic_name,\"%s\", %d) == 0) {" % (t, len(t)))
+		print("\t} else if (strcmp(topic_name,\"%s\") == 0) {" % (t))
 	print("\t\tlistener(listener_print_topic<%s_s>, ORB_ID(%s), num_msgs, topic_instance, topic_interval);" % (m, t))
 
 print("\t} else {")


### PR DESCRIPTION
In current master things like `listener actuator_controls_0` aren't working because it's matching with actuator_controls first.