### PR TITLE
commander: make battery failsafes sane by default

### DIFF
--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -313,18 +313,16 @@ PARAM_DEFINE_INT32(COM_ARM_SWISBTN, 0);
 /**
  * Battery failsafe mode
  *
- * Action the system takes on low battery. Defaults to off
+ * Action the system takes at critical battery.
  *
  * @group Commander
  * @value 0 Warning
- * @value 1 Return mode
  * @value 2 Land mode
- * @value 3 Return mode at critically low level, Land mode at current position if reaching dangerously low levels
+ * @value 3 Return at critical level, land at emergency level
  * @decimal 0
  * @increment 1
- * @increment 1
  */
-PARAM_DEFINE_INT32(COM_LOW_BAT_ACT, 0);
+PARAM_DEFINE_INT32(COM_LOW_BAT_ACT, 3);
 
 /**
  * Time-out to wait when offboard connection is lost before triggering offboard lost action.


### PR DESCRIPTION
I propose two changes to the battery failsafes:
1. Remove the return only mode because it means the drone is likely to crash during RTL. I think this is not expected by users chosing the option and therefore better not exposed as an option.
2. Make Return/Land the default battery failsafe because it is expected that a drone does the right thing when battery is low.

Also, this changes the description of the Return/Land behaviour to make the drop down menu less long and awkward in QGC.

![Selection_061](https://user-images.githubusercontent.com/1419688/67671490-5a6c1280-f976-11e9-9a5a-8f5fb98ecde5.png)
