### PR TITLE
Rally Points: enable rally points always, independent of RTL_TYPE set…

### DIFF
--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -100,6 +100,11 @@ RTL::find_RTL_destination()
 		}
 	}
 
+	// do not consider rally point if RTL type is set to RTL_MISSION, so exit function and use either home or mission landing
+	if (rtl_type() == RTL_MISSION) {
+		return;
+	}
+
 	// compare to safe landing positions
 	mission_safe_point_s closest_safe_point {} ;
 	mission_stats_entry_s stats;

--- a/src/modules/navigator/rtl.h
+++ b/src/modules/navigator/rtl.h
@@ -74,7 +74,6 @@ public:
 	void on_activation() override;
 	void on_active() override;
 
-	void find_closest_landing_point();
 	void find_RTL_destination();
 
 	void set_return_alt_min(bool min);

--- a/src/modules/navigator/rtl_params.c
+++ b/src/modules/navigator/rtl_params.c
@@ -110,10 +110,10 @@ PARAM_DEFINE_FLOAT(RTL_MIN_DIST, 5.0f);
  * Fly straight to the return location or planned mission landing and land there or
  * use the planned mission to get to those points.
  *
- * @value 0 Return home via direct path
- * @value 1 Return to a planned mission landing, if available, via direct path, else return to home via direct path
- * @value 2 Return to a planned mission landing, if available, using the mission path, else return to home via the reverse mission path
- * @value 3 Return via direct path to closest destination: home, mission landing pattern or safe point
+ * @value 0 Return to closest safe point (home or rally point) via direct path.
+ * @value 1 Return to closest safe point other than home (mission landing pattern or rally point), via direct path. If no mission landing or rally points are defined return home via direct path.
+ * @value 2 Same as above (2nd option), but return via mission path (for return to mission landing), via the reverse mission path (home) or via direct path (rally point).
+ * @value 3 Return via direct path to closest destination: home, start of mission landing pattern or safe point. If the destination is a mission landing pattern, follow the pattern to land.
  * @group Return Mode
  */
 PARAM_DEFINE_INT32(RTL_TYPE, 0);

--- a/src/modules/navigator/rtl_params.c
+++ b/src/modules/navigator/rtl_params.c
@@ -107,12 +107,11 @@ PARAM_DEFINE_FLOAT(RTL_MIN_DIST, 5.0f);
 /**
  * Return type
  *
- * Fly straight to the return location or planned mission landing and land there or
- * use the planned mission to get to those points.
+ * Return mode destination and flight path (home location, rally point, mission landing pattern, reverse mission)
  *
  * @value 0 Return to closest safe point (home or rally point) via direct path.
  * @value 1 Return to closest safe point other than home (mission landing pattern or rally point), via direct path. If no mission landing or rally points are defined return home via direct path.
- * @value 2 Same as above (2nd option), but return via mission path (for return to mission landing), via the reverse mission path (home) or via direct path (rally point).
+ * @value 2 Return to a planned mission landing, if available, using the mission path, else return to home via the reverse mission path. Do not consider rally points.
  * @value 3 Return via direct path to closest destination: home, start of mission landing pattern or safe point. If the destination is a mission landing pattern, follow the pattern to land.
  * @group Return Mode
  */


### PR DESCRIPTION
**Describe problem solved by this pull request**
This PR is a follow-up of https://github.com/PX4/Firmware/pull/12696, where safe landing points (aka rally points) where enabled.

 With the above mentioned PR, safe landing points were only considered if RTL_TYPE is set to 3 (which is a new rtl_type). After giving it some more thoughts and getting feedback from others I want to change that with this PR: safe landing points are now always considered and chosen when closer then the default option (see below), plus with RTL_TYPE=3 home and mission landing are always considered. In more detail for the different RTL settings:

- RTL_TYPE = 0 (home): vehicle lands whatever is closest: home or nearest safe landing point (if set)
- RTL_TYPE = 1(landing):  vehicle lands whatever is closest: mission landing( if set) or nearest safe landing point (if set) or home. It only considers home if mission landing is not set.
- <del>(RTL_TYPE = 2(reverse):  same as 1, but now if mission landing is chosen, it follows the mission path in reverse)
- RTL_TYPE = 3 (home/landing): vehicle lands whatever is closest: home, mission landing (if set) or nearest safe landing point (if set). Other than 1 and 2 it always considers home and mission landing (if set), as well as the potential safe landing points. 

EDIT: RTL_TYPE=2 is now unchanged from current master, so it won't consider rally points for the rtl type

For me tpye 3 makes most sense for big missions (potentially VTOL/ BVLOS), where the start and landing point are not on the same place.

**Test data / coverage**
SITL tested. 

