### PR TITLE
platforms: remove usage of SIGCONT

### DIFF
--- a/platforms/common/work_queue/hrt_queue.c
+++ b/platforms/common/work_queue/hrt_queue.c
@@ -125,15 +125,6 @@ int hrt_work_queue(struct work_s *work, worker_t worker, void *arg, uint32_t del
 
 	dq_addlast((dq_entry_t *)work, &wqueue->q);
 
-	if (px4_getpid() != wqueue->pid) { /* only need to wake up if called from a different thread */
-#ifdef __PX4_QURT
-		px4_task_kill(wqueue->pid, SIGALRM);      /* Wake up the worker thread */
-#else
-		//wqueue->pid == own task? -> don't signal
-		px4_task_kill(wqueue->pid, SIGCONT);      /* Wake up the worker thread */
-#endif
-	}
-
 	hrt_work_unlock();
 	return PX4_OK;
 }

--- a/platforms/common/work_queue/hrt_thread.c
+++ b/platforms/common/work_queue/hrt_thread.c
@@ -44,7 +44,6 @@
 #include <px4_platform_common/tasks.h>
 #include <px4_platform_common/time.h>
 #include <stdint.h>
-#include <signal.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <queue.h>
@@ -78,26 +77,6 @@ px4_sem_t _hrt_work_lock;
  * Private Functions
  ****************************************************************************/
 static void hrt_work_process(void);
-
-static void _sighandler(int sig_num);
-
-/****************************************************************************
- * Name: _sighandler
- *
- * Description:
- *   This is the handler for the signal to wake the queue processing thread
- *
- * Input parameters:
- *   sig_num - the received signal
- *
- * Returned Value:
- *   None
- *
- ****************************************************************************/
-static void _sighandler(int sig_num)
-{
-	PX4_DEBUG("RECEIVED SIGNAL %d", sig_num);
-}
 
 /****************************************************************************
  * Name: work_process
@@ -212,12 +191,11 @@ static void hrt_work_process()
 		}
 	}
 
-	/* Wait awhile to check the work list.  We will wait here until either
-	 * the time elapses or until we are awakened by a signal.
+	/* Wait awhile to check the work list.  We will wait here until
+	 * the time elapses.
 	 */
 	hrt_work_unlock();
 
-	/* might sleep less if a signal received and new item was queued */
 	//PX4_INFO("Sleeping for %u usec", next);
 	px4_usleep(next);
 }
@@ -285,12 +263,5 @@ void hrt_work_queue_init(void)
 					    2000,
 					    work_hrtthread,
 					    (char *const *)NULL);
-
-
-#ifdef __PX4_QURT
-	signal(SIGALRM, _sighandler);
-#else
-	signal(SIGCONT, _sighandler);
-#endif
 }
 

--- a/platforms/common/work_queue/work_queue.c
+++ b/platforms/common/work_queue/work_queue.c
@@ -42,7 +42,6 @@
 #include <px4_platform_common/workqueue.h>
 #include <px4_platform_common/tasks.h>
 
-#include <signal.h>
 #include <stdint.h>
 #include <queue.h>
 #include <stdio.h>
@@ -125,11 +124,6 @@ int work_queue(int qid, struct work_s *work, worker_t worker, void *arg, uint32_
 	work->qtime  = clock_systimer(); /* Time work queued */
 
 	dq_addlast((dq_entry_t *)work, &wqueue->q);
-#ifdef __PX4_QURT
-	px4_task_kill(wqueue->pid, SIGALRM);      /* Wake up the worker thread */
-#else
-	px4_task_kill(wqueue->pid, SIGCONT);      /* Wake up the worker thread */
-#endif
 
 	work_unlock(qid);
 	return PX4_OK;


### PR DESCRIPTION
I was wondering if this was still required or how this worked but it seems like it still works without.

The reason I looked into SIGCONT was that lldb in vscode does currently
not ignore the signal as it should.

@bkueng @dagar what am I missing?