### PR TITLE
smbus: fix invalid memory access in read_word()

### DIFF
--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -87,7 +87,7 @@ int BATT_SMBUS::task_spawn(int argc, char *argv[])
 	int ch;
 	const char *myoptarg = nullptr;
 
-	while ((ch = px4_getopt(argc, argv, "XTRIA:", &myoptind, &myoptarg)) != EOF) {
+	while ((ch = px4_getopt(argc, argv, "XTRIA", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'X':
 			busid = BATT_SMBUS_BUS_I2C_EXTERNAL;

--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -117,10 +117,10 @@ int BATT_SMBUS::task_spawn(int argc, char *argv[])
 
 	for (unsigned i = 0; i < NUM_BUS_OPTIONS; i++) {
 
-		if (!is_running() && (busid == BATT_SMBUS_BUS_ALL || bus_options[i].busid == busid)) {
+		if (!is_running() && (busid == BATT_SMBUS_BUS_ALL || smbus_bus_options[i].busid == busid)) {
 
-			SMBus *interface = new SMBus(bus_options[i].busnum, BATT_SMBUS_ADDR);
-			BATT_SMBUS *dev = new BATT_SMBUS(interface, bus_options[i].devpath);
+			SMBus *interface = new SMBus(smbus_bus_options[i].busnum, BATT_SMBUS_ADDR);
+			BATT_SMBUS *dev = new BATT_SMBUS(interface, smbus_bus_options[i].devpath);
 
 			// Successful read of device type, we've found our battery
 			_object.store(dev);

--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -571,6 +571,11 @@ int BATT_SMBUS::custom_command(int argc, char *argv[])
 	uint8_t man_name[22];
 	int result = 0;
 
+	if (!is_running()) {
+		PX4_ERR("not running");
+		return -1;
+	}
+
 	BATT_SMBUS *obj = get_instance();
 
 	if (!strcmp(input, "man_info")) {

--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -122,15 +122,16 @@ int BATT_SMBUS::task_spawn(int argc, char *argv[])
 			SMBus *interface = new SMBus(smbus_bus_options[i].busnum, BATT_SMBUS_ADDR);
 			BATT_SMBUS *dev = new BATT_SMBUS(interface, smbus_bus_options[i].devpath);
 
-			// Successful read of device type, we've found our battery
-			_object.store(dev);
-			_task_id = task_id_is_work_queue;
-
 			int result = dev->get_startup_info();
 
 			if (result != PX4_OK) {
-				return PX4_ERROR;
+				delete dev;
+				continue;
 			}
+
+			// Successful read of device type, we've found our battery
+			_object.store(dev);
+			_task_id = task_id_is_work_queue;
 
 			dev->ScheduleOnInterval(BATT_SMBUS_MEASUREMENT_INTERVAL_US);
 

--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -687,6 +687,7 @@ $ batt_smbus -X write_flash 19069 2 27 0
 	PRINT_MODULE_USAGE_ARG("address", "The address to start writing.", true);
 	PRINT_MODULE_USAGE_ARG("number of bytes", "Number of bytes to send.", true);
 	PRINT_MODULE_USAGE_ARG("data[0]...data[n]", "One byte of data at a time separated by spaces.", true);
+	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 
 	return PX4_OK;
 }

--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -620,7 +620,7 @@ int BATT_SMBUS::custom_command(int argc, char *argv[])
 	}
 
 	if (!strcmp(input, "write_flash")) {
-		if (argv[1] && argv[2]) {
+		if (argc >= 3) {
 			uint16_t address = atoi(argv[1]);
 			unsigned length = atoi(argv[2]);
 			uint8_t tx_buf[32] = {};
@@ -632,7 +632,9 @@ int BATT_SMBUS::custom_command(int argc, char *argv[])
 
 			// Data needs to be fed in 1 byte (0x01) at a time.
 			for (unsigned i = 0; i < length; i++) {
-				tx_buf[i] = atoi(argv[3 + i]);
+				if ((unsigned)argc <= 3 + i) {
+					tx_buf[i] = atoi(argv[3 + i]);
+				}
 			}
 
 			if (PX4_OK != obj->dataflash_write(address, tx_buf, length)) {

--- a/src/drivers/batt_smbus/batt_smbus.h
+++ b/src/drivers/batt_smbus/batt_smbus.h
@@ -62,12 +62,10 @@
 #define BATT_CURRENT_UNDERVOLTAGE_THRESHOLD             5.0f            ///< Threshold in amps to disable undervoltage protection
 #define BATT_VOLTAGE_UNDERVOLTAGE_THRESHOLD             3.4f            ///< Threshold in volts to re-enable undervoltage protection
 
+#define BATT_SMBUS_ADDR                                 0x0B            ///< Default 7 bit address I2C address. 8 bit = 0x16
+
 #define BATT_SMBUS_CURRENT                              0x0A            ///< current register
 #define BATT_SMBUS_AVERAGE_CURRENT                      0x0B            ///< current register
-#define BATT_SMBUS_ADDR                                 0x0B            ///< Default 7 bit address I2C address. 8 bit = 0x16
-#define BATT_SMBUS_ADDR_MIN                             0x00            ///< lowest possible address
-#define BATT_SMBUS_ADDR_MAX                             0xFF            ///< highest possible address
-#define BATT_SMBUS_PEC_POLYNOMIAL                       0x07            ///< Polynomial for calculating PEC
 #define BATT_SMBUS_TEMP                                 0x08            ///< temperature register
 #define BATT_SMBUS_VOLTAGE                              0x09            ///< voltage register
 #define BATT_SMBUS_FULL_CHARGE_CAPACITY                 0x10            ///< capacity when fully charged
@@ -81,7 +79,6 @@
 #define BATT_SMBUS_MANUFACTURE_DATE                     0x1B            ///< manufacture date register
 #define BATT_SMBUS_SERIAL_NUMBER                        0x1C            ///< serial number register
 #define BATT_SMBUS_MEASUREMENT_INTERVAL_US              100000          ///< time in microseconds, measure at 10Hz
-#define BATT_SMBUS_TIMEOUT_US                           1000000         ///< timeout looking for battery 10seconds after startup
 #define BATT_SMBUS_MANUFACTURER_ACCESS                  0x00
 #define BATT_SMBUS_MANUFACTURER_DATA                    0x23
 #define BATT_SMBUS_MANUFACTURER_BLOCK_ACCESS            0x44

--- a/src/drivers/batt_smbus/batt_smbus.h
+++ b/src/drivers/batt_smbus/batt_smbus.h
@@ -95,7 +95,7 @@
 #define BATT_SMBUS_ENABLED_PROTECTIONS_A_DEFAULT        0xcf
 #define BATT_SMBUS_ENABLED_PROTECTIONS_A_CUV_DISABLED   0xce
 
-#define NUM_BUS_OPTIONS (sizeof(bus_options)/sizeof(bus_options[0]))
+#define NUM_BUS_OPTIONS (sizeof(smbus_bus_options)/sizeof(smbus_bus_options[0]))
 
 enum BATT_SMBUS_BUS {
 	BATT_SMBUS_BUS_ALL = 0,
@@ -109,7 +109,7 @@ struct batt_smbus_bus_option {
 	enum BATT_SMBUS_BUS busid;
 	const char *devpath;
 	uint8_t busnum;
-} bus_options[] = {
+} const smbus_bus_options[] = {
 	{ BATT_SMBUS_BUS_I2C_EXTERNAL, "/dev/batt_smbus_ext", PX4_I2C_BUS_EXPANSION},
 #ifdef PX4_I2C_BUS_EXPANSION1
 	{ BATT_SMBUS_BUS_I2C_EXTERNAL1, "/dev/batt_smbus_ext1", PX4_I2C_BUS_EXPANSION1},

--- a/src/drivers/batt_smbus/batt_smbus.h
+++ b/src/drivers/batt_smbus/batt_smbus.h
@@ -263,8 +263,6 @@ private:
 
 	float _min_cell_voltage{0};
 
-	bool _should_suspend{false};
-
 	/** @param _last_report Last published report, used for test(). */
 	battery_status_s _last_report{};
 

--- a/src/lib/drivers/smbus/SMBus.cpp
+++ b/src/lib/drivers/smbus/SMBus.cpp
@@ -50,23 +50,23 @@ SMBus::SMBus(int bus_num, uint16_t address) :
 {
 }
 
-int SMBus::read_word(const uint8_t cmd_code, void *data)
+int SMBus::read_word(const uint8_t cmd_code, uint16_t &data)
 {
+	uint8_t buf[6];
 	// 2 data bytes + pec byte
-	int result = transfer(&cmd_code, 1, (uint8_t *)data, 3);
+	int result = transfer(&cmd_code, 1, buf + 3, 3);
 
 	if (result == PX4_OK) {
+		data = buf[3] | ((uint16_t)buf[4] << 8);
 		// Check PEC.
 		uint8_t addr = get_device_address() << 1;
-		uint8_t full_data_packet[5];
-		full_data_packet[0] = addr | 0x00;
-		full_data_packet[1] = cmd_code;
-		full_data_packet[2] = addr | 0x01;
-		memcpy(&full_data_packet[3], data, 2);
+		buf[0] = addr | 0x00;
+		buf[1] = cmd_code;
+		buf[2] = addr | 0x01;
 
-		uint8_t pec = get_pec(full_data_packet, sizeof(full_data_packet) / sizeof(full_data_packet[0]));
+		uint8_t pec = get_pec(buf, sizeof(buf) - 1);
 
-		if (pec != ((uint8_t *)data)[2]) {
+		if (pec != buf[sizeof(buf) - 1]) {
 			result = -EINVAL;
 		}
 	}
@@ -74,14 +74,14 @@ int SMBus::read_word(const uint8_t cmd_code, void *data)
 	return result;
 }
 
-int SMBus::write_word(const uint8_t cmd_code, void *data)
+int SMBus::write_word(const uint8_t cmd_code, uint16_t data)
 {
 	// 2 data bytes + pec byte
-	uint8_t buf[5] = {};
+	uint8_t buf[5];
 	buf[0] = (get_device_address() << 1) | 0x10;
 	buf[1] = cmd_code;
-	buf[2] = ((uint8_t *)data)[0];
-	buf[3] = ((uint8_t *)data)[1];
+	buf[2] = data & 0xff;
+	buf[3] = (data >> 8) & 0xff;
 
 	buf[4] = get_pec(buf, 4);
 

--- a/src/lib/drivers/smbus/SMBus.hpp
+++ b/src/lib/drivers/smbus/SMBus.hpp
@@ -55,7 +55,7 @@ public:
 	 * @param cmd_code The command code.
 	 * @param data The data to be written.
 	 * @param length The number of bytes being written.
-	 * @return Returns PX4_OK on success, PX4_ERROR on failure.
+	 * @return Returns PX4_OK on success, -errno on failure.
 	 */
 	int block_write(const uint8_t cmd_code, void *data, uint8_t byte_count, bool use_pec);
 
@@ -64,7 +64,7 @@ public:
 	 * @param cmd_code The command code.
 	 * @param data The returned data.
 	 * @param length The number of bytes being read
-	 * @return Returns PX4_OK on success, PX4_ERROR on failure.
+	 * @return Returns PX4_OK on success, -errno on failure.
 	 */
 	int block_read(const uint8_t cmd_code, void *data, const uint8_t length, bool use_pec);
 
@@ -72,23 +72,23 @@ public:
 	 * @brief Sends a read word command.
 	 * @param cmd_code The command code.
 	 * @param data The 2 bytes of returned data plus a 1 byte CRC if used.
-	 * @return Returns PX4_OK on success, PX4_ERROR on failure.
+	 * @return Returns PX4_OK on success, -errno on failure.
 	 */
-	int read_word(const uint8_t cmd_code, void *data);
+	int read_word(const uint8_t cmd_code, uint16_t &data);
 
 	/**
 	 * @brief Sends a write word command.
 	 * @param cmd_code The command code.
 	 * @param data The 2 bytes of data to be transfered.
-	 * @return Returns PX4_OK on success, PX4_ERROR on failure.
+	 * @return Returns PX4_OK on success, -errno on failure.
 	 */
-	int write_word(const uint8_t cmd_code, void *data);
+	int write_word(const uint8_t cmd_code, uint16_t data);
 
 	/**
 	 * @brief Calculates the PEC from the data.
 	 * @param buffer The buffer that stores the data to perform the CRC over.
 	 * @param length The number of bytes being written.
-	 * @return Returns PX4_OK on success, PX4_ERROR on failure.
+	 * @return Returns PX4_OK on success, -errno on failure.
 	 */
 	uint8_t get_pec(uint8_t *buffer, uint8_t length);
 


### PR DESCRIPTION
read_word() expected 3 bytes (uint16_t + PEC byte), but was passed an address to an uint16_t value.

write_word() is changed to be type-safe as well.

@dakejahl can you test this?