### PR TITLE
fix for issue where flight_uuid in flight_information mavlink message was stuck

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2338,8 +2338,7 @@ Commander::run()
 
 			if (!armed.armed) { // increase the flight uuid upon disarming
 				++flight_uuid;
-				// no need for param notification: the only user is mavlink which reads the param upon request
-				param_set_no_notification(_param_flight_uuid, &flight_uuid);
+				param_set(_param_flight_uuid, &flight_uuid);
 				last_disarmed_timestamp = hrt_absolute_time();
 			}
 		}


### PR DESCRIPTION
Now that we have the parameter cache if a parameter is changed in the firmware it has the option to notify or not. The COM_FLIGHT_UUID was not notifying when updating after disarm and therefore the mavlink receiver was not sending out the latest UUID but the one from boot in the FLIGHT_INFORMATION message.