### PR TITLE
mpu9250: fully remove dead interval perf counter

### DIFF
--- a/src/drivers/imu/mpu9250/mpu9250.cpp
+++ b/src/drivers/imu/mpu9250/mpu9250.cpp
@@ -94,7 +94,6 @@ MPU9250::~MPU9250()
 
 	// delete the perf counter
 	perf_free(_sample_perf);
-	perf_free(_interval_perf);
 	perf_free(_bad_transfers);
 	perf_free(_bad_registers);
 	perf_free(_good_transfers);
@@ -620,7 +619,6 @@ void
 MPU9250::measure()
 {
 	perf_begin(_sample_perf);
-	perf_count(_interval_perf);
 
 	if (hrt_absolute_time() < _reset_wait) {
 		// we're waiting for a reset to complete

--- a/src/drivers/imu/mpu9250/mpu9250.h
+++ b/src/drivers/imu/mpu9250/mpu9250.h
@@ -261,7 +261,6 @@ private:
 	unsigned		_sample_rate{1000};
 
 	perf_counter_t		_sample_perf;
-	perf_counter_t		_interval_perf;
 	perf_counter_t		_bad_transfers;
 	perf_counter_t		_bad_registers;
 	perf_counter_t		_good_transfers;


### PR DESCRIPTION
This is the cause of the intermittent hard fault we saw on the test rack recently. The partially leftover perf counter came in with this mpu9250 update to run on linux and qurt (https://github.com/PX4/Firmware/commit/c5520cbaca3f3fd94e23e4a5cdf4e2769c5097d4#diff-f9d2527970d38e4a023074577b550968), which really came from a partial rebase of an old PR (https://github.com/PX4/Firmware/pull/12783).