### PR TITLE
fix voltage & current scaling for H7

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ This repository contains code supporting these boards:
   * [Airmind MindPX V2.8](http://www.mindpx.net/assets/accessories/UserGuide_MindPX.pdf)
   * [Airmind MindRacer V1.2](http://mindpx.net/assets/accessories/mindracer_user_guide_v1.2.pdf)
   * [Bitcraze Crazyflie 2.0](https://docs.px4.io/en/flight_controller/crazyflie2.html)
+  * [Omnibus F4 SD](https://docs.px4.io/en/flight_controller/omnibus_f4_sd.html)
+  * [BeagleBone Blue](https://docs.px4.io/en/flight_controller/beaglebone_blue.html)
+  * [Holybro Durandal](https://docs.px4.io/en/flight_controller/durandal.html)
+  * [Holybro Kakute F7](https://docs.px4.io/en/flight_controller/kakutef7.html)
 
 Additional information about supported hardware can be found in [PX4 user Guide > Autopilot Hardware](https://docs.px4.io/en/flight_controller/).
 

--- a/boards/intel/aerofc-v1/aerofc_adc/aerofc_adc.cpp
+++ b/boards/intel/aerofc-v1/aerofc_adc/aerofc_adc.cpp
@@ -56,6 +56,13 @@
 // 10Hz
 #define CYCLE_TICKS_DELAY MSEC2TICK(100)
 
+
+uint32_t px4_arch_adc_dn_fullcount(void)
+{
+	return 1 << 12; // 12 bit ADC
+}
+
+
 enum AEROFC_ADC_BUS {
 	AEROFC_ADC_BUS_ALL = 0,
 	AEROFC_ADC_BUS_I2C_INTERNAL,

--- a/platforms/common/include/px4_platform_common/board_common.h
+++ b/platforms/common/include/px4_platform_common/board_common.h
@@ -147,6 +147,14 @@
 #define ADC_3V3_SCALE                    (2.0f) // The scale factor defined by HW's resistive divider (Rt+Rb)/ Rb
 #endif
 
+#ifndef BOARD_ADC_POS_REF_V_FOR_CURRENT_CHAN
+#define BOARD_ADC_POS_REF_V_FOR_CURRENT_CHAN (3.3f) // Reference voltage for reading out the current channel
+#endif
+
+#ifndef BOARD_ADC_POS_REF_V_FOR_VOLTAGE_CHAN
+#define BOARD_ADC_POS_REF_V_FOR_VOLTAGE_CHAN (3.3f) // Reference voltage for reading out the voltage channel
+#endif
+
 /* Provide define for Bricks and Battery */
 
 /* Define the default maximum voltage resulting from the bias on ADC termination */

--- a/platforms/posix/src/px4/common/CMakeLists.txt
+++ b/platforms/posix/src/px4/common/CMakeLists.txt
@@ -49,6 +49,7 @@ if("${CONFIG_SHMEM}" STREQUAL "1")
 endif()
 
 add_library(px4_layer
+	adc.cpp
 	px4_posix_impl.cpp
 	px4_posix_tasks.cpp
 	px4_sem.cpp

--- a/platforms/posix/src/px4/common/adc.cpp
+++ b/platforms/posix/src/px4/common/adc.cpp
@@ -1,0 +1,40 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <drivers/drv_adc.h>
+
+uint32_t px4_arch_adc_dn_fullcount(void)
+{
+	return 1 << 12; // 12 bit ADC
+}
+

--- a/src/modules/battery_status/parameters.cpp
+++ b/src/modules/battery_status/parameters.cpp
@@ -40,6 +40,7 @@
 #include "parameters.h"
 
 #include <px4_platform_common/log.h>
+#include <drivers/drv_adc.h>
 
 namespace battery_status
 {
@@ -67,7 +68,7 @@ int update_parameters(const ParameterHandles &parameter_handles, Parameters &par
 
 	} else if (parameters.battery_voltage_scaling < 0.0f) {
 		/* apply scaling according to defaults if set to default */
-		parameters.battery_voltage_scaling = (3.3f / 4096);
+		parameters.battery_voltage_scaling = (3.3f / px4_arch_adc_dn_fullcount());
 		param_set_no_notification(parameter_handles.battery_voltage_scaling, &parameters.battery_voltage_scaling);
 	}
 
@@ -77,7 +78,7 @@ int update_parameters(const ParameterHandles &parameter_handles, Parameters &par
 
 	} else if (parameters.battery_current_scaling < 0.0f) {
 		/* apply scaling according to defaults if set to default */
-		parameters.battery_current_scaling = (3.3f / 4096);
+		parameters.battery_current_scaling = (3.3f / px4_arch_adc_dn_fullcount());
 		param_set_no_notification(parameter_handles.battery_current_scaling, &parameters.battery_current_scaling);
 	}
 

--- a/src/modules/battery_status/parameters.cpp
+++ b/src/modules/battery_status/parameters.cpp
@@ -40,6 +40,7 @@
 #include "parameters.h"
 
 #include <px4_platform_common/log.h>
+#include <px4_platform_common/px4_config.h>
 #include <drivers/drv_adc.h>
 
 namespace battery_status
@@ -68,7 +69,7 @@ int update_parameters(const ParameterHandles &parameter_handles, Parameters &par
 
 	} else if (parameters.battery_voltage_scaling < 0.0f) {
 		/* apply scaling according to defaults if set to default */
-		parameters.battery_voltage_scaling = (3.3f / px4_arch_adc_dn_fullcount());
+		parameters.battery_voltage_scaling = (BOARD_ADC_POS_REF_V_FOR_VOLTAGE_CHAN / px4_arch_adc_dn_fullcount());
 		param_set_no_notification(parameter_handles.battery_voltage_scaling, &parameters.battery_voltage_scaling);
 	}
 
@@ -78,7 +79,7 @@ int update_parameters(const ParameterHandles &parameter_handles, Parameters &par
 
 	} else if (parameters.battery_current_scaling < 0.0f) {
 		/* apply scaling according to defaults if set to default */
-		parameters.battery_current_scaling = (3.3f / px4_arch_adc_dn_fullcount());
+		parameters.battery_current_scaling = (BOARD_ADC_POS_REF_V_FOR_CURRENT_CHAN / px4_arch_adc_dn_fullcount());
 		param_set_no_notification(parameter_handles.battery_current_scaling, &parameters.battery_current_scaling);
 	}
 


### PR DESCRIPTION
Fixes the scaling on h7 boards: the ADC has 16 bits resolution (vs 12 bits on F4/F7). Otherwise the logic on the durandal is the same as on fmu-v5, therefore the board-specific scalings do not need to be changed.

I also wanted to remove  `BAT_CNT_V_VOLT` and `BAT_CNT_V_CURR` completely, as I don't think they are required. But it would conflict with  #12551 even more.
@ItsTimmy fyi