### PR TITLE
ATTITUDE_QUATERNION: fill repr_offset_q for tailsitters

### DIFF
--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -71,6 +71,7 @@ uint8 vehicle_type          # Type of vehicle (fixed-wing, rotary wing, ground)
                             # and VEHICLE_TYPE_FIXED_WING when flying as a fixed-wing
 
 bool is_vtol				# True if the system is VTOL capable
+bool is_vtol_tailsitter                 # True if the system performs a 90° pitch down rotation during transition from MC to FW
 bool vtol_fw_permanent_stab		# True if VTOL should stabilize attitude for fw in manual mode
 bool in_transition_mode			# True if VTOL is doing a transition
 bool in_transition_to_fw		# True if VTOL is doing a transition from MC to FW

--- a/src/lib/conversion/rotation.cpp
+++ b/src/lib/conversion/rotation.cpp
@@ -50,6 +50,15 @@ get_rot_matrix(enum Rotation rot)
 			math::radians((float)rot_lookup[rot].yaw)}};
 }
 
+__EXPORT matrix::Quatf
+get_rot_quaternion(enum Rotation rot)
+{
+	return matrix::Quatf{matrix::Eulerf{
+			math::radians((float)rot_lookup[rot].roll),
+			math::radians((float)rot_lookup[rot].pitch),
+			math::radians((float)rot_lookup[rot].yaw)}};
+}
+
 __EXPORT void
 rotate_3f(enum Rotation rot, float &x, float &y, float &z)
 {

--- a/src/lib/conversion/rotation.h
+++ b/src/lib/conversion/rotation.h
@@ -136,8 +136,14 @@ const rot_lookup_t rot_lookup[] = {
 /**
  * Get the rotation matrix
  */
+__EXPORT matrix::Dcmf
+get_rot_matrix(enum Rotation rot);
 
-__EXPORT matrix::Dcmf get_rot_matrix(enum Rotation rot);
+/**
+ * Get the rotation quaternion
+ */
+__EXPORT matrix::Quatf
+get_rot_quaternion(enum Rotation rot);
 
 /**
  * rotate a 3 element float vector in-place

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1378,6 +1378,7 @@ Commander::run()
 	}
 
 	status.is_vtol = is_vtol(&status);
+	status.is_vtol_tailsitter = is_vtol_tailsitter(&status);
 
 	commander_boot_timestamp = hrt_absolute_time();
 
@@ -1498,6 +1499,7 @@ Commander::run()
 
 				/* set vehicle_status.is_vtol flag */
 				status.is_vtol = is_vtol(&status);
+				status.is_vtol_tailsitter = is_vtol_tailsitter(&status);
 
 				/* check and update system / component ID */
 				int32_t sys_id = 0;

--- a/src/modules/commander/commander_helper.cpp
+++ b/src/modules/commander/commander_helper.cpp
@@ -110,6 +110,12 @@ bool is_vtol(const struct vehicle_status_s *current_status)
 		current_status->system_type == VEHICLE_TYPE_VTOL_RESERVED5);
 }
 
+bool is_vtol_tailsitter(const struct vehicle_status_s *current_status)
+{
+	return (current_status->system_type == VEHICLE_TYPE_VTOL_DUOROTOR ||
+		current_status->system_type == VEHICLE_TYPE_VTOL_QUADROTOR);
+}
+
 bool is_fixed_wing(const struct vehicle_status_s *current_status)
 {
 	return current_status->system_type == VEHICLE_TYPE_FIXED_WING;

--- a/src/modules/commander/commander_helper.h
+++ b/src/modules/commander/commander_helper.h
@@ -53,6 +53,7 @@
 bool is_multirotor(const struct vehicle_status_s *current_status);
 bool is_rotary_wing(const struct vehicle_status_s *current_status);
 bool is_vtol(const struct vehicle_status_s *current_status);
+bool is_vtol_tailsitter(const struct vehicle_status_s *current_status);
 bool is_fixed_wing(const struct vehicle_status_s *current_status);
 bool is_ground_rover(const struct vehicle_status_s *current_status);
 


### PR DESCRIPTION
This is a follow up for the MAVLink update https://github.com/mavlink/mavlink/pull/1247.

A new field `repr_offset_q` was added to the message ATTITUDE_QUATERNION to indicate that the attitude have to be rotated before it is displayed to the user.

This is useful for example for tailsitters, which rotate their reference frame by 90 between hover mode and fixed wing mode. This leads to discontinuities in the euler representation (see screenshots in the MAVLink PR).
With this new field, a correct attitude can be displayed in QGC in both modes.

fixes #10405
partially fixes #9179