### PR TITLE
dataman: add read and write perf counters

### DIFF
--- a/src/modules/dataman/dataman.cpp
+++ b/src/modules/dataman/dataman.cpp
@@ -1071,7 +1071,6 @@ _ram_flash_wait(px4_sem_t *sem)
 __EXPORT ssize_t
 dm_write(dm_item_t item, unsigned index, dm_persitence_t persistence, const void *buf, size_t count)
 {
-	perf_begin(_dm_write_perf);
 	work_q_item_t *work;
 
 	/* Make sure data manager has been started and is not shutting down */
@@ -1079,8 +1078,11 @@ dm_write(dm_item_t item, unsigned index, dm_persitence_t persistence, const void
 		return -1;
 	}
 
+	perf_begin(_dm_write_perf);
+
 	/* get a work item and queue up a write request */
 	if ((work = create_work_item()) == nullptr) {
+		perf_end(_dm_write_perf);
 		return -1;
 	}
 
@@ -1101,7 +1103,6 @@ dm_write(dm_item_t item, unsigned index, dm_persitence_t persistence, const void
 __EXPORT ssize_t
 dm_read(dm_item_t item, unsigned index, void *buf, size_t count)
 {
-	perf_begin(_dm_read_perf);
 	work_q_item_t *work;
 
 	/* Make sure data manager has been started and is not shutting down */
@@ -1109,8 +1110,11 @@ dm_read(dm_item_t item, unsigned index, void *buf, size_t count)
 		return -1;
 	}
 
+	perf_begin(_dm_read_perf);
+
 	/* get a work item and queue up a read request */
 	if ((work = create_work_item()) == nullptr) {
+		perf_end(_dm_read_perf);
 		return -1;
 	}
 
@@ -1434,8 +1438,12 @@ end:
 	px4_sem_destroy(&g_work_queued_sema);
 	px4_sem_destroy(&g_sys_state_mutex_mission);
 	px4_sem_destroy(&g_sys_state_mutex_fence);
+
 	perf_free(_dm_read_perf);
+	_dm_read_perf = nullptr;
+
 	perf_free(_dm_write_perf);
+	_dm_write_perf = nullptr;
 
 	return 0;
 }

--- a/src/modules/dataman/dataman.cpp
+++ b/src/modules/dataman/dataman.cpp
@@ -47,26 +47,16 @@
 #include <px4_platform_common/posix.h>
 #include <px4_platform_common/tasks.h>
 #include <px4_platform_common/getopt.h>
-#include <stdio.h>
-#include <stdbool.h>
-#include <stdlib.h>
-#include <errno.h>
-#include <fcntl.h>
-#include <systemlib/err.h>
-#include <queue.h>
-#include <string.h>
-#include <semaphore.h>
-#include <unistd.h>
 #include <drivers/drv_hrt.h>
+#include <lib/parameters/param.h>
+#include <lib/perf/perf_counter.h>
 
 #include "dataman.h"
-#include <parameters/param.h>
 
 #if defined(FLASH_BASED_DATAMAN)
 #include <nuttx/clock.h>
 #include <nuttx/progmem.h>
 #endif
-
 
 __BEGIN_DECLS
 __EXPORT int dataman_main(int argc, char *argv[]);
@@ -246,6 +236,9 @@ static unsigned int g_key_offsets[DM_KEY_NUM_KEYS];
 static px4_sem_t *g_item_locks[DM_KEY_NUM_KEYS];
 static px4_sem_t g_sys_state_mutex_mission;
 static px4_sem_t g_sys_state_mutex_fence;
+
+static perf_counter_t _dm_read_perf{nullptr};
+static perf_counter_t _dm_write_perf{nullptr};
 
 /* The data manager store file handle and file name */
 static const char *default_device_path = PX4_STORAGEDIR "/dataman";
@@ -1078,6 +1071,7 @@ _ram_flash_wait(px4_sem_t *sem)
 __EXPORT ssize_t
 dm_write(dm_item_t item, unsigned index, dm_persitence_t persistence, const void *buf, size_t count)
 {
+	perf_begin(_dm_write_perf);
 	work_q_item_t *work;
 
 	/* Make sure data manager has been started and is not shutting down */
@@ -1098,13 +1092,16 @@ dm_write(dm_item_t item, unsigned index, dm_persitence_t persistence, const void
 	work->write_params.count = count;
 
 	/* Enqueue the item on the work queue and wait for the worker thread to complete processing it */
-	return (ssize_t)enqueue_work_item_and_wait_for_result(work);
+	ssize_t ret = (ssize_t)enqueue_work_item_and_wait_for_result(work);
+	perf_end(_dm_write_perf);
+	return ret;
 }
 
 /** Retrieve from the data manager file */
 __EXPORT ssize_t
 dm_read(dm_item_t item, unsigned index, void *buf, size_t count)
 {
+	perf_begin(_dm_read_perf);
 	work_q_item_t *work;
 
 	/* Make sure data manager has been started and is not shutting down */
@@ -1124,7 +1121,9 @@ dm_read(dm_item_t item, unsigned index, void *buf, size_t count)
 	work->read_params.count = count;
 
 	/* Enqueue the item on the work queue and wait for the worker thread to complete processing it */
-	return (ssize_t)enqueue_work_item_and_wait_for_result(work);
+	ssize_t ret = (ssize_t)enqueue_work_item_and_wait_for_result(work);
+	perf_end(_dm_read_perf);
+	return ret;
 }
 
 /** Clear a data Item */
@@ -1307,6 +1306,9 @@ task_main(int argc, char *argv[])
 
 	px4_sem_setprotocol(&g_work_queued_sema, SEM_PRIO_NONE);
 
+	_dm_read_perf = perf_alloc(PC_ELAPSED, MODULE_NAME": read");
+	_dm_write_perf = perf_alloc(PC_ELAPSED, MODULE_NAME": write");
+
 	/* see if we need to erase any items based on restart type */
 	int sys_restart_val;
 
@@ -1432,6 +1434,8 @@ end:
 	px4_sem_destroy(&g_work_queued_sema);
 	px4_sem_destroy(&g_sys_state_mutex_mission);
 	px4_sem_destroy(&g_sys_state_mutex_fence);
+	perf_free(_dm_read_perf);
+	perf_free(_dm_write_perf);
 
 	return 0;
 }
@@ -1471,6 +1475,8 @@ status()
 	PX4_INFO("Clears   %d", g_func_counts[dm_clear_func]);
 	PX4_INFO("Restarts %d", g_func_counts[dm_restart_func]);
 	PX4_INFO("Max Q lengths work %d, free %d", g_work_q.max_size, g_free_q.max_size);
+	perf_print_counter(_dm_read_perf);
+	perf_print_counter(_dm_write_perf);
 }
 
 static void


### PR DESCRIPTION
Adding read and write perf counters in dataman for the dm_read and dm_write operations. It's helpful to be able to keep an eye on these things in real operation.

Related: https://github.com/PX4/Firmware/issues/13536