### PR TITLE
Removed lidar lite reset after intialization

### DIFF
--- a/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.cpp
+++ b/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.cpp
@@ -150,7 +150,7 @@ LidarLiteI2C::probe()
 			}
 
 			_retries = 3;
-			return reset_sensor();
+			return OK;
 		}
 
 		PX4_DEBUG("probe failed unit_id=0x%02x hw_version=0x%02x sw_version=0x%02x",


### PR DESCRIPTION
**Describe problem solved by this pull request**
Lidar Lite V3 on i2c fails to initialize.

 Must start from the shell `ll40ls start` and even then it fails a few times before actually functioning. Related to
#12604
#12278
https://discuss.px4.io/t/lidarlite-v3-driver-does-not-automatically-start-with-i2c/10783
![lidar_lite](https://user-images.githubusercontent.com/37091262/67811809-35090280-fa63-11e9-83b4-63c3033e0384.png)

The driver is resetting the device after reading the device ID. I do not have hardware, however removing this reset solved the issue for someone I was helping who is using a V3.

**From the datasheet:**
 _On power-up or reset, the device performs a self-test sequence and initializes all registers with default values_

This makes me think the reset after discovery is unnecessary, as the driver has not written to any registers at this point. 

**Test data / coverage**
Can some others who have hardware please verify this works (with LidarLite v1/2/3)
@mcsauder 
@cmic0 
@TSC21 



- [x] V3HP
- [x] V3
- [ ] V2
- [ ] V1