### PR TITLE
bl_update: build and include board bootloader if config available

### DIFF
--- a/ROMFS/CMakeLists.txt
+++ b/ROMFS/CMakeLists.txt
@@ -120,15 +120,6 @@ add_custom_command(
 # copy extras into ROMFS
 set(extras_dependencies)
 
-# copy px4io binary if configured
-if(config_io_board)
-	list(APPEND extras_dependencies
-		copy_px4io_bin
-		${fw_io_bin}
-		)
-endif()
-
-
 if(config_bl_file)
 	file(MAKE_DIRECTORY ${PX4_BINARY_DIR}/romfs_extras)
 	configure_file(${config_bl_file} ${PX4_BINARY_DIR}/romfs_extras COPYONLY)
@@ -136,6 +127,21 @@ if(config_bl_file)
 	list(APPEND extras_dependencies
 		${config_bl_file}
 		)
+endif()
+
+# copy px4io binary if configured
+if(config_io_board)
+	list(APPEND extras_dependencies
+		copy_px4io_bin
+		${fw_io_bin}
+	)
+endif()
+
+if(config_build_bootloader)
+	list(APPEND extras_dependencies
+		copy_bootloader_bin
+		${bootloader_bin}
+	)
 endif()
 
 set(OPTIONAL_BOARD_RC)

--- a/boards/holybro/durandal-v1/default.cmake
+++ b/boards/holybro/durandal-v1/default.cmake
@@ -7,6 +7,7 @@ px4_add_board(
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m7
 	ROMFSROOT px4fmu_common
+	BUILD_BOOTLOADER
 	IO px4_io-v2_default
 	TESTING
 #	UAVCAN_INTERFACES 2  - No H7 or FD can support in UAVCAN

--- a/boards/holybro/durandal-v1/init/rc.board_defaults
+++ b/boards/holybro/durandal-v1/init/rc.board_defaults
@@ -4,6 +4,24 @@
 #------------------------------------------------------------------------------
 
 
+#
+# Bootloader upgrade
+#
+set BL_FILE /etc/extras/holybro_durandal-v1_bootloader.bin
+if [ -f $BL_FILE ]
+then
+	if param compare SYS_BL_UPDATE 1
+	then
+		param set SYS_BL_UPDATE 0
+		param save
+		echo "BL update..." >> $LOG_FILE
+		bl_update $BL_FILE
+		echo "BL update done" >> $LOG_FILE
+		reboot
+	fi
+fi
+unset BL_FILE
+
 if [ $AUTOCNF = yes ]
 then
 

--- a/cmake/px4_add_board.cmake
+++ b/cmake/px4_add_board.cmake
@@ -46,6 +46,7 @@
 #			[ TOOLCHAIN <string> ]
 #			[ ARCHITECTURE <string> ]
 #			[ ROMFSROOT <string> ]
+#			[ BUILD_BOOTLOADER ]
 #			[ IO <string> ]
 #			[ BOOTLOADER <string> ]
 #			[ UAVCAN_INTERFACES <string> ]
@@ -67,6 +68,7 @@
 #		TOOLCHAIN		: cmake toolchain
 #		ARCHITECTURE		: name of the CPU CMake is building for (used by the toolchain)
 #		ROMFSROOT		: relative path to the ROMFS root directory (currently NuttX only)
+#		BUILD_BOOTLOADER	: flag to enable building and including the bootloader config
 #		IO			: name of IO board to be built and included in the ROMFS (requires a valid ROMFSROOT)
 #		BOOTLOADER		: bootloader file to include for flashing via bl_update (currently NuttX only)
 #		UAVCAN_INTERFACES	: number of interfaces for UAVCAN
@@ -148,6 +150,7 @@ function(px4_add_board)
 			SERIAL_PORTS
 			DF_DRIVERS
 		OPTIONS
+			BUILD_BOOTLOADER
 			CONSTRAINED_FLASH
 			TESTING
 		REQUIRED
@@ -203,6 +206,10 @@ function(px4_add_board)
 	# ROMFS
 	if(ROMFSROOT)
 		set(config_romfs_root ${ROMFSROOT} CACHE INTERNAL "ROMFS root" FORCE)
+
+		if(BUILD_BOOTLOADER)
+			set(config_build_bootloader "1" CACHE INTERNAL "build bootloader" FORCE)
+		endif()
 
 		# IO board (placed in ROMFS)
 		if(IO)

--- a/src/systemcmds/bl_update/CMakeLists.txt
+++ b/src/systemcmds/bl_update/CMakeLists.txt
@@ -38,4 +38,43 @@ px4_add_module(
 		-Wno-cast-align # TODO: fix and enable
 	SRCS
 		bl_update.c
+)
+
+if(config_build_bootloader)
+	# include the bootloader binary in ROMFS
+	set(bootloader_config "${PX4_BOARD_VENDOR}_${PX4_BOARD_MODEL}_bootloader")
+
+	if(NOT EXISTS ${PX4_BOARD_DIR}/nuttx-config/bootloader)
+		message(FATAL_ERROR "${bootloader_config} does not exist")
+	endif()
+
+	message(STATUS "Building and including bootloader ${bootloader_config}")
+
+	include(ExternalProject)
+	ExternalProject_Add(bootloader_firmware
+		SOURCE_DIR ${CMAKE_SOURCE_DIR}
+		DOWNLOAD_COMMAND ""
+		UPDATE_COMMAND ""
+		CMAKE_ARGS -DCONFIG=${bootloader_config}
+		INSTALL_COMMAND ""
+		USES_TERMINAL_BUILD true
+		DEPENDS git_nuttx git_nuttx_apps
+		BUILD_ALWAYS 1
 	)
+
+	ExternalProject_Get_Property(bootloader_firmware BINARY_DIR)
+
+	set(bootloader_exe "${BINARY_DIR}/${bootloader_config}.elf")
+	set(bootloader_bin "${PX4_BINARY_DIR}/romfs_extras/${bootloader_config}.bin" CACHE FILEPATH "bootloader binary path")
+
+	file(RELATIVE_PATH bootloader_exe_relative ${CMAKE_CURRENT_BINARY_DIR} ${bootloader_exe})
+	file(RELATIVE_PATH bootloader_bin_relative ${CMAKE_CURRENT_BINARY_DIR} ${bootloader_bin})
+
+	add_custom_command(OUTPUT ${bootloader_bin}
+		COMMAND ${CMAKE_COMMAND} -E make_directory ${PX4_BINARY_DIR}/romfs_extras
+		COMMAND ${CMAKE_OBJCOPY} -O binary ${bootloader_exe_relative} ${bootloader_bin_relative}
+		DEPENDS bootloader_firmware
+		COMMENT "Copying ${bootloader_config} to ROMFS extras"
+		)
+	add_custom_target(copy_bootloader_bin DEPENDS ${bootloader_bin})
+endif()


### PR DESCRIPTION
This is a quick PR to build and include the bootloader if available as part of the bl_update systemcmd.

Currently only works for the Holybro Durandal.

The idea is to do this for all boards eventually once the bootloader build system is cleaned up. https://github.com/PX4/Bootloader/pull/137