### PR TITLE
Added synchronization to the t_send worker thread

### DIFF
--- a/msg/templates/urtps/RtpsTopics.h.em
+++ b/msg/templates/urtps/RtpsTopics.h.em
@@ -55,6 +55,7 @@ recv_topics = [(alias[idx] if alias[idx] else s.short_name) for idx, s in enumer
 
 #include <fastcdr/Cdr.h>
 #include <condition_variable>
+#include <queue>
 
 @[for topic in send_topics]@
 #include "@(topic)_Publisher.h"
@@ -65,12 +66,11 @@ recv_topics = [(alias[idx] if alias[idx] else s.short_name) for idx, s in enumer
 
 class RtpsTopics {
 public:
-    bool init(std::condition_variable* cv);
+    bool init(std::condition_variable* t_send_queue_cv, std::mutex* t_send_queue_mutex, std::queue<uint8_t>* t_send_queue);
 @[if send_topics]@
     void publish(uint8_t topic_ID, char data_buffer[], size_t len);
 @[end if]@
 @[if recv_topics]@
-    bool hasMsg(uint8_t *topic_ID);
     bool getMsg(const uint8_t topic_ID, eprosima::fastcdr::Cdr &scdr);
 @[end if]@
 
@@ -88,11 +88,5 @@ private:
     @(topic)_Subscriber _@(topic)_sub;
 @[end for]@
 
-    unsigned _next_sub_idx = 0;
-    unsigned char _sub_topics[@(len(recv_topics))] = {
-@[for topic in recv_topics]@
-        @(rtps_message_id(ids, topic)), // @(topic)
-@[end for]@
-    };
 @[end if]@
 };

--- a/msg/templates/urtps/Subscriber.cpp.em
+++ b/msg/templates/urtps/Subscriber.cpp.em
@@ -74,9 +74,12 @@ except AttributeError:
 
 @(topic)_Subscriber::~@(topic)_Subscriber() {   Domain::removeParticipant(mp_participant);}
 
-bool @(topic)_Subscriber::init(std::condition_variable* cv)
+bool @(topic)_Subscriber::init(uint8_t topic_ID, std::condition_variable* t_send_queue_cv, std::mutex* t_send_queue_mutex, std::queue<uint8_t>* t_send_queue)
 {
-    m_listener.cv_msg = cv;
+    m_listener.topic_ID = topic_ID;
+    m_listener.t_send_queue_cv = t_send_queue_cv;
+    m_listener.t_send_queue_mutex = t_send_queue_mutex;
+    m_listener.t_send_queue = t_send_queue;
 
     // Create RTPSParticipant
     ParticipantAttributes PParam;
@@ -132,17 +135,27 @@ void @(topic)_Subscriber::SubListener::onSubscriptionMatched(Subscriber* sub, Ma
 
 void @(topic)_Subscriber::SubListener::onNewDataMessage(Subscriber* sub)
 {
+        std::unique_lock<std::mutex> has_msg_lock(has_msg_mutex);
+        if(has_msg.load() == true) // Check if msg has been fetched
+        {
+            has_msg_cv.wait(has_msg_lock); // Wait till msg has been fetched
+        }
+        has_msg_lock.unlock();
+        
+
         // Take data
         if(sub->takeNextData(&msg, &m_info))
         {
             if(m_info.sampleKind == ALIVE)
             {
-                // Print your structure data here.
+                std::unique_lock<std::mutex> lk(*t_send_queue_mutex);
+            
                 ++n_msg;
-                //std::cout << "Sample received, count=" << n_msg << std::endl;
                 has_msg = true;
                 
-                cv_msg->notify_all();
+                t_send_queue->push(topic_ID);
+                lk.unlock();
+                t_send_queue_cv->notify_one();
 
             }
         }
@@ -174,6 +187,13 @@ bool @(topic)_Subscriber::hasMsg()
 @[    end if]@
 @[end if]@
 {
-    m_listener.has_msg = false;
     return m_listener.msg;
+}
+
+void @(topic)_Subscriber::unlockMsg()
+{
+    std::unique_lock<std::mutex> has_msg_lock(m_listener.has_msg_mutex);
+    m_listener.has_msg = false;
+    has_msg_lock.unlock();
+    m_listener.has_msg_cv.notify_one();
 }

--- a/msg/templates/urtps/Subscriber.h.em
+++ b/msg/templates/urtps/Subscriber.h.em
@@ -76,6 +76,7 @@ except AttributeError:
 
 #include <atomic>
 #include <condition_variable>
+#include <queue>
 
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
@@ -85,7 +86,7 @@ class @(topic)_Subscriber
 public:
     @(topic)_Subscriber();
     virtual ~@(topic)_Subscriber();
-    bool init(std::condition_variable* cv);
+    bool init(uint8_t topic_ID, std::condition_variable* t_send_queue_cv, std::mutex* t_send_queue_mutex, std::queue<uint8_t>* t_send_queue);
     void run();
     bool hasMsg();
 @[if 1.5 <= fastrtpsgen_version <= 1.7]@
@@ -101,6 +102,8 @@ public:
     @(topic) getMsg();
 @[    end if]@
 @[end if]@
+    void unlockMsg();
+
 private:
     Participant *mp_participant;
     Subscriber *mp_subscriber;
@@ -129,7 +132,12 @@ private:
 @[    end if]@
 @[end if]@
         std::atomic_bool has_msg;
-        std::condition_variable* cv_msg;
+        uint8_t topic_ID;
+        std::condition_variable* t_send_queue_cv;
+        std::mutex* t_send_queue_mutex; 
+        std::queue<uint8_t>* t_send_queue;
+        std::condition_variable has_msg_cv;
+        std::mutex has_msg_mutex; 
 
     } m_listener;
 @[if 1.5 <= fastrtpsgen_version <= 1.7]@


### PR DESCRIPTION
**Describe problem solved by this pull request**
In my previous pull request #13391 @jkflying noted that there might be some possible cases where the condition variable notifies the t_send worker thread, while the t_send worker thread is in the process of setting up the wait. Thus we had a possible deadlock

**Describe your solution**
Replaced the hasMsg() polling subsystem by a synchronized queue using mutexes and a condition variable. Furthermore it was possible that in the Subscriber.cpp.em code new msg data would overwrite the old msg data, this has now been guarded by a mutex.

**Test data / coverage**
Same test as in #13391, @TSC21 I'm looking into how to share the app I've used to test and measure the RTT and latency.

Test repo for px4_ros_com is located here https://github.com/PetervdPerk-NXP/px4_ros_com/tree/rtps-jitter-fix