### PR TITLE
PX4 work queue: extend to UARTs

### DIFF
--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
@@ -66,9 +66,20 @@ static constexpr wq_config_t I2C4{"wq:I2C4", 1400, -12};
 
 static constexpr wq_config_t att_pos_ctrl{"wq:att_pos_ctrl", 6600, -11}; // PX4 att/pos controllers, highest priority after sensors
 
+static constexpr wq_config_t hp_default{"wq:hp_default", 1800, -12};
+
 static constexpr wq_config_t uavcan{"uavcan", 2400, -13};
 
-static constexpr wq_config_t hp_default{"wq:hp_default", 1800, -12};
+static constexpr wq_config_t UART0{"wq:UART0", 1400, -14};
+static constexpr wq_config_t UART1{"wq:UART1", 1400, -15};
+static constexpr wq_config_t UART2{"wq:UART2", 1400, -16};
+static constexpr wq_config_t UART3{"wq:UART3", 1400, -17};
+static constexpr wq_config_t UART4{"wq:UART4", 1400, -18};
+static constexpr wq_config_t UART5{"wq:UART5", 1400, -19};
+static constexpr wq_config_t UART6{"wq:UART6", 1400, -20};
+static constexpr wq_config_t UART7{"wq:UART7", 1400, -21};
+static constexpr wq_config_t UART8{"wq:UART8", 1400, -22};
+
 static constexpr wq_config_t lp_default{"wq:lp_default", 1700, -50};
 
 static constexpr wq_config_t test1{"wq:test1", 800, 0};
@@ -106,6 +117,14 @@ WorkQueue *WorkQueueFindOrCreate(const wq_config_t &new_wq);
  * @return		A work queue configuration.
  */
 const wq_config_t &device_bus_to_wq(uint32_t device_id);
+
+/**
+ * Map a serial device path (eg /dev/ttyS1) to a work queue.
+ *
+ * @param device_id		The device path.
+ * @return		A work queue configuration.
+ */
+const wq_config_t &serial_port_to_wq(const char *serial);
 
 
 } // namespace px4

--- a/platforms/common/px4_work_queue/WorkQueueManager.cpp
+++ b/platforms/common/px4_work_queue/WorkQueueManager.cpp
@@ -162,6 +162,45 @@ device_bus_to_wq(uint32_t device_id_int)
 	return wq_configurations::hp_default;
 };
 
+const wq_config_t &
+serial_port_to_wq(const char *serial)
+{
+	if (serial == nullptr) {
+		return wq_configurations::hp_default;
+
+	} else if (strstr(serial, "ttyS0")) {
+		return wq_configurations::UART0;
+
+	} else if (strstr(serial, "ttyS1")) {
+		return wq_configurations::UART1;
+
+	} else if (strstr(serial, "ttyS2")) {
+		return wq_configurations::UART2;
+
+	} else if (strstr(serial, "ttyS3")) {
+		return wq_configurations::UART3;
+
+	} else if (strstr(serial, "ttyS4")) {
+		return wq_configurations::UART4;
+
+	} else if (strstr(serial, "ttyS5")) {
+		return wq_configurations::UART5;
+
+	} else if (strstr(serial, "ttyS6")) {
+		return wq_configurations::UART6;
+
+	} else if (strstr(serial, "ttyS7")) {
+		return wq_configurations::UART7;
+
+	} else if (strstr(serial, "ttyS8")) {
+		return wq_configurations::UART8;
+	}
+
+	PX4_ERR("unknown serial port: %s", serial);
+
+	return wq_configurations::hp_default;
+}
+
 static void *
 WorkQueueRunner(void *context)
 {

--- a/src/drivers/distance_sensor/cm8jl65/CM8JL65.cpp
+++ b/src/drivers/distance_sensor/cm8jl65/CM8JL65.cpp
@@ -84,7 +84,7 @@ static constexpr unsigned char crc_lsb_vector[] = {
 };
 
 CM8JL65::CM8JL65(const char *port, uint8_t rotation) :
-	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::hp_default),
+	ScheduledWorkItem(MODULE_NAME, px4::serial_port_to_wq(port)),
 	_px4_rangefinder(0 /* TODO: device ids */, ORB_PRIO_DEFAULT, rotation)
 {
 	// Store the port name.

--- a/src/drivers/distance_sensor/leddar_one/leddar_one.cpp
+++ b/src/drivers/distance_sensor/leddar_one/leddar_one.cpp
@@ -174,7 +174,7 @@ private:
 
 LeddarOne::LeddarOne(const char *device_path, const char *serial_port, uint8_t device_orientation):
 	CDev(device_path),
-	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::hp_default),
+	ScheduledWorkItem(MODULE_NAME, px4::serial_port_to_wq(serial_port)),
 	_px4_rangefinder(0 /* device id not yet used */, ORB_PRIO_DEFAULT, device_orientation)
 {
 	_serial_port = strdup(serial_port);

--- a/src/drivers/distance_sensor/sf0x/sf0x.cpp
+++ b/src/drivers/distance_sensor/sf0x/sf0x.cpp
@@ -158,7 +158,7 @@ extern "C" __EXPORT int sf0x_main(int argc, char *argv[]);
 
 SF0X::SF0X(const char *port, uint8_t rotation) :
 	CDev(RANGE_FINDER0_DEVICE_PATH),
-	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::hp_default),
+	ScheduledWorkItem(MODULE_NAME, px4::serial_port_to_wq(port)),
 	_rotation(rotation),
 	_min_distance(0.30f),
 	_max_distance(40.0f),

--- a/src/drivers/distance_sensor/tfmini/TFMINI.cpp
+++ b/src/drivers/distance_sensor/tfmini/TFMINI.cpp
@@ -34,7 +34,7 @@
 #include "TFMINI.hpp"
 
 TFMINI::TFMINI(const char *port, uint8_t rotation) :
-	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::hp_default),
+	ScheduledWorkItem(MODULE_NAME, px4::serial_port_to_wq(port)),
 	_px4_rangefinder(0 /* TODO: device id */, ORB_PRIO_DEFAULT, rotation)
 {
 	// store port name

--- a/src/drivers/distance_sensor/ulanding/ulanding.cpp
+++ b/src/drivers/distance_sensor/ulanding/ulanding.cpp
@@ -172,7 +172,7 @@ private:
 
 Radar::Radar(const char *port, uint8_t rotation) :
 	CDev(RANGE_FINDER0_DEVICE_PATH),
-	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::hp_default),
+	ScheduledWorkItem(MODULE_NAME, px4::serial_port_to_wq(port)),
 	_rotation(rotation)
 {
 	/* store port name */


### PR DESCRIPTION
WQ threads are cheap enough that I'd like to use them for serial devices as well. Typically these are things that end up in thrown into the default high priority work queue (wq:hp_default). Once in place we can consider using blocking reads. This could also become an additional mechanism to prevent potential serial port conflicts (updating WorkQueues to optionally allow only a single WorkItem).

TODO: think about priorities and stack sizes

 - [ ] drivers/rc_input
 - [x] drivers/distance_sensor/cm8jl65
 - [x] drivers/distance_sensor/leddar_one
 - [ ] drivers/distance_sensor/pga460 (bigger refactor, currently a task FYI @mcsauder)
 - [x] drivers/distance_sensor/sf0x
 - [x] drivers/distance_sensor/tfmini
 - [x] drivers/distance_sensor/ulanding
 - [ ] px4io? (dedicated UART WQ thread or rate ctrl?)
 - [ ] gps?
 - [ ] roboclaw?
 - [ ] tap_esc? (dedicated UART WQ thread or rate ctrl?)
 - [ ] frsky_telemetry?