### PR TITLE
Clean up mistake in fix for #13471

### DIFF
--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -3012,7 +3012,7 @@ start(int argc, char *argv[])
 		if (!strcmp(argv[extra_args], "norc")) {
 			rc_handling_disabled = true;
 
-		} else if (!strcmp(argv[1], "hil")) {
+		} else if (!strcmp(argv[extra_args], "hil")) {
 			hitl_mode = true;
 
 		} else {


### PR DESCRIPTION
Fix mistake in previoust commit, which could the "hil" argument to be ignored if px4io were to be started with two or more optional arguments

Flew in HITL sim and verified that the drone takes off as expected.
