### PR TITLE
mavlink_receiver: simplify and fix statustext.severity handling

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2592,30 +2592,7 @@ void MavlinkReceiver::handle_message_statustext(mavlink_message_t *msg)
 
 		log_message_s log_message{};
 
-		switch (statustext.severity) {
-		case MAV_SEVERITY_EMERGENCY:
-		case MAV_SEVERITY_ALERT:
-		case MAV_SEVERITY_CRITICAL:
-			log_message.severity = 0;
-			break;
-
-		case MAV_SEVERITY_ERROR:
-			log_message.severity = 3;
-			break;
-
-		case MAV_SEVERITY_WARNING:
-			log_message.severity = 4;
-			break;
-
-		case MAV_SEVERITY_NOTICE:
-		case MAV_SEVERITY_INFO:
-			log_message.severity = 6;
-			break;
-
-		default:
-			return;
-		}
-
+		log_message.severity = statustext.severity;
 		log_message.timestamp = hrt_absolute_time();
 
 		snprintf(log_message.text, sizeof(log_message.text),


### PR DESCRIPTION
This is continuation of https://github.com/PX4/Firmware/pull/13327. I misinterpreted that severity levels in MAVLink did not match severity levels in `log_message` uORB topic and in logs. Turns out they match (both are from Linux kernel convention). So the code can be simplify and fixed.

Tested in SITL. Now all the levels are available.

<img width="374" alt="Screenshot 2019-11-12 at 00 17 58" src="https://user-images.githubusercontent.com/1683279/68622193-9eb4f200-04e2-11ea-988d-f791d8876159.png">

(If someone's wondering, here is the script I used for publishing: https://gist.github.com/okalachev/d1c70d6d1677a607d1948d39fe116613).

@dagar 