### PR TITLE
uORB: fix several race conditions during topic initialization

### DIFF
--- a/src/drivers/drv_orb_dev.h
+++ b/src/drivers/drv_orb_dev.h
@@ -73,7 +73,7 @@
 /** Get the minimum interval at which the topic can be seen to be updated for this subscription */
 #define ORBIOCGETINTERVAL	_ORBIOC(16)
 
-/** Check whether the topic is published, sets *(unsigned long *)arg to 1 if published, 0 otherwise */
-#define ORBIOCISPUBLISHED	_ORBIOC(17)
+/** Check whether the topic is advertised, sets *(unsigned long *)arg to 1 if advertised, 0 otherwise */
+#define ORBIOCISADVERTISED	_ORBIOC(17)
 
 #endif /* _DRV_UORB_H */

--- a/src/drivers/heater/heater.cpp
+++ b/src/drivers/heater/heater.cpp
@@ -136,7 +136,7 @@ void Heater::initialize_topics()
 	for (uint8_t x = 0; x < number_of_imus; x++) {
 		_sensor_accel_sub = uORB::Subscription{ORB_ID(sensor_accel), x};
 
-		if (!_sensor_accel_sub.published()) {
+		if (!_sensor_accel_sub.advertised()) {
 			continue;
 		}
 

--- a/src/modules/airspeed_selector/airspeed_selector_main.cpp
+++ b/src/modules/airspeed_selector/airspeed_selector_main.cpp
@@ -248,7 +248,7 @@ AirspeedModule::check_for_connected_airspeed_sensors()
 	if (_param_airspeed_primary_index.get() > 0) {
 
 		for (int i = 0; i < MAX_NUM_AIRSPEED_SENSORS; i++) {
-			if (!_airspeed_sub[i].published()) {
+			if (!_airspeed_sub[i].advertised()) {
 				break;
 			}
 

--- a/src/modules/mavlink/mavlink_orb_subscription.cpp
+++ b/src/modules/mavlink/mavlink_orb_subscription.cpp
@@ -42,7 +42,7 @@
 bool
 MavlinkOrbSubscription::is_published()
 {
-	const bool published = _sub.published();
+	const bool published = _sub.advertised();
 
 	if (published) {
 		return true;

--- a/src/modules/uORB/Subscription.cpp
+++ b/src/modules/uORB/Subscription.cpp
@@ -116,7 +116,7 @@ Subscription::init()
 bool
 Subscription::update(uint64_t *time, void *dst)
 {
-	if ((time != nullptr) && (dst != nullptr) && published()) {
+	if ((time != nullptr) && (dst != nullptr) && advertised()) {
 		// always copy data to dst regardless of update
 		const uint64_t t = _node->copy_and_get_timestamp(dst, _last_generation);
 

--- a/src/modules/uORB/Subscription.hpp
+++ b/src/modules/uORB/Subscription.hpp
@@ -75,17 +75,17 @@ public:
 	void unsubscribe();
 
 	bool valid() const { return _node != nullptr; }
-	bool published()
+	bool advertised()
 	{
 		if (valid()) {
-			return _node->is_published();
+			return _node->is_advertised();
 		}
 
 		// try to initialize
 		if (init()) {
 			// check again if valid
 			if (valid()) {
-				return _node->is_published();
+				return _node->is_advertised();
 			}
 		}
 
@@ -95,7 +95,7 @@ public:
 	/**
 	 * Check if there is a new update.
 	 * */
-	bool updated() { return published() ? (_node->published_message_count() != _last_generation) : false; }
+	bool updated() { return advertised() ? (_node->published_message_count() != _last_generation) : false; }
 
 	/**
 	 * Update the struct
@@ -118,7 +118,7 @@ public:
 	 * Copy the struct
 	 * @param data The uORB message struct we are updating.
 	 */
-	bool copy(void *dst) { return published() ? _node->copy(dst, _last_generation) : false; }
+	bool copy(void *dst) { return advertised() ? _node->copy(dst, _last_generation) : false; }
 
 	uint8_t		get_instance() const { return _instance; }
 	orb_id_t	get_topic() const { return _meta; }

--- a/src/modules/uORB/SubscriptionInterval.hpp
+++ b/src/modules/uORB/SubscriptionInterval.hpp
@@ -73,14 +73,14 @@ public:
 
 	bool subscribe() { return _subscription.subscribe(); }
 
-	bool published() { return _subscription.published(); }
+	bool advertised() { return _subscription.advertised(); }
 
 	/**
 	 * Check if there is a new update.
 	 * */
 	bool updated()
 	{
-		if (published() && (hrt_elapsed_time(&_last_update) >= _interval_us)) {
+		if (advertised() && (hrt_elapsed_time(&_last_update) >= _interval_us)) {
 			return _subscription.updated();
 		}
 

--- a/src/modules/uORB/uORBDeviceMaster.cpp
+++ b/src/modules/uORB/uORBDeviceMaster.cpp
@@ -55,7 +55,7 @@ uORB::DeviceMaster::~DeviceMaster()
 }
 
 int
-uORB::DeviceMaster::advertise(const struct orb_metadata *meta, int *instance, int priority)
+uORB::DeviceMaster::advertise(const struct orb_metadata *meta, bool is_advertiser, int *instance, int priority)
 {
 	int ret = PX4_ERROR;
 
@@ -119,22 +119,45 @@ uORB::DeviceMaster::advertise(const struct orb_metadata *meta, int *instance, in
 			delete node;
 
 			if (ret == -EEXIST) {
-				/* if the node exists already, get the existing one and check if
-				 * something has been published yet. */
+				/* if the node exists already, get the existing one and check if it's advertised. */
 				uORB::DeviceNode *existing_node = getDeviceNodeLocked(meta, group_tries);
 
-				if (existing_node != nullptr && !existing_node->is_advertised()) {
-					/* nothing has been published yet, lets claim it */
-					existing_node->set_priority(priority);
+				/*
+				 * We can claim an existing node in these cases:
+				 * - The node is not advertised (yet). It means there is already one or more subscribers or it was
+				 *   unadvertised.
+				 * - We are a single-instance advertiser requesting the first instance.
+				 *   (Usually we don't end up here, but we might in case of a race condition between 2
+				 *   advertisers).
+				 * - We are a subscriber requesting a certain instance.
+				 *   (Also we usually don't end up in that case, but we might in case of a race condtion
+				 *   between an advertiser and subscriber).
+				 */
+				bool is_single_instance_advertiser = is_advertiser && !instance;
+
+				if (existing_node != nullptr &&
+				    (!existing_node->is_advertised() || is_single_instance_advertiser || !is_advertiser)) {
+					if (is_advertiser) {
+						existing_node->set_priority(priority);
+						/* Set as advertised to avoid race conditions (otherwise 2 multi-instance advertisers
+						 * could get the same instance).
+						 */
+						existing_node->mark_as_advertised();
+					}
+
 					ret = PX4_OK;
 
 				} else {
-					/* otherwise: data has already been published, keep looking */
+					/* otherwise: already advertised, keep looking */
 				}
 			}
 
 		} else {
-			// add to the node map;.
+			if (is_advertiser) {
+				node->mark_as_advertised();
+			}
+
+			// add to the node map.
 			_node_list.add(node);
 		}
 

--- a/src/modules/uORB/uORBDeviceMaster.cpp
+++ b/src/modules/uORB/uORBDeviceMaster.cpp
@@ -123,7 +123,7 @@ uORB::DeviceMaster::advertise(const struct orb_metadata *meta, int *instance, in
 				 * something has been published yet. */
 				uORB::DeviceNode *existing_node = getDeviceNodeLocked(meta, group_tries);
 
-				if ((existing_node != nullptr) && !(existing_node->is_published())) {
+				if (existing_node != nullptr && !existing_node->is_advertised()) {
 					/* nothing has been published yet, lets claim it */
 					existing_node->set_priority(priority);
 					ret = PX4_OK;

--- a/src/modules/uORB/uORBDeviceMaster.hpp
+++ b/src/modules/uORB/uORBDeviceMaster.hpp
@@ -60,7 +60,7 @@ class uORB::DeviceMaster
 {
 public:
 
-	int advertise(const struct orb_metadata *meta, int *instance, int priority);
+	int advertise(const struct orb_metadata *meta, bool is_advertiser, int *instance, int priority);
 
 	/**
 	 * Public interface for getDeviceNodeLocked(). Takes care of synchronization.

--- a/src/modules/uORB/uORBDeviceNode.cpp
+++ b/src/modules/uORB/uORBDeviceNode.cpp
@@ -306,7 +306,7 @@ uORB::DeviceNode::write(cdev::file_t *filp, const char *buffer, size_t buflen)
 	/* update the timestamp and generation count */
 	_last_update = hrt_absolute_time();
 
-	_published = true;
+	_advertised = true;
 
 	// callbacks
 	for (auto item : _callbacks) {
@@ -394,8 +394,8 @@ uORB::DeviceNode::ioctl(cdev::file_t *filp, int cmd, unsigned long arg)
 
 		return OK;
 
-	case ORBIOCISPUBLISHED:
-		*(unsigned long *)arg = _published;
+	case ORBIOCISADVERTISED:
+		*(unsigned long *)arg = _advertised;
 
 		return OK;
 
@@ -473,7 +473,7 @@ int uORB::DeviceNode::unadvertise(orb_advert_t handle)
 	 * of subscribers and publishers. But we also do not have a leak since future
 	 * publishers reuse the same DeviceNode object.
 	 */
-	devnode->_published = false;
+	devnode->_advertised = false;
 
 	return PX4_OK;
 }

--- a/src/modules/uORB/uORBDeviceNode.cpp
+++ b/src/modules/uORB/uORBDeviceNode.cpp
@@ -90,6 +90,7 @@ uORB::DeviceNode::open(cdev::file_t *filp)
 			ret = -EBUSY;
 		}
 
+		mark_as_advertised();
 		unlock();
 
 		/* now complete the open */
@@ -306,7 +307,6 @@ uORB::DeviceNode::write(cdev::file_t *filp, const char *buffer, size_t buflen)
 	/* update the timestamp and generation count */
 	_last_update = hrt_absolute_time();
 
-	_advertised = true;
 
 	// callbacks
 	for (auto item : _callbacks) {

--- a/src/modules/uORB/uORBDeviceNode.hpp
+++ b/src/modules/uORB/uORBDeviceNode.hpp
@@ -39,6 +39,7 @@
 #include <lib/cdev/CDev.hpp>
 
 #include <containers/List.hpp>
+#include <px4_platform_common/atomic.h>
 
 namespace uORB
 {
@@ -185,7 +186,7 @@ public:
 
 	uint32_t lost_message_count() const { return _lost_messages; }
 
-	unsigned published_message_count() const { return _generation; }
+	unsigned published_message_count() const { return _generation.load(); }
 
 	const orb_metadata *get_meta() const { return _meta; }
 
@@ -267,7 +268,7 @@ private:
 	const uint8_t _instance; /**< orb multi instance identifier */
 	uint8_t     *_data{nullptr};   /**< allocated object buffer */
 	hrt_abstime   _last_update{0}; /**< time the object was last updated */
-	volatile unsigned   _generation{0};  /**< object generation count */
+	px4::atomic<unsigned>  _generation{0};  /**< object generation count */
 	List<uORB::SubscriptionCallback *>	_callbacks;
 	uint8_t   _priority;  /**< priority of the topic */
 	bool _published{false};  /**< has ever data been published */

--- a/src/modules/uORB/uORBDeviceNode.hpp
+++ b/src/modules/uORB/uORBDeviceNode.hpp
@@ -164,6 +164,8 @@ public:
 	 * and publish to this node or if another node should be tried. */
 	bool is_advertised() const { return _advertised; }
 
+	void mark_as_advertised() { _advertised = true; }
+
 	/**
 	 * Try to change the size of the queue. This can only be done as long as nobody published yet.
 	 * This is the case, for example when orb_subscribe was called before an orb_advertise.

--- a/src/modules/uORB/uORBDeviceNode.hpp
+++ b/src/modules/uORB/uORBDeviceNode.hpp
@@ -158,11 +158,11 @@ public:
 	void remove_internal_subscriber();
 
 	/**
-	 * Return true if this topic has been published.
+	 * Return true if this topic has been advertised.
 	 *
 	 * This is used in the case of multi_pub/sub to check if it's valid to advertise
 	 * and publish to this node or if another node should be tried. */
-	bool is_published() const { return _published; }
+	bool is_advertised() const { return _advertised; }
 
 	/**
 	 * Try to change the size of the queue. This can only be done as long as nobody published yet.
@@ -271,7 +271,7 @@ private:
 	px4::atomic<unsigned>  _generation{0};  /**< object generation count */
 	List<uORB::SubscriptionCallback *>	_callbacks;
 	uint8_t   _priority;  /**< priority of the topic */
-	bool _published{false};  /**< has ever data been published */
+	bool _advertised{false};  /**< has ever been advertised (not necessarily published data yet) */
 	uint8_t _queue_size; /**< maximum number of elements in the queue */
 	int8_t _subscriber_count{0};
 

--- a/src/modules/uORB/uORBDeviceNode.hpp
+++ b/src/modules/uORB/uORBDeviceNode.hpp
@@ -277,9 +277,6 @@ private:
 	uint8_t _queue_size; /**< maximum number of elements in the queue */
 	int8_t _subscriber_count{0};
 
-	px4_task_t _publisher{0}; /**< if nonzero, current publisher. Only used inside the advertise call.
-						We allow one publisher to have an open file descriptor at the same time. */
-
 	// statistics
 	uint32_t _lost_messages = 0; /**< nr of lost messages for all subscribers. If two subscribers lose the same
 					message, it is counted as two. */

--- a/src/modules/uORB/uORBManager.cpp
+++ b/src/modules/uORB/uORBManager.cpp
@@ -116,7 +116,7 @@ int uORB::Manager::orb_exists(const struct orb_metadata *meta, int instance)
 		uORB::DeviceNode *node = _device_master->getDeviceNode(meta, instance);
 
 		if (node != nullptr) {
-			if (node->is_published()) {
+			if (node->is_advertised()) {
 				return PX4_OK;
 			}
 		}
@@ -150,10 +150,10 @@ int uORB::Manager::orb_exists(const struct orb_metadata *meta, int instance)
 		int fd = px4_open(path, 0);
 
 		if (fd >= 0) {
-			unsigned long is_published;
+			unsigned long is_advertised;
 
-			if (px4_ioctl(fd, ORBIOCISPUBLISHED, (unsigned long)&is_published) == 0) {
-				if (!is_published) {
+			if (px4_ioctl(fd, ORBIOCISADVERTISED, (unsigned long)&is_advertised) == 0) {
+				if (!is_advertised) {
 					ret = PX4_ERROR;
 				}
 			}

--- a/src/modules/uORB/uORBManager.cpp
+++ b/src/modules/uORB/uORBManager.cpp
@@ -327,14 +327,12 @@ int uORB::Manager::orb_get_interval(int handle, unsigned *interval)
 	return ret;
 }
 
-int uORB::Manager::node_advertise(const struct orb_metadata *meta, int *instance, int priority)
+int uORB::Manager::node_advertise(const struct orb_metadata *meta, bool is_advertiser, int *instance, int priority)
 {
 	int ret = PX4_ERROR;
 
-	/* fill advertiser data */
-
 	if (get_device_master()) {
-		ret = _device_master->advertise(meta, instance, priority);
+		ret = _device_master->advertise(meta, is_advertiser, instance, priority);
 	}
 
 	/* it's PX4_OK if it already exists */
@@ -384,7 +382,7 @@ int uORB::Manager::node_open(const struct orb_metadata *meta, bool advertiser, i
 	if (fd < 0) {
 
 		/* try to create the node */
-		ret = node_advertise(meta, instance, priority);
+		ret = node_advertise(meta, advertiser, instance, priority);
 
 		if (ret == PX4_OK) {
 			/* update the path, as it might have been updated during the node_advertise call */
@@ -396,7 +394,7 @@ int uORB::Manager::node_open(const struct orb_metadata *meta, bool advertiser, i
 			}
 		}
 
-		/* on success, try the open again */
+		/* on success, try to open again */
 		if (ret == PX4_OK) {
 			fd = px4_open(path, (advertiser) ? PX4_F_WRONLY : PX4_F_RDONLY);
 		}

--- a/src/modules/uORB/uORBManager.hpp
+++ b/src/modules/uORB/uORBManager.hpp
@@ -392,11 +392,9 @@ private: // class methods
 	/**
 	 * Advertise a node; don't consider it an error if the node has
 	 * already been advertised.
-	 *
-	 * @todo verify that the existing node is the same as the one
-	 *       we tried to advertise.
 	 */
-	int node_advertise(const struct orb_metadata *meta, int *instance = nullptr, int priority = ORB_PRIO_DEFAULT);
+	int node_advertise(const struct orb_metadata *meta, bool is_advertiser, int *instance = nullptr,
+			   int priority = ORB_PRIO_DEFAULT);
 
 	/**
 	 * Common implementation for orb_advertise and orb_subscribe.


### PR DESCRIPTION
Possible race conditions (they all happen between the check of existence of a topic and trying to create the node):
- single instance, with multiple advertisers during the first advertise:
  both advertisers see the topic as non-existent and try to advertise it.
  One of them will fail, leading to an error message.
  This is the cause for `telemetry_status` advert failure seen in SITL in
  rare cases.
- multi-instance: subscription to non-existing instance -> px4_open fails,
  and the subscriber tries to create the node. If during that time a
  publisher publishes that instance, the subscriber will get (instance+1)
  (or fails if the max number of instances is exceeded).
  This is a race that goes pretty much unnoticed.
- multi-instance: 2 publishers can get the same instance (if is_published()
  is false in case both have not published data yet).
  This can also go unnoticed.
- 2 single-instance advertisers, and they both open a node exclusively during advertisement, and one of them will fail to open the node with -EBUSY.

This PR fixes all of them, and there should be no noticeable changes for the rest of the system.

There's a semantic change for the flag `_published` to `_advertised`. This does not change anything for the system, since a topic was required to do a publication when advertised.
The change is however required to avoid race conditions.
It also allows to do an advertisement w/o data publication, avoiding the need for garbage/zeroed data publication on startup at many places.

See individual commits as well.