### PR TITLE
Organize CM8JL65 #includes and add rangefinder dependency to the CMakeList

### DIFF
--- a/src/drivers/distance_sensor/cm8jl65/CM8JL65.hpp
+++ b/src/drivers/distance_sensor/cm8jl65/CM8JL65.hpp
@@ -43,13 +43,14 @@
 
 #pragma once
 
+#include <termios.h>
+
+#include <drivers/drv_hrt.h>
+#include <drivers/rangefinder/PX4Rangefinder.hpp>
+#include <perf/perf_counter.h>
 #include <px4_config.h>
 #include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
-#include <drivers/drv_hrt.h>
-#include <lib/perf/perf_counter.h>
-#include <lib/drivers/rangefinder/PX4Rangefinder.hpp>
 
-#include <termios.h>
 
 using namespace time_literals;
 

--- a/src/drivers/distance_sensor/cm8jl65/CMakeLists.txt
+++ b/src/drivers/distance_sensor/cm8jl65/CMakeLists.txt
@@ -39,4 +39,6 @@ px4_add_module(
 		cm8jl65_main.cpp
 	MODULE_CONFIG
 		module.yaml
+	DEPENDS
+		drivers_rangefinder
 	)


### PR DESCRIPTION
**Describe problem solved by this pull request**
This PR solves issue #13250 by adding the proper dependency in the CMakeLists.txt file and organizes the #includes a little bit.

**Test data / coverage**
Issue #13250 is a build issue, it is easily reproducible/verifiable by simply adding `distance_sensor/cm8jl65` to the px4_fmu-v2 `default.cmake` file and compiling the code.

**Additional context**
See also #13250.  @jordancoult, this should solve your issue.

Please let me know if you have any questions on this PR!
