### PR TITLE
commander: battery failsafe action back to warning

### DIFF
--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -323,7 +323,7 @@ PARAM_DEFINE_INT32(COM_ARM_SWISBTN, 0);
  * @decimal 0
  * @increment 1
  */
-PARAM_DEFINE_INT32(COM_LOW_BAT_ACT, 3);
+PARAM_DEFINE_INT32(COM_LOW_BAT_ACT, 0);
 
 /**
  * Time-out to wait when offboard connection is lost before triggering offboard lost action.


### PR DESCRIPTION
This reverts a previous change because we're not entirely sure about all implications on various airframes. It makes sense to change this default after the failsafe state machines have been consolidated and the various failsafe behaviours are more predictable for all airframes (not just
multicopter).

This was brought up by @bkueng after #13295.