### PR TITLE
Change RC override to affect offboard mode as well

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1741,7 +1741,7 @@ Commander::run()
 
 		// abort auto mode or geofence reaction if sticks are moved significantly
 		// but only if not in a low battery handling action
-		const bool low_battery_reaction = _battery_warning < battery_status_s::BATTERY_WARNING_CRITICAL;
+		const bool low_battery_reaction = _battery_warning >= battery_status_s::BATTERY_WARNING_CRITICAL;
 		const bool is_rotary_wing = status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING;
 		const bool in_auto_mode =
 			_internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_LAND ||

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -223,7 +223,7 @@ private:
 		(ParamInt<px4::params::COM_FLIGHT_UUID>) _param_flight_uuid,
 		(ParamInt<px4::params::COM_TAKEOFF_ACT>) _param_takeoff_finished_action,
 
-		(ParamBool<px4::params::COM_RC_OVERRIDE>) _param_rc_override,
+		(ParamInt<px4::params::COM_RC_OVERRIDE>) _param_rc_override,
 		(ParamInt<px4::params::COM_RC_IN_MODE>) _param_rc_in_off,
 		(ParamInt<px4::params::COM_RC_ARM_HYST>) _param_rc_arm_hyst,
 		(ParamFloat<px4::params::COM_RC_STICK_OV>) _param_min_stick_change,
@@ -256,6 +256,12 @@ private:
 		DISABLED = 0,
 		SAFETY_BUTTON = 1,
 		ALWAYS = 2
+	};
+
+	enum OverrideMode {
+		OVERRIDE_DISABLED = 0,
+		OVERRIDE_AUTO_MODE_BIT = (1 << 0),
+		OVERRIDE_OFFBOARD_MODE_BIT = (1 << 1)
 	};
 
 	/* Decouple update interval and hysteresis counters, all depends on intervals */

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -631,13 +631,18 @@ PARAM_DEFINE_INT32(COM_ARM_MAG_STR, 1);
 
 /**
  * Enable RC stick override of auto modes
+ * Enable RC stick override of auto or offboard modes
  *
- * When an auto mode is active (except a critical battery reaction) moving the RC sticks
- * gives control back to the pilot in manual position mode immediately.
+ * Moving the RC sticks gives control back to the pilot in manual position mode immediately when:
+ * 0: an auto mode is active (except a critical battery reaction)
+ * 1: offboard mode is active
  *
  * Only has an effect on multicopters and VTOLS in multicopter mode.
  *
- * @boolean
+ * @min 0
+ * @max 3
+ * @bit 0  Enable override of auto modes
+ * @bit 1  Enable override of offboard mode
  * @group Commander
  */
 PARAM_DEFINE_INT32(COM_RC_OVERRIDE, 1);


### PR DESCRIPTION
-Redefines COM_RC_OVERRIDE as a bitmask
-Changes RC override to affect auto modes, offboard mode, or both
-Fixes regression from #13695. Otherwise, RC override would only work during a low battery reaction, which is the opposite of the intended effect.

Signed-off-by: Tal Zaitsev <16272783+tzai@users.noreply.github.com>

**Describe problem solved by this pull request**
Offboard mode is inherently dangerous, especially during early development. Currently, there is no built-in way that allows a user to take over control in case an offboard node misbehaves.

**Describe your solution**
Change COM_RC_OVERRIDE parameter to be a bitmask, with bit 0 enabling override for auto modes, and bit 1 enabling override for offboard mode. Default value is 1 to maintain backward compatibility.

**Describe possible alternatives**
Alternatively, manual override capability can be added by any offboard node that requires it, but this would lead to numerous ad hoc solutions instead of handling the problem at the source.

**Test data / coverage**
Tested in SITL. Each bit confirmed to work both when it is the only one set, and in conjunction with the other.

**Additional context**
New parameter metadata in QGroundControl:
![com_rc_override_qgc](https://user-images.githubusercontent.com/16272783/69768402-69e5a380-114e-11ea-94bb-651c057e9692.png)

