### PR TITLE
flexcan: fix code style

### DIFF
--- a/Tools/astyle/files_to_check_code_style.sh
+++ b/Tools/astyle/files_to_check_code_style.sh
@@ -11,7 +11,7 @@ exec find boards msg src platforms \
     -path msg/templates/urtps -prune -o \
     -path platforms/nuttx/NuttX -prune -o \
     -path src/drivers/uavcan/libuavcan -prune -o \
-    -path src/drivers/uavcan/uavcan_drivers/kinetis/driver/include/uavcan_kinetis/flexcan.hpp -prune -o \
+    -path src/drivers/uavcan/uavcan_drivers/kinetis/driver/include/uavcan_kinetis -prune -o \
     -path src/lib/DriverFramework -prune -o \
     -path src/lib/ecl -prune -o \
     -path src/lib/matrix -prune -o \

--- a/Tools/astyle/files_to_check_code_style.sh
+++ b/Tools/astyle/files_to_check_code_style.sh
@@ -11,6 +11,7 @@ exec find boards msg src platforms \
     -path msg/templates/urtps -prune -o \
     -path platforms/nuttx/NuttX -prune -o \
     -path src/drivers/uavcan/libuavcan -prune -o \
+    -path src/drivers/uavcan/uavcan_drivers/kinetis/driver/include/uavcan_kinetis/flexcan.hpp -prune -o \
     -path src/lib/DriverFramework -prune -o \
     -path src/lib/ecl -prune -o \
     -path src/lib/matrix -prune -o \

--- a/src/drivers/uavcan/uavcan_drivers/kinetis/driver/include/uavcan_kinetis/flexcan.hpp
+++ b/src/drivers/uavcan/uavcan_drivers/kinetis/driver/include/uavcan_kinetis/flexcan.hpp
@@ -30,32 +30,32 @@ union MBcsType {
 	volatile uint32_t w;
 	struct {
 		volatile uint32_t time_stamp : 16;
-			volatile uint32_t dlc : 4;
-			volatile uint32_t rtr : 1;
-			volatile uint32_t ide : 1;
-			volatile uint32_t srr : 1;
-			volatile uint32_t res : 1;
-			volatile uint32_t code : 4;
-			volatile uint32_t res2 : 4;
-		};
+		volatile uint32_t dlc : 4;
+		volatile uint32_t rtr : 1;
+		volatile uint32_t ide : 1;
+		volatile uint32_t srr : 1;
+		volatile uint32_t res : 1;
+		volatile uint32_t code : 4;
+		volatile uint32_t res2 : 4;
 	};
+};
 
-	union FIFOcsType {
-			volatile uint32_t cs;
-			struct {
-	volatile uint32_t time_stamp : 16;
+union FIFOcsType {
+	volatile uint32_t cs;
+	struct {
+		volatile uint32_t time_stamp : 16;
 		volatile uint32_t dlc : 4;
 		volatile uint32_t rtr : 1;
 		volatile uint32_t ide : 1;
 		volatile uint32_t srr : 1;
 		volatile uint32_t res : 9;
 	};
-	};
+};
 
-	union IDType {
-			volatile uint32_t w;
-			struct {
-	volatile uint32_t ext : 29;
+union IDType {
+	volatile uint32_t w;
+	struct {
+		volatile uint32_t ext : 29;
 		volatile uint32_t resex : 3;
 	};
 	struct {
@@ -63,12 +63,12 @@ union MBcsType {
 		volatile uint32_t std : 11;
 		volatile uint32_t resstd : 3;
 	};
-	};
+};
 
-	union FilterType {
-			volatile uint32_t w;
-			struct {
-	volatile uint32_t res : 1; // Bit 0 - Reserved
+union FilterType {
+	volatile uint32_t w;
+	struct {
+		volatile uint32_t res : 1; // Bit 0 - Reserved
 		volatile uint32_t ext : 29; // Bits 1 - 29 EID
 	};
 	struct {
@@ -76,17 +76,17 @@ union MBcsType {
 		volatile uint32_t std : 11; // StD ID
 	};
 	struct {
-	volatile uint32_t resc : 30; // Bits 0 - 29  Reserved
+		volatile uint32_t resc : 30; // Bits 0 - 29  Reserved
 		volatile uint32_t ide : 1; // Bit 30 - EID
 		volatile uint32_t rtr : 1; // Bit 31 Remote
 	};
-	};
+};
 
-	union DataType {
-			volatile uint32_t l;
-			volatile uint32_t h;
-			struct {
-	volatile uint32_t b3 : 8;
+union DataType {
+	volatile uint32_t l;
+	volatile uint32_t h;
+	struct {
+		volatile uint32_t b3 : 8;
 		volatile uint32_t b2 : 8;
 		volatile uint32_t b1 : 8;
 		volatile uint32_t b0 : 8;
@@ -95,10 +95,10 @@ union MBcsType {
 		volatile uint32_t b5 : 8;
 		volatile uint32_t b4 : 8;
 	};
-	};
+};
 
 
-	struct MessageBufferType {
+struct MessageBufferType {
 	MBcsType CS;
 	IDType ID;
 	DataType data;


### PR DESCRIPTION
**Describe problem solved by this pull request**
Not sure what's going on with astyle indentation with the version CI and @bkueng use but my `make format` constantly complains about these lines and the changes look useful to me.

```
[maetugr@manjarovm ~]$ astyle --version
Artistic Style Version 3.1
```

**Additional context**
These lines were changed from spaces to tabs here: https://github.com/PX4/Firmware/commit/6622f04feb162297a06308515cf22a0b96b61bfb#diff-b5a11f8afae4e6819f4c9ce7321490bdR32-R41
which makes sense because PX4 is tabs indentation but somehow the indentation generated and checked by astyle doesn't line up.

FYI @cmic0, I know it also showed up for you.
