### PR TITLE
UAVCAN ESC: add min and max parameters for ESC raw commands

### DIFF
--- a/src/drivers/uavcan/actuators/esc.hpp
+++ b/src/drivers/uavcan/actuators/esc.hpp
@@ -67,6 +67,8 @@ public:
 	void arm_single_esc(int num, bool arm);
 
 	void enable_idle_throttle_when_armed(bool value) { _run_at_idle_throttle_when_armed = value; }
+	void set_esc_min_factor(float value) { _raw_value_min_factor = value; }
+	void set_esc_max_factor(float value) { _raw_value_max_factor = value; }
 
 	/**
 	 * Sets the number of rotors
@@ -102,6 +104,8 @@ private:
 
 	bool		_armed{false};
 	bool		_run_at_idle_throttle_when_armed{false};
+	float 		_raw_value_min_factor{0.0};
+	float 		_raw_value_max_factor{1.0};
 
 	esc_status_s	_esc_status{};
 

--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -438,6 +438,22 @@ UavcanNode::update_params()
 	if (param_handle != PARAM_INVALID) {
 		param_get(param_handle, &_thr_mdl_factor);
 	}
+
+	param_handle = param_find("UAVCAN_ESC_MIN");
+
+	if (param_handle != PARAM_INVALID) {
+		float _esc_min_factor;
+		param_get(param_handle, &_esc_min_factor);
+		_esc_controller.set_esc_min_factor(_esc_min_factor);
+	}
+
+	param_handle = param_find("UAVCAN_ESC_MAX");
+
+	if (param_handle != PARAM_INVALID) {
+		float _esc_max_factor;
+		param_get(param_find("UAVCAN_ESC_MAX"), &_esc_max_factor);
+		_esc_controller.set_esc_max_factor(_esc_max_factor);
+	}
 }
 
 int

--- a/src/drivers/uavcan/uavcan_params.c
+++ b/src/drivers/uavcan/uavcan_params.c
@@ -88,3 +88,25 @@ PARAM_DEFINE_INT32(UAVCAN_BITRATE, 1000000);
  * @group UAVCAN
  */
 PARAM_DEFINE_INT32(UAVCAN_ESC_IDLT, 1);
+
+/**
+ * UAVCAN ESC min RAW value factor
+ * Specifies the minimum RAW value of the UAVCAN ESC message
+ * as a function of the maximum value
+ *
+ * @min 0.0
+ * @max 1.0
+ * @group UAVCAN
+ */
+PARAM_DEFINE_FLOAT(UAVCAN_ESC_MIN, 0.0);
+
+/**
+ * UAVCAN ESC max RAW value factor
+ * Specifies the maximum RAW value of the UAVCAN ESC message
+ * as a function of the maximum value
+ *
+ * @min 0.0
+ * @max 1.0
+ * @group UAVCAN
+ */
+PARAM_DEFINE_FLOAT(UAVCAN_ESC_MAX, 1.0);


### PR DESCRIPTION
This adds the possibility to define the min and max UAVCAN RAW values the autopilot sends to the ESCs in order to avoid early saturation of the ESCs leading to instability at high and low thrust.

To be intuitive to set, the parameters are factors (between 0 and 1) of the max raw value message:
e.g: setting UAVCAN_ESC_MAX to 0.9 maps full thrust to 90% of the
maximum raw value message

Here is a representation of the scaling where:
s_min = `UAVCAN_ESC_MIN`
s_max = `UAVCAN_ESC_MAX`
m = `uavcan::equipment::esc::RawCommand::FieldTypes::cmd::RawValueType::max()`
https://www.desmos.com/calculator/piocnsvfpb
