### PR TITLE
Fixed issue with px4_ros_com not being able to publish to PX4

### DIFF
--- a/msg/templates/urtps/Subscriber.cpp.em
+++ b/msg/templates/urtps/Subscriber.cpp.em
@@ -131,21 +131,7 @@ void @(topic)_Subscriber::SubListener::onSubscriptionMatched(Subscriber* sub, Ma
 void @(topic)_Subscriber::SubListener::onNewDataMessage(Subscriber* sub)
 {
         // Take data
-@[if 1.5 <= fastrtpsgen_version <= 1.7]@
-@[    if ros2_distro]@
-        @(package)::msg::dds_::@(topic)_ st;
-@[    else]@
-        @(topic)_ st;
-@[    end if]@
-@[else]@
-@[    if ros2_distro]@
-        @(package)::msg::@(topic) st;
-@[    else]@
-        @(topic) st;
-@[    end if]@
-@[end if]@
-
-        if(sub->takeNextData(&st, &m_info))
+        if(sub->takeNextData(&msg, &m_info))
         {
             if(m_info.sampleKind == ALIVE)
             {


### PR DESCRIPTION
Problem: publishing msgs from ROS2 to PX4 will yield empty msgs in PX4 uORB topics.
Cause: The px4_ros_com FastRTPS subscriber didn't copy the data to the msg variable.
Which is used in the getMsg function and thus the msg will it will return an empty msg.

**Describe your solution**
Removed unused st variable copy FastRTPS data directly to the msg variable

**Describe possible alternatives**
It's unclear to me why there is this st variable.
Do we need to copy the st variable to the msg variable?

**Test data / coverage**
Tested with basic uORB subscriber that outputs topic data.

**Additional context**

