### PR TITLE
ll40ls: Fix rotation argument parse bug

### DIFF
--- a/src/drivers/distance_sensor/ll40ls/ll40ls.cpp
+++ b/src/drivers/distance_sensor/ll40ls/ll40ls.cpp
@@ -276,7 +276,7 @@ extern "C" __EXPORT int ll40ls_main(int argc, char *argv[])
 	bool start_i2c_all = false;
 	bool start_pwm = false;
 
-	while ((ch = px4_getopt(argc, argv, "ab:R", &myoptind, &myoptarg)) != EOF) {
+	while ((ch = px4_getopt(argc, argv, "ab:R:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'a':
 			start_i2c_all = true;


### PR DESCRIPTION
**Describe problem solved by this pull request**

The option parser for the Garmin Lidar-Lite (ll40ls) distance sensor doesn't work--it's not possible to specify sensor orientation using the command line option `R` (the option exists, but doesn't work).

**Describe your solution**
The option parser was set up to not expect an argument for the `R` option. With getopt, you add a colon after the option letter to indicate that it should take an argument. This was missing for `R`, so I added it.

**Describe possible alternatives**
No other alternatives considered.

**Test data / coverage**
Tested by first flashing a Pixhawk 4 with the current master build (b1099379ae), and trying to stop/start `ll40ls`, then repeating after flashing with a build that includes my fix. Used qgc's mavlink console.

Before: Setting `-a -R 8` gives orientation 0 (should be 8).
![lidar-a-r8](https://user-images.githubusercontent.com/6639836/69737867-6bef3880-1135-11ea-9690-8816e523c6e9.png)

Before: Setting `-b 4 -R 8` gives orientation 4 (should be 8).
![lidar-b4-R8](https://user-images.githubusercontent.com/6639836/69737868-6bef3880-1135-11ea-9ab0-397bbeee7a43.png)

After: `-a -R 8` gives correct orientation 8.
![fixed-a-R8](https://user-images.githubusercontent.com/6639836/69738031-b53f8800-1135-11ea-9279-90e3aa7aeeb5.png)

After: `-b 4 -R 8` gives correct orientation 8.
![fixed-b4-R8](https://user-images.githubusercontent.com/6639836/69738032-b5d81e80-1135-11ea-812b-8f8301f41ec6.png)
