### PR TITLE
astyle shift module documentation to bottom of files

### DIFF
--- a/src/drivers/dshot/dshot.cpp
+++ b/src/drivers/dshot/dshot.cpp
@@ -1531,6 +1531,65 @@ int DShotOutput::custom_command(int argc, char *argv[])
 	return print_usage("unknown command");
 }
 
+int DShotOutput::print_status()
+{
+	const char *mode_str = nullptr;
+
+	switch (_mode) {
+
+	case MODE_NONE: mode_str = "no outputs"; break;
+
+	case MODE_1PWM: mode_str = "outputs1"; break;
+
+	case MODE_2PWM: mode_str = "outputs2"; break;
+
+	case MODE_2PWM2CAP: mode_str = "outputs2cap2"; break;
+
+	case MODE_3PWM: mode_str = "outputs3"; break;
+
+	case MODE_3PWM1CAP: mode_str = "outputs3cap1"; break;
+
+	case MODE_4PWM: mode_str = "outputs4"; break;
+
+	case MODE_4PWM1CAP: mode_str = "outputs4cap1"; break;
+
+	case MODE_4PWM2CAP: mode_str = "outputs4cap2"; break;
+
+	case MODE_5PWM: mode_str = "outputs5"; break;
+
+	case MODE_5PWM1CAP: mode_str = "outputs5cap1"; break;
+
+	case MODE_6PWM: mode_str = "outputs6"; break;
+
+	case MODE_8PWM: mode_str = "outputs8"; break;
+
+	case MODE_4CAP: mode_str = "cap4"; break;
+
+	case MODE_5CAP: mode_str = "cap5"; break;
+
+	case MODE_6CAP: mode_str = "cap6"; break;
+
+	default:
+		break;
+	}
+
+	if (mode_str) {
+		PX4_INFO("Mode: %s", mode_str);
+	}
+
+	PX4_INFO("Outputs initialized: %s", _outputs_initialized ? "yes" : "no");
+	PX4_INFO("Outputs on: %s", _outputs_on ? "yes" : "no");
+	perf_print_counter(_cycle_perf);
+	_mixing_output.printStatus();
+
+	if (_telemetry) {
+		PX4_INFO("telemetry on: %s", _telemetry_device);
+		_telemetry->handler.printStatus();
+	}
+
+	return 0;
+}
+
 int DShotOutput::print_usage(const char *reason)
 {
 	if (reason) {
@@ -1614,68 +1673,7 @@ After saving, the reversed direction will be regarded as the normal one. So to r
 	return 0;
 }
 
-int DShotOutput::print_status()
-{
-	const char *mode_str = nullptr;
-
-	switch (_mode) {
-
-	case MODE_NONE: mode_str = "no outputs"; break;
-
-	case MODE_1PWM: mode_str = "outputs1"; break;
-
-	case MODE_2PWM: mode_str = "outputs2"; break;
-
-	case MODE_2PWM2CAP: mode_str = "outputs2cap2"; break;
-
-	case MODE_3PWM: mode_str = "outputs3"; break;
-
-	case MODE_3PWM1CAP: mode_str = "outputs3cap1"; break;
-
-	case MODE_4PWM: mode_str = "outputs4"; break;
-
-  	case MODE_4PWM1CAP: mode_str = "outputs4cap1"; break;
-
-	case MODE_4PWM2CAP: mode_str = "outputs4cap2"; break;
-
-  	case MODE_5PWM: mode_str = "outputs5"; break;
-
-  	case MODE_5PWM1CAP: mode_str = "outputs5cap1"; break;
-
-  	case MODE_6PWM: mode_str = "outputs6"; break;
-
-	case MODE_8PWM: mode_str = "outputs8"; break;
-
-	case MODE_4CAP: mode_str = "cap4"; break;
-
-	case MODE_5CAP: mode_str = "cap5"; break;
-
-	case MODE_6CAP: mode_str = "cap6"; break;
-
-	default:
-		break;
-	}
-
-	if (mode_str) {
-		PX4_INFO("Mode: %s", mode_str);
-	}
-
-	PX4_INFO("Outputs initialized: %s", _outputs_initialized ? "yes" : "no");
-	PX4_INFO("Outputs on: %s", _outputs_on ? "yes" : "no");
-	perf_print_counter(_cycle_perf);
-	_mixing_output.printStatus();
-	if (_telemetry) {
-		PX4_INFO("telemetry on: %s", _telemetry_device);
-		_telemetry->handler.printStatus();
-	}
-
-	return 0;
-}
-
-extern "C" __EXPORT int dshot_main(int argc, char *argv[]);
-
-int
-dshot_main(int argc, char *argv[])
+extern "C" __EXPORT int dshot_main(int argc, char *argv[])
 {
 	return DShotOutput::main(argc, argv);
 }

--- a/src/drivers/pwm_out_sim/PWMSim.cpp
+++ b/src/drivers/pwm_out_sim/PWMSim.cpp
@@ -39,8 +39,6 @@
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/parameter_update.h>
 
-extern "C" __EXPORT int pwm_out_sim_main(int argc, char *argv[]);
-
 PWMSim::PWMSim(bool hil_mode_enabled) :
 	CDev(PWM_OUTPUT0_DEVICE_PATH),
 	OutputModuleInterface(MODULE_NAME, px4::wq_configurations::hp_default)
@@ -273,6 +271,12 @@ int PWMSim::custom_command(int argc, char *argv[])
 	return print_usage("unknown command");
 }
 
+int PWMSim::print_status()
+{
+	_mixing_output.printStatus();
+	return 0;
+}
+
 int PWMSim::print_usage(const char *reason)
 {
 	if (reason) {
@@ -300,14 +304,7 @@ It is used in SITL and HITL.
 	return 0;
 }
 
-int PWMSim::print_status()
-{
-	_mixing_output.printStatus();
-	return 0;
-}
-
-int
-pwm_out_sim_main(int argc, char *argv[])
+extern "C" __EXPORT int pwm_out_sim_main(int argc, char *argv[])
 {
 	return PWMSim::main(argc, argv);
 }

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -2173,6 +2173,59 @@ int PX4FMU::custom_command(int argc, char *argv[])
 	return print_usage("unknown command");
 }
 
+int PX4FMU::print_status()
+{
+	PX4_INFO("Max update rate: %i Hz", _current_update_rate);
+
+	const char *mode_str = nullptr;
+
+	switch (_mode) {
+	case MODE_NONE: mode_str = "no pwm"; break;
+
+	case MODE_1PWM: mode_str = "pwm1"; break;
+
+	case MODE_2PWM: mode_str = "pwm2"; break;
+
+	case MODE_2PWM2CAP: mode_str = "pwm2cap2"; break;
+
+	case MODE_3PWM: mode_str = "pwm3"; break;
+
+	case MODE_3PWM1CAP: mode_str = "pwm3cap1"; break;
+
+	case MODE_4PWM: mode_str = "pwm4"; break;
+
+	case MODE_4PWM1CAP: mode_str = "pwm4cap1"; break;
+
+	case MODE_4PWM2CAP: mode_str = "pwm4cap2"; break;
+
+	case MODE_5PWM: mode_str = "pwm5"; break;
+
+	case MODE_5PWM1CAP: mode_str = "pwm5cap1"; break;
+
+	case MODE_6PWM: mode_str = "pwm6"; break;
+
+	case MODE_8PWM: mode_str = "pwm8"; break;
+
+	case MODE_4CAP: mode_str = "cap4"; break;
+
+	case MODE_5CAP: mode_str = "cap5"; break;
+
+	case MODE_6CAP: mode_str = "cap6"; break;
+
+	default:
+		break;
+	}
+
+	if (mode_str) {
+		PX4_INFO("PWM Mode: %s", mode_str);
+	}
+
+	perf_print_counter(_cycle_perf);
+	_mixing_output.printStatus();
+
+	return 0;
+}
+
 int PX4FMU::print_usage(const char *reason)
 {
 	if (reason) {
@@ -2252,64 +2305,7 @@ mixer files.
 	return 0;
 }
 
-int PX4FMU::print_status()
-{
-	PX4_INFO("Max update rate: %i Hz", _current_update_rate);
-
-	const char *mode_str = nullptr;
-
-	switch (_mode) {
-
-	case MODE_NONE: mode_str = "no pwm"; break;
-
-	case MODE_1PWM: mode_str = "pwm1"; break;
-
-	case MODE_2PWM: mode_str = "pwm2"; break;
-
-	case MODE_2PWM2CAP: mode_str = "pwm2cap2"; break;
-
-	case MODE_3PWM: mode_str = "pwm3"; break;
-
-	case MODE_3PWM1CAP: mode_str = "pwm3cap1"; break;
-
-	case MODE_4PWM: mode_str = "pwm4"; break;
-
-  	case MODE_4PWM1CAP: mode_str = "pwm4cap1"; break;
-
-	case MODE_4PWM2CAP: mode_str = "pwm4cap2"; break;
-
-  	case MODE_5PWM: mode_str = "pwm5"; break;
-
-  	case MODE_5PWM1CAP: mode_str = "pwm5cap1"; break;
-
-  	case MODE_6PWM: mode_str = "pwm6"; break;
-
-	case MODE_8PWM: mode_str = "pwm8"; break;
-
-	case MODE_4CAP: mode_str = "cap4"; break;
-
-	case MODE_5CAP: mode_str = "cap5"; break;
-
-	case MODE_6CAP: mode_str = "cap6"; break;
-
-	default:
-		break;
-	}
-
-	if (mode_str) {
-		PX4_INFO("PWM Mode: %s", mode_str);
-	}
-
-	perf_print_counter(_cycle_perf);
-	_mixing_output.printStatus();
-
-	return 0;
-}
-
-extern "C" __EXPORT int fmu_main(int argc, char *argv[]);
-
-int
-fmu_main(int argc, char *argv[])
+extern "C" __EXPORT int fmu_main(int argc, char *argv[])
 {
 	return PX4FMU::main(argc, argv);
 }

--- a/src/drivers/rc_input/RCInput.cpp
+++ b/src/drivers/rc_input/RCInput.cpp
@@ -768,7 +768,38 @@ int RCInput::custom_command(int argc, char *argv[])
 	return print_usage("unknown command");
 }
 
-int RCInput::print_usage(const char *reason)
+int RCInput::print_status()
+{
+	PX4_INFO("Running %s", (_run_as_task ? "as task" : "on work queue"));
+
+	if (!_run_as_task) {
+		PX4_INFO("Max update rate: %i Hz", 1000000 / _current_update_interval);
+	}
+
+	if (_device[0] != '\0') {
+		PX4_INFO("Serial device: %s", _device);
+	}
+
+	PX4_INFO("RC scan state: %s, locked: %s", RC_SCAN_STRING[_rc_scan_state], _rc_scan_locked ? "yes" : "no");
+	PX4_INFO("CRSF Telemetry: %s", _crsf_telemetry ? "yes" : "no");
+	PX4_INFO("SBUS frame drops: %u", sbus_dropped_frames());
+
+#if ADC_RC_RSSI_CHANNEL
+	PX4_INFO("vrssi: %dmV", (int)(_analog_rc_rssi_volt * 1000.0f));
+#endif
+
+	perf_print_counter(_cycle_perf);
+	perf_print_counter(_publish_interval_perf);
+
+	if (hrt_elapsed_time(&_rc_in.timestamp) < 1_s) {
+		print_message(_rc_in);
+	}
+
+	return 0;
+}
+
+int
+RCInput::print_usage(const char *reason)
 {
 	if (reason) {
 		PX4_WARN("%s\n", reason);
@@ -805,39 +836,7 @@ When running on the work queue, it schedules at a fixed frequency.
 	return 0;
 }
 
-int RCInput::print_status()
-{
-	PX4_INFO("Running %s", (_run_as_task ? "as task" : "on work queue"));
-
-	if (!_run_as_task) {
-		PX4_INFO("Max update rate: %i Hz", 1000000 / _current_update_interval);
-	}
-	if (_device[0] != '\0') {
-		PX4_INFO("Serial device: %s", _device);
-	}
-
-	PX4_INFO("RC scan state: %s, locked: %s", RC_SCAN_STRING[_rc_scan_state], _rc_scan_locked ? "yes" : "no");
-	PX4_INFO("CRSF Telemetry: %s", _crsf_telemetry ? "yes" : "no");
-	PX4_INFO("SBUS frame drops: %u", sbus_dropped_frames());
-
-#if ADC_RC_RSSI_CHANNEL
-        PX4_INFO("vrssi: %dmV", (int)(_analog_rc_rssi_volt * 1000.0f));
-#endif
-
-	perf_print_counter(_cycle_perf);
-	perf_print_counter(_publish_interval_perf);
-
-	if (hrt_elapsed_time(&_rc_in.timestamp) < 1_s) {
-		print_message(_rc_in);
-	}
-
-	return 0;
-}
-
-extern "C" __EXPORT int rc_input_main(int argc, char *argv[]);
-
-int
-rc_input_main(int argc, char *argv[])
+extern "C" __EXPORT int rc_input_main(int argc, char *argv[])
 {
 	return RCInput::main(argc, argv);
 }

--- a/src/drivers/safety_button/SafetyButton.cpp
+++ b/src/drivers/safety_button/SafetyButton.cpp
@@ -200,6 +200,14 @@ SafetyButton::custom_command(int argc, char *argv[])
 }
 
 int
+SafetyButton::print_status()
+{
+	PX4_INFO("Safety State (from button): %s", _safety_btn_off ? "off" : "on");
+
+	return 0;
+}
+
+int
 SafetyButton::print_usage(const char *reason)
 {
 	if (reason) {
@@ -219,18 +227,7 @@ This module is responsible for the safety button.
 	return 0;
 }
 
-int
-SafetyButton::print_status()
-{
-	PX4_INFO("Safety State (from button): %s", _safety_btn_off ? "off" : "on");
-
-	return 0;
-}
-
-extern "C" __EXPORT int safety_button_main(int argc, char *argv[]);
-
-int
-safety_button_main(int argc, char *argv[])
+extern "C" __EXPORT int safety_button_main(int argc, char *argv[])
 {
 	return SafetyButton::main(argc, argv);
 }

--- a/src/drivers/tap_esc/tap_esc.cpp
+++ b/src/drivers/tap_esc/tap_esc.cpp
@@ -778,9 +778,7 @@ tap_esc start -d /dev/ttyS2 -n <1-8>
 	return PX4_OK;
 }
 
-extern "C" __EXPORT int tap_esc_main(int argc, char *argv[]);
-
-int tap_esc_main(int argc, char *argv[])
+extern "C" __EXPORT int tap_esc_main(int argc, char *argv[])
 {
 	return TAP_ESC::main(argc, argv);
 }

--- a/src/drivers/telemetry/frsky_telemetry/frsky_telemetry.cpp
+++ b/src/drivers/telemetry/frsky_telemetry/frsky_telemetry.cpp
@@ -208,23 +208,6 @@ static void set_uart_single_wire(int uart, bool single_wire)
 }
 
 /**
- * Print command usage information
- */
-static void usage()
-{
-	PRINT_MODULE_DESCRIPTION("FrSky Telemetry support. Auto-detects D or S.PORT protocol.");
-
-	PRINT_MODULE_USAGE_NAME("frsky_telemetry", "communication");
-	PRINT_MODULE_USAGE_COMMAND("start");
-	PRINT_MODULE_USAGE_PARAM_STRING('d', "/dev/ttyS6", "<file:dev>", "Select Serial Device", true);
-	PRINT_MODULE_USAGE_PARAM_INT('t', 0, 0, 60, "Scanning timeout [s] (default: no timeout)", true);
-	PRINT_MODULE_USAGE_PARAM_STRING('m', "auto", "sport|sport_single|dtype", "Select protocol (default: auto-detect)",
-					true);
-	PRINT_MODULE_USAGE_COMMAND("stop");
-	PRINT_MODULE_USAGE_COMMAND("status");
-}
-
-/**
  * The daemon thread.
  */
 static int frsky_telemetry_thread_main(int argc, char *argv[])
@@ -805,4 +788,21 @@ int frsky_telemetry_main(int argc, char *argv[])
 	PX4_ERR("unrecognized command");
 	usage();
 	return 0;
+}
+
+/**
+ * Print command usage information
+ */
+static void usage()
+{
+	PRINT_MODULE_DESCRIPTION("FrSky Telemetry support. Auto-detects D or S.PORT protocol.");
+
+	PRINT_MODULE_USAGE_NAME("frsky_telemetry", "communication");
+	PRINT_MODULE_USAGE_COMMAND("start");
+	PRINT_MODULE_USAGE_PARAM_STRING('d', "/dev/ttyS6", "<file:dev>", "Select Serial Device", true);
+	PRINT_MODULE_USAGE_PARAM_INT('t', 0, 0, 60, "Scanning timeout [s] (default: no timeout)", true);
+	PRINT_MODULE_USAGE_PARAM_STRING('m', "auto", "sport|sport_single|dtype", "Select protocol (default: auto-detect)",
+					true);
+	PRINT_MODULE_USAGE_COMMAND("stop");
+	PRINT_MODULE_USAGE_COMMAND("status");
 }

--- a/src/modules/airspeed_selector/airspeed_selector_main.cpp
+++ b/src/modules/airspeed_selector/airspeed_selector_main.cpp
@@ -536,6 +536,19 @@ int AirspeedModule::custom_command(int argc, char *argv[])
 	return print_usage("unknown command");
 }
 
+int AirspeedModule::print_status()
+{
+	perf_print_counter(_perf_elapsed);
+
+	int instance = 0;
+	uORB::SubscriptionData<airspeed_validated_s> est{ORB_ID(airspeed_validated), (uint8_t)instance};
+	est.update();
+	PX4_INFO("Number of airspeed sensors: %i", _number_of_airspeed_sensors);
+	print_message(est.get());
+
+	return 0;
+}
+
 int AirspeedModule::print_usage(const char *reason)
 {
 	if (reason) {
@@ -562,23 +575,7 @@ and also publishes those.
 	return 0;
 }
 
-int AirspeedModule::print_status()
-{
-	perf_print_counter(_perf_elapsed);
-
-	int instance = 0;
-	uORB::SubscriptionData<airspeed_validated_s> est{ORB_ID(airspeed_validated), (uint8_t)instance};
-	est.update();
-	PX4_INFO("Number of airspeed sensors: %i", _number_of_airspeed_sensors);
-	print_message(est.get());
-
-	return 0;
-}
-
-extern "C" __EXPORT int airspeed_selector_main(int argc, char *argv[]);
-
-int
-airspeed_selector_main(int argc, char *argv[])
+extern "C" __EXPORT int airspeed_selector_main(int argc, char *argv[])
 {
 	return AirspeedModule::main(argc, argv);
 }

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -92,8 +92,6 @@
 using math::constrain;
 using namespace time_literals;
 
-extern "C" __EXPORT int ekf2_main(int argc, char *argv[]);
-
 class Ekf2 final : public ModuleBase<Ekf2>, public ModuleParams, public px4::WorkItem
 {
 public:
@@ -2368,35 +2366,10 @@ int Ekf2::custom_command(int argc, char *argv[])
 	return print_usage("unknown command");
 }
 
-int Ekf2::print_usage(const char *reason)
-{
-	if (reason) {
-		PX4_WARN("%s\n", reason);
-	}
-
-	PRINT_MODULE_DESCRIPTION(
-		R"DESCR_STR(
-### Description
-Attitude and position estimator using an Extended Kalman Filter. It is used for Multirotors and Fixed-Wing.
-
-The documentation can be found on the [ECL/EKF Overview & Tuning](https://docs.px4.io/en/advanced_config/tuning_the_ecl_ekf.html) page.
-
-ekf2 can be started in replay mode (`-r`): in this mode it does not access the system time, but only uses the
-timestamps from the sensor topics.
-
-)DESCR_STR");
-
-	PRINT_MODULE_USAGE_NAME("ekf2", "estimator");
-	PRINT_MODULE_USAGE_COMMAND("start");
-	PRINT_MODULE_USAGE_PARAM_FLAG('r', "Enable replay mode", true);
-	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
-
-	return 0;
-}
-
 int Ekf2::task_spawn(int argc, char *argv[])
 {
 	bool replay_mode = false;
+
 	if (argc > 1 && !strcmp(argv[1], "-r")) {
 		PX4_INFO("replay mode enabled");
 		replay_mode = true;
@@ -2423,7 +2396,33 @@ int Ekf2::task_spawn(int argc, char *argv[])
 	return PX4_ERROR;
 }
 
-int ekf2_main(int argc, char *argv[])
+int Ekf2::print_usage(const char *reason)
+{
+	if (reason) {
+		PX4_WARN("%s\n", reason);
+	}
+
+	PRINT_MODULE_DESCRIPTION(
+		R"DESCR_STR(
+### Description
+Attitude and position estimator using an Extended Kalman Filter. It is used for Multirotors and Fixed-Wing.
+
+The documentation can be found on the [ECL/EKF Overview & Tuning](https://docs.px4.io/en/advanced_config/tuning_the_ecl_ekf.html) page.
+
+ekf2 can be started in replay mode (`-r`): in this mode it does not access the system time, but only uses the
+timestamps from the sensor topics.
+
+)DESCR_STR");
+
+	PRINT_MODULE_USAGE_NAME("ekf2", "estimator");
+	PRINT_MODULE_USAGE_COMMAND("start");
+	PRINT_MODULE_USAGE_PARAM_FLAG('r', "Enable replay mode", true);
+	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
+
+	return 0;
+}
+
+extern "C" __EXPORT int ekf2_main(int argc, char *argv[])
 {
 	return Ekf2::main(argc, argv);
 }

--- a/src/modules/events/send_event.cpp
+++ b/src/modules/events/send_event.cpp
@@ -201,32 +201,6 @@ void SendEvent::answer_command(const vehicle_command_s &cmd, unsigned result)
 	command_ack_pub.publish(command_ack);
 }
 
-int SendEvent::print_usage(const char *reason)
-{
-	if (reason) {
-		printf("%s\n\n", reason);
-	}
-
-	PRINT_MODULE_DESCRIPTION(
-		R"DESCR_STR(
-### Description
-Background process running periodically on the LP work queue to perform housekeeping tasks.
-It is currently only responsible for temperature calibration and tone alarm on RC Loss.
-
-The tasks can be started via CLI or uORB topics (vehicle_command from MAVLink, etc.).
-)DESCR_STR");
-
-	PRINT_MODULE_USAGE_NAME("send_event", "system");
-	PRINT_MODULE_USAGE_COMMAND_DESCR("start", "Start the background task");
-	PRINT_MODULE_USAGE_COMMAND_DESCR("temperature_calibration", "Run temperature calibration process");
-	PRINT_MODULE_USAGE_PARAM_FLAG('g', "calibrate the gyro", true);
-	PRINT_MODULE_USAGE_PARAM_FLAG('a', "calibrate the accel", true);
-	PRINT_MODULE_USAGE_PARAM_FLAG('b', "calibrate the baro (if none of these is given, all will be calibrated)", true);
-	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
-
-	return 0;
-}
-
 int SendEvent::custom_command(int argc, char *argv[])
 {
 	if (!strcmp(argv[0], "temperature_calibration")) {
@@ -267,13 +241,16 @@ int SendEvent::custom_command(int argc, char *argv[])
 
 		vehicle_command_s vcmd{};
 		vcmd.timestamp = hrt_absolute_time();
-		vcmd.param1 = (float)((gyro_calib || calib_all) ? vehicle_command_s::PREFLIGHT_CALIBRATION_TEMPERATURE_CALIBRATION : NAN);
+		vcmd.param1 = (float)((gyro_calib
+				       || calib_all) ? vehicle_command_s::PREFLIGHT_CALIBRATION_TEMPERATURE_CALIBRATION : NAN);
 		vcmd.param2 = NAN;
 		vcmd.param3 = NAN;
 		vcmd.param4 = NAN;
-		vcmd.param5 = ((accel_calib || calib_all) ? vehicle_command_s::PREFLIGHT_CALIBRATION_TEMPERATURE_CALIBRATION : (double)NAN);
+		vcmd.param5 = ((accel_calib
+				|| calib_all) ? vehicle_command_s::PREFLIGHT_CALIBRATION_TEMPERATURE_CALIBRATION : (double)NAN);
 		vcmd.param6 = (double)NAN;
-		vcmd.param7 = (float)((baro_calib || calib_all) ? vehicle_command_s::PREFLIGHT_CALIBRATION_TEMPERATURE_CALIBRATION : NAN);
+		vcmd.param7 = (float)((baro_calib
+				       || calib_all) ? vehicle_command_s::PREFLIGHT_CALIBRATION_TEMPERATURE_CALIBRATION : NAN);
 		vcmd.command = vehicle_command_s::VEHICLE_CMD_PREFLIGHT_CALIBRATION;
 
 		uORB::PublicationQueued<vehicle_command_s> vcmd_pub{ORB_ID(vehicle_command)};
@@ -282,6 +259,32 @@ int SendEvent::custom_command(int argc, char *argv[])
 	} else {
 		print_usage("unrecognized command");
 	}
+
+	return 0;
+}
+
+int SendEvent::print_usage(const char *reason)
+{
+	if (reason) {
+		printf("%s\n\n", reason);
+	}
+
+	PRINT_MODULE_DESCRIPTION(
+		R"DESCR_STR(
+### Description
+Background process running periodically on the LP work queue to perform housekeeping tasks.
+It is currently only responsible for temperature calibration and tone alarm on RC Loss.
+
+The tasks can be started via CLI or uORB topics (vehicle_command from MAVLink, etc.).
+)DESCR_STR");
+
+	PRINT_MODULE_USAGE_NAME("send_event", "system");
+	PRINT_MODULE_USAGE_COMMAND_DESCR("start", "Start the background task");
+	PRINT_MODULE_USAGE_COMMAND_DESCR("temperature_calibration", "Run temperature calibration process");
+	PRINT_MODULE_USAGE_PARAM_FLAG('g', "calibrate the gyro", true);
+	PRINT_MODULE_USAGE_PARAM_FLAG('a', "calibrate the accel", true);
+	PRINT_MODULE_USAGE_PARAM_FLAG('b', "calibrate the baro (if none of these is given, all will be calibrated)", true);
+	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 
 	return 0;
 }

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -40,13 +40,6 @@ using math::constrain;
 using math::gradual;
 using math::radians;
 
-/**
- * Fixedwing attitude control app start / stop handling function
- *
- * @ingroup apps
- */
-extern "C" __EXPORT int fw_att_control_main(int argc, char *argv[]);
-
 FixedwingAttitudeControl::FixedwingAttitudeControl() :
 	ModuleParams(nullptr),
 	WorkItem(MODULE_NAME, px4::wq_configurations::att_pos_ctrl),
@@ -762,6 +755,13 @@ int FixedwingAttitudeControl::custom_command(int argc, char *argv[])
 	return print_usage("unknown command");
 }
 
+int FixedwingAttitudeControl::print_status()
+{
+	PX4_INFO("Running");
+	perf_print_counter(_loop_perf);
+	return 0;
+}
+
 int FixedwingAttitudeControl::print_usage(const char *reason)
 {
 	if (reason) {
@@ -776,24 +776,13 @@ fw_att_control is the fixed wing attitude controller.
 )DESCR_STR");
 
 	PRINT_MODULE_USAGE_COMMAND("start");
-
 	PRINT_MODULE_USAGE_NAME("fw_att_control", "controller");
-
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 
 	return 0;
 }
 
-int FixedwingAttitudeControl::print_status()
-{
-	PX4_INFO("Running");
-
-	perf_print_counter(_loop_perf);
-
-	return 0;
-}
-
-int fw_att_control_main(int argc, char *argv[])
+extern "C" __EXPORT int fw_att_control_main(int argc, char *argv[])
 {
 	return FixedwingAttitudeControl::main(argc, argv);
 }

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -33,8 +33,6 @@
 
 #include "FixedwingPositionControl.hpp"
 
-extern "C" __EXPORT int fw_pos_control_l1_main(int argc, char *argv[]);
-
 FixedwingPositionControl::FixedwingPositionControl() :
 	ModuleParams(nullptr),
 	WorkItem(MODULE_NAME, px4::wq_configurations::att_pos_ctrl),
@@ -1972,6 +1970,13 @@ int FixedwingPositionControl::custom_command(int argc, char *argv[])
 	return print_usage("unknown command");
 }
 
+int FixedwingPositionControl::print_status()
+{
+	PX4_INFO("Running");
+	perf_print_counter(_loop_perf);
+	return 0;
+}
+
 int FixedwingPositionControl::print_usage(const char *reason)
 {
 	if (reason) {
@@ -1993,16 +1998,7 @@ fw_pos_control_l1 is the fixed wing position controller.
 	return 0;
 }
 
-int FixedwingPositionControl::print_status()
-{
-	PX4_INFO("Running");
-
-	perf_print_counter(_loop_perf);
-
-	return 0;
-}
-
-int fw_pos_control_l1_main(int argc, char *argv[])
+extern "C" __EXPORT int fw_pos_control_l1_main(int argc, char *argv[])
 {
 	return FixedwingPositionControl::main(argc, argv);
 }

--- a/src/modules/replay/Replay.cpp
+++ b/src/modules/replay/Replay.cpp
@@ -954,6 +954,84 @@ Replay::custom_command(int argc, char *argv[])
 }
 
 int
+Replay::task_spawn(int argc, char *argv[])
+{
+	// check if a log file was found
+	if (!isSetup()) {
+		if (argc > 0 && strncmp(argv[0], "try", 3) == 0) {
+			return 0;
+		}
+
+		PX4_ERR("no log file given (via env variable %s)", replay::ENV_FILENAME);
+		return -1;
+	}
+
+	_task_id = px4_task_spawn_cmd("replay",
+				      SCHED_DEFAULT,
+				      SCHED_PRIORITY_MAX - 5,
+				      4000,
+				      (px4_main_t)&run_trampoline,
+				      (char *const *)argv);
+
+	if (_task_id < 0) {
+		_task_id = -1;
+		return -errno;
+	}
+
+	return 0;
+}
+
+int
+Replay::applyParams(bool quiet)
+{
+	if (!isSetup()) {
+		if (quiet) {
+			return 0;
+		}
+
+		PX4_ERR("no log file given (via env variable %s)", replay::ENV_FILENAME);
+		return -1;
+	}
+
+	int ret = 0;
+	Replay *r = new Replay();
+
+	if (r == nullptr) {
+		PX4_ERR("alloc failed");
+		return -ENOMEM;
+	}
+
+	ifstream replay_file(_replay_file, ios::in | ios::binary);
+
+	if (!r->readDefinitionsAndApplyParams(replay_file)) {
+		ret = -1;
+	}
+
+	delete r;
+
+	return ret;
+}
+
+Replay *
+Replay::instantiate(int argc, char *argv[])
+{
+	// check the replay mode
+	const char *replay_mode = getenv(replay::ENV_MODE);
+
+	Replay *instance = nullptr;
+
+	if (replay_mode && strcmp(replay_mode, "ekf2") == 0) {
+		PX4_INFO("Ekf2 replay mode");
+		instance = new ReplayEkf2();
+
+	} else {
+		instance = new Replay();
+	}
+
+	return instance;
+}
+
+int
 Replay::print_usage(const char *reason)
 {
 	if (reason) {
@@ -987,81 +1065,6 @@ page.
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 
 	return 0;
-}
-
-int
-Replay::task_spawn(int argc, char *argv[])
-{
-	// check if a log file was found
-	if (!isSetup()) {
-		if (argc > 0 && strncmp(argv[0], "try", 3)==0) {
-			return 0;
-		}
-		PX4_ERR("no log file given (via env variable %s)", replay::ENV_FILENAME);
-		return -1;
-	}
-
-	_task_id = px4_task_spawn_cmd("replay",
-				      SCHED_DEFAULT,
-				      SCHED_PRIORITY_MAX - 5,
-				      4000,
-				      (px4_main_t)&run_trampoline,
-				      (char *const *)argv);
-
-	if (_task_id < 0) {
-		_task_id = -1;
-		return -errno;
-	}
-
-	return 0;
-}
-
-int
-Replay::applyParams(bool quiet)
-{
-	if (!isSetup()) {
-		if (quiet) {
-			return 0;
-		}
-		PX4_ERR("no log file given (via env variable %s)", replay::ENV_FILENAME);
-		return -1;
-	}
-
-	int ret = 0;
-	Replay *r = new Replay();
-
-	if (r == nullptr) {
-		PX4_ERR("alloc failed");
-		return -ENOMEM;
-	}
-
-	ifstream replay_file(_replay_file, ios::in | ios::binary);
-
-	if (!r->readDefinitionsAndApplyParams(replay_file)) {
-		ret = -1;
-	}
-
-	delete r;
-
-	return ret;
-}
-
-Replay *
-Replay::instantiate(int argc, char *argv[])
-{
-	// check the replay mode
-	const char *replay_mode = getenv(replay::ENV_MODE);
-
-	Replay *instance = nullptr;
-	if (replay_mode && strcmp(replay_mode, "ekf2") == 0) {
-		PX4_INFO("Ekf2 replay mode");
-		instance = new ReplayEkf2();
-
-	} else {
-		instance = new Replay();
-	}
-
-	return instance;
 }
 
 } //namespace px4

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -478,6 +478,14 @@ VtolAttitudeControl::custom_command(int argc, char *argv[])
 }
 
 int
+VtolAttitudeControl::print_status()
+{
+	PX4_INFO("Running");
+	perf_print_counter(_loop_perf);
+	return PX4_OK;
+}
+
+int
 VtolAttitudeControl::print_usage(const char *reason)
 {
 	if (reason) {
@@ -491,22 +499,10 @@ fw_att_control is the fixed wing attitude controller.
 )DESCR_STR");
 
 	PRINT_MODULE_USAGE_COMMAND("start");
-
 	PRINT_MODULE_USAGE_NAME("vtol_att_control", "controller");
-
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 
 	return 0;
-}
-
-int
-VtolAttitudeControl::print_status()
-{
-	PX4_INFO("Running");
-
-	perf_print_counter(_loop_perf);
-
-	return PX4_OK;
 }
 
 int vtol_att_control_main(int argc, char *argv[])

--- a/src/systemcmds/dmesg/dmesg.cpp
+++ b/src/systemcmds/dmesg/dmesg.cpp
@@ -46,28 +46,6 @@ extern "C" {
 	__EXPORT int dmesg_main(int argc, char *argv[]);
 }
 
-static void
-usage()
-{
-
-	PRINT_MODULE_DESCRIPTION(
-		R"DESCR_STR(
-### Description
-
-Command-line tool to show bootup console messages.
-Note that output from NuttX's work queues and syslog are not captured.
-
-### Examples
-
-Keep printing all messages in the background:
-$ dmesg -f &
-)DESCR_STR");
-
-	PRINT_MODULE_USAGE_NAME("dmesg", "system");
-	PRINT_MODULE_USAGE_PARAM_FLAG('f', "Follow: wait for new messages", true);
-
-}
-
 int
 dmesg_main(int argc, char *argv[])
 {
@@ -92,4 +70,26 @@ dmesg_main(int argc, char *argv[])
 	px4_console_buffer_print(follow);
 
 	return 0;
+}
+
+static void
+usage()
+{
+
+	PRINT_MODULE_DESCRIPTION(
+		R"DESCR_STR(
+### Description
+
+Command-line tool to show bootup console messages.
+Note that output from NuttX's work queues and syslog are not captured.
+
+### Examples
+
+Keep printing all messages in the background:
+$ dmesg -f &
+)DESCR_STR");
+
+	PRINT_MODULE_USAGE_NAME("dmesg", "system");
+	PRINT_MODULE_USAGE_PARAM_FLAG('f', "Follow: wait for new messages", true);
+
 }


### PR DESCRIPTION
Astyle chokes on the module description strings, so for now we can keep them near the bottom of each file.
