### PR TITLE
micro-CDR: bump submodule version and update CMake and src code

### DIFF
--- a/msg/templates/uorb_microcdr/microRTPS_client.cpp.em
+++ b/msg/templates/uorb_microcdr/microRTPS_client.cpp.em
@@ -85,7 +85,7 @@ void* send(void* /*unused*/)
     uint64_t sent = 0, total_sent = 0;
     int loop = 0, read = 0;
     uint32_t length = 0;
-    uint16_t header_length = 0;
+    size_t header_length = 0;
 
     /* subscribe to topics */
 @[for idx, topic in enumerate(send_topics)]@

--- a/msg/templates/urtps/microRTPS_agent.cpp.em
+++ b/msg/templates/urtps/microRTPS_agent.cpp.em
@@ -170,7 +170,7 @@ std::queue<uint8_t> t_send_queue;
 void t_send(void *data)
 {
     char data_buffer[BUFFER_SIZE] = {};
-    int length = 0;
+    uint32_t length = 0;
 
     while (running && !exit_sender_thread.load())
     {
@@ -183,7 +183,7 @@ void t_send(void *data)
         t_send_queue.pop();
         lk.unlock();
 
-        uint16_t header_length = transport_node->get_header_length();
+        size_t header_length = transport_node->get_header_length();
         /* make room for the header to fill in later */
         eprosima::fastcdr::FastBuffer cdrbuffer(&data_buffer[header_length], sizeof(data_buffer)-header_length);
         eprosima::fastcdr::Cdr scdr(cdrbuffer);

--- a/msg/templates/urtps/microRTPS_transport.cpp
+++ b/msg/templates/urtps/microRTPS_transport.cpp
@@ -213,7 +213,7 @@ ssize_t Transport_node::read(uint8_t *topic_ID, char out_buffer[], size_t buffer
 	return len;
 }
 
-ssize_t Transport_node::get_header_length()
+size_t Transport_node::get_header_length()
 {
     return sizeof(struct Header);
 }

--- a/msg/templates/urtps/microRTPS_transport.h
+++ b/msg/templates/urtps/microRTPS_transport.h
@@ -63,7 +63,7 @@ public:
 	ssize_t write(const uint8_t topic_ID, char buffer[], size_t length);
 
 	/** Get the Length of struct Header to make headroom for the size of struct Header along with payload */
-	ssize_t get_header_length();
+	size_t get_header_length();
 
 protected:
 	virtual ssize_t node_read(void *buffer, size_t len) = 0;

--- a/src/modules/micrortps_bridge/CMakeLists.txt
+++ b/src/modules/micrortps_bridge/CMakeLists.txt
@@ -87,10 +87,6 @@ if (FASTRTPSGEN AND (config_rtps_send_topics OR config_rtps_receive_topics))
 endif()
 
 if (GENERATE_RTPS_BRIDGE)
-
-	# temporarily set to OFF
-	option(CHECK_ENDIANNESS OFF)
-
 	add_subdirectory(micrortps_client)
 
 	###############################################################################
@@ -98,6 +94,8 @@ if (GENERATE_RTPS_BRIDGE)
 	###############################################################################
 	include(px4_git)
 	px4_add_git_submodule(TARGET git_micro_cdr PATH micro-CDR)
+
+	set(UCDR_SUPERBUILD CACHE BOOL "Disable micro-CDR superbuild compilation.")
 	add_subdirectory(micro-CDR)
 
 	set(msg_out_path_microcdr ${PX4_BINARY_DIR}/uORB_microcdr/topics)


### PR DESCRIPTION
Bring latest upstream Micro-CDR. No major changes on src code. Endianness check is reset.
