### PR TITLE
Log and handle cellular_status messages

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -42,6 +42,7 @@ set(msg_files
 	battery_status.msg
 	camera_capture.msg
 	camera_trigger.msg
+	cellular_status.msg
 	collision_report.msg
 	collision_constraints.msg
 	commander_state.msg

--- a/msg/cellular_status.msg
+++ b/msg/cellular_status.msg
@@ -1,0 +1,9 @@
+uint64 timestamp	# time since system start (microseconds)
+
+uint16 status 	# Status bitmap 1: Roaming is active
+uint8 type 	# Cellular network radio type 0: none 1: gsm 2: cdma 3: wcdma 4: lte
+uint8 quality	# Cellular network RSSI/RSRP in dBm, absolute value
+uint16 mcc	# Mobile country code. If unknown, set to: UINT16_MAX
+uint16 mnc	# Mobile network code. If unknown, set to: UINT16_MAX
+uint16 lac	# Location area code. If unknown, set to: 0
+uint32 cid	# Cell ID. If unknown, set to: UINT32_MAX

--- a/msg/tools/uorb_rtps_message_ids.yaml
+++ b/msg/tools/uorb_rtps_message_ids.yaml
@@ -264,6 +264,8 @@ rtps:
     id: 115
   - msg: onboard_computer_status
     id: 116
+  - msg: cellular_status
+    id: 117
   ########## multi topics: begin ##########
   - msg: actuator_controls_0
     id: 150

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -637,6 +637,7 @@ void Logger::add_sensor_comparison_topics()
 
 void Logger::add_vision_and_avoidance_topics()
 {
+	add_topic("cellular_status", 200);
 	add_topic("collision_constraints");
 	add_topic("obstacle_distance_fused");
 	add_topic("onboard_computer_status", 200);

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -189,6 +189,10 @@ MavlinkReceiver::handle_message(mavlink_message_t *msg)
 		handle_message_landing_target(msg);
 		break;
 
+	case MAVLINK_MSG_ID_CELLULAR_STATUS:
+		handle_message_cellular_status(msg);
+		break;
+
 	case MAVLINK_MSG_ID_ADSB_VEHICLE:
 		handle_message_adsb_vehicle(msg);
 		break;
@@ -2184,6 +2188,25 @@ MavlinkReceiver::handle_message_landing_target(mavlink_message_t *msg)
 
 		_landing_target_pose_pub.publish(landing_target_pose);
 	}
+}
+
+void
+MavlinkReceiver::handle_message_cellular_status(mavlink_message_t *msg)
+{
+	mavlink_cellular_status_t status;
+	mavlink_msg_cellular_status_decode(msg, &status);
+
+	cellular_status_s cellular_status{};
+
+	cellular_status.status = status.status;
+	cellular_status.type = status.type;
+	cellular_status.quality = status.quality;
+	cellular_status.mcc = status.mcc;
+	cellular_status.mnc = status.mnc;
+	cellular_status.lac = status.lac;
+	cellular_status.cid = status.cid;
+
+	_cellular_status_pub.publish(cellular_status);
 }
 
 void

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2198,6 +2198,7 @@ MavlinkReceiver::handle_message_cellular_status(mavlink_message_t *msg)
 
 	cellular_status_s cellular_status{};
 
+	cellular_status.timestamp = hrt_absolute_time();
 	cellular_status.status = status.status;
 	cellular_status.type = status.type;
 	cellular_status.quality = status.quality;

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -57,6 +57,7 @@
 #include <uORB/topics/airspeed.h>
 #include <uORB/topics/airspeed.h>
 #include <uORB/topics/battery_status.h>
+#include <uORB/topics/cellular_status.h>
 #include <uORB/topics/collision_report.h>
 #include <uORB/topics/debug_array.h>
 #include <uORB/topics/debug_key_value.h>
@@ -130,6 +131,7 @@ private:
 	void handle_message_adsb_vehicle(mavlink_message_t *msg);
 	void handle_message_att_pos_mocap(mavlink_message_t *msg);
 	void handle_message_battery_status(mavlink_message_t *msg);
+	void handle_message_cellular_status(mavlink_message_t *msg);
 	void handle_message_collision(mavlink_message_t *msg);
 	void handle_message_command_ack(mavlink_message_t *msg);
 	void handle_message_command_int(mavlink_message_t *msg);
@@ -220,6 +222,7 @@ private:
 	uORB::Publication<actuator_controls_s>			_actuator_controls_pubs[4] {ORB_ID(actuator_controls_0), ORB_ID(actuator_controls_1), ORB_ID(actuator_controls_2), ORB_ID(actuator_controls_3)};
 	uORB::Publication<airspeed_s>				_airspeed_pub{ORB_ID(airspeed)};
 	uORB::Publication<battery_status_s>			_battery_pub{ORB_ID(battery_status)};
+	uORB::Publication<cellular_status_s>			_cellular_status_pub{ORB_ID(cellular_status)};
 	uORB::Publication<collision_report_s>			_collision_report_pub{ORB_ID(collision_report)};
 	uORB::Publication<debug_array_s>			_debug_array_pub{ORB_ID(debug_array)};
 	uORB::Publication<debug_key_value_s>			_debug_key_value_pub{ORB_ID(debug_key_value)};


### PR DESCRIPTION
**Describe problem solved by this pull request**
As [cellular status](https://mavlink.io/en/messages/common.html#CELLULAR_STATUS) was added a [long time ago](https://github.com/mavlink/mavlink/pull/932) and can be easily sent to the flight controller, the message is not being handled and thus not being logged as part of the flight log.

**Describe your solution**
This PR adds a handler for the CELLULAR_STATUS mavlink message.

**Describe possible alternatives**
Currently the message is defined as `vision_and_avoidance` topics since it is coming from the companion computer. This could be included in other groups if there is a more suitable one. 

**Additional context**
This information is also important for enabling failsafe for BVLOS operations in the future by monitoring the signal strength.
