### PR TITLE
Retune SITL model typhoon h480

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/6011_typhoon_h480
+++ b/ROMFS/px4fmu_common/init.d-posix/6011_typhoon_h480
@@ -10,7 +10,11 @@ sh /etc/init.d/rc.mc_defaults
 if [ $AUTOCNF = yes ]
 then
 	param set MC_PITCHRATE_P 0.1
-	param set MC_ROLLRATE_P 0.05
+	param set MC_PITCHRATE_I 0.05
+	param set MC_PITCH 6.0
+	param set MC_ROLLRATE_P 0.15
+	param set MC_ROLLRATE_I 0.1
+	param set MC_ROLL 6.0
 	param set MPC_XY_VEL_I 0.2
 	param set MPC_XY_VEL_P 0.15
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
This Fixes #13163 where the typhoon_480 was showing oscillations is forward flight in SITL

**Describe your solution**
These are the retuned values of the typhoon h480 coming from the suggestion of @dayjaby

**Test data / coverage**
Log: https://review.px4.io/plot_app?log=7d5eae16-1c0e-4c42-8912-b9176f4d27e6
