### PR TITLE
disable airspeed selector module startup for 1.10

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.fw_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.fw_apps
@@ -15,7 +15,7 @@ ekf2 start
 #
 fw_att_control start
 fw_pos_control_l1 start
-airspeed_selector start
+# airspeed_selector start
 #
 # Start Land Detector.
 #

--- a/ROMFS/px4fmu_common/init.d/rc.vtol_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_apps
@@ -21,7 +21,7 @@ mc_att_control start
 mc_pos_control start
 fw_att_control start
 fw_pos_control_l1 start
-airspeed_selector start
+# airspeed_selector start
 
 #
 # Start Land Detector

--- a/posix-configs/SITL/init/test/test_shutdown
+++ b/posix-configs/SITL/init/test/test_shutdown
@@ -29,7 +29,7 @@ mc_pos_control start
 mc_att_control start
 fw_pos_control_l1 start
 fw_att_control start
-airspeed_selector start
+# airspeed_selector start
 
 #mixer load /dev/pwm_output0 ROMFS/sitl/mixers/standard_vtol_sitl.main.mix
 
@@ -56,7 +56,7 @@ mc_pos_control status
 mc_att_control status
 fw_pos_control_l1 status
 fw_att_control status
-airspeed_selector status
+# airspeed_selector status
 dataman status
 uorb status
 
@@ -72,7 +72,7 @@ navigator stop
 commander stop
 land_detector stop
 ekf2 stop
-airspeed_selector stop
+# airspeed_selector stop
 sensors stop
 
 sleep 2


### PR DESCRIPTION
This PR removes the airspeed selector module from the start up of VTOL and FW vehicles. 

Reasoning: The module is currently (before https://github.com/PX4/Firmware/pull/12887 gets in) not used in any control module. So for 1.10 we should remove it from the startup, as otherwise the parameter settings would be shown and error messages displayed when an airspeed was declared invalid (but no action taken). The airspeed checks are still there in commander currently (they will only be moved to the airspeed selector with https://github.com/PX4/Firmware/pull/12887).

@dagar @RomanBapst FYI.
