### PR TITLE
Trivial: Remove duplicate EOF trailing newlines

### DIFF
--- a/Tools/astyle/pre-commit
+++ b/Tools/astyle/pre-commit
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # An example hook script to verify what is about to be committed.
-# Called by "git commit" with no arguments.  The hook should
+# Called by "git commit" with no arguments. The hook should
 # exit with non-zero status after issuing an appropriate message if
 # it wants to stop the commit.
 #
@@ -50,16 +50,16 @@ fi
 git diff-index --check --cached $against --
 if [ $? -ne 0 ]; then
 	echo "Pre-commit style error: Whitespace issues"
-        exit 1
+	exit 1
 fi
 
 # Check for code style, only in changed files
 for i in `git diff --cached --name-only --diff-filter=ACM`
 do
-        ./Tools/astyle/files_to_check_code_style.sh $i | xargs -n 1 -P 8 -I % ./Tools/astyle/check_code_style.sh %
-        if [ $? -ne 0 ]
-        then
+	./Tools/astyle/files_to_check_code_style.sh $i | xargs -n 1 -P 8 -I % ./Tools/astyle/check_code_style.sh %
+	if [ $? -ne 0 ]
+	then
 		echo "Pre-commit style error: Bad formatting according to astyle rules"
-                exit 1
-        fi
+		exit 1
+	fi
 done

--- a/Tools/astyle/pre-commit
+++ b/Tools/astyle/pre-commit
@@ -31,7 +31,7 @@ if [ "$allownonascii" != "true" ] &&
 	test $(git diff --cached --name-only --diff-filter=A -z $against |
 	  LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
 then
-	echo "Error: Attempt to add a non-ascii file name."
+	echo "Pre-commit style error: Attempt to add a non-ascii file name."
 	echo
 	echo "This can cause problems if you want to work"
 	echo "with people on other platforms."
@@ -49,6 +49,7 @@ fi
 # If there are whitespace errors, print the offending file names and fail.
 git diff-index --check --cached $against --
 if [ $? -ne 0 ]; then
+	echo "Pre-commit style error: Whitespace issues"
         exit 1
 fi
 
@@ -58,6 +59,7 @@ do
         ./Tools/astyle/files_to_check_code_style.sh $i | xargs -n 1 -P 8 -I % ./Tools/astyle/check_code_style.sh %
         if [ $? -ne 0 ]
         then
+		echo "Pre-commit style error: Bad formatting according to astyle rules"
                 exit 1
         fi
 done

--- a/platforms/common/include/px4_defines.h
+++ b/platforms/common/include/px4_defines.h
@@ -38,4 +38,3 @@
 #pragma once
 
 #include <px4_platform_common/defines.h>
-

--- a/platforms/common/include/px4_log.h
+++ b/platforms/common/include/px4_log.h
@@ -39,4 +39,3 @@
 #pragma once
 
 #include <px4_platform_common/log.h>
-

--- a/platforms/common/include/px4_platform_common/app.h
+++ b/platforms/common/include/px4_platform_common/app.h
@@ -70,5 +70,3 @@ private:
 #ifdef PX4_MAIN
 extern int PX4_MAIN(int argc, char *argv[]);
 #endif
-
-

--- a/platforms/common/include/px4_platform_common/board_common.h
+++ b/platforms/common/include/px4_platform_common/board_common.h
@@ -1078,4 +1078,3 @@ __EXPORT bool board_has_bus(enum board_bus_types type, uint32_t bus);
  *               32000 resets.
  */
 int board_hardfault_init(int display_to_console, bool allow_prompt);
-

--- a/platforms/common/include/px4_platform_common/cli.h
+++ b/platforms/common/include/px4_platform_common/cli.h
@@ -50,5 +50,3 @@
  * @return 0 on success, -errno otherwise
  */
 int px4_get_parameter_value(const char *option, int &value);
-
-

--- a/platforms/common/include/px4_platform_common/getopt.h
+++ b/platforms/common/include/px4_platform_common/getopt.h
@@ -43,4 +43,3 @@ __BEGIN_DECLS
 int px4_getopt(int argc, char *argv[], const char *options, int *myoptind, const char **myoptarg);
 
 __END_DECLS
-

--- a/platforms/common/include/px4_platform_common/init.h
+++ b/platforms/common/include/px4_platform_common/init.h
@@ -51,4 +51,3 @@ __EXPORT void init(int argc, char *argv[], const char *process_name);
 } // namespace px4
 
 #endif /* __cplusplus */
-

--- a/platforms/common/include/px4_platform_common/micro_hal.h
+++ b/platforms/common/include/px4_platform_common/micro_hal.h
@@ -38,4 +38,3 @@
 
 // include arch-specific header
 #include <px4_arch/micro_hal.h>
-

--- a/platforms/common/include/px4_platform_common/shutdown.h
+++ b/platforms/common/include/px4_platform_common/shutdown.h
@@ -96,4 +96,3 @@ __EXPORT int px4_shutdown_lock(void);
 __EXPORT int px4_shutdown_unlock(void);
 
 __END_DECLS
-

--- a/platforms/common/include/px4_platform_common/tasks.h
+++ b/platforms/common/include/px4_platform_common/tasks.h
@@ -190,4 +190,3 @@ __EXPORT int px4_prctl(int option, const char *arg2, px4_task_t pid);
 __EXPORT const char *px4_get_taskname(void);
 
 __END_DECLS
-

--- a/platforms/common/include/px4_time.h
+++ b/platforms/common/include/px4_time.h
@@ -38,4 +38,3 @@
 #pragma once
 
 #include <px4_platform_common/time.h>
-

--- a/platforms/nuttx/src/px4/common/include/px4_platform/board_determine_hw_info.h
+++ b/platforms/nuttx/src/px4/common/include/px4_platform/board_determine_hw_info.h
@@ -59,4 +59,3 @@ __BEGIN_DECLS
 __EXPORT int board_determine_hw_info(void);
 
 __END_DECLS
-

--- a/platforms/nuttx/src/px4/common/include/px4_platform/gpio.h
+++ b/platforms/nuttx/src/px4/common/include/px4_platform/gpio.h
@@ -53,4 +53,3 @@ __BEGIN_DECLS
 __EXPORT void px4_gpio_init(const uint32_t list[], int count);
 
 __END_DECLS
-

--- a/platforms/nuttx/src/px4/nxp/kinetis/version/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/nxp/kinetis/version/CMakeLists.txt
@@ -35,4 +35,3 @@ px4_add_library(arch_version
 	board_identity.c
 	board_mcu_version.c
 )
-

--- a/platforms/nuttx/src/px4/stm/stm32_common/version/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/stm/stm32_common/version/CMakeLists.txt
@@ -35,4 +35,3 @@ px4_add_library(arch_version
 	board_identity.c
 	board_mcu_version.c
 )
-


### PR DESCRIPTION
**Describe problem solved by this pull request**
When merging master into a branch the and experiencing conflicts the merge can be completed after resolving the conflicts using `git commit` but with the currently existing EOF trailing newlines you get a bunch of messages like `path/filename:linenumber: new blank line at EOF` and it doesn't continue.

**Describe your solution**
Since these newlines are useless anyways I suggest to just remove them.

**Test data / coverage**
It's a trivial change and still compiles.

**Additional context**
I'm still following up to create usefull prs out of #12072 and using the oportunity to learn merging correctly since I have to still keep it up to date to take over missing things.