### PR TITLE
NuttX microRTPS UDP support

### DIFF
--- a/msg/templates/urtps/microRTPS_agent.cpp.em
+++ b/msg/templates/urtps/microRTPS_agent.cpp.em
@@ -80,6 +80,7 @@ recv_topics = [(alias[idx] if alias[idx] else s.short_name) for idx, s in enumer
 #define WAIT_CNST 2
 #define DEFAULT_RECV_PORT 2020
 #define DEFAULT_SEND_PORT 2019
+#define DEFAULT_IP "127.0.0.1"
 
 using namespace eprosima;
 using namespace eprosima::fastrtps;
@@ -119,6 +120,7 @@ struct options {
     int poll_ms = POLL_MS;
     uint16_t recv_port = DEFAULT_RECV_PORT;
     uint16_t send_port = DEFAULT_SEND_PORT;
+    char ip[16] = DEFAULT_IP;
 } _options;
 
 static void usage(const char *name)
@@ -130,7 +132,8 @@ static void usage(const char *name)
              "  -b <baudrate>           UART device baudrate. Default 460800\n"
              "  -p <poll_ms>            Time in ms to poll over UART. Default 1ms\n"
              "  -r <reception port>     UDP port for receiving. Default 2019\n"
-             "  -s <sending port>       UDP port for sending. Default 2020\n",
+             "  -s <sending port>       UDP port for sending. Default 2020\n"
+             "  -i <ip_address>         Target IP for UDP. Default 127.0.0.1\n",
              name);
 }
 
@@ -147,7 +150,7 @@ static int parse_options(int argc, char **argv)
 {
     int ch;
 
-    while ((ch = getopt(argc, argv, "t:d:w:b:p:r:s:")) != EOF)
+    while ((ch = getopt(argc, argv, "t:d:w:b:p:r:s:i:")) != EOF)
     {
         switch (ch)
         {
@@ -160,6 +163,7 @@ static int parse_options(int argc, char **argv)
             case 'p': _options.poll_ms        = strtol(optarg, nullptr, 10);  break;
             case 'r': _options.recv_port      = strtoul(optarg, nullptr, 10); break;
             case 's': _options.send_port      = strtoul(optarg, nullptr, 10); break;
+            case 'i': if (nullptr != optarg) strcpy(_options.ip, optarg); break;
             default:
                 usage(argv[0]);
             return -1;
@@ -237,9 +241,9 @@ int main(int argc, char** argv)
         break;
         case options::eTransports::UDP:
         {
-            transport_node = new UDP_node(_options.recv_port, _options.send_port);
-            printf("\nUDP transport: recv port: %u; send port: %u; sleep: %dus\n\n",
-                    _options.recv_port, _options.send_port, _options.sleep_us);
+            transport_node = new UDP_node(_options.ip, _options.recv_port, _options.send_port);
+            printf("\nUDP transport: ip address: %s; recv port: %u; send port: %u; sleep: %dus\n\n",
+                    _options.ip, _options.recv_port, _options.send_port, _options.sleep_us);
         }
         break;
         default:

--- a/msg/templates/urtps/microRTPS_transport.h
+++ b/msg/templates/urtps/microRTPS_transport.h
@@ -113,7 +113,7 @@ protected:
 class UDP_node: public Transport_node
 {
 public:
-	UDP_node(uint16_t udp_port_recv, uint16_t udp_port_send);
+	UDP_node(const char* _udp_ip, uint16_t udp_port_recv, uint16_t udp_port_send);
 	virtual ~UDP_node();
 
 	int init();
@@ -128,6 +128,7 @@ protected:
 
 	int sender_fd;
 	int receiver_fd;
+	char udp_ip[16] = {};
 	uint16_t udp_port_recv;
 	uint16_t udp_port_send;
 	struct sockaddr_in sender_outaddr;

--- a/src/modules/micrortps_bridge/micrortps_client/microRTPS_client.h
+++ b/src/modules/micrortps_bridge/micrortps_client/microRTPS_client.h
@@ -62,6 +62,7 @@
 #endif
 #define DEVICE "/dev/ttyACM0"
 #define POLL_MS 1
+#define IP "127.0.0.1"
 #define DEFAULT_RECV_PORT 2019
 #define DEFAULT_SEND_PORT 2020
 
@@ -85,6 +86,7 @@ struct options {
 	int sleep_ms = SLEEP_MS;
 	struct baudtype baudrate = {.code = BAUDRATE, .val = BAUDRATE_VAL};
 	int poll_ms = POLL_MS;
+	char ip[16] = IP;
 	uint16_t recv_port = DEFAULT_RECV_PORT;
 	uint16_t send_port = DEFAULT_SEND_PORT;
 };

--- a/src/modules/micrortps_bridge/micrortps_client/microRTPS_client_main.cpp
+++ b/src/modules/micrortps_bridge/micrortps_client/microRTPS_client_main.cpp
@@ -84,6 +84,7 @@ static void usage(const char *name)
 	PRINT_MODULE_USAGE_PARAM_INT('w', 1, 1, 1000, "Time in ms for which each iteration sleeps", true);
 	PRINT_MODULE_USAGE_PARAM_INT('r', 2019, 0, 65536, "Select UDP Network Port for receiving (local)", true);
 	PRINT_MODULE_USAGE_PARAM_INT('s', 2020, 0, 65536, "Select UDP Network Port for sending (remote)", true);
+	PRINT_MODULE_USAGE_PARAM_STRING('i', "127.0.0.1", "<x.x.x.x>", "Select IP address (remote)", true);
 
 	PRINT_MODULE_USAGE_COMMAND("stop");
 	PRINT_MODULE_USAGE_COMMAND("status");
@@ -108,7 +109,7 @@ static int parse_options(int argc, char *argv[])
 	int myoptind = 1;
 	const char *myoptarg = nullptr;
 
-	while ((ch = px4_getopt(argc, argv, "t:d:u:l:w:b:p:r:s:", &myoptind, &myoptarg)) != EOF) {
+	while ((ch = px4_getopt(argc, argv, "t:d:u:l:w:b:p:r:s:i:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 't': _options.transport      = strcmp(myoptarg, "UDP") == 0 ?
 							    options::eTransports::UDP
@@ -129,6 +130,8 @@ static int parse_options(int argc, char *argv[])
 		case 'r': _options.recv_port      = strtoul(myoptarg, nullptr, 10);     break;
 
 		case 's': _options.send_port      = strtoul(myoptarg, nullptr, 10);     break;
+
+		case 'i': if (nullptr != myoptarg) strcpy(_options.ip, myoptarg); break;
 
 		default:
 			usage(argv[1]);
@@ -166,9 +169,9 @@ static int micrortps_start(int argc, char *argv[])
 		break;
 
 	case options::eTransports::UDP: {
-			transport_node = new UDP_node(_options.recv_port, _options.send_port);
-			PX4_INFO("UDP transport: recv port: %u; send port: %u; sleep: %dms",
-				 _options.recv_port, _options.send_port, _options.sleep_ms);
+			transport_node = new UDP_node(_options.ip, _options.recv_port, _options.send_port);
+			PX4_INFO("UDP transport: ip address: %s; recv port: %u; send port: %u; sleep: %dms",
+				 _options.ip, _options.recv_port, _options.send_port, _options.sleep_ms);
 		}
 		break;
 


### PR DESCRIPTION
Enabled UDP in NuttX microRTPS build
Added commandline argument to change microRTPS ip address

**Describe problem solved by this pull request**
In NuttX the microRTPS module disables the UDP socket mode by default through ifndefs.
The agent ip address in microRTPS client is fixed to 127.0.0.1

**Describe your solution**
The ifndefs are replaced by an extensive check, which checks whether the NuttX build has networking support. Added command line argument to the microRTPS client which allows you to change the target agent ip address.

**Describe possible alternatives**
-

**Test data / coverage**
Tested connection with a modified px4_ros_com (which can change the client ip address) and ROS2 crystal.

**Additional context**
The px4_ros_com package also requires a change since there as well the client ip address is fixed to 127.0.0.1
