### PR TITLE
TECS: remove height rate complementary filter

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -104,7 +104,6 @@ FixedwingPositionControl::FixedwingPositionControl(bool vtol) :
 	_parameter_handles.throttle_damp = param_find("FW_T_THR_DAMP");
 	_parameter_handles.integrator_gain = param_find("FW_T_INTEG_GAIN");
 	_parameter_handles.vertical_accel_limit = param_find("FW_T_VERT_ACC");
-	_parameter_handles.height_comp_filter_omega = param_find("FW_T_HGT_OMEGA");
 	_parameter_handles.speed_comp_filter_omega = param_find("FW_T_SPD_OMEGA");
 	_parameter_handles.roll_throttle_compensation = param_find("FW_T_RLL2THR");
 	_parameter_handles.speed_weight = param_find("FW_T_SPDWEIGHT");
@@ -242,10 +241,6 @@ FixedwingPositionControl::parameters_update()
 
 	if (param_get(_parameter_handles.vertical_accel_limit, &v) == PX4_OK) {
 		_tecs.set_vertical_accel_limit(v);
-	}
-
-	if (param_get(_parameter_handles.height_comp_filter_omega, &v) == PX4_OK) {
-		_tecs.set_height_comp_filter_omega(v);
 	}
 
 	if (param_get(_parameter_handles.speed_comp_filter_omega, &v) == PX4_OK) {
@@ -1889,7 +1884,7 @@ FixedwingPositionControl::tecs_update_pitch_throttle(float alt_sp, float airspee
 	/* update TECS vehicle state estimates */
 	_tecs.update_vehicle_state_estimates(_airspeed, _R_nb,
 					     accel_body, (_global_pos.timestamp > 0), in_air_alt_control,
-					     _global_pos.alt, _local_pos.v_z_valid, _local_pos.vz, _local_pos.az);
+					     _global_pos.alt, _local_pos.vz);
 
 	/* scale throttle cruise by baro pressure */
 	if (_parameters.throttle_alt_scale > FLT_EPSILON) {

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -325,7 +325,6 @@ private:
 		param_t throttle_damp;
 		param_t integrator_gain;
 		param_t vertical_accel_limit;
-		param_t height_comp_filter_omega;
 		param_t speed_comp_filter_omega;
 		param_t roll_throttle_compensation;
 		param_t speed_weight;

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -602,24 +602,6 @@ PARAM_DEFINE_FLOAT(FW_T_INTEG_GAIN, 0.1f);
 PARAM_DEFINE_FLOAT(FW_T_VERT_ACC, 7.0f);
 
 /**
- * Complementary filter "omega" parameter for height
- *
- * This is the cross-over frequency (in radians/second) of the complementary
- * filter used to fuse vertical acceleration and barometric height to obtain
- * an estimate of height rate and height. Increasing this frequency weights
- * the solution more towards use of the barometer, whilst reducing it weights
- * the solution more towards use of the accelerometer data.
- *
- * @unit rad/s
- * @min 1.0
- * @max 10.0
- * @decimal 1
- * @increment 0.5
- * @group FW TECS
- */
-PARAM_DEFINE_FLOAT(FW_T_HGT_OMEGA, 3.0f);
-
-/**
  * Complementary filter "omega" parameter for speed
  *
  * This is the cross-over frequency (in radians/second) of the complementary


### PR DESCRIPTION
This pull request removes the height rate complementary filter in TECS and corresponding tuning parameter `FW_T_HGT_OMEGA`. This effectively hasn't been used in quite some time as the FW position controller only runs on vehicle global position updates, which means vz will always be valid.

Requires https://github.com/PX4/ecl/pull/671

https://github.com/PX4/Firmware/pull/13527#issuecomment-557354415