### PR TITLE
SITL: adds 'iris_rtps' target

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/1016_iris_rtps
+++ b/ROMFS/px4fmu_common/init.d-posix/1016_iris_rtps
@@ -1,0 +1,8 @@
+#!/bin/sh
+#
+# @name 3DR Iris Quadrotor SITL (RTPS)
+#
+# @type Quadrotor Wide
+#
+
+sh /etc/init.d-posix/10016_iris

--- a/ROMFS/px4fmu_common/init.d-posix/1016_iris_rtps.post
+++ b/ROMFS/px4fmu_common/init.d-posix/1016_iris_rtps.post
@@ -1,0 +1,2 @@
+# shellcheck disable=SC2154
+micrortps_client start -t UDP

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -49,7 +49,7 @@ ExternalProject_Add(sitl_gazebo
 set(viewers none jmavsim gazebo)
 set(debuggers none ide gdb lldb ddd valgrind callgrind)
 set(models none shell
-	if750a iris iris_opt_flow iris_vision iris_rplidar iris_irlock iris_obs_avoid solo typhoon_h480
+	if750a iris iris_opt_flow iris_vision iris_rplidar iris_irlock iris_obs_avoid iris_rtps solo typhoon_h480
 	plane
 	standard_vtol tailsitter tiltrotor
 	hippocampus rover)


### PR DESCRIPTION
**Describe problem solved by this pull request**
Adds `iris_rtps` SITL target, which starts the `micrortps_client` with UDP link on boot. The main goal is to add a `gazebo_rtps_interface` plugin in `sitl_gazebo` so one is capable of also retrieving sensor data from DDS participants (out of the ROS framework), or even connect Gazebo directly with MAVSDK.

This model is being directly used on the `px4_ros_com` CI testing.

**Describe your solution**
Adds a SITL target for the Iris that launches the `micrortps_client` on boot.