### PR TITLE
Do not overwrite landing gear state

### DIFF
--- a/src/lib/FlightTasks/tasks/AutoMapper/FlightTaskAutoMapper.cpp
+++ b/src/lib/FlightTasks/tasks/AutoMapper/FlightTaskAutoMapper.cpp
@@ -69,7 +69,7 @@ bool FlightTaskAutoMapper::update()
 	if (_type_previous == WaypointType::idle) {
 		_thrust_setpoint = Vector3f(NAN, NAN, NAN);
 	}
-	
+
 	// during mission and reposition, raise the landing gears but only
 	// if altitude is high enough
 	if (_highEnoughForLandingGear()) {

--- a/src/lib/FlightTasks/tasks/AutoMapper/FlightTaskAutoMapper.cpp
+++ b/src/lib/FlightTasks/tasks/AutoMapper/FlightTaskAutoMapper.cpp
@@ -69,6 +69,12 @@ bool FlightTaskAutoMapper::update()
 	if (_type_previous == WaypointType::idle) {
 		_thrust_setpoint = Vector3f(NAN, NAN, NAN);
 	}
+	
+	// during mission and reposition, raise the landing gears but only
+	// if altitude is high enough
+	if (_highEnoughForLandingGear()) {
+		_gear.landing_gear = _mission_gear;
+	}
 
 	if (_type == WaypointType::idle) {
 		_generateIdleSetpoints();
@@ -90,12 +96,6 @@ bool FlightTaskAutoMapper::update()
 		_obstacle_avoidance.updateAvoidanceDesiredSetpoints(_position_setpoint, _velocity_setpoint, (int)_type);
 		_obstacle_avoidance.injectAvoidanceSetpoints(_position_setpoint, _velocity_setpoint, _yaw_setpoint,
 				_yawspeed_setpoint);
-	}
-
-	// during mission and reposition, raise the landing gears but only
-	// if altitude is high enough
-	if (_highEnoughForLandingGear()) {
-		_gear.landing_gear = _mission_gear;
 	}
 
 	// update previous type

--- a/src/lib/FlightTasks/tasks/AutoMapper2/FlightTaskAutoMapper2.cpp
+++ b/src/lib/FlightTasks/tasks/AutoMapper2/FlightTaskAutoMapper2.cpp
@@ -61,7 +61,7 @@ bool FlightTaskAutoMapper2::update()
 	if (_type_previous == WaypointType::idle) {
 		_thrust_setpoint = Vector3f(NAN, NAN, NAN);
 	}
-	
+
 	// during mission and reposition, raise the landing gears but only
 	// if altitude is high enough
 	if (_highEnoughForLandingGear()) {

--- a/src/lib/FlightTasks/tasks/AutoMapper2/FlightTaskAutoMapper2.cpp
+++ b/src/lib/FlightTasks/tasks/AutoMapper2/FlightTaskAutoMapper2.cpp
@@ -61,6 +61,12 @@ bool FlightTaskAutoMapper2::update()
 	if (_type_previous == WaypointType::idle) {
 		_thrust_setpoint = Vector3f(NAN, NAN, NAN);
 	}
+	
+	// during mission and reposition, raise the landing gears but only
+	// if altitude is high enough
+	if (_highEnoughForLandingGear()) {
+		_gear.landing_gear = landing_gear_s::GEAR_UP;
+	}
 
 	switch (_type) {
 	case WaypointType::idle:
@@ -99,12 +105,6 @@ bool FlightTaskAutoMapper2::update()
 
 
 	_generateSetpoints();
-
-	// during mission and reposition, raise the landing gears but only
-	// if altitude is high enough
-	if (_highEnoughForLandingGear()) {
-		_gear.landing_gear = landing_gear_s::GEAR_UP;
-	}
 
 	// update previous type
 	_type_previous = _type;


### PR DESCRIPTION
**Describe problem solved by this pull request**
Landing gear properly retract upon takeoff. When landing, the gear do not start to deploy until the copter is 2m above the ground. This is caused by the landing gear state being incorrectly overwritten. See issue below:

https://github.com/PX4/Firmware/issues/13313

**Describe your solution**
Reorder the highEnoughForLandingGear() call so that it is still executed but allows for a setpoint change that includes GEAR_DOWN to persist.
