### PR TITLE
Battery: make battery states not sticky when vehicle is not armed

### DIFF
--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -210,14 +210,17 @@ Battery::determineWarning(bool connected)
 {
 	if (connected) {
 		// propagate warning state only if the state is higher, otherwise remain in current warning state
-		if (_remaining < _param_bat_emergen_thr.get() || (_warning == battery_status_s::BATTERY_WARNING_EMERGENCY)) {
+		if (_remaining < _param_bat_emergen_thr.get()) {
 			_warning = battery_status_s::BATTERY_WARNING_EMERGENCY;
 
-		} else if (_remaining < _param_bat_crit_thr.get() || (_warning == battery_status_s::BATTERY_WARNING_CRITICAL)) {
+		} else if (_remaining < _param_bat_crit_thr.get()) {
 			_warning = battery_status_s::BATTERY_WARNING_CRITICAL;
 
-		} else if (_remaining < _param_bat_low_thr.get() || (_warning == battery_status_s::BATTERY_WARNING_LOW)) {
+		} else if (_remaining < _param_bat_low_thr.get()) {
 			_warning = battery_status_s::BATTERY_WARNING_LOW;
+
+		} else {
+			_warning = battery_status_s::BATTERY_WARNING_NONE;
 		}
 	}
 }


### PR DESCRIPTION
**Problem solved this this PR:**
Hot swapping the battery was not supported until now if the battery was already in a state <= warning.
Furthermore, hot swapping using a battery with a lower voltage always lead to the system being in the emergency battery states.

This PR removes the stickiness of the battery levels when the vehicle is NOT armed.

**Open Question:**
If folks think this is a safety issue then we could make this a parameter. By default the battery warning levels could be sticky always (current state). Then we can introduce to have them sticky only when armed and as a third option to never have them sticky.
I'm saying this because it's not the first time I hear somebody complaining about battery states being sticky.