### PR TITLE
Fix for big latency spikes in RTPS communication

### DIFF
--- a/msg/templates/urtps/RtpsTopics.cpp.em
+++ b/msg/templates/urtps/RtpsTopics.cpp.em
@@ -61,12 +61,12 @@ except AttributeError:
 
 #include "RtpsTopics.h"
 
-bool RtpsTopics::init()
+bool RtpsTopics::init(std::condition_variable* cv)
 {
 @[if recv_topics]@
     // Initialise subscribers
 @[for topic in recv_topics]@
-    if (_@(topic)_sub.init()) {
+    if (_@(topic)_sub.init(cv)) {
         std::cout << "@(topic) subscriber started" << std::endl;
     } else {
         std::cout << "ERROR starting @(topic) subscriber" << std::endl;

--- a/msg/templates/urtps/RtpsTopics.h.em
+++ b/msg/templates/urtps/RtpsTopics.h.em
@@ -54,6 +54,7 @@ recv_topics = [(alias[idx] if alias[idx] else s.short_name) for idx, s in enumer
  ****************************************************************************/
 
 #include <fastcdr/Cdr.h>
+#include <condition_variable>
 
 @[for topic in send_topics]@
 #include "@(topic)_Publisher.h"
@@ -64,7 +65,7 @@ recv_topics = [(alias[idx] if alias[idx] else s.short_name) for idx, s in enumer
 
 class RtpsTopics {
 public:
-    bool init();
+    bool init(std::condition_variable* cv);
 @[if send_topics]@
     void publish(uint8_t topic_ID, char data_buffer[], size_t len);
 @[end if]@

--- a/msg/templates/urtps/Subscriber.h.em
+++ b/msg/templates/urtps/Subscriber.h.em
@@ -74,6 +74,9 @@ except AttributeError:
 #include "@(topic)PubSubTypes.h"
 @[end if]@
 
+#include <atomic>
+#include <condition_variable>
+
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 
@@ -82,7 +85,7 @@ class @(topic)_Subscriber
 public:
     @(topic)_Subscriber();
     virtual ~@(topic)_Subscriber();
-    bool init();
+    bool init(std::condition_variable* cv);
     void run();
     bool hasMsg();
 @[if 1.5 <= fastrtpsgen_version <= 1.7]@
@@ -105,7 +108,7 @@ private:
     class SubListener : public SubscriberListener
     {
     public:
-        SubListener() : n_matched(0), n_msg(0){};
+        SubListener() : n_matched(0), n_msg(0), has_msg(false){};
         ~SubListener(){};
         void onSubscriptionMatched(Subscriber* sub, MatchingInfo& info);
         void onNewDataMessage(Subscriber* sub);
@@ -125,7 +128,8 @@ private:
         @(topic) msg;
 @[    end if]@
 @[end if]@
-        bool has_msg = false;
+        std::atomic_bool has_msg;
+        std::condition_variable* cv_msg;
 
     } m_listener;
 @[if 1.5 <= fastrtpsgen_version <= 1.7]@


### PR DESCRIPTION
**Describe problem solved by this pull request**
As shown in figure 1 the RTPS communication between ROS2 and PX4 over RTPS suffers from latency spikes up to 500ms.
![image](https://user-images.githubusercontent.com/57130844/68215070-e61d1900-ffde-11e9-9828-4c96b2f38f9d.png)
Figure 1: Round trip time latency measure between ROS2 -> PX4 -> ROS2

This caused by the usleep function in microRTPS_agent.cpp:void t_send(void *data).
As quoted from the Linux man page

> The usleep() function suspends execution of the calling thread for (at least) usec microseconds. The sleep may be lengthened slightly by any system activity or by the time spent processing the call or by the granularity of system timers.

Its seems that this usleep takes much longer then expected. Therefore the active polling of the hasMsg boolean with a usleep function in the t_send worker thread causes big latency spikes as shown in figure 1.

**Describe your solution**
Signal the t_send worker thread through a condition variable instead of active polling with an usleep, the condition variable notify function immediately resumes the t_send worker thread. Therefore improving reaction time, below a figure of the performance with a condition variable
![image](https://user-images.githubusercontent.com/57130844/68215035-d69dd000-ffde-11e9-90f2-35c496b22204.png)
Figure 2: Round trip time latency measure between ROS2 -> PX4 -> ROS2 with fixed px4_ros_com

**Describe possible alternatives**
Instead a condition variable, we could use concurrent queue that receives the ROS2 msgs and wakes t_send worker thread. The t_send worker does not have to check all the hasMsg booleans but instead just pops the queue and sends the data. However the ROS2 msgs have a variable size therefore a lot dynamic allocation is required, current solution is static.

**Test data / coverage**
A ROS2 test application, that sends data which gets echo'd back from PX4 to ROS2. Figure 1 & 2 are plots from the output of this application.


**Additional context**
PX4_ros_com test repository is located on https://github.com/PetervdPerk-NXP/px4_ros_com/tree/rtps-jitter-fix

This pull request includes the fix mentioned in  #13319 

