### PR TITLE
mission: ensure precland::on_inactivation() is called once landed

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -174,6 +174,17 @@ Mission::on_activation()
 void
 Mission::on_active()
 {
+	if (_work_item_type == WORK_ITEM_TYPE_PRECISION_LAND) {
+		// switch out of precision land once landed
+		if (_navigator->get_land_detected()->landed) {
+			_navigator->get_precland()->on_inactivation();
+			_work_item_type = WORK_ITEM_TYPE_DEFAULT;
+
+		} else {
+			_navigator->get_precland()->on_active();
+		}
+	}
+
 	check_mission_valid(false);
 
 	/* check if anything has changed */
@@ -262,17 +273,6 @@ Mission::on_active()
 	    && (_navigator->abort_landing())) {
 
 		do_abort_landing();
-	}
-
-	if (_work_item_type == WORK_ITEM_TYPE_PRECISION_LAND) {
-		// switch out of precision land once landed
-		if (_navigator->get_land_detected()->landed) {
-			_navigator->get_precland()->on_inactivation();
-			_work_item_type = WORK_ITEM_TYPE_DEFAULT;
-
-		} else {
-			_navigator->get_precland()->on_active();
-		}
 	}
 }
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
When the drone lands after the precision landing part of the mission, `_navigator->get_precland()->on_inactivation()` is not called. This is because before that call, mission item reached check passes and the `set_mission_items()` sets the `_work_item_type` to `WORK_ITEM_TYPE_DEFAULT` and the following precision landing logic is not entered:

```
if (_work_item_type == WORK_ITEM_TYPE_PRECISION_LAND) {
// switch out of precision land once landed
if (_navigator->get_land_detected()->landed) {
_navigator->get_precland()->on_inactivation();
_work_item_type = WORK_ITEM_TYPE_DEFAULT;

} else {
_navigator->get_precland()->on_active();
}
}
```

Note: Currently the `on_inactivation()` is not used in precision landing, so this bug was hidden. This fix is thus just fixing the wrong logic, and preventing potential future problems if this function gets used, otherwise it should not effect the current functionality in any way.

**Describe your solution**
I just moved the precision landing logic to be processed before setting the new mission item.

**Test data / coverage**
I checked that `on_inactivation()` is being called when landing is completed.

