### PR TITLE
sensors: ensure angular velocity publication on selected sensor update

### DIFF
--- a/src/modules/sensors/vehicle_acceleration/VehicleAcceleration.cpp
+++ b/src/modules/sensors/vehicle_acceleration/VehicleAcceleration.cpp
@@ -171,11 +171,12 @@ void
 VehicleAcceleration::Run()
 {
 	// update corrections first to set _selected_sensor
-	SensorCorrectionsUpdate();
+	bool sensor_select_update = SensorCorrectionsUpdate();
 
-	sensor_accel_s sensor_data;
+	if (_sensor_sub[_selected_sensor].updated() || sensor_select_update) {
+		sensor_accel_s sensor_data;
+		_sensor_sub[_selected_sensor].copy(&sensor_data);
 
-	if (_sensor_sub[_selected_sensor].update(&sensor_data)) {
 		ParametersUpdate();
 		SensorBiasUpdate();
 

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
@@ -210,13 +210,14 @@ void
 VehicleAngularVelocity::Run()
 {
 	// update corrections first to set _selected_sensor
-	SensorCorrectionsUpdate();
+	bool sensor_select_update = SensorCorrectionsUpdate();
 
 	if (_sensor_control_available) {
 		//  using sensor_gyro_control is preferred, but currently not all drivers (eg df_*) provide sensor_gyro_control
-		sensor_gyro_control_s sensor_data;
+		if (_sensor_control_sub[_selected_sensor].updated() || sensor_select_update) {
+			sensor_gyro_control_s sensor_data;
+			_sensor_control_sub[_selected_sensor].copy(&sensor_data);
 
-		if (_sensor_control_sub[_selected_sensor].update(&sensor_data)) {
 			ParametersUpdate();
 			SensorBiasUpdate();
 
@@ -239,9 +240,10 @@ VehicleAngularVelocity::Run()
 
 	} else {
 		// otherwise fallback to using sensor_gyro (legacy that will be removed)
-		sensor_gyro_s sensor_data;
+		if (_sensor_sub[_selected_sensor].updated() || sensor_select_update) {
+			sensor_gyro_s sensor_data;
+			_sensor_sub[_selected_sensor].copy(&sensor_data);
 
-		if (_sensor_sub[_selected_sensor].update(&sensor_data)) {
 			ParametersUpdate();
 			SensorBiasUpdate();
 


### PR DESCRIPTION
During `SensorCorrectionsUpdate()` each sensor message is copied to check the device id.

https://github.com/PX4/Firmware/blob/02271a471d7cd202fae39af99f20956b650caca9/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp#L152

Then back in `Run()` the update() fails because we've just copied the latest data.

https://github.com/PX4/Firmware/blob/02271a471d7cd202fae39af99f20956b650caca9/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp#L219