### PR TITLE
Position Control Refactoring Part 3

### DIFF
--- a/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018 - 2019 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -349,6 +349,20 @@ void PositionControl::updateConstraints(const vehicle_constraints_s &constraints
 	if (!PX4_ISFINITE(constraints.speed_xy) || !(constraints.speed_xy < _param_mpc_xy_vel_max.get())) {
 		_constraints.speed_xy = _param_mpc_xy_vel_max.get();
 	}
+}
+
+void PositionControl::getLocalPositionSetpoint(vehicle_local_position_setpoint_s &local_position_setpoint)
+{
+	local_position_setpoint.x = _pos_sp(0);
+	local_position_setpoint.y = _pos_sp(1);
+	local_position_setpoint.z = _pos_sp(2);
+	local_position_setpoint.yaw = _yaw_sp;
+	local_position_setpoint.yawspeed = _yawspeed_sp;
+	local_position_setpoint.vx = _vel_sp(0);
+	local_position_setpoint.vy = _vel_sp(1);
+	local_position_setpoint.vz = _vel_sp(2);
+	_acc_sp.copyTo(local_position_setpoint.acceleration);
+	_thr_sp.copyTo(local_position_setpoint.thrust);
 }
 
 void PositionControl::updateParams()

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
@@ -351,7 +351,7 @@ void PositionControl::updateConstraints(const vehicle_constraints_s &constraints
 	}
 }
 
-void PositionControl::getLocalPositionSetpoint(vehicle_local_position_setpoint_s &local_position_setpoint)
+void PositionControl::getLocalPositionSetpoint(vehicle_local_position_setpoint_s &local_position_setpoint) const
 {
 	local_position_setpoint.x = _pos_sp(0);
 	local_position_setpoint.y = _pos_sp(1);
@@ -365,7 +365,7 @@ void PositionControl::getLocalPositionSetpoint(vehicle_local_position_setpoint_s
 	_thr_sp.copyTo(local_position_setpoint.thrust);
 }
 
-void PositionControl::getAttitudeSetpoint(vehicle_attitude_setpoint_s &attitude_setpoint)
+void PositionControl::getAttitudeSetpoint(vehicle_attitude_setpoint_s &attitude_setpoint) const
 {
 	attitude_setpoint = ControlMath::thrustToAttitude(_thr_sp, _yaw_sp);
 	attitude_setpoint.yaw_sp_move_rate = _yawspeed_sp;

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
@@ -365,6 +365,12 @@ void PositionControl::getLocalPositionSetpoint(vehicle_local_position_setpoint_s
 	_thr_sp.copyTo(local_position_setpoint.thrust);
 }
 
+void PositionControl::getAttitudeSetpoint(vehicle_attitude_setpoint_s &attitude_setpoint)
+{
+	attitude_setpoint = ControlMath::thrustToAttitude(_thr_sp, _yaw_sp);
+	attitude_setpoint.yaw_sp_move_rate = _yawspeed_sp;
+}
+
 void PositionControl::updateParams()
 {
 	ModuleParams::updateParams();

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
@@ -130,20 +130,6 @@ public:
 
 	/**
 	 * 	Get the
-	 * 	@see _thr_sp
-	 * 	@return The thrust set-point member.
-	 */
-	const matrix::Vector3f &getThrustSetpoint() { return _thr_sp; }
-
-	/**
-	 * 	Get the
-	 * 	@see _yaw_sp
-	 * 	@return The yaw set-point member.
-	 */
-	const float &getYawSetpoint() { return _yaw_sp; }
-
-	/**
-	 * 	Get the
 	 * 	@see _yawspeed_sp
 	 * 	@return The yawspeed set-point member.
 	 */
@@ -171,25 +157,12 @@ public:
 	}
 
 	/**
-	 * 	Get the
-	 * 	@see _pos_sp
-	 * 	@return The position set-point that was executed in the control-loop. Nan if the position control-loop was skipped.
+	 * Get the controllers output local position setpoint
+	 * These setpoints are the ones which were executed on including PID output and feed-forward.
+	 * The acceleration or thrust setpoints can be used for attitude control.
+	 * @param local_position_setpoint reference to struct to fill up
 	 */
-	const matrix::Vector3f getPosSp()
-	{
-		matrix::Vector3f pos_sp{};
-
-		for (int i = 0; i <= 2; i++) {
-			if (_ctrl_pos[i]) {
-				pos_sp(i) = _pos_sp(i);
-
-			} else {
-				pos_sp(i) = NAN;
-			}
-		}
-
-		return pos_sp;
-	}
+	void getLocalPositionSetpoint(vehicle_local_position_setpoint_s &local_position_setpoint);
 
 protected:
 

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
@@ -134,7 +134,7 @@ public:
 	 * 	@see _vel_sp
 	 * 	@return The velocity set-point that was executed in the control-loop. Nan if velocity control-loop was skipped.
 	 */
-	const matrix::Vector3f getVelSp()
+	const matrix::Vector3f getVelSp() const
 	{
 		matrix::Vector3f vel_sp{};
 
@@ -156,7 +156,7 @@ public:
 	 * The acceleration or thrust setpoints can be used for attitude control.
 	 * @param local_position_setpoint reference to struct to fill up
 	 */
-	void getLocalPositionSetpoint(vehicle_local_position_setpoint_s &local_position_setpoint);
+	void getLocalPositionSetpoint(vehicle_local_position_setpoint_s &local_position_setpoint) const;
 
 	/**
 	 * Get the controllers output attitude setpoint
@@ -164,7 +164,7 @@ public:
 	 * It needs to be executed by the attitude controller to achieve velocity and position tracking.
 	 * @param attitude_setpoint reference to struct to fill up
 	 */
-	void getAttitudeSetpoint(vehicle_attitude_setpoint_s &attitude_setpoint);
+	void getAttitudeSetpoint(vehicle_attitude_setpoint_s &attitude_setpoint) const;
 
 protected:
 

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018 - 2019 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,6 +39,7 @@
 
 #include <matrix/matrix/math.hpp>
 
+#include <uORB/topics/vehicle_attitude_setpoint.h>
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_local_position_setpoint.h>
 #include <uORB/topics/vehicle_constraints.h>
@@ -130,13 +131,6 @@ public:
 
 	/**
 	 * 	Get the
-	 * 	@see _yawspeed_sp
-	 * 	@return The yawspeed set-point member.
-	 */
-	const float &getYawspeedSetpoint() { return _yawspeed_sp; }
-
-	/**
-	 * 	Get the
 	 * 	@see _vel_sp
 	 * 	@return The velocity set-point that was executed in the control-loop. Nan if velocity control-loop was skipped.
 	 */
@@ -163,6 +157,14 @@ public:
 	 * @param local_position_setpoint reference to struct to fill up
 	 */
 	void getLocalPositionSetpoint(vehicle_local_position_setpoint_s &local_position_setpoint);
+
+	/**
+	 * Get the controllers output attitude setpoint
+	 * This attitude setpoint was generated from the resulting acceleration setpoint after position and velocity control.
+	 * It needs to be executed by the attitude controller to achieve velocity and position tracking.
+	 * @param attitude_setpoint reference to struct to fill up
+	 */
+	void getAttitudeSetpoint(vehicle_attitude_setpoint_s &attitude_setpoint);
 
 protected:
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -68,7 +68,6 @@
 #include <uORB/topics/vehicle_trajectory_waypoint.h>
 
 #include <PositionControl.hpp>
-#include <ControlMath.hpp>
 #include "Takeoff.hpp"
 
 #include <float.h>
@@ -689,12 +688,10 @@ MulticopterPositionControl::Run()
 				limit_thrust_during_landing(local_pos_sp);
 			}
 
-			// Fill attitude setpoint. Attitude is computed from yaw and thrust setpoint.
 			vehicle_attitude_setpoint_s attitude_setpoint{};
-			attitude_setpoint = ControlMath::thrustToAttitude(matrix::Vector3f(local_pos_sp.thrust), local_pos_sp.yaw);
-			attitude_setpoint.yaw_sp_move_rate = _control.getYawspeedSetpoint();
-			attitude_setpoint.fw_control_yaw = false;
-			attitude_setpoint.apply_flaps = false;
+			attitude_setpoint.timestamp = hrt_absolute_time();
+			_control.getAttitudeSetpoint(attitude_setpoint);
+
 
 			// publish attitude setpoint
 			// Note: this requires review. The reason for not sending

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -668,15 +668,10 @@ MulticopterPositionControl::Run()
 			// PositionController.
 			vehicle_local_position_setpoint_s local_pos_sp{};
 			local_pos_sp.timestamp = hrt_absolute_time();
-			local_pos_sp.x = setpoint.x;
-			local_pos_sp.y = setpoint.y;
-			local_pos_sp.z = setpoint.z;
-			local_pos_sp.yaw = _control.getYawSetpoint();
-			local_pos_sp.yawspeed = _control.getYawspeedSetpoint();
+			_control.getLocalPositionSetpoint(local_pos_sp);
 			local_pos_sp.vx = PX4_ISFINITE(_control.getVelSp()(0)) ? _control.getVelSp()(0) : setpoint.vx;
 			local_pos_sp.vy = PX4_ISFINITE(_control.getVelSp()(1)) ? _control.getVelSp()(1) : setpoint.vy;
 			local_pos_sp.vz = PX4_ISFINITE(_control.getVelSp()(2)) ? _control.getVelSp()(2) : setpoint.vz;
-			_control.getThrustSetpoint().copyTo(local_pos_sp.thrust);
 
 			// Publish local position setpoint
 			// This message will be used by other modules (such as Landdetector) to determine


### PR DESCRIPTION
**Describe problem solved by this pull request**
This is part 3 of the refactoring from the monster pr #12072 and should be easy to understand and review since the diff is manageable.

**Describe your solution**
- Updated year in license of PositionControl
- Move filling the executed `vehicle_local_position_setpoint` for logging inside a getter of the PositionControl class
- Move filling the output `vehicle_attitude_setpoint` for execution by attitude control inside getter of the PositionControl class
- Remove all the getters for all independent member variables of `PositionControl`

**Test data / coverage**
SITL hover goto tested.

**Additional context**
Part 2 that goes before this: #13248
