### PR TITLE
Move `set PWM_OUT 1234` and `set MIXER quad_x` from individual multicopter airframe files to `rc.mc_defaults`.

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4001_quad_x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4001_quad_x
@@ -21,7 +21,3 @@
 #
 
 sh /etc/init.d/rc.mc_defaults
-
-set MIXER quad_x
-
-set PWM_OUT 1234

--- a/ROMFS/px4fmu_common/init.d/airframes/4002_quad_x_mount
+++ b/ROMFS/px4fmu_common/init.d/airframes/4002_quad_x_mount
@@ -27,8 +27,5 @@ then
 	param set PWM_AUX_RATE 50
 fi
 
-set MIXER quad_x
-set PWM_OUT 1234
-
 set MIXER_AUX mount
 set PWM_AUX_OUT 123456

--- a/ROMFS/px4fmu_common/init.d/airframes/4003_qavr5
+++ b/ROMFS/px4fmu_common/init.d/airframes/4003_qavr5
@@ -12,9 +12,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	param set MC_ROLL_P 8

--- a/ROMFS/px4fmu_common/init.d/airframes/4004_H4_680mm
+++ b/ROMFS/px4fmu_common/init.d/airframes/4004_H4_680mm
@@ -10,12 +10,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
-
-set MIXER_AUX mount
-set PWM_AUX_OUT 123456
-
 # The Z1 Tiny2 can handle up to 400Hz
 # and works with min 1020us, middle 1520us, max 2020us
 # see http://www.zhiyun-tech.com/uploadfile/datedown/instruction/Tiny2_English_instructionV1.03.pdf
@@ -28,6 +22,9 @@ then
 	param set PWM_AUX_MAX 2020
 	param set PWM_AUX_RATE 400
 fi
+
+set MIXER_AUX mount
+set PWM_AUX_OUT 123456
 
 # Start FrSky telemetry on SERIAL4 (ttyS6, designated "SERIAL4/5" on the case)
 frsky_telemetry start -d /dev/ttyS6

--- a/ROMFS/px4fmu_common/init.d/airframes/4009_qav250
+++ b/ROMFS/px4fmu_common/init.d/airframes/4009_qav250
@@ -10,9 +10,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	param set ATT_BIAS_MAX 0

--- a/ROMFS/px4fmu_common/init.d/airframes/4010_dji_f330
+++ b/ROMFS/px4fmu_common/init.d/airframes/4010_dji_f330
@@ -10,9 +10,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	param set MC_ROLL_P 7

--- a/ROMFS/px4fmu_common/init.d/airframes/4011_dji_f450
+++ b/ROMFS/px4fmu_common/init.d/airframes/4011_dji_f450
@@ -10,9 +10,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	param set MC_ROLL_P 7

--- a/ROMFS/px4fmu_common/init.d/airframes/4012_quad_x_can
+++ b/ROMFS/px4fmu_common/init.d/airframes/4012_quad_x_can
@@ -10,9 +10,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	param set MC_ROLL_P 7

--- a/ROMFS/px4fmu_common/init.d/airframes/4013_bebop
+++ b/ROMFS/px4fmu_common/init.d/airframes/4013_bebop
@@ -38,6 +38,7 @@ then
 	param set MC_YAWRATE_D 0
 fi
 
-set OUTPUT_MODE bebop
-set USE_IO no
 set MIXER bebop
+set OUTPUT_MODE bebop
+set PWM_OUT none
+set USE_IO no

--- a/ROMFS/px4fmu_common/init.d/airframes/4014_s500
+++ b/ROMFS/px4fmu_common/init.d/airframes/4014_s500
@@ -10,9 +10,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	param set MC_ROLLRATE_P 0.18

--- a/ROMFS/px4fmu_common/init.d/airframes/4015_holybro_s500
+++ b/ROMFS/px4fmu_common/init.d/airframes/4015_holybro_s500
@@ -10,9 +10,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	param set IMU_GYRO_CUTOFF 80

--- a/ROMFS/px4fmu_common/init.d/airframes/4020_hk_micro_pcb
+++ b/ROMFS/px4fmu_common/init.d/airframes/4020_hk_micro_pcb
@@ -18,9 +18,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	param set MC_ROLL_P 7

--- a/ROMFS/px4fmu_common/init.d/airframes/4030_3dr_solo
+++ b/ROMFS/px4fmu_common/init.d/airframes/4030_3dr_solo
@@ -87,8 +87,4 @@ then
 	param set SER_TEL1_BAUD 921600
 fi
 
-set MIXER quad_x
-
-set PWM_OUT 1234
 set MIXER_AUX none
-

--- a/ROMFS/px4fmu_common/init.d/airframes/4031_3dr_quad
+++ b/ROMFS/px4fmu_common/init.d/airframes/4031_3dr_quad
@@ -10,8 +10,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
 
 if [ $AUTOCNF = yes ]
 then

--- a/ROMFS/px4fmu_common/init.d/airframes/4040_reaper
+++ b/ROMFS/px4fmu_common/init.d/airframes/4040_reaper
@@ -42,9 +42,3 @@ then
 fi
 
 set MIXER quad_h
-
-set PWM_OUT 1234
-
-set MIXER_AUX pass
-
-set PWM_AUX_OUT 1234

--- a/ROMFS/px4fmu_common/init.d/airframes/4041_beta75x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4041_beta75x
@@ -62,5 +62,3 @@ fi
 
 # The Whoop uses reversed props
 set MIXER quad_h
-set PWM_OUT 1234
-

--- a/ROMFS/px4fmu_common/init.d/airframes/4050_generic_250
+++ b/ROMFS/px4fmu_common/init.d/airframes/4050_generic_250
@@ -10,9 +10,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	param set MC_ROLL_P 8

--- a/ROMFS/px4fmu_common/init.d/airframes/4051_s250aq
+++ b/ROMFS/px4fmu_common/init.d/airframes/4051_s250aq
@@ -21,11 +21,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_s250aq
-set MAV_TYPE 2
-
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	param set ATT_BIAS_MAX 0
@@ -61,3 +56,6 @@ then
 
 	param set PWM_MIN 1075
 fi
+
+set MAV_TYPE 2
+set MIXER quad_s250aq

--- a/ROMFS/px4fmu_common/init.d/airframes/4052_holybro_qav250
+++ b/ROMFS/px4fmu_common/init.d/airframes/4052_holybro_qav250
@@ -13,9 +13,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	# The set does not include a battery, but most people will probably use 4S
@@ -54,4 +51,3 @@ then
 	param set RC_FLT_CUTOFF 0
 	param set THR_MDL_FAC 0.3
 fi
-

--- a/ROMFS/px4fmu_common/init.d/airframes/4053_holybro_kopis2
+++ b/ROMFS/px4fmu_common/init.d/airframes/4053_holybro_kopis2
@@ -12,9 +12,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	param set BAT_N_CELLS 4
@@ -58,4 +55,3 @@ then
 
 	param set EV_TSK_RC_LOSS 1
 fi
-

--- a/ROMFS/px4fmu_common/init.d/airframes/4060_dji_matrice_100
+++ b/ROMFS/px4fmu_common/init.d/airframes/4060_dji_matrice_100
@@ -10,9 +10,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	param set BAT_N_CELLS 6

--- a/ROMFS/px4fmu_common/init.d/airframes/4070_aerofc
+++ b/ROMFS/px4fmu_common/init.d/airframes/4070_aerofc
@@ -77,6 +77,5 @@ then
   set OUTPUT_MODE tap_esc
 fi
 
-set MIXER quad_x
 set USE_IO no
 

--- a/ROMFS/px4fmu_common/init.d/airframes/4071_ifo
+++ b/ROMFS/px4fmu_common/init.d/airframes/4071_ifo
@@ -20,10 +20,6 @@
 # @maintainer Hyon Lim <lim@uvify.com>
 #
 
-set VEHICLE_TYPE mc
-set MIXER quad_x
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	# Attitude & rate gains
@@ -121,3 +117,7 @@ then
 	param set MAV_1_MODE 0	# normal
 	param set SER_TEL2_BAUD 57600
 fi
+
+set MIXER quad_x
+set PWM_OUT 1234
+set VEHICLE_TYPE mc

--- a/ROMFS/px4fmu_common/init.d/airframes/4072_draco
+++ b/ROMFS/px4fmu_common/init.d/airframes/4072_draco
@@ -20,10 +20,6 @@
 # @maintainer Hyon Lim <lim@uvify.com>
 #
 
-set VEHICLE_TYPE mc
-set MIXER quad_x
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	# Attitude & rate gains
@@ -117,3 +113,7 @@ then
 	# TELEM2 ttyS2
 	param set MAV_1_CONFIG 0
 fi
+
+set MIXER quad_x
+set PWM_OUT 1234
+set VEHICLE_TYPE mc

--- a/ROMFS/px4fmu_common/init.d/airframes/4080_zmr250
+++ b/ROMFS/px4fmu_common/init.d/airframes/4080_zmr250
@@ -13,9 +13,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER zmr250
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	param set CBRK_IO_SAFETY 22027
@@ -52,3 +49,5 @@ then
 	param set PWM_RATE 400
 	param set PWM_DISARMED 900
 fi
+
+set MIXER zmr250

--- a/ROMFS/px4fmu_common/init.d/airframes/4090_nanomind
+++ b/ROMFS/px4fmu_common/init.d/airframes/4090_nanomind
@@ -17,9 +17,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
-
 if [ $AUTOCNF = yes ]
 then
 	param set BAT_N_CELLS 1

--- a/ROMFS/px4fmu_common/init.d/airframes/4100_tiltquadrotor
+++ b/ROMFS/px4fmu_common/init.d/airframes/4100_tiltquadrotor
@@ -31,5 +31,3 @@ param set LED_RGB_MAXBRT 8
 # Set mixer
 set MIXER tilt_quad
 set MIXER_AUX tilt_quad
-
-set PWM_OUT 1234

--- a/ROMFS/px4fmu_common/init.d/airframes/4250_teal
+++ b/ROMFS/px4fmu_common/init.d/airframes/4250_teal
@@ -15,15 +15,8 @@
 # @output MAIN3 motor 3
 # @output MAIN4 motor 4
 #
-# @maintainer Jacob Dahl <jacob.dahl@tealdrones.com>
-#
-
-echo "Executing 4250_teal script."
 
 sh /etc/init.d/rc.mc_defaults
-
-set MIXER quad_x
-set PWM_OUT 1234
 
 if [ $AUTOCNF = yes ]
 then

--- a/ROMFS/px4fmu_common/init.d/airframes/4900_crazyflie
+++ b/ROMFS/px4fmu_common/init.d/airframes/4900_crazyflie
@@ -17,8 +17,6 @@
 #
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
-set PWM_OUT 1234
 if [ $AUTOCNF = yes ]
 then
 	param set BAT_N_CELLS 1
@@ -79,4 +77,3 @@ set PWM_MIN none
 
 syslink start
 mavlink start -d /dev/bridge0 -b 57600 -m osd -r 40000
-

--- a/ROMFS/px4fmu_common/init.d/rc.mc_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.mc_defaults
@@ -5,8 +5,6 @@
 # NOTE: Script variables are declared/initialized/unset in the rcS script.
 #
 
-set VEHICLE_TYPE mc
-
 if [ $AUTOCNF = yes ]
 then
 	param set NAV_ACC_RAD 2
@@ -20,9 +18,11 @@ then
 	param set PWM_RATE 400
 fi
 
-#
-# This is the gimbal pass mixer.
-#
+set MIXER quad_x
+
 set MIXER_AUX pass
 
+set PWM_OUT 1234
 set PWM_AUX_OUT 1234
+
+set VEHICLE_TYPE mc


### PR DESCRIPTION
**Describe problem solved by this pull request**
Most multicopter airframe files are calling rc.mc_defaults and also setting `PWM_OUT 1234` and `MIXER quad_x`, so this PR saves ~500 bytes by moving the `set PWM_OUT 1234` to a single call in `rc.mc_defaults` and deleting redundant `set MIXER quad_x` instances.

(Only the `4013_bebop` airframe requires `PWM_OUT` to be set to `none`, which has been attended to here.)

This PR also standardizes the structure of the files touched so that script variable `set`'s occur in the same relative location file to file.

**Additional context**
This PR decouples some of the changes in PR #13074 and simplifies the diff.

Let me know if you have any questions on this PR!  Thanks!
