### PR TITLE
Rover: Enable driving backwards when using attitude setpoints (offboard)

### DIFF
--- a/src/modules/rover_pos_control/RoverPositionControl.cpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.cpp
@@ -335,11 +335,17 @@ RoverPositionControl::control_attitude(const vehicle_attitude_s &att, const vehi
 	float control_effort = euler_sp(2) / _param_max_turn_angle.get();
 	control_effort = math::constrain(control_effort, -1.0f, 1.0f);
 
-	_act_controls.control[actuator_controls_s::INDEX_YAW] = control_effort;
+	const float control_throttle = math::constrain(att_sp.thrust_body[0], -1.0f, 1.0f);
 
-	const float control_throttle = att_sp.thrust_body[0];
+	if (control_throttle >= 0.0f) {
+		_act_controls.control[actuator_controls_s::INDEX_YAW] = control_effort;
 
-	_act_controls.control[actuator_controls_s::INDEX_THROTTLE] =  math::constrain(control_throttle, 0.0f, 1.0f);
+	} else {
+		// reverse steering, if driving backwards
+		_act_controls.control[actuator_controls_s::INDEX_YAW] = -control_effort;
+	}
+
+	_act_controls.control[actuator_controls_s::INDEX_THROTTLE] = control_throttle;
 
 }
 


### PR DESCRIPTION
The Offboard attitude control can now drive backwards. The steering angle is reversed to steer in the right direction.

The possibility to drive backwards was not added to velocity control, because we would need to guess the intended driving direction from the data then. Maybe the difference of velocity vector and heading/ yaw data? (Currently heading is ignored, because the "normal" rovers can not move in one direction and look in another.) But I don't see that this is an urgent addition.