### PR TITLE
mpu9250: fix mag spikes on fmu-v4pro

### DIFF
--- a/src/drivers/imu/mpu9250/MPU9250_mag.h
+++ b/src/drivers/imu/mpu9250/MPU9250_mag.h
@@ -106,18 +106,6 @@ struct ak8963_regs {
 };
 #pragma pack(pop)
 
-#pragma pack(push, 1)
-struct ak09916_regs {
-	uint8_t st1;
-	int16_t x;
-	int16_t y;
-	int16_t z;
-	uint8_t tmps;
-	uint8_t st2;
-};
-#pragma pack(pop)
-
-
 extern device::Device *AK8963_I2C_interface(int bus, bool external_bus);
 
 typedef device::Device *(*MPU9250_mag_constructor)(int, bool);
@@ -150,11 +138,8 @@ protected:
 
 	friend class MPU9250;
 
-	/* Directly measure from the _interface if possible */
 	void measure();
-
-	/* Update the state with prefetched data (internally called by the regular measure() )*/
-	void _measure(hrt_abstime timestamp, struct ak8963_regs data);
+	void _measure(hrt_abstime timestamp_sample, ak8963_regs data);
 
 	uint8_t read_reg(unsigned reg);
 	void write_reg(unsigned reg, uint8_t value);
@@ -162,7 +147,6 @@ protected:
 	bool is_passthrough() { return _interface == nullptr; }
 
 private:
-
 	PX4Magnetometer		_px4_mag;
 
 	MPU9250 *_parent;
@@ -171,12 +155,7 @@ private:
 
 	perf_counter_t _mag_overruns;
 	perf_counter_t _mag_overflows;
-	perf_counter_t _mag_duplicates;
-
-	bool check_duplicate(uint8_t *mag_data);
-
-	// keep last mag reading for duplicate detection
-	uint8_t			_last_mag_data[6] {};
+	perf_counter_t _mag_errors;
 
 	/* do not allow to copy this class due to pointer data members */
 	MPU9250_mag(const MPU9250_mag &);


### PR DESCRIPTION
This should fix spikes in the mag data on MPU9250 found inside Drotek Pixhawk 3Pro.

The problem turned out to be that we are not checking the DRDY bit before reading the data. We presumably threw away most of the stale data by doing a duplicate check, however, sometimes we might have run into a race where the mag data was already being updated in the chip while
still being read.

Before merging we should make sure this doesn't break other boards or external GPS/mag with MPU9250.


This was the spikes I could see:
![Selection_066](https://user-images.githubusercontent.com/1419688/68040318-6802fe80-fcce-11e9-829a-3e977481ccfb.png)

I'm not sure if this is related to the mag values seen in this log:
https://review.px4.io/plot_app?log=49829594-e88e-4f85-8740-6b2f7bf87c47&fbclid=IwAR1vs4sYoGntIlDX6kiA_58IYzI2y26o6n-Zo_7NfdaaunZl9lXonkU9zls