### PR TITLE
Trivial: remove unused position control function declarations

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -258,11 +258,6 @@ private:
 	void reset_setpoint_to_nan(vehicle_local_position_setpoint_s &setpoint);
 
 	/**
-	 * Shim for calling task_main from task_create.
-	 */
-	static int	task_main_trampoline(int argc, char *argv[]);
-
-	/**
 	 * check if task should be switched because of failsafe
 	 */
 	void check_failure(bool task_failure, uint8_t nav_state);
@@ -271,11 +266,6 @@ private:
 	 * send vehicle command to inform commander about failsafe
 	 */
 	void send_vehicle_cmd_do(uint8_t nav_state);
-
-	/**
-	 * Main sensor collection task.
-	 */
-	void		task_main();
 };
 
 MulticopterPositionControl::MulticopterPositionControl() :


### PR DESCRIPTION
**Describe problem solved by this pull request**
Just ran into these unused declaration and wanted to quickly remove them.

**Test data / coverage**
Compiles

**Additional context**
They were probably accidentally left there in https://github.com/PX4/Firmware/commit/f7b65c577b80f912be7e79d0a8ddbe4057e71220#diff-fc77c3ef569029d45764664c75d4b0c1L448
