### PR TITLE
Commander: Define parameter for enabling arm authorization

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1268,6 +1268,7 @@ Commander::run()
 	param_t _param_arm_switch_is_button = param_find("COM_ARM_SWISBTN");
 	param_t _param_rc_override = param_find("COM_RC_OVERRIDE");
 	param_t _param_arm_mission_required = param_find("COM_ARM_MIS_REQ");
+	param_t _param_arm_auth_required = param_find("COM_ARM_AUTH_REQ");
 	param_t _param_escs_checks_required = param_find("COM_ARM_CHK_ESCS");
 	param_t _param_flight_uuid = param_find("COM_FLIGHT_UUID");
 	param_t _param_takeoff_finished_action = param_find("COM_TAKEOFF_ACT");
@@ -1395,8 +1396,13 @@ Commander::run()
 
 	int32_t arm_mission_required_param = 0;
 	param_get(_param_arm_mission_required, &arm_mission_required_param);
-	arm_requirements |= (arm_mission_required_param &
-			     (PreFlightCheck::ARM_REQ_MISSION_BIT | PreFlightCheck::ARM_REQ_ARM_AUTH_BIT));
+	arm_requirements |= (arm_mission_required_param == 0) ? PreFlightCheck::ARM_REQ_NONE :
+			    PreFlightCheck::ARM_REQ_MISSION_BIT;
+
+	int32_t arm_auth_required_param = 0;
+	param_get(_param_arm_auth_required, &arm_auth_required_param);
+	arm_requirements |= (arm_auth_required_param == 0) ? PreFlightCheck::ARM_REQ_NONE :
+			    PreFlightCheck::ARM_REQ_ARM_AUTH_BIT;
 
 	int32_t arm_escs_checks_required_param = 0;
 	param_get(_param_escs_checks_required, &arm_escs_checks_required_param);
@@ -1530,9 +1536,15 @@ Commander::run()
 
 			param_get(_param_arm_without_gps, &arm_without_gps_param);
 			arm_requirements = (arm_without_gps_param == 1) ? PreFlightCheck::ARM_REQ_NONE : PreFlightCheck::ARM_REQ_GPS_BIT;
+
 			param_get(_param_arm_mission_required, &arm_mission_required_param);
-			arm_requirements |= (arm_mission_required_param &
-					     (PreFlightCheck::ARM_REQ_MISSION_BIT | PreFlightCheck::ARM_REQ_ARM_AUTH_BIT));
+			arm_requirements |= (arm_mission_required_param == 0) ? PreFlightCheck::ARM_REQ_NONE :
+					    PreFlightCheck::ARM_REQ_MISSION_BIT;
+
+			param_get(_param_arm_auth_required, &arm_auth_required_param);
+			arm_requirements |= (arm_auth_required_param == 0) ? PreFlightCheck::ARM_REQ_NONE :
+					    PreFlightCheck::ARM_REQ_ARM_AUTH_BIT;
+
 			param_get(_param_escs_checks_required, &arm_escs_checks_required_param);
 			arm_requirements |= (arm_escs_checks_required_param == 0) ? PreFlightCheck::ARM_REQ_NONE :
 					    PreFlightCheck::ARM_REQ_ESCS_CHECK_BIT;

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -679,6 +679,16 @@ PARAM_DEFINE_INT32(COM_POSCTL_NAVL, 0);
 PARAM_DEFINE_INT32(COM_ARM_AUTH, 256010);
 
 /**
+ * Require arm authorization to arm
+ *
+ * The default allows to arm the vehicle without a arm authorization.
+ *
+ * @group Commander
+ * @boolean
+ */
+PARAM_DEFINE_INT32(COM_ARM_AUTH_REQ, 0);
+
+/**
  * Loss of position failsafe activation delay.
  *
  * This sets number of seconds that the position checks need to be failed before the failsafe will activate.


### PR DESCRIPTION
In current implementation Arm authorization is enabled by setting  `COM_ARM_MIS_REQ` to a value of 2.
This is conceptually wrong for the following reasons:
-  the parameter is a boolean 
- in the parameter description such use case is not covered
- arm authorization is not related to having a valid mission on board, thus makes no sense to enable the feature in the same parameter for requiring a valid mission. 

This PR splits the logic by introducing a dedicated parameter for arm authorization, `COM_ARM_AUTH_REQ`, making more explicit the use case.

**Test data / coverage**
Tested on a pixracer rig and SITL. 
During SITL testing I was not able to test the `COM_ARM_MIS_REQ` functionality as I was still able to take off without a valid mission. I'll open an issue to keep track of that.
 
