### PR TITLE
Land detector (MC): Increase ground detection robustness

### DIFF
--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -164,8 +164,17 @@ bool MulticopterLandDetector::_get_ground_contact_state()
 		      && (_vehicle_local_position_setpoint.vz >= land_speed_threshold);
 	bool hit_ground = _in_descend && !vertical_movement;
 
+	bool ground_contact = false;
+
+	if (_maybe_landed_hysteresis.get_state() || _landed_hysteresis.get_state()) {
+		ground_contact = _has_low_thrust() || hit_ground;
+
+	} else {
+		ground_contact = _has_low_thrust() && hit_ground;
+	}
+
 	// TODO: we need an accelerometer based check for vertical movement for flying without GPS
-	return (_has_low_thrust() || hit_ground) && (!_horizontal_movement || !_has_position_lock())
+	return ground_contact && (!_horizontal_movement || !_has_position_lock())
 	       && (!vertical_movement || !_has_altitude_lock());
 }
 


### PR DESCRIPTION
I would like to figure out if this change adds any value to the community.

**Description**
The ground contact state in the multicopter land detector, as the name suggest, tries to capture the instant when the vehicle touches the ground during a landing. It uses the following conditions for the detection:
1) There is a spread between down velocity and down velocity setpoint -> hit_ground. This assumes that either the pilot or the mission is demanding a large enough down velocity setpoint during landing. This is also the reason why you should keep pulling the throttle stick down when landing.
2) The vehicle is in a low_thrust condition which basically means that the current throttle is below a predefined threshold.

In the current implementation only one condition is necessary to trigger the ground_contact state.
This implementation requires both condition to be true at the same time.
However, if the vehicle already has landed or maybe_landed state active, then the old logic is used.

**Advantages**
- reduces changes of false ground_contact detection. A false positive will lead to the controller pulling the throttle to 0 instantly which will result in the vehicle free-falling for a split second before the free-fall detection kicks in. Some vehicles might not recover from such a situation and crash.
This is the primary reason why this logic was implemented.

**Disadvantages**
- landing detection might be slower for setups with bad land detector parameters.

I can confirm that this logic works well if the land detector is setup properly.
The main question is if this deteriorates the land detection performance for vehicles in general (because the land detection params are not setup properly.)
Looking forward to hear some opinions and to get some test results.

@PX4/testflights FYI.