### PR TITLE
Add COEX Clover 4 airframe

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4500_clover4
+++ b/ROMFS/px4fmu_common/init.d/airframes/4500_clover4
@@ -1,0 +1,31 @@
+#!/bin/sh
+#
+# @name COEX Clover 4
+#
+# @type Quadrotor x
+# @class Copter
+#
+# @maintainer Oleg Kalachev <okalachev@gmail.com>
+#
+
+sh /etc/init.d/rc.mc_defaults
+
+set MIXER quad_x
+set PWM_OUT 1234
+
+if [ $AUTOCNF = yes ]
+then
+	param set MC_PITCHRATE_P 0.087
+	param set MC_PITCHRATE_I 0.037
+	param set MC_PITCHRATE_D 0.0044
+	param set MC_PITCH_P 8.5
+	param set MC_ROLLRATE_P 0.087
+	param set MC_ROLLRATE_I 0.037
+	param set MC_ROLLRATE_D 0.0044
+	param set MC_ROLL_P 8.5
+	param set MPC_XY_VEL_P 0.11
+	param set MPC_XY_VEL_D 0.013
+	param set MPC_XY_P 1.1
+	param set MPC_Z_VEL_P 0.24
+	param set MPC_Z_P 1.2
+fi

--- a/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
@@ -87,6 +87,7 @@ px4_add_romfs_files(
 	4090_nanomind
 	4100_tiltquadrotor
 	4250_teal
+	4500_clover4
 	4900_crazyflie
 
 	# [5000, 5999] Quadrotor +"


### PR DESCRIPTION
COEX Clover (previously Clever) is an education quadcopter that is quite popular in Russia. Some of the educational initiatives with it were presented on PX4 Dev Summit talk: https://www.youtube.com/watch?v=aB5HgR1rP54.

There is an incomplete list of events where it's officially used:

* NTI Contest 2017, 2018, 2019 (https://www.youtube.com/watch?v=dnipvu4ZLxk, https://www.youtube.com/watch?v=E1_ehvJRKxg, https://www.youtube.com/watch?v=VlVLG2ZiOn8).
* Official drone of WorldSkills Drone Operating competition (https://www.youtube.com/watch?v=xHGsgtq_GIo, https://worldskills2019.com/en/projects/worldskills-juniors-2019/skills/drone-operating/index.html, https://worldskills2019.com/en/projects/future-skills-2019/skills/drone-operating/).
* Copter Hack (https://www.youtube.com/watch?v=xgXheg3TTs4, https://www.youtube.com/watch?v=iv9I-JwaAhE, https://www.youtube.com/watch?v=--zHqDQO014).
* AeroHack (https://www.youtube.com/watch?v=Z0eRCgRNIyI).
 
See the map of adoption: https://coex.tech/clover#map.

Now only PID coefficients were added (considering this setting only related to the airframe itself), but other parameters may be added later.