### PR TITLE
px_uploader.py: increase estimated erase time

### DIFF
--- a/Tools/px_uploader.py
+++ b/Tools/px_uploader.py
@@ -405,10 +405,10 @@ class uploader(object):
         deadline = time.time() + 30.0
         while time.time() < deadline:
 
-            # Draw progress bar (erase usually takes about 9 seconds to complete)
+            usualEraseDuration = 15.0
             estimatedTimeRemaining = deadline-time.time()
-            if estimatedTimeRemaining >= 9.0:
-                self.__drawProgressBar(label, 30.0-estimatedTimeRemaining, 9.0)
+            if estimatedTimeRemaining >= usualEraseDuration:
+                self.__drawProgressBar(label, 30.0-estimatedTimeRemaining, usualEraseDuration)
             else:
                 self.__drawProgressBar(label, 10.0, 10.0)
                 sys.stdout.write(" (timeout: %d seconds) " % int(deadline-time.time()))
@@ -733,13 +733,13 @@ def main():
             pyserial_installed = True
     except:
         pass
-    
+
     try:
         if serial.VERSION:
             pyserial_installed = True
     except:
         pass
-    
+
     if not pyserial_installed:
         print("Error: pyserial not installed!")
         print("    (Install using: sudo pip install pyserial)")


### PR DESCRIPTION
The 9 seconds to erase a board probably still come from the FMU-v1 and Pixhawks with only 1 MB flash. By now, many targets have 2 MB flash and take a bit longer to erase. Therefore, we can increase the estimated time a bit and don't need to resort to the timeout notice.