### PR TITLE
Added support for MAV_CMD_REQUEST_MESSAGE for mavlink streams

### DIFF
--- a/src/modules/mavlink/mavlink_stream.h
+++ b/src/modules/mavlink/mavlink_stream.h
@@ -93,6 +93,13 @@ public:
 	virtual unsigned get_size() = 0;
 
 	/**
+	 * This function is called in response to a MAV_CMD_REQUEST_MESSAGE command. The default implementation is to
+	 * just reset the counter to immediately send one message.
+	 */
+	virtual void request_message(float param1 = 0.0, float param2 = 0.0, float param3 = 0.0, float param4 = 0.0,
+				     float param5 = 0.0, float param6 = 0.0, float param7 = 0.0) { reset_last_sent(); }
+
+	/**
 	 * Get the average message size
 	 *
 	 * For a normal stream this equals the message size,


### PR DESCRIPTION
**Describe problem solved by this pull request**
PX4 does not support the command [`MAV_CMD_REQUEST_MESSAGE`](https://mavlink.io/en/messages/common.html#MAV_CMD_REQUEST_MESSAGE)

**Describe your solution**
Added a function to MavlinkStream which, by default, calls `reset_last_sent()`. It can be overridden for situations where a parameter should be used.

**Describe possible alternatives**
This could be handled outside of MavlinkStream.

**Test data / coverage**
Used MavSDK to send `MAV_CMD_REQUEST_MESSAGE` to PX4 running in SITL, and verified that the requested message was sent.