### PR TITLE
Add support for offboard ActuatorControl set points to RoverPositionControl (fixes #13192)

### DIFF
--- a/src/modules/rover_pos_control/RoverPositionControl.cpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.cpp
@@ -520,8 +520,6 @@ RoverPositionControl::run()
 
 			/* Only publish if any of the proper modes are enabled */
 			if (_control_mode.flag_control_velocity_enabled ||
-			    _control_mode.flag_control_rates_enabled ||
-			    _control_mode.flag_control_attitude_enabled ||
 			    manual_mode) {
 				/* publish the actuator controls */
 				if (_actuator_controls_pub != nullptr) {

--- a/src/modules/rover_pos_control/RoverPositionControl.cpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.cpp
@@ -518,13 +518,20 @@ RoverPositionControl::run()
 			//orb_copy(ORB_ID(vehicle_attitude), _vehicle_attitude_sub, &_vehicle_att);
 			_act_controls.timestamp = hrt_absolute_time();
 
-			if (_actuator_controls_pub != nullptr) {
-				//PX4_INFO("Publishing actuator from pos control");
-				orb_publish(ORB_ID(actuator_controls_0), _actuator_controls_pub, &_act_controls);
+			/* Only publish if any of the proper modes are enabled */
+			if (_control_mode.flag_control_velocity_enabled ||
+			    _control_mode.flag_control_rates_enabled ||
+			    _control_mode.flag_control_attitude_enabled ||
+			    manual_mode) {
+				/* publish the actuator controls */
+				if (_actuator_controls_pub != nullptr) {
+					//PX4_INFO("Publishing actuator from pos control");
+					orb_publish(ORB_ID(actuator_controls_0), _actuator_controls_pub, &_act_controls);
 
-			} else {
+				} else {
 
-				_actuator_controls_pub = orb_advertise(ORB_ID(actuator_controls_0), &_act_controls);
+					_actuator_controls_pub = orb_advertise(ORB_ID(actuator_controls_0), &_act_controls);
+				}
 			}
 		}
 

--- a/src/modules/rover_pos_control/RoverPositionControl.cpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.cpp
@@ -462,12 +462,7 @@ RoverPositionControl::run()
 
 					pos_ctrl_status.timestamp = hrt_absolute_time();
 
-					if (_pos_ctrl_status_pub != nullptr) {
-						orb_publish(ORB_ID(position_controller_status), _pos_ctrl_status_pub, &pos_ctrl_status);
-
-					} else {
-						_pos_ctrl_status_pub = orb_advertise(ORB_ID(position_controller_status), &pos_ctrl_status);
-					}
+					_pos_ctrl_status_pub.publish(pos_ctrl_status);
 
 				}
 
@@ -520,16 +515,10 @@ RoverPositionControl::run()
 
 			/* Only publish if any of the proper modes are enabled */
 			if (_control_mode.flag_control_velocity_enabled ||
+			    _control_mode.flag_control_attitude_enabled ||
 			    manual_mode) {
 				/* publish the actuator controls */
-				if (_actuator_controls_pub != nullptr) {
-					//PX4_INFO("Publishing actuator from pos control");
-					orb_publish(ORB_ID(actuator_controls_0), _actuator_controls_pub, &_act_controls);
-
-				} else {
-
-					_actuator_controls_pub = orb_advertise(ORB_ID(actuator_controls_0), &_act_controls);
-				}
+				_actuator_controls_pub.publish(_act_controls);
 			}
 		}
 

--- a/src/modules/rover_pos_control/RoverPositionControl.hpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.hpp
@@ -99,28 +99,28 @@ public:
 
 private:
 	orb_advert_t	_pos_ctrl_status_pub{nullptr};		/**< navigation capabilities publication */
-	orb_advert_t    _actuator_controls_pub{nullptr};	/**< actuator controls publication */
+	orb_advert_t	_actuator_controls_pub{nullptr};	/**< actuator controls publication */
 
-	int		_control_mode_sub{-1};		/**< control mode subscription */
+	int		_control_mode_sub{-1};			/**< control mode subscription */
 	int		_global_pos_sub{-1};
 	int		_local_pos_sub{-1};
 	int		_manual_control_sub{-1};		/**< notification of manual control updates */
 	int		_pos_sp_triplet_sub{-1};
-	int 		_att_sp_sub{-1};
-	int     _vehicle_attitude_sub{-1};
+	int		_att_sp_sub{-1};
+	int		_vehicle_attitude_sub{-1};
 	int		_sensor_combined_sub{-1};
 
 	uORB::Subscription	_parameter_update_sub{ORB_ID(parameter_update)};
 
-	manual_control_setpoint_s		_manual{};			    /**< r/c channel data */
+	manual_control_setpoint_s		_manual{};			/**< r/c channel data */
 	position_setpoint_triplet_s		_pos_sp_triplet{};		/**< triplet of mission items */
 	vehicle_attitude_setpoint_s		_att_sp{};			/**< attitude setpoint > */
 	vehicle_control_mode_s			_control_mode{};		/**< control mode */
 	vehicle_global_position_s		_global_pos{};			/**< global vehicle position */
 	vehicle_local_position_s		_local_pos{};			/**< global vehicle position */
-	actuator_controls_s			    _act_controls{};		/**< direct control of actuators */
-	vehicle_attitude_s              _vehicle_att{};
-	sensor_combined_s				_sensor_combined{};
+	actuator_controls_s			_act_controls{};		/**< direct control of actuators */
+	vehicle_attitude_s			_vehicle_att{};
+	sensor_combined_s			_sensor_combined{};
 
 	SubscriptionData<vehicle_acceleration_s>		_vehicle_acceleration_sub{ORB_ID(vehicle_acceleration)};
 

--- a/src/modules/rover_pos_control/RoverPositionControl.hpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.hpp
@@ -56,6 +56,7 @@
 #include <px4_platform_common/module.h>
 #include <px4_platform_common/module_params.h>
 #include <uORB/Subscription.hpp>
+#include <uORB/Publication.hpp>
 #include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/position_controller_status.h>
@@ -98,8 +99,8 @@ public:
 	void run() override;
 
 private:
-	orb_advert_t	_pos_ctrl_status_pub{nullptr};		/**< navigation capabilities publication */
-	orb_advert_t	_actuator_controls_pub{nullptr};	/**< actuator controls publication */
+	uORB::Publication<position_controller_status_s>	_pos_ctrl_status_pub{ORB_ID(position_controller_status)};
+	uORB::Publication<actuator_controls_s>		_actuator_controls_pub{ORB_ID(actuator_controls_0)};
 
 	int		_control_mode_sub{-1};			/**< control mode subscription */
 	int		_global_pos_sub{-1};


### PR DESCRIPTION
As discussed in #13192, RoverPositionControl overrides the ActuatorControl messages, that get published by the mavlink_receiver.cpp when an SET_ACTUATOR_CONTROL_TARGET message is received.
This prevented using ActuatorControl set points in offboard mode (e.g. using the MAVSDK).

I took a look at the other position and attitude controllers and realized, that they simply do not publish the `actuator_controls_0`, when the control modes does not state, that the corresponding control loop should be activated.

(I fixed some indentation/ formatting issues in the header file too.)