### PR TITLE
Exclude middle-idx each loop, in Binary Search(in "param_find_internal" function)

### DIFF
--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -353,10 +353,10 @@ param_find_internal(const char *name, bool notification)
 			break;
 
 		} else if (ret < 0) {
-			last = middle;
+			last = middle - 1;
 
 		} else {
-			front = middle;
+			front = middle + 1;
 		}
 	}
 

--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -348,15 +348,12 @@ param_find_internal(const char *name, bool notification)
 			perf_end(param_find_perf);
 			return middle;
 
-		} else if (middle == front) {
-			/* An end point has been hit, but there has been no match */
-			break;
-
 		} else if (ret < 0) {
 			last = middle - 1;
 
 		} else {
 			front = middle + 1;
+
 		}
 	}
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
Hmm, basic binary-search algorithm. So maybe faster param_find function execution?

**Describe your solution**
Basically, I just excluded middle idx from the search-range, from each loop, because the parameter at the middle idx definitely isn't the param we are interested at, after getting non-zero value output from strcmp( ).

**Describe possible alternatives**
Not sure. This is a pretty minor modification.

**Test data / coverage**
Haven't tested. But according to binary-search algorithm online, this should work.

**Additional context**
My fist PR! Hope this helps px4.
