### PR TITLE
mavlink_receiver: Reject own autopilot messages for battery status

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1593,8 +1593,8 @@ MavlinkReceiver::handle_message_ping(mavlink_message_t *msg)
 void
 MavlinkReceiver::handle_message_battery_status(mavlink_message_t *msg)
 {
-	if (msg->sysid != mavlink_system.sysid) {
-		// ignore battery status of other system
+	if ((msg->sysid != mavlink_system.sysid) || (msg->compid == mavlink_system.compid)) {
+		// ignore battery status coming from other systems or from the autopilot itself
 		return;
 	}
 


### PR DESCRIPTION
This PR is just an hotfix for the false triggering of  "_Dangerously low battery! Shutting system down_".
that might happen when mavlink messages from the autopilot are looping back to itself (long term solution is described in https://github.com/PX4/Firmware/issues/13400).


**Test data / coverage**
If you want to replicate the issue connect themself RX/TX pins of TELEM1 and plug it on your PC via USB. The message ""_Dangerously low battery! Shutting system down_" will be triggered.
With this PR the issue will be fixed.

Tested on a pixhawk4.

