### PR TITLE
px4io: When running HITL, don't publish actuator_outputs. Fixes #13471.

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.io
+++ b/ROMFS/px4fmu_common/init.d/rc.io
@@ -2,9 +2,17 @@
 #
 # PX4IO interface init script.
 #
+
+# If $OUTPUT_MODE indicated Hardware-int-the-loop simulation, px4io should not publish actuator_outputs,
+# instead, pwm_out_sim will publish that uORB
+if [ $OUTPUT_MODE = hil ]
+then
+    set HIL_ARG $OUTPUT_MODE
+fi
+
 if [ $USE_IO = yes -a $IO_PRESENT = yes ]
 then
-	if px4io start
+	if px4io start $HIL_ARG
 	then
 		# Allow PX4IO to recover from midair restarts.
 		px4io recovery


### PR DESCRIPTION
See [Issue 13471 - vehicle doesn't take off in HITL SIM](https://github.com/PX4/Firmware/issues/13471)

The reason it fails:

When running in HITL mode, pwm_out_sim publishes actuator_outputs.

px4io unconditionally publishes the uOrb actuator_outputs. When HITL
is configured, the px4io copy of the uOrb has all zeros.

The result is that there are two publications, one valid, and one
all-zeros. This causes the HIL_ACTUATOR_CONTROLS mavlink message
to be incorrect (all-zeros) and the SERVO_OUTPUTS_RAW mavlink
message to be inconsistent, as it takes the data from one or the
other uOrb randomly each cycle.

The fix is to let px4io know that HITL is in effect when it is
started, and modify px4io to suppress publication in this case.

This is a bigger more complicated fix than I would like, but I
think it is conceptually correct.

An alternative would be to change src/modules/mavlink/mavlink_messages.cpp so that
MavlinkStreamHILActuatorControls() explicitly subscribed to instance 1 of the uOrb:

         _act_sub(_mavlink->add_orb_subscription(ORB_ID(actuator_outputs), 1)), _act_time(0)

That's a one-line solution, but I think it is incorrect because nothing enforces which pub of the uOrb is instance 0 and which is instance 1. And, I just think it doesn't make sense to have two pubs.

**Test data / coverage**
I simply verified that the failure case in #13471 is fixed. I also verified that the Pixhawk still boots when HITL is not enabled.

Signed-off-by: Nik Langrind <langrind@gmail.com>
