### PR TITLE
Add rangefinder module dependency to tfmini CMakeLists.txt.

### DIFF
--- a/src/drivers/distance_sensor/tfmini/CMakeLists.txt
+++ b/src/drivers/distance_sensor/tfmini/CMakeLists.txt
@@ -40,4 +40,6 @@ px4_add_module(
 		tfmini_parser.cpp
 	MODULE_CONFIG
 		module.yaml
+	DEPENDS
+		drivers_rangefinder
 	)


### PR DESCRIPTION
**Describe problem solved by this pull request**
The TFMini CmakeLists.tx file was missing a dependency on the rangefinder module.  This PR solves #13616.

@gianni-carbone , could you please let us know if this solves your issue?  Thanks!

**Additional context**
See issue #13616

Please let me know if you have any questions on this PR!  Thanks!

-Mark
