### PR TITLE
Update Supported Hardware in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,34 +70,34 @@ See also [About Us](http://px4.io/about-us/#development_team) (px4.io) and the [
 ## Supported Hardware
 
 This repository contains code supporting these boards:
-  * [Snapdragon Flight](https://docs.px4.io/en/flight_controller/snapdragon_flight.html)
-  * [Intel Aero](https://docs.px4.io/en/flight_controller/intel_aero.html)
-  * [Raspberry PI with Navio 2](https://docs.px4.io/en/flight_controller/raspberry_pi_navio2.html)
-  * [Parrot Bebop 2](https://dev.px4.io/en/advanced/parrot_bebop.html)
+  * [Snapdragon Flight](https://docs.px4.io/master/en/flight_controller/snapdragon_flight.html)
+  * [Intel Aero](https://docs.px4.io/master/en/flight_controller/intel_aero.html)
+  * [Raspberry PI with Navio 2](https://docs.px4.io/master/en/flight_controller/raspberry_pi_navio2.html)
+  * [Parrot Bebop 2](https://dev.px4.io/master/en/advanced/parrot_bebop.html)
   * FMUv2
-    * [Pixhawk](https://docs.px4.io/en/flight_controller/pixhawk.html)
-    * [Pixfalcon](https://docs.px4.io/en/flight_controller/pixfalcon.html)
+    * [Pixhawk](https://docs.px4.io/master/en/flight_controller/pixhawk.html)
+    * [Pixfalcon](https://docs.px4.io/master/en/flight_controller/pixfalcon.html)
   * FMUv3
-    * [Pixhawk 2](https://docs.px4.io/en/flight_controller/pixhawk-2.html)
-    * [Pixhawk Mini](https://docs.px4.io/en/flight_controller/pixhawk_mini.html)
-    * [CUAV Pixhack v3](https://docs.px4.io/en/flight_controller/pixhack_v3.html)
+    * [Pixhawk 2](https://docs.px4.io/master/en/flight_controller/pixhawk-2.html)
+    * [Pixhawk Mini](https://docs.px4.io/master/en/flight_controller/pixhawk_mini.html)
+    * [CUAV Pixhack v3](https://docs.px4.io/master/en/flight_controller/pixhack_v3.html)
   * FMUv4
-    * [Pixracer](https://docs.px4.io/en/flight_controller/pixracer.html)
-    * [Pixhawk 3 Pro](https://docs.px4.io/en/flight_controller/pixhawk3_pro.html)
+    * [Pixracer](https://docs.px4.io/master/en/flight_controller/pixracer.html)
+    * [Pixhawk 3 Pro](https://docs.px4.io/master/en/flight_controller/pixhawk3_pro.html)
   * FMUv5 (ARM Cortex M7)
-    * [Pixhawk 4](https://docs.px4.io/en/flight_controller/pixhawk4.html)
-    * [Pixhawk 4 mini](https://docs.px4.io/en/flight_controller/pixhawk4_mini.html)  
+    * [Pixhawk 4](https://docs.px4.io/master/en/flight_controller/pixhawk4.html)
+    * [Pixhawk 4 mini](https://docs.px4.io/master/en/flight_controller/pixhawk4_mini.html)  
     * [CUAV V5+](https://docs.px4.io/master/en/flight_controller/cuav_v5_plus.html)
     * [CUAV V5 nano](https://docs.px4.io/master/en/flight_controller/cuav_v5_nano.html)
   * [Airmind MindPX V2.8](http://www.mindpx.net/assets/accessories/UserGuide_MindPX.pdf)
   * [Airmind MindRacer V1.2](http://mindpx.net/assets/accessories/mindracer_user_guide_v1.2.pdf)
-  * [Bitcraze Crazyflie 2.0](https://docs.px4.io/en/flight_controller/crazyflie2.html)
-  * [Omnibus F4 SD](https://docs.px4.io/en/flight_controller/omnibus_f4_sd.html)
-  * [BeagleBone Blue](https://docs.px4.io/en/flight_controller/beaglebone_blue.html)
+  * [Bitcraze Crazyflie 2.0](https://docs.px4.io/master/en/flight_controller/crazyflie2.html)
+  * [Omnibus F4 SD](https://docs.px4.io/master/en/flight_controller/omnibus_f4_sd.html)
+  * [BeagleBone Blue](https://docs.px4.io/master/en/flight_controller/beaglebone_blue.html)
   * [Holybro Durandal](https://docs.px4.io/master/en/flight_controller/durandal.html)
   * [Holybro Kakute F7](https://docs.px4.io/master/en/flight_controller/kakutef7.html)
 
-Additional information about supported hardware can be found in [PX4 user Guide > Autopilot Hardware](https://docs.px4.io/en/flight_controller/).
+Additional information about supported hardware can be found in [PX4 user Guide > Autopilot Hardware](https://docs.px4.io/master/en/flight_controller/).
 
 ## Project Roadmap
 

--- a/README.md
+++ b/README.md
@@ -76,22 +76,26 @@ This repository contains code supporting these boards:
   * [Parrot Bebop 2](https://dev.px4.io/en/advanced/parrot_bebop.html)
   * FMUv2
     * [Pixhawk](https://docs.px4.io/en/flight_controller/pixhawk.html)
-    * [Pixhawk Mini](https://docs.px4.io/en/flight_controller/pixhawk_mini.html)
     * [Pixfalcon](https://docs.px4.io/en/flight_controller/pixfalcon.html)
-  * FMUv3 [Pixhawk 2](https://docs.px4.io/en/flight_controller/pixhawk-2.html)
+  * FMUv3
+    * [Pixhawk 2](https://docs.px4.io/en/flight_controller/pixhawk-2.html)
+    * [Pixhawk Mini](https://docs.px4.io/en/flight_controller/pixhawk_mini.html)
+    * [CUAV Pixhack v3](https://docs.px4.io/en/flight_controller/pixhack_v3.html)
   * FMUv4
     * [Pixracer](https://docs.px4.io/en/flight_controller/pixracer.html)
     * [Pixhawk 3 Pro](https://docs.px4.io/en/flight_controller/pixhawk3_pro.html)
   * FMUv5 (ARM Cortex M7)
     * [Pixhawk 4](https://docs.px4.io/en/flight_controller/pixhawk4.html)
     * [Pixhawk 4 mini](https://docs.px4.io/en/flight_controller/pixhawk4_mini.html)  
+    * [CUAV V5+](https://docs.px4.io/master/en/flight_controller/cuav_v5_plus.html)
+    * [CUAV V5 nano](https://docs.px4.io/master/en/flight_controller/cuav_v5_nano.html)
   * [Airmind MindPX V2.8](http://www.mindpx.net/assets/accessories/UserGuide_MindPX.pdf)
   * [Airmind MindRacer V1.2](http://mindpx.net/assets/accessories/mindracer_user_guide_v1.2.pdf)
   * [Bitcraze Crazyflie 2.0](https://docs.px4.io/en/flight_controller/crazyflie2.html)
   * [Omnibus F4 SD](https://docs.px4.io/en/flight_controller/omnibus_f4_sd.html)
   * [BeagleBone Blue](https://docs.px4.io/en/flight_controller/beaglebone_blue.html)
-  * [Holybro Durandal](https://docs.px4.io/en/flight_controller/durandal.html)
-  * [Holybro Kakute F7](https://docs.px4.io/en/flight_controller/kakutef7.html)
+  * [Holybro Durandal](https://docs.px4.io/master/en/flight_controller/durandal.html)
+  * [Holybro Kakute F7](https://docs.px4.io/master/en/flight_controller/kakutef7.html)
 
 Additional information about supported hardware can be found in [PX4 user Guide > Autopilot Hardware](https://docs.px4.io/en/flight_controller/).
 


### PR DESCRIPTION
1. Move Pixhawk Mini to FMUv3, due to it's using Rev.3 chip, has 2MB flash, and fmuv3 bootloader.
2. Add CUAV V5+ to FMUv5
3. Add CUAV v5 nano
4. Add CUAV Pixhack v3 to FMUv3
5. Make sure Durandal and kakuteF7 URL works.

Also continue #13591