### PR TITLE
FlightTask: add 1st order lpf on yawrate satepoint for smooth motion

### DIFF
--- a/src/lib/flight_tasks/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
+++ b/src/lib/flight_tasks/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
@@ -98,7 +98,8 @@ float FlightTaskManualAltitude::_applyYawspeedFilter(float yawspeed_target)
 {
 	const float den = math::max(_param_mpc_man_y_tau.get() + _deltatime, 0.001f);
 	const float alpha = _deltatime / den;
-	return (1.f - alpha) * _yawspeed_setpoint + alpha * yawspeed_target;
+	_yawspeed_filter_state = (1.f - alpha) * _yawspeed_filter_state + alpha * yawspeed_target;
+	return _yawspeed_filter_state;
 }
 
 void FlightTaskManualAltitude::_updateAltitudeLock()
@@ -327,7 +328,7 @@ void FlightTaskManualAltitude::_lockYaw()
 	// hold the current heading when no more rotation commanded
 	if (!PX4_ISFINITE(_yaw_setpoint)) {
 		_yaw_setpoint = _yaw;
-		_yawspeed_setpoint = 0.f;
+		_yawspeed_setpoint = NAN;
 	}
 }
 

--- a/src/lib/flight_tasks/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
+++ b/src/lib/flight_tasks/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
@@ -328,7 +328,6 @@ void FlightTaskManualAltitude::_lockYaw()
 	// hold the current heading when no more rotation commanded
 	if (!PX4_ISFINITE(_yaw_setpoint)) {
 		_yaw_setpoint = _yaw;
-		_yawspeed_setpoint = NAN;
 	}
 }
 

--- a/src/lib/flight_tasks/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
+++ b/src/lib/flight_tasks/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
@@ -76,6 +76,7 @@ protected:
 					(ParamFloat<px4::params::MPC_HOLD_MAX_XY>) _param_mpc_hold_max_xy,
 					(ParamFloat<px4::params::MPC_Z_P>) _param_mpc_z_p, /**< position controller altitude propotional gain */
 					(ParamFloat<px4::params::MPC_MAN_Y_MAX>) _param_mpc_man_y_max, /**< scaling factor from stick to yaw rate */
+					(ParamFloat<px4::params::MPC_MAN_Y_TAU>) _param_mpc_man_y_tau,
 					(ParamFloat<px4::params::MPC_MAN_TILT_MAX>) _param_mpc_man_tilt_max, /**< maximum tilt allowed for manual flight */
 					(ParamFloat<px4::params::MPC_LAND_ALT1>) _param_mpc_land_alt1, /**< altitude at which to start downwards slowdown */
 					(ParamFloat<px4::params::MPC_LAND_ALT2>) _param_mpc_land_alt2, /**< altitude below wich to land with land speed */
@@ -85,6 +86,11 @@ protected:
 					_param_mpc_tko_speed /**< desired upwards speed when still close to the ground */
 				       )
 private:
+	bool _isYawInput();
+	void _unlockYaw();
+	void _lockYaw();
+	float _applyYawspeedFilter(float yawspeed_target);
+
 	/**
 	 * Terrain following.
 	 * During terrain following, the position setpoint is adjusted

--- a/src/lib/flight_tasks/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
+++ b/src/lib/flight_tasks/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
@@ -131,4 +131,6 @@ private:
 	 * _dist_to_ground_lock.
 	 */
 	float _dist_to_ground_lock = NAN;
+
+	float _yawspeed_filter_state{};
 };

--- a/src/lib/flight_tasks/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
+++ b/src/lib/flight_tasks/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
@@ -89,6 +89,13 @@ private:
 	bool _isYawInput();
 	void _unlockYaw();
 	void _lockYaw();
+
+	/**
+	 * Filter between stick input and yaw setpoint
+	 *
+	 * @param yawspeed_target yaw setpoint desired by the stick
+	 * @return filtered value from independent filter state
+	 */
 	float _applyYawspeedFilter(float yawspeed_target);
 
 	/**
@@ -118,6 +125,7 @@ private:
 
 	uORB::SubscriptionData<home_position_s> _sub_home_position{ORB_ID(home_position)};
 
+	float _yawspeed_filter_state{}; /**< state of low-pass filter in rad/s */
 	uint8_t _reset_counter = 0; /**< counter for estimator resets in z-direction */
 	float _max_speed_up = 10.0f;
 	float _min_speed_down = 1.0f;
@@ -131,6 +139,4 @@ private:
 	 * _dist_to_ground_lock.
 	 */
 	float _dist_to_ground_lock = NAN;
-
-	float _yawspeed_filter_state{};
 };

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -396,6 +396,18 @@ PARAM_DEFINE_FLOAT(MPC_MAN_TILT_MAX, 35.0f);
 PARAM_DEFINE_FLOAT(MPC_MAN_Y_MAX, 150.0f);
 
 /**
+ * Manual yaw rate input filter time constant
+ * Setting this parameter to 0 disables the filter
+ *
+ * @unit s
+ * @min 0.0
+ * @max 5.0
+ * @decimal 2
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_MAN_Y_TAU, 0.08f);
+
+/**
  * Deadzone of sticks where position hold is enabled
  *
  * @min 0.0


### PR DESCRIPTION
Currently, there is no way to have a smooth yaw stop as the yaw locking mechanism is based on the position of the yaw stick: when the stick goes back to zero, the yaw setpoint is set to the current yaw and since the vehicle is moving, it is not physically possible to stop without overshoot.
![2019-11-11_11-11-48_01_plot](https://user-images.githubusercontent.com/14822839/68586738-99758a00-0485-11ea-996e-1788d7f76dfe.png)

To fix this issue, the yawspeed setpoint (generated from the stick position) is passed through a 1st order lowpass filter. The yaw lock now occurs when the output of the filter is at zero.
As shown below, there is no overshoot anymore:
![2019-11-11_11-13-01_01_plot](https://user-images.githubusercontent.com/14822839/68586926-13a60e80-0486-11ea-9350-acba455d87f0.png)

Note: this modification affects altitude and position controlled modes (i.e.:not stabilized, not auto)