### PR TITLE
Send PDOP to EKF

### DIFF
--- a/Tools/ecl_ekf/analysis/post_processing.py
+++ b/Tools/ecl_ekf/analysis/post_processing.py
@@ -104,7 +104,7 @@ def get_gps_check_fail_flags(estimator_status: dict) -> dict:
 
     # 0 : insufficient fix type (no 3D solution)
     # 1 : minimum required sat count fail
-    # 2 : minimum required GDoP fail
+    # 2 : minimum required PDOP fail
     # 3 : maximum allowed horizontal position error fail
     # 4 : maximum allowed vertical position error fail
     # 5 : maximum allowed speed error fail
@@ -114,7 +114,7 @@ def get_gps_check_fail_flags(estimator_status: dict) -> dict:
     # 9 : maximum allowed vertical velocity discrepancy fail
     gps_fail_flags['gfix_fail'] = ((2 ** 0 & estimator_status['gps_check_fail_flags']) > 0) * 1
     gps_fail_flags['nsat_fail'] = ((2 ** 1 & estimator_status['gps_check_fail_flags']) > 0) * 1
-    gps_fail_flags['gdop_fail'] = ((2 ** 2 & estimator_status['gps_check_fail_flags']) > 0) * 1
+    gps_fail_flags['pdop_fail'] = ((2 ** 2 & estimator_status['gps_check_fail_flags']) > 0) * 1
     gps_fail_flags['herr_fail'] = ((2 ** 3 & estimator_status['gps_check_fail_flags']) > 0) * 1
     gps_fail_flags['verr_fail'] = ((2 ** 4 & estimator_status['gps_check_fail_flags']) > 0) * 1
     gps_fail_flags['serr_fail'] = ((2 ** 5 & estimator_status['gps_check_fail_flags']) > 0) * 1

--- a/Tools/ecl_ekf/plotting/pdf_report.py
+++ b/Tools/ecl_ekf/plotting/pdf_report.py
@@ -219,11 +219,11 @@ def create_pdf_report(ulog: ULog, output_plot_filename: str) -> None:
         # gps_check_fail_flags summary
         data_plot = CheckFlagsPlot(
             status_time, gps_fail_flags,
-            [['nsat_fail', 'gdop_fail', 'herr_fail', 'verr_fail', 'gfix_fail', 'serr_fail'],
+            [['nsat_fail', 'pdop_fail', 'herr_fail', 'verr_fail', 'gfix_fail', 'serr_fail'],
              ['hdrift_fail', 'vdrift_fail', 'hspd_fail', 'veld_diff_fail']],
             x_label='time (sec)', y_lim=(-0.1, 1.1), y_labels=['failed', 'failed'],
             sub_titles=['GPS Direct Output Check Failures', 'GPS Derived Output Check Failures'],
-            legend=[['N sats', 'GDOP', 'horiz pos error', 'vert pos error', 'fix type',
+            legend=[['N sats', 'PDOP', 'horiz pos error', 'vert pos error', 'fix type',
                      'speed error'], ['horiz drift', 'vert drift', 'horiz speed',
                                       'vert vel inconsistent']], annotate=False, pdf_handle=pdf_pages)
         data_plot.save()

--- a/msg/estimator_status.msg
+++ b/msg/estimator_status.msg
@@ -13,7 +13,7 @@ uint16 gps_check_fail_flags     # Bitmask to indicate status of GPS checks - see
 # bits are true when corresponding test has failed
 uint8 GPS_CHECK_FAIL_GPS_FIX = 0		# 0 : insufficient fix type (no 3D solution)
 uint8 GPS_CHECK_FAIL_MIN_SAT_COUNT = 1		# 1 : minimum required sat count fail
-uint8 GPS_CHECK_FAIL_MIN_GDOP = 2		# 2 : minimum required GDoP fail
+uint8 GPS_CHECK_FAIL_MIN_PDOP = 2		# 2 : minimum required PDOP fail
 uint8 GPS_CHECK_FAIL_MAX_HORZ_ERR = 3		# 3 : maximum allowed horizontal position error fail
 uint8 GPS_CHECK_FAIL_MAX_VERT_ERR = 4		# 4 : maximum allowed vertical position error fail
 uint8 GPS_CHECK_FAIL_MAX_SPD_ERR = 5		# 5 : maximum allowed speed error fail

--- a/src/modules/commander/Arming/PreFlightCheck/checks/ekf2Check.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/ekf2Check.cpp
@@ -186,8 +186,8 @@ bool PreFlightCheck::ekf2Check(orb_advert_t *mavlink_log_pub, vehicle_status_s &
 				} else if (status.gps_check_fail_flags & (1 << estimator_status_s::GPS_CHECK_FAIL_MIN_SAT_COUNT)) {
 					message = "Preflight%s: not enough GPS Satellites";
 
-				} else if (status.gps_check_fail_flags & (1 << estimator_status_s::GPS_CHECK_FAIL_MIN_GDOP)) {
-					message = "Preflight%s: GPS GDoP too low";
+				} else if (status.gps_check_fail_flags & (1 << estimator_status_s::GPS_CHECK_FAIL_MIN_PDOP)) {
+					message = "Preflight%s: GPS PDOP too low";
 
 				} else if (status.gps_check_fail_flags & (1 << estimator_status_s::GPS_CHECK_FAIL_MAX_HORZ_ERR)) {
 					message = "Preflight%s: GPS Horizontal Pos Error too high";

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -977,12 +977,8 @@ void Ekf2::Run()
 				}
 
 				// Only use selected receiver data if it has been updated
-				if ((gps1_updated && _gps_select_index == 0) || (gps2_updated && _gps_select_index == 1)) {
-					_gps_new_output_data = true;
-
-				} else {
-					_gps_new_output_data = false;
-				}
+				_gps_new_output_data = (gps1_updated && _gps_select_index == 0) ||
+						       (gps2_updated && _gps_select_index == 1);
 			}
 
 			if (_gps_new_output_data) {

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -944,8 +944,8 @@ void Ekf2::Run()
 				_gps_state[0].vel_ned[2] = gps.vel_d_m_s;
 				_gps_state[0].vel_ned_valid = gps.vel_ned_valid;
 				_gps_state[0].nsats = gps.satellites_used;
-				//TODO: add gdop to gps topic
-				_gps_state[0].gdop = 0.0f;
+				const float tdop = 0.9f;
+				_gps_state[0].gdop = sqrtf(gps.hdop * gps.hdop + gps.vdop * gps.vdop + tdop * tdop);
 				_gps_alttitude_ellipsoid[0] = gps.alt_ellipsoid;
 
 				ekf2_timestamps.gps_timestamp_rel = (int16_t)((int64_t)gps.timestamp / 100 - (int64_t)ekf2_timestamps.timestamp / 100);
@@ -975,8 +975,8 @@ void Ekf2::Run()
 				_gps_state[1].vel_ned[2] = gps.vel_d_m_s;
 				_gps_state[1].vel_ned_valid = gps.vel_ned_valid;
 				_gps_state[1].nsats = gps.satellites_used;
-				//TODO: add gdop to gps topic
-				_gps_state[1].gdop = 0.0f;
+				const float tdop = 0.9f;
+				_gps_state[0].gdop = sqrtf(gps.hdop * gps.hdop + gps.vdop * gps.vdop + tdop * tdop);
 				_gps_alttitude_ellipsoid[1] = gps.alt_ellipsoid;
 			}
 		}

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -153,7 +153,7 @@ PARAM_DEFINE_FLOAT(EKF2_AVEL_DELAY, 5);
  *
  * Set bits to 1 to enable checks. Checks enabled by the following bit positions
  * 0 : Minimum required sat count set by EKF2_REQ_NSATS
- * 1 : Minimum required GDoP set by EKF2_REQ_GDOP
+ * 1 : Minimum required PDOP set by EKF2_REQ_PDOP
  * 2 : Maximum allowed horizontal position error set by EKF2_REQ_EPH
  * 3 : Maximum allowed vertical position error set by EKF2_REQ_EPV
  * 4 : Maximum allowed speed error set by EKF2_REQ_SACC
@@ -166,7 +166,7 @@ PARAM_DEFINE_FLOAT(EKF2_AVEL_DELAY, 5);
  * @min 0
  * @max 511
  * @bit 0 Min sat count (EKF2_REQ_NSATS)
- * @bit 1 Min GDoP (EKF2_REQ_GDOP)
+ * @bit 1 Min PDOP (EKF2_REQ_PDOP)
  * @bit 2 Max horizontal position error (EKF2_REQ_EPH)
  * @bit 3 Max vertical position error (EKF2_REQ_EPV)
  * @bit 4 Max speed error (EKF2_REQ_SACC)
@@ -220,14 +220,14 @@ PARAM_DEFINE_FLOAT(EKF2_REQ_SACC, 0.5f);
 PARAM_DEFINE_INT32(EKF2_REQ_NSATS, 6);
 
 /**
- * Required GDoP to use GPS.
+ * Required PDOP to use GPS.
  *
  * @group EKF2
  * @min 1.5
  * @max 5.0
  * @decimal 1
  */
-PARAM_DEFINE_FLOAT(EKF2_REQ_GDOP, 2.5f);
+PARAM_DEFINE_FLOAT(EKF2_REQ_PDOP, 2.5f);
 
 /**
  * Maximum horizontal drift speed to use GPS.


### PR DESCRIPTION
EKF2 has a GDOP check available but we currently don't send GDOP to it. As we only have VDOP and HDOP (an not TDOP, that should be part of GDOP), we can still compute PDOP and send it to the EKF:

`PDOP = sqrt(VDOP^2 + HDOP^2)`

requires https://github.com/PX4/ecl/pull/673

ref: https://web.archive.org/web/20141122153439/http://www.gmat.unsw.edu.au/snap/gps/gps_survey/chap1/149.htm