### PR TITLE
Fix typhoon h480 parameter for SITL

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/6011_typhoon_h480
+++ b/ROMFS/px4fmu_common/init.d-posix/6011_typhoon_h480
@@ -11,10 +11,10 @@ if [ $AUTOCNF = yes ]
 then
 	param set MC_PITCHRATE_P 0.1
 	param set MC_PITCHRATE_I 0.05
-	param set MC_PITCH 6.0
+	param set MC_PITCH_P 6.0
 	param set MC_ROLLRATE_P 0.15
 	param set MC_ROLLRATE_I 0.1
-	param set MC_ROLL 6.0
+	param set MC_ROLL_P 6.0
 	param set MPC_XY_VEL_I 0.2
 	param set MPC_XY_VEL_P 0.15
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
There was a typo in the parameter settings of the typhoon h480 SITL model that was merged in https://github.com/PX4/Firmware/pull/13246

This was a mistake on my side where I didn't check properly what I had put in the parameter files.

**Test data / coverage**
Tested with the correct parameter in the [log](https://review.px4.io/plot_app?log=5b9b796b-e174-41bc-ba33-51ae1a4e9798)

