### PR TITLE
mixer_module: add clockwise motor numbering configuration

### DIFF
--- a/src/lib/mixer_module/mixer_module.cpp
+++ b/src/lib/mixer_module/mixer_module.cpp
@@ -439,6 +439,18 @@ MixingOutput::reorderOutputs(uint16_t values[MAX_ACTUATORS])
 		values[1] = value_tmp[0];
 		values[2] = value_tmp[1];
 		values[3] = value_tmp[2];
+
+	} else if ((MotorOrdering)_param_mot_ordering.get() == MotorOrdering::CW) {
+		/*
+		 * Clock-wise motor ordering:
+		 * 4     1
+		 *    ^
+		 * 3     2
+		 */
+		const uint16_t value_tmp[4] = {values[0], values[1], values[2], values[3] };
+		values[1] = value_tmp[3];
+		values[2] = value_tmp[1];
+		values[3] = value_tmp[2];
 	}
 
 	/* else: PX4, no need to reorder
@@ -459,6 +471,17 @@ int MixingOutput::reorderedMotorIndex(int index) const
 		case 2: return 3;
 
 		case 3: return 0;
+		}
+
+	} else if ((MotorOrdering)_param_mot_ordering.get() == MotorOrdering::CW) {
+		switch (index) {
+		case 0: return 0;
+
+		case 1: return 2;
+
+		case 2: return 3;
+
+		case 3: return 1;
 		}
 	}
 

--- a/src/lib/mixer_module/mixer_module.hpp
+++ b/src/lib/mixer_module/mixer_module.hpp
@@ -200,7 +200,8 @@ private:
 
 	enum class MotorOrdering : int32_t {
 		PX4 = 0,
-		Betaflight = 1
+		Betaflight = 1,
+		CW = 2
 	};
 
 	struct Command {

--- a/src/systemcmds/motor_test/motor_test.cpp
+++ b/src/systemcmds/motor_test/motor_test.cpp
@@ -67,7 +67,7 @@ void motor_test(unsigned channel, float value, uint8_t driver_instance)
 		PX4_INFO("motors stop command sent");
 
 	} else {
-		PX4_INFO("motor %d set to %.2f", channel, (double)value);
+		PX4_INFO("motor %d set to %.2f", channel + 1, (double)value);
 	}
 }
 
@@ -88,7 +88,7 @@ Note: this can only be used for drivers which support the motor_test uorb topic 
 
 	PRINT_MODULE_USAGE_NAME("motor_test", "command");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("test", "Set motor(s) to a specific output value");
-	PRINT_MODULE_USAGE_PARAM_INT('m', -1, 0, 7, "Motor to test (0...7, all if not specified)", true);
+	PRINT_MODULE_USAGE_PARAM_INT('m', -1, 1, 8, "Motor to test (1...8, all if not specified)", true);
 	PRINT_MODULE_USAGE_PARAM_INT('p', 0, 0, 100, "Power (0...100)", true);
 	PRINT_MODULE_USAGE_PARAM_INT('i', 0, 0, 4, "driver instance", true);
 	PRINT_MODULE_USAGE_COMMAND_DESCR("stop", "Stop all motors");
@@ -117,6 +117,12 @@ int motor_test_main(int argc, char *argv[])
 		case 'm':
 			/* Read in motor number */
 			channel = (int)strtol(myoptarg, NULL, 0);
+
+			if (channel < 1 || channel > 8) {
+				usage("value invalid");
+				return 1;
+			}
+			channel = channel -1;
 			break;
 
 		case 'p':


### PR DESCRIPTION
This PR adds support to vehicles / 4in1 ESCs that have clock-wise motor ordering:
4     1
3     2

To enable this configuration `MOT_ORDERING` needs to be set to 2. 

To be consistent with PX4 documentation, motor_test numbering has also been unified to 1..8 instead of 0..7.


**Test data / coverage**
Tested on a vehicle (pixhawk4) where motors were wired accordingly the clock-wise convention.
