### PR TITLE
uORB/microRTPS: add deprecated uORB msg/topic list to CMake

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -31,6 +31,9 @@
 #
 ############################################################################
 
+# Support IN_LIST if() operator
+cmake_policy(SET CMP0057 NEW)
+
 set(msg_files
 	actuator_armed.msg
 	actuator_controls.msg
@@ -52,7 +55,7 @@ set(msg_files
 	debug_vect.msg
 	differential_pressure.msg
 	distance_sensor.msg
-	ekf2_innovations.msg
+	ekf2_innovations.msg		# TODO: remove as soon as https://github.com/PX4/Firmware/pull/13127 is rebased over this
 	ekf2_timestamps.msg
 	ekf_gps_drift.msg
 	ekf_gps_position.msg
@@ -150,6 +153,30 @@ set(msg_files
 	wheel_encoders.msg
 	wind_estimate.msg
 	)
+
+set(deprecated_msgs
+	# TODO: uncomment as soon as https://github.com/PX4/Firmware/pull/13127 is rebased over this
+	# ekf2_innovations.msg	# 2019-11-22, Updated estimator interface and logging; replaced by 'estimator_innovations'.
+	)
+
+foreach(msg IN LISTS deprecated_msgs)
+	if(msg IN_LIST msg_files)
+		get_filename_component(msg_we ${msg} NAME_WE)
+		list(APPEND invalid_msgs ${msg_we})
+	endif()
+endforeach()
+if(invalid_msgs)
+	list(LENGTH invalid_msgs invalid_msgs_size)
+	if(${invalid_msgs_size} GREATER 1)
+		foreach(msg IN LISTS invalid_msgs)
+			string(CONCAT invalid_msgs_cs ${invalid_msgs_cs} "'${msg}', ")
+		endforeach()
+		STRING(REGEX REPLACE ", +$" "" invalid_msgs_cs ${invalid_msgs_cs})
+		message(FATAL_ERROR "${invalid_msgs_cs} are listed as deprecated. Please use different names for the messages.")
+	else()
+		message(FATAL_ERROR "'${invalid_msgs}' is listed as deprecated. Please use a different name for the message.")
+	endif()
+endif()
 
 if(NOT EXTERNAL_MODULES_LOCATION STREQUAL "")
 	# Check that the msg directory and the CMakeLists.txt file exists

--- a/msg/tools/uorb_rtps_message_ids.yaml
+++ b/msg/tools/uorb_rtps_message_ids.yaml
@@ -45,6 +45,7 @@ rtps:
   - msg: distance_sensor
     id: 17
     send: true
+  # TODO: replace with 'estimator_innovations' as https://github.com/PX4/Firmware/pull/13127 is rebased over this
   - msg: ekf2_innovations
     id: 18
   - msg: ekf2_timestamps


### PR DESCRIPTION
**Describe problem solved by this pull request**
https://github.com/PX4/Firmware/pull/13127 brought an issue regarding core uORB messages: deprecation. Rather than totally remove them immediately, we need a way of deprecating upstream, and probably totally removed them after a couple of patches, or even a major/minor release.

**Describe your solution**
Created a *yaml* file, called `deprecated_uorb_topics.yaml`, where we should list the deprecated msgs (also includes data regarding the date of deprecation, reason and other observations that can be used in different contexts). This file is used on the RTPS related code generators, though it could also be used in the uORB source code generators. Though, for this last one, I consider it more reasonable to just comment the msg in [`msg/CMakeLists.txt`](https://github.com/PX4/Firmware/blob/master/msg/CMakeLists.txt).

**Describe possible alternatives**
We could also add a CMake list and store it as an env variable to be used on different scripts. But I think the current approach is more reasonable, as it can also add context information to the deprecation and it's much more straightforward to use where we want.

**Additional context**
@kamilritz https://github.com/PX4/Firmware/compare/feature/add_deprecated_msg_list?expand=1#diff-01bb974d51b52aded2beded6eb218bb1R55 should be totally commented and kept, though adding `estimator_innovations.msg` as by https://github.com/PX4/Firmware/pull/13127. Also replace  https://github.com/PX4/Firmware/compare/feature/add_deprecated_msg_list?expand=1#diff-5ab2857fc37dbdba7433b5f5dcc438ffR48 by `estimator_innovations`, giving it the same ID.
