### PR TITLE
modalai-fc-v1- rotate default orientation 180° yaw

### DIFF
--- a/boards/modalai/fc-v1/init/rc.board_sensors
+++ b/boards/modalai/fc-v1/init/rc.board_sensors
@@ -7,16 +7,16 @@
 voxlpm -R start
 
 # Internal SPI bus ICM-20602
-mpu6000 -R 2 -s -T 20602 start
+mpu6000 -R 6 -s -T 20602 start
 
 # Internal SPI bus ICM-42688
 # TODO
 
 # Internal SPI bus BMI088 accel
-bmi088 -A start
+bmi088 -A -R 4 start
 
 # Internal SPI bus BMI088 gyro
-bmi088 -G start
+bmi088 -G -R 4 start
 
 # Possible external compasses
 ist8310 -C -b 1 start


### PR DESCRIPTION
**Describe problem solved by this pull request**
Change the default orientation of the ModalAI FC v1 flight controller such that ROTATION_NONE can be used as default with upcoming combo board (VOXL-Flight).