### PR TITLE
Properly reset position control velocity derivatives

### DIFF
--- a/src/lib/controllib/BlockDerivative.hpp
+++ b/src/lib/controllib/BlockDerivative.hpp
@@ -87,6 +87,7 @@ public:
 	float update(float input);
 // accessors
 	void setU(float u) {_u = u;}
+	void reset() { _initialized = false; };
 	float getU() {return _u;}
 	float getLP() {return _lowPass.getFCut();}
 	float getO() { return _lowPass.getState(); }

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -702,6 +702,12 @@ MulticopterPositionControl::Run()
 			}
 
 			_old_landing_gear_position = gear.landing_gear;
+
+		} else {
+			// reset the numerical derivatives to not generate d term spikes when coming from non-position controlled operation
+			_vel_x_deriv.reset();
+			_vel_y_deriv.reset();
+			_vel_z_deriv.reset();
 		}
 	}
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
@bresch found that when switching from stabilized mode to any position controlled mode the first sample of thrust setpoint output can be a huge spike that makes the drone twitch. He also found out that it's correlated to the velocity you have when switching modes. And after digging more we realized that the derivative for the D-term of the position controller does not get reset and hence the first sample is based on the difference between velocity before switching to stabilized and after switching back to a position controlled mode.

**Describe your solution**
The `BlockDerivative` class handles proper initialization but only through the constructor so I'm adding a `reset()` function to repeat that later on. When no position controlled mode is running I continuously call this `reset()` function which only sets an internal flag.

**Test data / coverage**
Not tested. @bresch please verify with the test you had yesterday to reproduce it.

**Additional context**
This is an inportant enough issue to backport the low complexity fix to 1.10. I'll create a pr once it's verified. **EDIT:** Done here: #13524

fixes https://github.com/PX4/Firmware/issues/13415