### PR TITLE
cmake NuttX linker print memory usage

### DIFF
--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -109,6 +109,7 @@ target_link_libraries(px4 PRIVATE
 	-Wl,-Map=${PX4_CONFIG}.map
 	-Wl,--warn-common
 	-Wl,--gc-sections
+	-Wl,--print-memory-usage
 
 	-Wl,--start-group
 		${nuttx_libs}


### PR DESCRIPTION
I typically like to minimize as much of the build output noise as possible, but I think this is important enough to show every build.

### Examples

``` Console
 [205/207] Linking CXX executable px4_io-v2_default.elf
Memory region         Used Size  Region Size  %age Used
           flash:       59696 B        60 KB     97.16%
            sram:        4044 B         8 KB     49.37%
```

``` Console
[705/707] Linking CXX executable px4_fmu-v2_default.elf
Memory region         Used Size  Region Size  %age Used
           flash:     1021161 B      1008 KB     98.93%
            sram:       22584 B       192 KB     11.49%
          ccsram:          0 GB        64 KB      0.00%
```

``` Console
[955/957] Linking CXX executable px4_fmu-v5_default.elf
Memory region         Used Size  Region Size  %age Used
            itcm:          0 GB      2016 KB      0.00%
           flash:     1690721 B      2016 KB     81.90%
            dtcm:          0 GB       128 KB      0.00%
           sram1:       44424 B       368 KB     11.79%
           sram2:          0 GB        16 KB      0.00%
```