### PR TITLE
FlightTasks: shift DEFINE_PARAMETERS to end of access modifiers

### DIFF
--- a/src/lib/FlightTasks/tasks/AutoLine/FlightTaskAutoLine.hpp
+++ b/src/lib/FlightTasks/tasks/AutoLine/FlightTaskAutoLine.hpp
@@ -50,17 +50,18 @@ public:
 
 protected:
 
+	void _generateSetpoints() override; /**< Generate setpoints along line. */
+
+	void _generateHeadingAlongTrack(); /**< Generates heading along track. */
+	void _generateAltitudeSetpoints(); /**< Generate velocity and position setpoints for following line along z. */
+	void _generateXYsetpoints(); /**< Generate velocity and position setpoints for following line along xy. */
+
 	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTaskAutoMapper,
 					(ParamFloat<px4::params::MPC_ACC_HOR>) _param_mpc_acc_hor, // acceleration in flight
 					(ParamFloat<px4::params::MPC_ACC_UP_MAX>) _param_mpc_acc_up_max,
 					(ParamFloat<px4::params::MPC_ACC_DOWN_MAX>) _param_mpc_acc_down_max
 				       );
 
-	void _generateSetpoints() override; /**< Generate setpoints along line. */
-
-	void _generateHeadingAlongTrack(); /**< Generates heading along track. */
-	void _generateAltitudeSetpoints(); /**< Generate velocity and position setpoints for following line along z. */
-	void _generateXYsetpoints(); /**< Generate velocity and position setpoints for following line along xy. */
 
 private:
 	void _setSpeedAtTarget(); /**< Sets desiered speed at target */

--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
@@ -54,16 +54,6 @@ public:
 
 protected:
 
-	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTaskAutoMapper2,
-					(ParamFloat<px4::params::MIS_YAW_ERR>) _param_mis_yaw_err, // yaw-error threshold
-					(ParamFloat<px4::params::MPC_ACC_HOR>) _param_mpc_acc_hor, // acceleration in flight
-					(ParamFloat<px4::params::MPC_ACC_UP_MAX>) _param_mpc_acc_up_max,
-					(ParamFloat<px4::params::MPC_ACC_DOWN_MAX>) _param_mpc_acc_down_max,
-					(ParamFloat<px4::params::MPC_JERK_AUTO>) _param_mpc_jerk_auto,
-					(ParamFloat<px4::params::MPC_XY_TRAJ_P>) _param_mpc_xy_traj_p,
-					(ParamFloat<px4::params::MPC_Z_TRAJ_P>) _param_mpc_z_traj_p
-				       );
-
 	void checkSetpoints(vehicle_local_position_setpoint_s &setpoints);
 
 	/** Reset position or velocity setpoints in case of EKF reset event */
@@ -102,4 +92,14 @@ protected:
 	bool _want_takeoff{false};
 
 	VelocitySmoothing _trajectory[3]; ///< Trajectories in x, y and z directions
+
+	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTaskAutoMapper2,
+					(ParamFloat<px4::params::MIS_YAW_ERR>) _param_mis_yaw_err, // yaw-error threshold
+					(ParamFloat<px4::params::MPC_ACC_HOR>) _param_mpc_acc_hor, // acceleration in flight
+					(ParamFloat<px4::params::MPC_ACC_UP_MAX>) _param_mpc_acc_up_max,
+					(ParamFloat<px4::params::MPC_ACC_DOWN_MAX>) _param_mpc_acc_down_max,
+					(ParamFloat<px4::params::MPC_JERK_AUTO>) _param_mpc_jerk_auto,
+					(ParamFloat<px4::params::MPC_XY_TRAJ_P>) _param_mpc_xy_traj_p,
+					(ParamFloat<px4::params::MPC_Z_TRAJ_P>) _param_mpc_z_traj_p
+				       );
 };

--- a/src/lib/FlightTasks/tasks/AutoMapper/FlightTaskAutoMapper.hpp
+++ b/src/lib/FlightTasks/tasks/AutoMapper/FlightTaskAutoMapper.hpp
@@ -52,6 +52,16 @@ public:
 
 protected:
 
+	virtual void _generateSetpoints() = 0; /**< Generate velocity and position setpoint for following line. */
+
+	void _generateIdleSetpoints();
+	void _generateLandSetpoints();
+	void _generateVelocitySetpoints();
+	void _generateTakeoffSetpoints();
+
+	void _updateAltitudeAboveGround(); /**< Computes altitude above ground based on sensors available. */
+	void updateParams() override; /**< See ModuleParam class */
+
 	float _alt_above_ground{0.0f}; /**< If home provided, then it is altitude above home, otherwise it is altitude above local position reference. */
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTaskAuto,
@@ -63,16 +73,6 @@ protected:
 					_param_mpc_land_alt2, // altitude at which speed limit downwards reached minimum speed
 					(ParamFloat<px4::params::MPC_TKO_SPEED>) _param_mpc_tko_speed
 				       );
-
-	virtual void _generateSetpoints() = 0; /**< Generate velocity and position setpoint for following line. */
-
-	void _generateIdleSetpoints();
-	void _generateLandSetpoints();
-	void _generateVelocitySetpoints();
-	void _generateTakeoffSetpoints();
-
-	void _updateAltitudeAboveGround(); /**< Computes altitude above ground based on sensors available. */
-	void updateParams() override; /**< See ModuleParam class */
 
 private:
 

--- a/src/lib/FlightTasks/tasks/AutoMapper2/FlightTaskAutoMapper2.hpp
+++ b/src/lib/FlightTasks/tasks/AutoMapper2/FlightTaskAutoMapper2.hpp
@@ -52,6 +52,17 @@ public:
 
 protected:
 
+	virtual void _generateSetpoints() = 0; /**< Generate velocity and position setpoint for following line. */
+
+	void _prepareIdleSetpoints();
+	void _prepareLandSetpoints();
+	void _prepareVelocitySetpoints();
+	void _prepareTakeoffSetpoints();
+	void _preparePositionSetpoints();
+
+	void _updateAltitudeAboveGround(); /**< Computes altitude above ground based on sensors available. */
+	void updateParams() override; /**< See ModuleParam class */
+
 	float _alt_above_ground{0.0f}; /**< If home provided, then it is altitude above home, otherwise it is altitude above local position reference. */
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTaskAuto,
@@ -64,17 +75,6 @@ protected:
 					_param_mpc_land_alt2, // altitude at which speed limit downwards reached minimum speed
 					(ParamFloat<px4::params::MPC_TKO_SPEED>) _param_mpc_tko_speed
 				       );
-
-	virtual void _generateSetpoints() = 0; /**< Generate velocity and position setpoint for following line. */
-
-	void _prepareIdleSetpoints();
-	void _prepareLandSetpoints();
-	void _prepareVelocitySetpoints();
-	void _prepareTakeoffSetpoints();
-	void _preparePositionSetpoints();
-
-	void _updateAltitudeAboveGround(); /**< Computes altitude above ground based on sensors available. */
-	void updateParams() override; /**< See ModuleParam class */
 
 private:
 


### PR DESCRIPTION
 - DEFINE_PARAMETERS includes a private access modifier, so we need to
keep these at the end to prevent issues when extending a flight task

https://github.com/PX4/Firmware/blob/cc060099323354d7a94a92328058e40e31eb44ce/platforms/common/include/px4_platform_common/param.h#L83-L89