### PR TITLE
Parameter for disarm kill switch timeout

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -558,7 +558,6 @@ Commander::Commander() :
 	_failure_detector(this)
 {
 	_auto_disarm_landed.set_hysteresis_time_from(false, _param_com_disarm_preflight.get() * 1_s);
-	_auto_disarm_killed.set_hysteresis_time_from(false, 5_s);
 
 	// We want to accept RC inputs as default
 	status.rc_input_mode = vehicle_status_s::RC_IN_MODE_DEFAULT;
@@ -1548,6 +1547,8 @@ Commander::run()
 			param_get(_param_fmode_6, &_flight_mode_slots[5]);
 
 			param_get(_param_takeoff_finished_action, &takeoff_complete_act);
+
+			_auto_disarm_killed.set_hysteresis_time_from(false, _param_com_kill_disarm.get() * 1_s);
 
 			/* check for unsafe Airmode settings: yaw airmode requires the use of an arming switch */
 			if (_param_airmode != PARAM_INVALID && _param_rc_map_arm_switch != PARAM_INVALID) {

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -149,6 +149,8 @@ private:
 		(ParamInt<px4::params::COM_PREARM_MODE>) _param_com_prearm_mode,
 		(ParamInt<px4::params::COM_MOT_TEST_EN>) _param_com_mot_test_en,
 
+		(ParamFloat<px4::params::COM_KILL_DISARM>) _param_com_kill_disarm,
+
 		(ParamInt<px4::params::CBRK_SUPPLY_CHK>) _param_cbrk_supply_chk,
 		(ParamInt<px4::params::CBRK_USB_CHK>) _param_cbrk_usb_chk,
 		(ParamInt<px4::params::CBRK_AIRSPD_CHK>) _param_cbrk_airspd_chk,

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -977,3 +977,14 @@ PARAM_DEFINE_INT32(COM_PREARM_MODE, 1);
  * @group Commander
  */
 PARAM_DEFINE_INT32(COM_MOT_TEST_EN, 1);
+
+/**
+ * Timeout value for disarming when kill switch is engaged
+ *
+ * @group Commander
+ * @unit s
+ * @min 0.0
+ * @max 30.0
+ * @increment 0.1
+ */
+PARAM_DEFINE_FLOAT(COM_KILL_DISARM, 5.0f);


### PR DESCRIPTION
Added a float parameter to control the timeout value for disarming while the kill switch is engaged. Defaults to disarm after 5 seconds.

**Describe problem solved by this pull request**
Many users use the kill switch in emergency landing situations (maybe the vehicle landed on a non-flat surface in position mode). It can often be quite unintuitive and scary when the props start spinning again after disengaging the kill switch. 

**Describe your solution**
This PR alleviates this issue by allowing the disarm-on-kill timeout value to be set.

**Test data / coverage**
Tested on the bench successfully.
5 seconds
1 second
0.1 seconds
