### PR TITLE
set TC_ as 'system' parameters

### DIFF
--- a/src/modules/sensors/temp_comp_params_accel.c
+++ b/src/modules/sensors/temp_comp_params_accel.c
@@ -55,6 +55,7 @@ PARAM_DEFINE_INT32(TC_A_ENABLE, 0);
  * ID of Accelerometer that the calibration is for.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_INT32(TC_A0_ID, 0);
 
@@ -62,6 +63,7 @@ PARAM_DEFINE_INT32(TC_A0_ID, 0);
  * Accelerometer offset temperature ^3 polynomial coefficient - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A0_X3_0, 0.0f);
 
@@ -69,6 +71,7 @@ PARAM_DEFINE_FLOAT(TC_A0_X3_0, 0.0f);
  * Accelerometer offset temperature ^3 polynomial coefficient - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A0_X3_1, 0.0f);
 
@@ -76,6 +79,7 @@ PARAM_DEFINE_FLOAT(TC_A0_X3_1, 0.0f);
  * Accelerometer offset temperature ^3 polynomial coefficient - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A0_X3_2, 0.0f);
 
@@ -83,6 +87,7 @@ PARAM_DEFINE_FLOAT(TC_A0_X3_2, 0.0f);
  * Accelerometer offset temperature ^2 polynomial coefficient - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A0_X2_0, 0.0f);
 
@@ -90,6 +95,7 @@ PARAM_DEFINE_FLOAT(TC_A0_X2_0, 0.0f);
  * Accelerometer offset temperature ^2 polynomial coefficient - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A0_X2_1, 0.0f);
 
@@ -97,6 +103,7 @@ PARAM_DEFINE_FLOAT(TC_A0_X2_1, 0.0f);
  * Accelerometer offset temperature ^2 polynomial coefficient - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A0_X2_2, 0.0f);
 
@@ -104,6 +111,7 @@ PARAM_DEFINE_FLOAT(TC_A0_X2_2, 0.0f);
  * Accelerometer offset temperature ^1 polynomial coefficient - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A0_X1_0, 0.0f);
 
@@ -111,6 +119,7 @@ PARAM_DEFINE_FLOAT(TC_A0_X1_0, 0.0f);
  * Accelerometer offset temperature ^1 polynomial coefficient - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A0_X1_1, 0.0f);
 
@@ -118,6 +127,7 @@ PARAM_DEFINE_FLOAT(TC_A0_X1_1, 0.0f);
  * Accelerometer offset temperature ^1 polynomial coefficient - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A0_X1_2, 0.0f);
 
@@ -125,6 +135,7 @@ PARAM_DEFINE_FLOAT(TC_A0_X1_2, 0.0f);
  * Accelerometer offset temperature ^0 polynomial coefficient - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A0_X0_0, 0.0f);
 
@@ -132,6 +143,7 @@ PARAM_DEFINE_FLOAT(TC_A0_X0_0, 0.0f);
  * Accelerometer offset temperature ^0 polynomial coefficient - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A0_X0_1, 0.0f);
 
@@ -139,6 +151,7 @@ PARAM_DEFINE_FLOAT(TC_A0_X0_1, 0.0f);
  * Accelerometer offset temperature ^0 polynomial coefficient - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A0_X0_2, 0.0f);
 
@@ -146,6 +159,7 @@ PARAM_DEFINE_FLOAT(TC_A0_X0_2, 0.0f);
  * Accelerometer scale factor - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A0_SCL_0, 1.0f);
 
@@ -153,6 +167,7 @@ PARAM_DEFINE_FLOAT(TC_A0_SCL_0, 1.0f);
  * Accelerometer scale factor - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A0_SCL_1, 1.0f);
 
@@ -160,6 +175,7 @@ PARAM_DEFINE_FLOAT(TC_A0_SCL_1, 1.0f);
  * Accelerometer scale factor - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A0_SCL_2, 1.0f);
 
@@ -167,6 +183,7 @@ PARAM_DEFINE_FLOAT(TC_A0_SCL_2, 1.0f);
  * Accelerometer calibration reference temperature.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A0_TREF, 25.0f);
 
@@ -174,6 +191,7 @@ PARAM_DEFINE_FLOAT(TC_A0_TREF, 25.0f);
  * Accelerometer calibration minimum temperature.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A0_TMIN, 0.0f);
 
@@ -181,6 +199,7 @@ PARAM_DEFINE_FLOAT(TC_A0_TMIN, 0.0f);
  * Accelerometer calibration maximum temperature.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A0_TMAX, 100.0f);
 
@@ -190,6 +209,7 @@ PARAM_DEFINE_FLOAT(TC_A0_TMAX, 100.0f);
  * ID of Accelerometer that the calibration is for.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_INT32(TC_A1_ID, 0);
 
@@ -197,6 +217,7 @@ PARAM_DEFINE_INT32(TC_A1_ID, 0);
  * Accelerometer offset temperature ^3 polynomial coefficient - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A1_X3_0, 0.0f);
 
@@ -204,6 +225,7 @@ PARAM_DEFINE_FLOAT(TC_A1_X3_0, 0.0f);
  * Accelerometer offset temperature ^3 polynomial coefficient - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A1_X3_1, 0.0f);
 
@@ -211,6 +233,7 @@ PARAM_DEFINE_FLOAT(TC_A1_X3_1, 0.0f);
  * Accelerometer offset temperature ^3 polynomial coefficient - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A1_X3_2, 0.0f);
 
@@ -218,6 +241,7 @@ PARAM_DEFINE_FLOAT(TC_A1_X3_2, 0.0f);
  * Accelerometer offset temperature ^2 polynomial coefficient - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A1_X2_0, 0.0f);
 
@@ -225,6 +249,7 @@ PARAM_DEFINE_FLOAT(TC_A1_X2_0, 0.0f);
  * Accelerometer offset temperature ^2 polynomial coefficient - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A1_X2_1, 0.0f);
 
@@ -232,6 +257,7 @@ PARAM_DEFINE_FLOAT(TC_A1_X2_1, 0.0f);
  * Accelerometer offset temperature ^2 polynomial coefficient - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A1_X2_2, 0.0f);
 
@@ -239,6 +265,7 @@ PARAM_DEFINE_FLOAT(TC_A1_X2_2, 0.0f);
  * Accelerometer offset temperature ^1 polynomial coefficient - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A1_X1_0, 0.0f);
 
@@ -246,6 +273,7 @@ PARAM_DEFINE_FLOAT(TC_A1_X1_0, 0.0f);
  * Accelerometer offset temperature ^1 polynomial coefficient - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A1_X1_1, 0.0f);
 
@@ -253,6 +281,7 @@ PARAM_DEFINE_FLOAT(TC_A1_X1_1, 0.0f);
  * Accelerometer offset temperature ^1 polynomial coefficient - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A1_X1_2, 0.0f);
 
@@ -260,6 +289,7 @@ PARAM_DEFINE_FLOAT(TC_A1_X1_2, 0.0f);
  * Accelerometer offset temperature ^0 polynomial coefficient - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A1_X0_0, 0.0f);
 
@@ -267,6 +297,7 @@ PARAM_DEFINE_FLOAT(TC_A1_X0_0, 0.0f);
  * Accelerometer offset temperature ^0 polynomial coefficient - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A1_X0_1, 0.0f);
 
@@ -274,6 +305,7 @@ PARAM_DEFINE_FLOAT(TC_A1_X0_1, 0.0f);
  * Accelerometer offset temperature ^0 polynomial coefficient - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A1_X0_2, 0.0f);
 
@@ -281,6 +313,7 @@ PARAM_DEFINE_FLOAT(TC_A1_X0_2, 0.0f);
  * Accelerometer scale factor - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A1_SCL_0, 1.0f);
 
@@ -288,6 +321,7 @@ PARAM_DEFINE_FLOAT(TC_A1_SCL_0, 1.0f);
  * Accelerometer scale factor - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A1_SCL_1, 1.0f);
 
@@ -295,6 +329,7 @@ PARAM_DEFINE_FLOAT(TC_A1_SCL_1, 1.0f);
  * Accelerometer scale factor - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A1_SCL_2, 1.0f);
 
@@ -302,6 +337,7 @@ PARAM_DEFINE_FLOAT(TC_A1_SCL_2, 1.0f);
  * Accelerometer calibration reference temperature.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A1_TREF, 25.0f);
 
@@ -309,6 +345,7 @@ PARAM_DEFINE_FLOAT(TC_A1_TREF, 25.0f);
  * Accelerometer calibration minimum temperature.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A1_TMIN, 0.0f);
 
@@ -316,6 +353,7 @@ PARAM_DEFINE_FLOAT(TC_A1_TMIN, 0.0f);
  * Accelerometer calibration maximum temperature.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A1_TMAX, 100.0f);
 
@@ -325,6 +363,7 @@ PARAM_DEFINE_FLOAT(TC_A1_TMAX, 100.0f);
  * ID of Accelerometer that the calibration is for.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_INT32(TC_A2_ID, 0);
 
@@ -332,6 +371,7 @@ PARAM_DEFINE_INT32(TC_A2_ID, 0);
  * Accelerometer offset temperature ^3 polynomial coefficient - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A2_X3_0, 0.0f);
 
@@ -339,6 +379,7 @@ PARAM_DEFINE_FLOAT(TC_A2_X3_0, 0.0f);
  * Accelerometer offset temperature ^3 polynomial coefficient - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A2_X3_1, 0.0f);
 
@@ -346,6 +387,7 @@ PARAM_DEFINE_FLOAT(TC_A2_X3_1, 0.0f);
  * Accelerometer offset temperature ^3 polynomial coefficient - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A2_X3_2, 0.0f);
 
@@ -353,6 +395,7 @@ PARAM_DEFINE_FLOAT(TC_A2_X3_2, 0.0f);
  * Accelerometer offset temperature ^2 polynomial coefficient - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A2_X2_0, 0.0f);
 
@@ -360,6 +403,7 @@ PARAM_DEFINE_FLOAT(TC_A2_X2_0, 0.0f);
  * Accelerometer offset temperature ^2 polynomial coefficient - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A2_X2_1, 0.0f);
 
@@ -367,6 +411,7 @@ PARAM_DEFINE_FLOAT(TC_A2_X2_1, 0.0f);
  * Accelerometer offset temperature ^2 polynomial coefficient - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A2_X2_2, 0.0f);
 
@@ -374,6 +419,7 @@ PARAM_DEFINE_FLOAT(TC_A2_X2_2, 0.0f);
  * Accelerometer offset temperature ^1 polynomial coefficient - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A2_X1_0, 0.0f);
 
@@ -381,6 +427,7 @@ PARAM_DEFINE_FLOAT(TC_A2_X1_0, 0.0f);
  * Accelerometer offset temperature ^1 polynomial coefficient - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A2_X1_1, 0.0f);
 
@@ -388,6 +435,7 @@ PARAM_DEFINE_FLOAT(TC_A2_X1_1, 0.0f);
  * Accelerometer offset temperature ^1 polynomial coefficient - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A2_X1_2, 0.0f);
 
@@ -395,6 +443,7 @@ PARAM_DEFINE_FLOAT(TC_A2_X1_2, 0.0f);
  * Accelerometer offset temperature ^0 polynomial coefficient - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A2_X0_0, 0.0f);
 
@@ -402,6 +451,7 @@ PARAM_DEFINE_FLOAT(TC_A2_X0_0, 0.0f);
  * Accelerometer offset temperature ^0 polynomial coefficient - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A2_X0_1, 0.0f);
 
@@ -409,6 +459,7 @@ PARAM_DEFINE_FLOAT(TC_A2_X0_1, 0.0f);
  * Accelerometer offset temperature ^0 polynomial coefficient - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A2_X0_2, 0.0f);
 
@@ -416,6 +467,7 @@ PARAM_DEFINE_FLOAT(TC_A2_X0_2, 0.0f);
  * Accelerometer scale factor - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A2_SCL_0, 1.0f);
 
@@ -423,6 +475,7 @@ PARAM_DEFINE_FLOAT(TC_A2_SCL_0, 1.0f);
  * Accelerometer scale factor - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A2_SCL_1, 1.0f);
 
@@ -430,6 +483,7 @@ PARAM_DEFINE_FLOAT(TC_A2_SCL_1, 1.0f);
  * Accelerometer scale factor - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A2_SCL_2, 1.0f);
 
@@ -437,6 +491,7 @@ PARAM_DEFINE_FLOAT(TC_A2_SCL_2, 1.0f);
  * Accelerometer calibration reference temperature.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A2_TREF, 25.0f);
 
@@ -444,6 +499,7 @@ PARAM_DEFINE_FLOAT(TC_A2_TREF, 25.0f);
  * Accelerometer calibration minimum temperature.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A2_TMIN, 0.0f);
 
@@ -451,5 +507,6 @@ PARAM_DEFINE_FLOAT(TC_A2_TMIN, 0.0f);
  * Accelerometer calibration maximum temperature.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_A2_TMAX, 100.0f);

--- a/src/modules/sensors/temp_comp_params_baro.c
+++ b/src/modules/sensors/temp_comp_params_baro.c
@@ -55,6 +55,7 @@ PARAM_DEFINE_INT32(TC_B_ENABLE, 0);
  * ID of Barometer that the calibration is for.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_INT32(TC_B0_ID, 0);
 
@@ -62,6 +63,7 @@ PARAM_DEFINE_INT32(TC_B0_ID, 0);
  * Barometer offset temperature ^5 polynomial coefficient.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B0_X5, 0.0f);
 
@@ -69,6 +71,7 @@ PARAM_DEFINE_FLOAT(TC_B0_X5, 0.0f);
  * Barometer offset temperature ^4 polynomial coefficient.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B0_X4, 0.0f);
 
@@ -76,6 +79,7 @@ PARAM_DEFINE_FLOAT(TC_B0_X4, 0.0f);
  * Barometer offset temperature ^3 polynomial coefficient.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B0_X3, 0.0f);
 
@@ -83,6 +87,7 @@ PARAM_DEFINE_FLOAT(TC_B0_X3, 0.0f);
  * Barometer offset temperature ^2 polynomial coefficient.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B0_X2, 0.0f);
 
@@ -90,6 +95,7 @@ PARAM_DEFINE_FLOAT(TC_B0_X2, 0.0f);
  * Barometer offset temperature ^1 polynomial coefficients.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B0_X1, 0.0f);
 
@@ -97,6 +103,7 @@ PARAM_DEFINE_FLOAT(TC_B0_X1, 0.0f);
  * Barometer offset temperature ^0 polynomial coefficient.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B0_X0, 0.0f);
 
@@ -104,6 +111,7 @@ PARAM_DEFINE_FLOAT(TC_B0_X0, 0.0f);
  * Barometer scale factor - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B0_SCL, 1.0f);
 
@@ -111,6 +119,7 @@ PARAM_DEFINE_FLOAT(TC_B0_SCL, 1.0f);
  * Barometer calibration reference temperature.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B0_TREF, 40.0f);
 
@@ -118,6 +127,7 @@ PARAM_DEFINE_FLOAT(TC_B0_TREF, 40.0f);
  * Barometer calibration minimum temperature.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B0_TMIN, 5.0f);
 
@@ -125,6 +135,7 @@ PARAM_DEFINE_FLOAT(TC_B0_TMIN, 5.0f);
  * Barometer calibration maximum temperature.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B0_TMAX, 75.0f);
 
@@ -134,6 +145,7 @@ PARAM_DEFINE_FLOAT(TC_B0_TMAX, 75.0f);
  * ID of Barometer that the calibration is for.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_INT32(TC_B1_ID, 0);
 
@@ -141,6 +153,7 @@ PARAM_DEFINE_INT32(TC_B1_ID, 0);
  * Barometer offset temperature ^5 polynomial coefficient.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B1_X5, 0.0f);
 
@@ -148,6 +161,7 @@ PARAM_DEFINE_FLOAT(TC_B1_X5, 0.0f);
  * Barometer offset temperature ^4 polynomial coefficient.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B1_X4, 0.0f);
 
@@ -155,6 +169,7 @@ PARAM_DEFINE_FLOAT(TC_B1_X4, 0.0f);
  * Barometer offset temperature ^3 polynomial coefficient.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B1_X3, 0.0f);
 
@@ -162,6 +177,7 @@ PARAM_DEFINE_FLOAT(TC_B1_X3, 0.0f);
  * Barometer offset temperature ^2 polynomial coefficient.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B1_X2, 0.0f);
 
@@ -169,6 +185,7 @@ PARAM_DEFINE_FLOAT(TC_B1_X2, 0.0f);
  * Barometer offset temperature ^1 polynomial coefficients.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B1_X1, 0.0f);
 
@@ -176,6 +193,7 @@ PARAM_DEFINE_FLOAT(TC_B1_X1, 0.0f);
  * Barometer offset temperature ^0 polynomial coefficient.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B1_X0, 0.0f);
 
@@ -183,6 +201,7 @@ PARAM_DEFINE_FLOAT(TC_B1_X0, 0.0f);
  * Barometer scale factor - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B1_SCL, 1.0f);
 
@@ -190,6 +209,7 @@ PARAM_DEFINE_FLOAT(TC_B1_SCL, 1.0f);
  * Barometer calibration reference temperature.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B1_TREF, 40.0f);
 
@@ -197,6 +217,7 @@ PARAM_DEFINE_FLOAT(TC_B1_TREF, 40.0f);
  * Barometer calibration minimum temperature.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B1_TMIN, 5.0f);
 
@@ -204,6 +225,7 @@ PARAM_DEFINE_FLOAT(TC_B1_TMIN, 5.0f);
  * Barometer calibration maximum temperature.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B1_TMAX, 75.0f);
 
@@ -213,6 +235,7 @@ PARAM_DEFINE_FLOAT(TC_B1_TMAX, 75.0f);
  * ID of Barometer that the calibration is for.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_INT32(TC_B2_ID, 0);
 
@@ -220,6 +243,7 @@ PARAM_DEFINE_INT32(TC_B2_ID, 0);
  * Barometer offset temperature ^5 polynomial coefficient.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B2_X5, 0.0f);
 
@@ -227,6 +251,7 @@ PARAM_DEFINE_FLOAT(TC_B2_X5, 0.0f);
  * Barometer offset temperature ^4 polynomial coefficient.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B2_X4, 0.0f);
 
@@ -234,6 +259,7 @@ PARAM_DEFINE_FLOAT(TC_B2_X4, 0.0f);
  * Barometer offset temperature ^3 polynomial coefficient.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B2_X3, 0.0f);
 
@@ -241,6 +267,7 @@ PARAM_DEFINE_FLOAT(TC_B2_X3, 0.0f);
  * Barometer offset temperature ^2 polynomial coefficient.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B2_X2, 0.0f);
 
@@ -248,6 +275,7 @@ PARAM_DEFINE_FLOAT(TC_B2_X2, 0.0f);
  * Barometer offset temperature ^1 polynomial coefficients.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B2_X1, 0.0f);
 
@@ -255,6 +283,7 @@ PARAM_DEFINE_FLOAT(TC_B2_X1, 0.0f);
  * Barometer offset temperature ^0 polynomial coefficient.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B2_X0, 0.0f);
 
@@ -262,6 +291,7 @@ PARAM_DEFINE_FLOAT(TC_B2_X0, 0.0f);
  * Barometer scale factor - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B2_SCL, 1.0f);
 
@@ -269,6 +299,7 @@ PARAM_DEFINE_FLOAT(TC_B2_SCL, 1.0f);
  * Barometer calibration reference temperature.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B2_TREF, 40.0f);
 
@@ -276,6 +307,7 @@ PARAM_DEFINE_FLOAT(TC_B2_TREF, 40.0f);
  * Barometer calibration minimum temperature.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B2_TMIN, 5.0f);
 
@@ -283,5 +315,6 @@ PARAM_DEFINE_FLOAT(TC_B2_TMIN, 5.0f);
  * Barometer calibration maximum temperature.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_B2_TMAX, 75.0f);

--- a/src/modules/sensors/temp_comp_params_gyro.c
+++ b/src/modules/sensors/temp_comp_params_gyro.c
@@ -55,6 +55,7 @@ PARAM_DEFINE_INT32(TC_G_ENABLE, 0);
  * ID of Gyro that the calibration is for.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_INT32(TC_G0_ID, 0);
 
@@ -62,6 +63,7 @@ PARAM_DEFINE_INT32(TC_G0_ID, 0);
  * Gyro rate offset temperature ^3 polynomial coefficient - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G0_X3_0, 0.0f);
 
@@ -69,6 +71,7 @@ PARAM_DEFINE_FLOAT(TC_G0_X3_0, 0.0f);
  * Gyro rate offset temperature ^3 polynomial coefficient - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G0_X3_1, 0.0f);
 
@@ -76,6 +79,7 @@ PARAM_DEFINE_FLOAT(TC_G0_X3_1, 0.0f);
  * Gyro rate offset temperature ^3 polynomial coefficient - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G0_X3_2, 0.0f);
 
@@ -83,6 +87,7 @@ PARAM_DEFINE_FLOAT(TC_G0_X3_2, 0.0f);
  * Gyro rate offset temperature ^2 polynomial coefficient - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G0_X2_0, 0.0f);
 
@@ -90,6 +95,7 @@ PARAM_DEFINE_FLOAT(TC_G0_X2_0, 0.0f);
  * Gyro rate offset temperature ^2 polynomial coefficient - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G0_X2_1, 0.0f);
 
@@ -97,6 +103,7 @@ PARAM_DEFINE_FLOAT(TC_G0_X2_1, 0.0f);
  * Gyro rate offset temperature ^2 polynomial coefficient - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G0_X2_2, 0.0f);
 
@@ -104,6 +111,7 @@ PARAM_DEFINE_FLOAT(TC_G0_X2_2, 0.0f);
  * Gyro rate offset temperature ^1 polynomial coefficient - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G0_X1_0, 0.0f);
 
@@ -111,6 +119,7 @@ PARAM_DEFINE_FLOAT(TC_G0_X1_0, 0.0f);
  * Gyro rate offset temperature ^1 polynomial coefficient - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G0_X1_1, 0.0f);
 
@@ -118,6 +127,7 @@ PARAM_DEFINE_FLOAT(TC_G0_X1_1, 0.0f);
  * Gyro rate offset temperature ^1 polynomial coefficient - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G0_X1_2, 0.0f);
 
@@ -125,6 +135,7 @@ PARAM_DEFINE_FLOAT(TC_G0_X1_2, 0.0f);
  * Gyro rate offset temperature ^0 polynomial coefficient - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G0_X0_0, 0.0f);
 
@@ -132,6 +143,7 @@ PARAM_DEFINE_FLOAT(TC_G0_X0_0, 0.0f);
  * Gyro rate offset temperature ^0 polynomial coefficient - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G0_X0_1, 0.0f);
 
@@ -139,6 +151,7 @@ PARAM_DEFINE_FLOAT(TC_G0_X0_1, 0.0f);
  * Gyro rate offset temperature ^0 polynomial coefficient - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G0_X0_2, 0.0f);
 
@@ -146,6 +159,7 @@ PARAM_DEFINE_FLOAT(TC_G0_X0_2, 0.0f);
  * Gyro scale factor - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G0_SCL_0, 1.0f);
 
@@ -153,6 +167,7 @@ PARAM_DEFINE_FLOAT(TC_G0_SCL_0, 1.0f);
  * Gyro scale factor - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G0_SCL_1, 1.0f);
 
@@ -160,6 +175,7 @@ PARAM_DEFINE_FLOAT(TC_G0_SCL_1, 1.0f);
  * Gyro scale factor - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G0_SCL_2, 1.0f);
 
@@ -167,6 +183,7 @@ PARAM_DEFINE_FLOAT(TC_G0_SCL_2, 1.0f);
  * Gyro calibration reference temperature.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G0_TREF, 25.0f);
 
@@ -174,6 +191,7 @@ PARAM_DEFINE_FLOAT(TC_G0_TREF, 25.0f);
  * Gyro calibration minimum temperature.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G0_TMIN, 0.0f);
 
@@ -181,6 +199,7 @@ PARAM_DEFINE_FLOAT(TC_G0_TMIN, 0.0f);
  * Gyro calibration maximum temperature.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G0_TMAX, 100.0f);
 
@@ -190,6 +209,7 @@ PARAM_DEFINE_FLOAT(TC_G0_TMAX, 100.0f);
  * ID of Gyro that the calibration is for.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_INT32(TC_G1_ID, 0);
 
@@ -197,6 +217,7 @@ PARAM_DEFINE_INT32(TC_G1_ID, 0);
  * Gyro rate offset temperature ^3 polynomial coefficient - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G1_X3_0, 0.0f);
 
@@ -204,6 +225,7 @@ PARAM_DEFINE_FLOAT(TC_G1_X3_0, 0.0f);
  * Gyro rate offset temperature ^3 polynomial coefficient - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G1_X3_1, 0.0f);
 
@@ -211,6 +233,7 @@ PARAM_DEFINE_FLOAT(TC_G1_X3_1, 0.0f);
  * Gyro rate offset temperature ^3 polynomial coefficient - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G1_X3_2, 0.0f);
 
@@ -218,6 +241,7 @@ PARAM_DEFINE_FLOAT(TC_G1_X3_2, 0.0f);
  * Gyro rate offset temperature ^2 polynomial coefficient - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G1_X2_0, 0.0f);
 
@@ -225,6 +249,7 @@ PARAM_DEFINE_FLOAT(TC_G1_X2_0, 0.0f);
  * Gyro rate offset temperature ^2 polynomial coefficient - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G1_X2_1, 0.0f);
 
@@ -232,6 +257,7 @@ PARAM_DEFINE_FLOAT(TC_G1_X2_1, 0.0f);
  * Gyro rate offset temperature ^2 polynomial coefficient - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G1_X2_2, 0.0f);
 
@@ -239,6 +265,7 @@ PARAM_DEFINE_FLOAT(TC_G1_X2_2, 0.0f);
  * Gyro rate offset temperature ^1 polynomial coefficient - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G1_X1_0, 0.0f);
 
@@ -246,6 +273,7 @@ PARAM_DEFINE_FLOAT(TC_G1_X1_0, 0.0f);
  * Gyro rate offset temperature ^1 polynomial coefficient - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G1_X1_1, 0.0f);
 
@@ -253,6 +281,7 @@ PARAM_DEFINE_FLOAT(TC_G1_X1_1, 0.0f);
  * Gyro rate offset temperature ^1 polynomial coefficient - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G1_X1_2, 0.0f);
 
@@ -260,6 +289,7 @@ PARAM_DEFINE_FLOAT(TC_G1_X1_2, 0.0f);
  * Gyro rate offset temperature ^0 polynomial coefficient - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G1_X0_0, 0.0f);
 
@@ -267,6 +297,7 @@ PARAM_DEFINE_FLOAT(TC_G1_X0_0, 0.0f);
  * Gyro rate offset temperature ^0 polynomial coefficient - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G1_X0_1, 0.0f);
 
@@ -274,6 +305,7 @@ PARAM_DEFINE_FLOAT(TC_G1_X0_1, 0.0f);
  * Gyro rate offset temperature ^0 polynomial coefficient - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G1_X0_2, 0.0f);
 
@@ -281,6 +313,7 @@ PARAM_DEFINE_FLOAT(TC_G1_X0_2, 0.0f);
  * Gyro scale factor - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G1_SCL_0, 1.0f);
 
@@ -288,6 +321,7 @@ PARAM_DEFINE_FLOAT(TC_G1_SCL_0, 1.0f);
  * Gyro scale factor - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G1_SCL_1, 1.0f);
 
@@ -295,6 +329,7 @@ PARAM_DEFINE_FLOAT(TC_G1_SCL_1, 1.0f);
  * Gyro scale factor - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G1_SCL_2, 1.0f);
 
@@ -302,6 +337,7 @@ PARAM_DEFINE_FLOAT(TC_G1_SCL_2, 1.0f);
  * Gyro calibration reference temperature.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G1_TREF, 25.0f);
 
@@ -309,6 +345,7 @@ PARAM_DEFINE_FLOAT(TC_G1_TREF, 25.0f);
  * Gyro calibration minimum temperature.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G1_TMIN, 0.0f);
 
@@ -316,6 +353,7 @@ PARAM_DEFINE_FLOAT(TC_G1_TMIN, 0.0f);
  * Gyro calibration maximum temperature.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G1_TMAX, 100.0f);
 
@@ -325,6 +363,7 @@ PARAM_DEFINE_FLOAT(TC_G1_TMAX, 100.0f);
  * ID of Gyro that the calibration is for.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_INT32(TC_G2_ID, 0);
 
@@ -332,6 +371,7 @@ PARAM_DEFINE_INT32(TC_G2_ID, 0);
  * Gyro rate offset temperature ^3 polynomial coefficient - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G2_X3_0, 0.0f);
 
@@ -339,6 +379,7 @@ PARAM_DEFINE_FLOAT(TC_G2_X3_0, 0.0f);
  * Gyro rate offset temperature ^3 polynomial coefficient - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G2_X3_1, 0.0f);
 
@@ -346,6 +387,7 @@ PARAM_DEFINE_FLOAT(TC_G2_X3_1, 0.0f);
  * Gyro rate offset temperature ^3 polynomial coefficient - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G2_X3_2, 0.0f);
 
@@ -353,6 +395,7 @@ PARAM_DEFINE_FLOAT(TC_G2_X3_2, 0.0f);
  * Gyro rate offset temperature ^2 polynomial coefficient - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G2_X2_0, 0.0f);
 
@@ -360,6 +403,7 @@ PARAM_DEFINE_FLOAT(TC_G2_X2_0, 0.0f);
  * Gyro rate offset temperature ^2 polynomial coefficient - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G2_X2_1, 0.0f);
 
@@ -367,6 +411,7 @@ PARAM_DEFINE_FLOAT(TC_G2_X2_1, 0.0f);
  * Gyro rate offset temperature ^2 polynomial coefficient - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G2_X2_2, 0.0f);
 
@@ -374,6 +419,7 @@ PARAM_DEFINE_FLOAT(TC_G2_X2_2, 0.0f);
  * Gyro rate offset temperature ^1 polynomial coefficient - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G2_X1_0, 0.0f);
 
@@ -381,6 +427,7 @@ PARAM_DEFINE_FLOAT(TC_G2_X1_0, 0.0f);
  * Gyro rate offset temperature ^1 polynomial coefficient - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G2_X1_1, 0.0f);
 
@@ -388,6 +435,7 @@ PARAM_DEFINE_FLOAT(TC_G2_X1_1, 0.0f);
  * Gyro rate offset temperature ^1 polynomial coefficient - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G2_X1_2, 0.0f);
 
@@ -395,6 +443,7 @@ PARAM_DEFINE_FLOAT(TC_G2_X1_2, 0.0f);
  * Gyro rate offset temperature ^0 polynomial coefficient - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G2_X0_0, 0.0f);
 
@@ -402,6 +451,7 @@ PARAM_DEFINE_FLOAT(TC_G2_X0_0, 0.0f);
  * Gyro rate offset temperature ^0 polynomial coefficient - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G2_X0_1, 0.0f);
 
@@ -409,6 +459,7 @@ PARAM_DEFINE_FLOAT(TC_G2_X0_1, 0.0f);
  * Gyro rate offset temperature ^0 polynomial coefficient - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G2_X0_2, 0.0f);
 
@@ -416,6 +467,7 @@ PARAM_DEFINE_FLOAT(TC_G2_X0_2, 0.0f);
  * Gyro scale factor - X axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G2_SCL_0, 1.0f);
 
@@ -423,6 +475,7 @@ PARAM_DEFINE_FLOAT(TC_G2_SCL_0, 1.0f);
  * Gyro scale factor - Y axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G2_SCL_1, 1.0f);
 
@@ -430,6 +483,7 @@ PARAM_DEFINE_FLOAT(TC_G2_SCL_1, 1.0f);
  * Gyro scale factor - Z axis.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G2_SCL_2, 1.0f);
 
@@ -437,6 +491,7 @@ PARAM_DEFINE_FLOAT(TC_G2_SCL_2, 1.0f);
  * Gyro calibration reference temperature.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G2_TREF, 25.0f);
 
@@ -444,6 +499,7 @@ PARAM_DEFINE_FLOAT(TC_G2_TREF, 25.0f);
  * Gyro calibration minimum temperature.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G2_TMIN, 0.0f);
 
@@ -451,5 +507,6 @@ PARAM_DEFINE_FLOAT(TC_G2_TMIN, 0.0f);
  * Gyro calibration maximum temperature.
  *
  * @group Thermal Compensation
+ * @category system
  */
 PARAM_DEFINE_FLOAT(TC_G2_TMAX, 100.0f);


### PR DESCRIPTION
as describe on Thermal Compensation parameters are not categorized as system parameters #13165

**Describe problem solved by this pull request**
ts seems that the TC_xxx (Thermal Compensation) are not defined as system, but from my understood, parameters that categorized as 'system' are parameters that the user should not change manually, such as the calibration.
