### PR TITLE
gitmodules update NuttX to px4_firmware_nuttx-8.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -49,11 +49,11 @@
 [submodule "platforms/nuttx/NuttX/nuttx"]
 	path = platforms/nuttx/NuttX/nuttx
 	url = https://github.com/PX4/NuttX.git
-	branch = px4_firmware_nuttx-8.1+
+	branch = px4_firmware_nuttx-8.2
 [submodule "platforms/nuttx/NuttX/apps"]
 	path = platforms/nuttx/NuttX/apps
 	url = https://github.com/PX4/NuttX-apps.git
-	branch = px4_firmware_nuttx-8.1+
+	branch = px4_firmware_nuttx-8.2
 [submodule "cmake/configs/uavcan_board_ident"]
 	path = cmake/configs/uavcan_board_ident
 	url = https://github.com/PX4/uavcan_board_ident.git


### PR DESCRIPTION
Having the submodule branch set in .gitmodules allows automatically them to the latest in that branch with `git submodule update --remote`. This is what jenkins is doing.