### PR TITLE
mixer_module: fix poll error in SITL lockstep

### DIFF
--- a/src/lib/mixer_module/mixer_module.cpp
+++ b/src/lib/mixer_module/mixer_module.cpp
@@ -236,6 +236,7 @@ unsigned MixingOutput::motorTest()
 
 	while (_motor_test.test_motor_sub.update(&test_motor)) {
 		if (test_motor.driver_instance != _driver_instance ||
+		    test_motor.timestamp == 0 ||
 		    hrt_elapsed_time(&test_motor.timestamp) > 100_ms) {
 			continue;
 		}


### PR DESCRIPTION
This fixes the case where the mixer_module would subscribe and use its own test_motor publication which was created only to make sure the topic is advertised and subsequent updates will work properly.

This happened in SITL lockstep because the timestamp would be 0 at the very beginning, and hence elapsed time would be 0 as well.
This lead to an actuator publication which would then get lockstep out of sync causing poll errors on the Gazebo side.

This fixes #13377 and maybe fixes #13334 and maybe closes #13371.