### PR TITLE
[WIP] Compile PX4 on ARM GCC 9

### DIFF
--- a/boards/px4/fmu-v4/default.cmake
+++ b/boards/px4/fmu-v4/default.cmake
@@ -44,7 +44,7 @@ px4_add_board(
 		telemetry # all available telemetry drivers
 		test_ppm
 		tone_alarm
-		uavcan
+		#uavcan
 
 	MODULES
 		airspeed_selector

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -300,7 +300,7 @@ private:
 	/**
 	 * Trampoline to the worker task
 	 */
-	static void		task_main_trampoline(int argc, char *argv[]);
+	static int		task_main_trampoline(int argc, char *argv[]);
 
 	/**
 	 * worker task
@@ -876,7 +876,7 @@ PX4IO::init()
 				   SCHED_DEFAULT,
 				   SCHED_PRIORITY_ACTUATOR_OUTPUTS,
 				   1500,
-				   (main_t)&PX4IO::task_main_trampoline,
+				   (px4_main_t)&PX4IO::task_main_trampoline,
 				   nullptr);
 
 	if (_task < 0) {
@@ -887,10 +887,11 @@ PX4IO::init()
 	return OK;
 }
 
-void
+int
 PX4IO::task_main_trampoline(int argc, char *argv[])
 {
 	g_dev->task_main();
+	return 0;
 }
 
 void

--- a/src/drivers/telemetry/iridiumsbd/IridiumSBD.cpp
+++ b/src/drivers/telemetry/iridiumsbd/IridiumSBD.cpp
@@ -213,7 +213,7 @@ int IridiumSBD::ioctl(struct file *filp, int cmd, unsigned long arg)
 // private functions                                                 //
 ///////////////////////////////////////////////////////////////////////
 
-void IridiumSBD::main_loop_helper(int argc, char *argv[])
+int IridiumSBD::main_loop_helper(int argc, char *argv[])
 {
 	// start the main loop and stay in it
 	IridiumSBD::instance->main_loop(argc, argv);
@@ -225,6 +225,7 @@ void IridiumSBD::main_loop_helper(int argc, char *argv[])
 	IridiumSBD::instance = nullptr;
 
 	PX4_WARN("stopped");
+	return 0;
 }
 
 void IridiumSBD::main_loop(int argc, char *argv[])

--- a/src/drivers/telemetry/iridiumsbd/IridiumSBD.h
+++ b/src/drivers/telemetry/iridiumsbd/IridiumSBD.h
@@ -139,7 +139,7 @@ private:
 	/*
 	 * Entry point of the task, has to be a static function
 	 */
-	static void main_loop_helper(int argc, char *argv[]);
+	static int main_loop_helper(int argc, char *argv[]);
 
 	/*
 	 * Main driver loop

--- a/src/lib/parameters/flashparams/CMakeLists.txt
+++ b/src/lib/parameters/flashparams/CMakeLists.txt
@@ -42,6 +42,7 @@ target_compile_options(flashparams
 	PRIVATE
 		-Wno-sign-compare # TODO: fix this
 		-Wno-cast-align # TODO: fix and enable
+		-Wno-address-of-packed-member # TODO: fix this
 )
 
 target_link_libraries(flashparams PRIVATE nuttx_arch)

--- a/src/systemcmds/tests/CMakeLists.txt
+++ b/src/systemcmds/tests/CMakeLists.txt
@@ -95,6 +95,7 @@ px4_add_module(
 		-Wno-unused-but-set-variable
 		-Wno-unused-result
 		-Wno-unused-variable
+		-Wno-vla-larger-than
 	SRCS
 		${srcs}
 	DEPENDS

--- a/src/systemcmds/tests/test_time.c
+++ b/src/systemcmds/tests/test_time.c
@@ -78,8 +78,8 @@ cycletime(void)
 int test_time(int argc, char *argv[])
 {
 	hrt_abstime h, c;
-	int64_t lowdelta, maxdelta = 0;
-	int64_t delta, deltadelta;
+	int lowdelta, maxdelta = 0;
+	int delta, deltadelta;
 
 	/* enable the cycle counter */
 	(*(unsigned long *)0xe000edfc) |= (1 << 24);    /* DEMCR |= DEMCR_TRCENA */
@@ -96,7 +96,7 @@ int test_time(int argc, char *argv[])
 
 		px4_leave_critical_section(flags);
 
-		delta += h - c;
+		delta += (int)(h - c);
 	}
 
 	lowdelta = abs(delta / 100);
@@ -113,7 +113,7 @@ int test_time(int argc, char *argv[])
 
 		px4_leave_critical_section(flags);
 
-		delta = abs(h - c);
+		delta = abs((int)(h - c));
 		deltadelta = abs(delta - lowdelta);
 
 		if (deltadelta > maxdelta) {
@@ -121,7 +121,7 @@ int test_time(int argc, char *argv[])
 		}
 
 		if (deltadelta > 1000) {
-			fprintf(stderr, "h %" PRIu64 " c %" PRIu64 " d %" PRId64 "\n", h, c, delta - lowdelta);
+			fprintf(stderr, "h %" PRIu64 " c %" PRIu64 " d %d\n", h, c, delta - lowdelta);
 		}
 	}
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
We are using GCC 9 for the posix build for quite some time and ARM released newer versions for the ARM GCC for a long time already as well. But there are certain corners that prevent us from using ARM GCC 9 for our daily work and release builds.

**Describe your solution**
I started investigating and listing the problems that make it not build on ARM GCC 9.2.

- [ ] NuttX only ccompiles with this fix: https://github.com/PX4/NuttX/pull/52
   I rebased it on our latest NuttX version here: https://github.com/MaEtUgR/NuttX/tree/arm-gcc-9 and included the submodule update for testing.
   Solved with the NuttX pr.
- [ ] The `task_main_trampoline`/`main_loop_helper` void to int return value casting fail. They can be declared `static int` in the header and `int` in the declaration
   Solved with this pr
- [ ] UAVCAN produces some deprecated warnings because of the `BitMask copy constructor`
   Unsolved, I just removed the library
- [ ]  timing tests use abs on uint64_t timestamps which is not supported by the math library we use. We can either support uint64_t or switch to int (done in this draft) or look at why abs is necessary at all.
   Unsolved, this is not a proper fix
- [ ] Some unit test that is still in the sitl tests uses fishy array assignments and the compiler complained it can't check the boundaries.
  Unsolved, I added a compiler flag to ignore it which is not a solution.
- [ ] In our flashparams implementation a casted 4 byte pointer iterates over a packed struct to overwrite it with 0xFFs which the compiler doesn't like.
  Unsolved, I added a compiler flag to ignore it which is not a solution.
- [ ] All binary output including io `overflows end of region flash` for every single section. This is probably due to `warning: creating a segment to contain the file and program headers outside of any MEMORY region`. Maybe the additional "default" section has to be disabled or placed in the linker file (thanks for input by @dinomani).
```
/usr/lib/gcc/arm-none-eabi/9.2.0/../../../../arm-none-eabi/bin/ld.gold: warning: creating a segment to contain the file and program headers outside of any MEMORY region
/usr/lib/gcc/arm-none-eabi/9.2.0/../../../../arm-none-eabi/bin/ld.gold: error: section .text overflows end of region flash
/usr/lib/gcc/arm-none-eabi/9.2.0/../../../../arm-none-eabi/bin/ld.gold: error: section .init_section overflows end of region flash
/usr/lib/gcc/arm-none-eabi/9.2.0/../../../../arm-none-eabi/bin/ld.gold: error: address 0x82e9bd4 is not within region flash
/usr/lib/gcc/arm-none-eabi/9.2.0/../../../../arm-none-eabi/bin/ld.gold: error: section __param overflows end of region flash
/usr/lib/gcc/arm-none-eabi/9.2.0/../../../../arm-none-eabi/bin/ld.gold: error: section .ARM.extab overflows end of region flash
/usr/lib/gcc/arm-none-eabi/9.2.0/../../../../arm-none-eabi/bin/ld.gold: error: section .ARM.exidx overflows end of region flash
/usr/lib/gcc/arm-none-eabi/9.2.0/../../../../arm-none-eabi/bin/ld.gold: error: section .data overflows end of region flash
```

**Additional context**
https://github.com/PX4/Firmware/issues/12814

FYI @dagar @bkueng @julianoes 
