### PR TITLE
NuttX cmake small debug helper improvements

### DIFF
--- a/.ci/Jenkinsfile-hardware
+++ b/.ci/Jenkinsfile-hardware
@@ -43,7 +43,7 @@ pipeline {
                     sh 'find /dev/serial'
                     unstash 'px4_fmu-v2_test'
                     // flash board and watch bootup
-                    sh './platforms/nuttx/Debug/jlink_gdb_upload.sh build/px4_fmu-v2_test/px4_fmu-v2_test.elf'
+                    sh './platforms/nuttx/Debug/upload_jlink_gdb.sh build/px4_fmu-v2_test/px4_fmu-v2_test.elf'
                     sh './Tools/HIL/monitor_firmware_upload.py --device `find /dev/serial -name *usb-FTDI_*` --baudrate 57600'
                   }
                 }
@@ -134,7 +134,7 @@ pipeline {
                     sh 'find /dev/serial'
                     unstash 'px4_fmu-v3_default'
                     // flash board and watch bootup
-                    sh './platforms/nuttx/Debug/jlink_gdb_upload.sh build/px4_fmu-v3_default/px4_fmu-v3_default.elf'
+                    sh './platforms/nuttx/Debug/upload_jlink_gdb.sh build/px4_fmu-v3_default/px4_fmu-v3_default.elf'
                     sh './Tools/HIL/monitor_firmware_upload.py --device `find /dev/serial -name *usb-FTDI_*` --baudrate 57600'
                   }
                 }
@@ -258,7 +258,7 @@ pipeline {
                     sh 'find /dev/serial'
                     unstash 'px4_fmu-v4_default'
                     // flash board and watch bootup
-                    sh './platforms/nuttx/Debug/jlink_gdb_upload.sh build/px4_fmu-v4_default/px4_fmu-v4_default.elf'
+                    sh './platforms/nuttx/Debug/upload_jlink_gdb.sh build/px4_fmu-v4_default/px4_fmu-v4_default.elf'
                     sh './Tools/HIL/monitor_firmware_upload.py --device `find /dev/serial -name *usb-FTDI_*` --baudrate 57600'
                   }
                 }
@@ -379,7 +379,7 @@ pipeline {
                     sh 'find /dev/serial'
                     unstash 'px4_fmu-v4pro_default'
                     // flash board and watch bootup
-                    sh './platforms/nuttx/Debug/jlink_gdb_upload.sh build/px4_fmu-v4pro_default/px4_fmu-v4pro_default.elf'
+                    sh './platforms/nuttx/Debug/upload_jlink_gdb.sh build/px4_fmu-v4pro_default/px4_fmu-v4pro_default.elf'
                     sh './Tools/HIL/monitor_firmware_upload.py --device `find /dev/serial -name *usb-FTDI_*` --baudrate 57600'
                   }
                 }
@@ -503,7 +503,7 @@ pipeline {
                     sh 'find /dev/serial'
                     unstash 'px4_fmu-v5_default'
                     // flash board and watch bootup
-                    sh './platforms/nuttx/Debug/jlink_gdb_upload.sh build/px4_fmu-v5_default/px4_fmu-v5_default.elf'
+                    sh './platforms/nuttx/Debug/upload_jlink_gdb.sh build/px4_fmu-v5_default/px4_fmu-v5_default.elf'
                     sh './Tools/HIL/monitor_firmware_upload.py --device `find /dev/serial -name *usb-FTDI_*` --baudrate 57600'
                   }
                 }
@@ -627,7 +627,7 @@ pipeline {
                     sh 'find /dev/serial'
                     unstash 'px4_fmu-v5x_default'
                     // flash board and watch bootup
-                    sh './platforms/nuttx/Debug/jlink_gdb_upload.sh build/px4_fmu-v5x_default/px4_fmu-v5x_default.elf'
+                    sh './platforms/nuttx/Debug/upload_jlink_gdb.sh build/px4_fmu-v5x_default/px4_fmu-v5x_default.elf'
                     sh './Tools/HIL/monitor_firmware_upload.py --device `find /dev/serial -name *usb-SEGGER_*` --baudrate 57600'
                   }
                 }
@@ -751,7 +751,7 @@ pipeline {
                     sh 'find /dev/serial'
                     unstash 'holybro_durandal-v1_default'
                     // flash board and watch bootup
-                    sh './platforms/nuttx/Debug/jlink_gdb_upload.sh build/holybro_durandal-v1_default/holybro_durandal-v1_default.elf'
+                    sh './platforms/nuttx/Debug/upload_jlink_gdb.sh build/holybro_durandal-v1_default/holybro_durandal-v1_default.elf'
                     sh './Tools/HIL/monitor_firmware_upload.py --device `find /dev/serial -name *usb-FTDI_*` --baudrate 57600'
                   }
                 }
@@ -876,7 +876,7 @@ pipeline {
                     sh 'find /dev/serial'
                     unstash 'holybro_durandal-v1_stackcheck'
                     // flash board and watch bootup
-                    sh './platforms/nuttx/Debug/jlink_gdb_upload.sh build/holybro_durandal-v1_stackcheck/holybro_durandal-v1_stackcheck.elf'
+                    sh './platforms/nuttx/Debug/upload_jlink_gdb.sh build/holybro_durandal-v1_stackcheck/holybro_durandal-v1_stackcheck.elf'
                     sh './Tools/HIL/monitor_firmware_upload.py --device `find /dev/serial -name *usb-FTDI_*` --baudrate 57600'
                   }
                 }
@@ -999,7 +999,7 @@ pipeline {
                     sh 'find /dev/serial'
                     unstash 'nxp_fmuk66-v3_default'
                     // flash board and watch bootup
-                    sh './platforms/nuttx/Debug/jlink_gdb_upload.sh build/nxp_fmuk66-v3_default/nxp_fmuk66-v3_default.elf'
+                    sh './platforms/nuttx/Debug/upload_jlink_gdb.sh build/nxp_fmuk66-v3_default/nxp_fmuk66-v3_default.elf'
                     sh './Tools/HIL/monitor_firmware_upload.py --device `find /dev/serial -name *usb-FTDI_*` --baudrate 57600'
                   }
                 }

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -19,7 +19,7 @@
                 "limitSymbolsToIncludedHeaders": true
             },
             "compileCommands": "${workspaceFolder}/.vscode/compile_commands.json",
-            "configurationProvider": "vector-of-bool.cmake-tools"
+            "configurationProvider": "ms-vscode.cmake-tools"
         }
     ],
     "version": 4

--- a/platforms/nuttx/Debug/gdbinit.in
+++ b/platforms/nuttx/Debug/gdbinit.in
@@ -14,6 +14,8 @@ set print pretty
 set pagination off
 
 set history save on
+set history filename ~/.gdb_history
 set history size unlimited
+set history expansion on
 
 set logging on

--- a/platforms/nuttx/Debug/jlink_debug_gdb.sh.in
+++ b/platforms/nuttx/Debug/jlink_debug_gdb.sh.in
@@ -1,0 +1,14 @@
+#! /bin/sh
+
+set -o xtrace
+
+@JLinkGDBServerExe_PATH@ -device @DEBUG_DEVICE@ -select usb -endian little -if SWD -speed auto -ir -LocalhostOnly 1 -strict -vd -singlerun &
+
+cd @PX4_BINARY_DIR@ && @CMAKE_GDB@ -silent -nh \
+	-iex "set auto-load safe-path @PX4_BINARY_DIR@" \
+	-ex "target remote localhost:2331" \
+	-ex "monitor reset 0" \
+	-ex "load" \
+	-ex "monitor reset 0" \
+	-ex "continue" \
+	@PX4_CONFIG@.elf

--- a/platforms/nuttx/Debug/jlink_debug_ozone.sh.in
+++ b/platforms/nuttx/Debug/jlink_debug_ozone.sh.in
@@ -1,0 +1,5 @@
+#! /bin/sh
+
+set -o xtrace
+
+@Ozone_PATH@ -device @DEBUG_DEVICE@ -if SWD -speed auto -select usb -programfile @PX4_BINARY_DIR@/@PX4_CONFIG@.elf

--- a/platforms/nuttx/Debug/jlink_gdb_start.sh
+++ b/platforms/nuttx/Debug/jlink_gdb_start.sh
@@ -1,7 +1,0 @@
-#! /bin/sh
-
-killall JLinkGDBServerCLExe
-
-# TODO: set device from nuttx config
-# eg CONFIG_ARCH_CHIP_STM32F427V or CONFIG_STM32_STM32F427
-JLinkGDBServerCLExe -device STM32F427II -select usb -silent -endian little -if SWD -speed auto -ir -LocalhostOnly 1 -strict -vd -singlerun &

--- a/platforms/nuttx/Debug/jlink_gdb_start.sh.in
+++ b/platforms/nuttx/Debug/jlink_gdb_start.sh.in
@@ -1,0 +1,7 @@
+#! /bin/sh
+
+set -o xtrace
+
+killall JLinkGDBServerCLExe
+
+JLinkGDBServerCLExe -silent -device @DEBUG_DEVICE@ -select usb -if SWD -speed auto -LocalhostOnly 1 -strict -vd -singlerun &

--- a/platforms/nuttx/Debug/launch.json.in
+++ b/platforms/nuttx/Debug/launch.json.in
@@ -10,6 +10,7 @@
             "type": "cortex-debug",
             "servertype": "jlink",
             "interface": "swd",
+            //"ipAddress": "server:19020",
             "cwd": "${workspaceRoot}",
             "internalConsoleOptions": "openOnSessionStart",
             "preLaunchCommands": [

--- a/platforms/nuttx/Debug/upload_jlink_gdb.sh
+++ b/platforms/nuttx/Debug/upload_jlink_gdb.sh
@@ -1,12 +1,14 @@
 #! /bin/sh
 
-gdb-multiarch -nx -batch \
+set -o xtrace
+
+gdb-multiarch -silent -nx -batch \
 	-ex "target remote localhost:2331" \
 	-ex "monitor reset 0" \
 	-ex "load" \
-	-ex "compare-sections" \
 	-ex "monitor reset 0" \
-	-ex "monitor sleep 1000" \
 	-ex "monitor go" \
-	-ex "kill" \
+	-ex "monitor sleep 3000" \
+	-ex "disconnect" \
+	-ex "quit" \
 	${1}

--- a/platforms/nuttx/cmake/jlink.cmake
+++ b/platforms/nuttx/cmake/jlink.cmake
@@ -31,28 +31,47 @@
 #
 ############################################################################
 
-add_custom_target(jlink_upload
-	COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/Debug/jlink_gdb_start.sh
-	COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/Debug/jlink_gdb_upload.sh $<TARGET_FILE:px4>
-	DEPENDS px4
-	WORKING_DIRECTORY ${PX4_BINARY_DIR}
-	USES_TERMINAL
+# jlink_upload (flash binary)
+find_program(JLinkGDBServerCLExe_PATH JLinkGDBServerCLExe)
+if(JLinkGDBServerCLExe_PATH)
+	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Debug/jlink_gdb_start.sh.in ${PX4_BINARY_DIR}/jlink_gdb_start.sh @ONLY)
+	add_custom_target(jlink_upload
+		COMMAND ${PX4_BINARY_DIR}/jlink_gdb_start.sh
+		COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/Debug/upload_jlink_gdb.sh $<TARGET_FILE:px4>
+		DEPENDS
+			px4
+			${PX4_BINARY_DIR}/jlink_gdb_start.sh
+			${CMAKE_CURRENT_SOURCE_DIR}/Debug/upload_jlink_gdb.sh
+		WORKING_DIRECTORY ${PX4_BINARY_DIR}
+		USES_TERMINAL
 	)
+endif()
 
-add_custom_target(jlink_debug
-	COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/Debug/jlink_gdb_start.sh
-	COMMAND ${CMAKE_GDB} -nh
-		-iex 'set auto-load safe-path ${PX4_BINARY_DIR}'
-		-ex 'target remote localhost:2331'
-		-ex 'monitor reset 0'
-		-ex 'load'
-		-ex 'compare-sections'
-		-ex 'monitor reset 0'
-		-ex 'monitor sleep 1000'
-		-ex 'monitor go'
-		-ex 'continue'
-		$<TARGET_FILE:px4>
-	DEPENDS px4 ${PX4_BINARY_DIR}/.gdbinit
-	WORKING_DIRECTORY ${PX4_BINARY_DIR}
-	USES_TERMINAL
+# jlink_debug_gdb (flash binary and run with gdb attached)
+find_program(JLinkGDBServerExe_PATH JLinkGDBServerExe)
+if(JLinkGDBServerExe_PATH AND CMAKE_GDB)
+	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Debug/jlink_debug_gdb.sh.in ${PX4_BINARY_DIR}/jlink_debug_gdb.sh @ONLY)
+	add_custom_target(jlink_debug_gdb
+		COMMAND ${PX4_BINARY_DIR}/jlink_debug_gdb.sh
+		DEPENDS
+			px4
+			${PX4_BINARY_DIR}/.gdbinit
+			${PX4_BINARY_DIR}/jlink_debug_gdb.sh
+		WORKING_DIRECTORY ${PX4_BINARY_DIR}
+		USES_TERMINAL
 	)
+endif()
+
+# jlink_debug_ozone (run Segger Ozone debugger with current target configuration)
+find_program(Ozone_PATH Ozone)
+if(Ozone_PATH)
+	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Debug/jlink_debug_ozone.sh.in ${PX4_BINARY_DIR}/jlink_debug_ozone.sh @ONLY)
+	add_custom_target(jlink_debug_ozone
+		COMMAND ${PX4_BINARY_DIR}/jlink_debug_ozone.sh
+		DEPENDS
+			px4
+			${PX4_BINARY_DIR}/jlink_debug_ozone.sh
+		WORKING_DIRECTORY ${PX4_BINARY_DIR}
+		USES_TERMINAL
+	)
+endif()


### PR DESCRIPTION
A few minor updates to my somewhat unorthodox debug helpers built into the build system. I utilize the build system to assist in finding binaries, settings paths, and populating the Segger device setting.

 - `make px4_fmu-v5_default jlink_upload`
      - runs gdb in batch mode to connect to jlink gdb server (default port locally) and load the binary, then detach
      - equivalent to running `./platforms/nuttx/Debug/upload_jlink_gdb.sh ./build/px4_fmu-v5_default/px4_fmu-v5_default.elf`
 - `make px4_fmu-v5_default jlink_debug_gdb`
      - runs jlink gdb server and gdb, but doesn't detach
      - includes generated `.gdbinit` that loads the PX4 and NuttX macros 
      - equivalent to running `./build/px4_fmu-v5_default/jlink_debug_gdb.sh` (generated script)
 - `make px4_fmu-v5_default jlink_debug_ozone`
      - runs Segger Ozone graphical debugger preconfigured for target
      - equivalent to running `./build/px4_fmu-v5_default/jlink_debug_ozone.sh` (generated script)
