### PR TITLE
sitl script: Do NOT kill px4 if debug in IDE

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -50,8 +50,12 @@ fi
 # kill process names that might stil
 # be running from last time
 pkill -x gazebo || true
-pkill -x px4 || true
-pkill -x px4_$model || true
+
+# Do NOT kill PX4 if debug in ide 
+if [ "$debugger" != "ide" ]; then
+	pkill -x px4 || true
+	pkill -x px4_$model || true
+fi
 
 cp "$src_path/Tools/posix_lldbinit" "$rootfs/.lldbinit"
 cp "$src_path/Tools/posix.gdbinit" "$rootfs/.gdbinit"


### PR DESCRIPTION
**Describe problem solved by this pull request**
If we want to debug in IDE, The px4  process and the simulator (gazebo, jmavsim) are launched separately. Killing px4 process is a bit annoying if we launch px4 in IDE （such as QT） first.

**Describe your solution**
Kill px4 if we are not debugging in ide

**Test data / coverage**
Tested in simulation debug with QtCreator

