### PR TITLE
sensors: own BAT_V_DIV and BAT_A_PER_V params

### DIFF
--- a/src/modules/sensors/parameters.cpp
+++ b/src/modules/sensors/parameters.cpp
@@ -159,6 +159,9 @@ void initialize_parameter_handles(ParameterHandles &parameter_handles)
 	// We do a param_find here to force them into the list.
 	(void)param_find("RC_CHAN_CNT");
 
+	(void)param_find("BAT_V_DIV");
+	(void)param_find("BAT_A_PER_V");
+
 	(void)param_find("CAL_ACC0_ID");
 	(void)param_find("CAL_GYRO0_ID");
 

--- a/src/modules/sensors/sensor_params_battery.c
+++ b/src/modules/sensors/sensor_params_battery.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2017 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2019 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,61 +32,26 @@
  ****************************************************************************/
 
 /**
- * Scaling from ADC counts to volt on the ADC input (battery voltage)
+ * Battery voltage divider (V divider)
  *
- * This is not the battery voltage, but the intermediate ADC voltage.
- * A value of -1 signifies that the board defaults are used, which is
- * highly recommended.
- *
- * @group Battery Calibration
- * @decimal 8
- */
-PARAM_DEFINE_FLOAT(BAT_CNT_V_VOLT, -1.0f);
-
-/**
- * Scaling from ADC counts to volt on the ADC input (battery current)
- *
- * This is not the battery current, but the intermediate ADC voltage.
- * A value of -1 signifies that the board defaults are used, which is
- * highly recommended.
+ * This is the divider from battery voltage to 3.3V ADC voltage.
+ * If using e.g. Mauch power modules the value from the datasheet
+ * can be applied straight here. A value of -1 means to use
+ * the board default.
  *
  * @group Battery Calibration
  * @decimal 8
  */
-PARAM_DEFINE_FLOAT(BAT_CNT_V_CURR, -1.0);
+PARAM_DEFINE_FLOAT(BAT_V_DIV, -1.0);
 
 /**
- * Offset in volt as seen by the ADC input of the current sensor.
+ * Battery current per volt (A/V)
  *
- * This offset will be subtracted before calculating the battery
- * current based on the voltage.
+ * The voltage seen by the 3.3V ADC multiplied by this factor
+ * will determine the battery current. A value of -1 means to use
+ * the board default.
  *
  * @group Battery Calibration
  * @decimal 8
  */
-PARAM_DEFINE_FLOAT(BAT_V_OFFS_CURR, 0.0);
-
-/**
- * Battery monitoring source.
- *
- * This parameter controls the source of battery data. The value 'Power Module'
- * means that measurements are expected to come from a power module. If the value is set to
- * 'External' then the system expects to receive mavlink battery status messages.
- *
- * @min 0
- * @max 1
- * @value 0 Power Module
- * @value 1 External
- * @group Battery Calibration
- */
-PARAM_DEFINE_INT32(BAT_SOURCE, 0);
-
-/**
- * Battery ADC Channel
- *
- * This parameter specifies the ADC channel used to monitor voltage of main power battery.
- * A value of -1 means to use the board default.
- *
- * @group Battery Calibration
- */
-PARAM_DEFINE_INT32(BAT_ADC_CHANNEL, -1);
+PARAM_DEFINE_FLOAT(BAT_A_PER_V, -1.0);


### PR DESCRIPTION
 - this is currently necessary for the QGC Power setup gui, but should
be reverted in the future
 - fixes #13292
