### PR TITLE
Add RM3100 start command for several boards

### DIFF
--- a/boards/px4/fmu-v3/init/rc.board_sensors
+++ b/boards/px4/fmu-v3/init/rc.board_sensors
@@ -115,4 +115,7 @@ else
 	lsm303d start
 fi
 
+# External RM3100 (I2C or SPI)
+rm3100 start
+
 unset BOARD_FMUV3

--- a/boards/px4/fmu-v4/init/rc.board_sensors
+++ b/boards/px4/fmu-v4/init/rc.board_sensors
@@ -68,3 +68,6 @@ then
 	# BMI160 internal SPI bus
 	bmi160 start
 fi
+
+# External RM3100 (I2C or SPI)
+rm3100 start

--- a/boards/px4/fmu-v5/init/rc.board_sensors
+++ b/boards/px4/fmu-v5/init/rc.board_sensors
@@ -34,3 +34,6 @@ ist8310 -C -b 5 start
 
 # Baro on internal SPI
 ms5611 -s start
+
+# External RM3100 (I2C or SPI)
+rm3100 start

--- a/boards/px4/fmu-v5x/init/rc.board_sensors
+++ b/boards/px4/fmu-v5x/init/rc.board_sensors
@@ -31,3 +31,6 @@ bmm150 start
 # Possible internal Barro
 bmp388 -I start
 #bmp388 -J start fixme
+
+# External RM3100 (I2C or SPI)
+rm3100 start


### PR DESCRIPTION
**Describe problem solved by this pull request**
Currently, the RM3100 magnetometer is built for many boards, but it is started only for the fmu-v4pro board. I am using a fmu-v3 Dropix board and I would like to use the RM3100 sensor as an external magnetometer without manually launching the command. Other boards should also start this driver automatically. 

**Describe your solution**
I added the rm3100 start command in the rc.board_sensors file of the Pixhawk series boards that build all the magnetometers available (fmu-v3, fmu-v4, fmu-v5, fmu-v5x). I am not sure if other boards outside the Pixhawk series will need it.   
The RM3100 provides an I2C and SPI connection. The start command tries each possible protocol connection.   

**Test data / coverage**
Only tested on px4 fmu-v3 Dropix board with I2C and it work. I have only this board available.
