### PR TITLE
Parameter parser/markdown includes boolean flag

### DIFF
--- a/src/lib/parameters/px4params/markdownout.py
+++ b/src/lib/parameters/px4params/markdownout.py
@@ -28,6 +28,7 @@ class MarkdownTablesOutput():
                 def_val = param.GetDefault() or ''
                 unit = param.GetFieldValue("unit") or ''
                 type = param.GetType()
+                is_boolean = param.GetBoolean()
                 reboot_required = param.GetFieldValue("reboot_required") or ''
                 #board = param.GetFieldValue("board") or '' ## Disabled as no board values are defined in any parameters!
                 #decimal = param.GetFieldValue("decimal") or '' #Disabled as is intended for GCS not people
@@ -78,8 +79,12 @@ class MarkdownTablesOutput():
                         bitmask_output+='  <li><strong>%s:</strong> %s</li> \n' % (bit, bit_text)
                     bitmask_output+='</ul>\n'
 
+                if is_boolean and def_val=='1':
+                    def_val='Enabled (1)'
+                if is_boolean and def_val=='0':
+                    def_val='Disabled (0)'
                     
-                result += '<tr>\n <td style="vertical-align: top;">%s (%s)</td>\n <td style="vertical-align: top;"><p>%s</p>%s %s %s %s</td>\n <td style="vertical-align: top;">%s</td>\n <td style="vertical-align: top;">%s </td>\n <td style="vertical-align: top;">%s</td>\n</tr>\n' % (code, type, name, long_desc, enum_output, bitmask_output, reboot_required, max_min_combined, def_val, unit)
+                result += '<tr>\n <td style="vertical-align: top;">%s (%s)</td>\n <td style="vertical-align: top;"><p>%s</p>%s %s %s %s</td>\n <td style="vertical-align: top;">%s</td>\n <td style="vertical-align: top;">%s</td>\n <td style="vertical-align: top;">%s</td>\n</tr>\n' % (code, type, name, long_desc, enum_output, bitmask_output, reboot_required, max_min_combined, def_val, unit)
 
             #Close the table.
             result += '</tbody></table>\n\n'

--- a/src/lib/parameters/px4params/srcparser.py
+++ b/src/lib/parameters/px4params/srcparser.py
@@ -59,6 +59,7 @@ class Parameter(object):
         self.default = default
         self.volatile = "false"
         self.category = ""
+        self.boolean = "false"
 
     def GetName(self):
         return self.name
@@ -74,6 +75,9 @@ class Parameter(object):
 
     def GetVolatile(self):
         return self.volatile
+
+    def GetBoolean(self):
+        return self.boolean
 
     def SetField(self, code, value):
         """
@@ -98,6 +102,12 @@ class Parameter(object):
         Set volatile flag
         """
         self.volatile = "true"
+
+    def SetBoolean(self):
+        """
+        Set boolean flag
+        """
+        self.boolean = "true"
 
     def SetCategory(self, category):
         """
@@ -305,6 +315,8 @@ class SourceParser(object):
                                 param.SetVolatile()
                             elif tag == "category":
                                 param.SetCategory(tags[tag])
+                            elif tag == "boolean":
+                                param.SetBoolean()
                             elif tag not in self.valid_tags:
                                 sys.stderr.write("Skipping invalid documentation tag: '%s'\n" % tag)
                                 return False

--- a/src/lib/parameters/px4params/srcparser.py
+++ b/src/lib/parameters/px4params/srcparser.py
@@ -59,7 +59,7 @@ class Parameter(object):
         self.default = default
         self.volatile = "false"
         self.category = ""
-        self.boolean = "false"
+        self.boolean = False
 
     def GetName(self):
         return self.name
@@ -107,7 +107,7 @@ class Parameter(object):
         """
         Set boolean flag
         """
-        self.boolean = "true"
+        self.boolean = True
 
     def SetCategory(self, category):
         """


### PR DESCRIPTION
Fixes #12546

Rendering for boolean parameters now shown Enabled/disabled. For example:

![image](https://user-images.githubusercontent.com/5368500/67536015-e08f1b80-f720-11e9-82b2-d84bfa40a837.png)
