### PR TITLE
Add fmu-v3 GPS2:/dev/ttyS6 to fmu-v3 default.cmake.

### DIFF
--- a/boards/px4/fmu-v3/default.cmake
+++ b/boards/px4/fmu-v3/default.cmake
@@ -15,6 +15,7 @@ px4_add_board(
 
 	SERIAL_PORTS
 		GPS1:/dev/ttyS3
+		GPS2:/dev/ttyS6
 		TEL1:/dev/ttyS1
 		TEL2:/dev/ttyS2
 		TEL4:/dev/ttyS6


### PR DESCRIPTION
**Describe problem solved by this pull request**
This might solve issue #13316.

@M-J-Murray, would you be willing to test/verify this solution fixes the issue you encountered?  Thanks!

**Additional context**
See #13316.
