### PR TITLE
Pr control allocation vtol

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/1040_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/1040_standard_vtol
@@ -44,6 +44,8 @@ then
 	param set MC_INERTIA_YY 1.0
 	param set MC_INERTIA_ZZ 1.0
 
+	param set CA_AIRFRAME 2
+
 	param set CA_ACT0_MIN 0.0
 	param set CA_ACT1_MIN 0.0
 	param set CA_ACT2_MIN 0.0

--- a/ROMFS/px4fmu_common/init.d-posix/1040_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/1040_standard_vtol
@@ -39,6 +39,30 @@ then
 	param set VT_FW_MOT_OFFID 1234
 	param set VT_TYPE 2
 
+
+	param set MC_INERTIA_XX 1.0
+	param set MC_INERTIA_YY 1.0
+	param set MC_INERTIA_ZZ 1.0
+
+	param set CA_ACT0_MIN 0.0
+	param set CA_ACT1_MIN 0.0
+	param set CA_ACT2_MIN 0.0
+	param set CA_ACT3_MIN 0.0
+	param set CA_ACT0_MAX 1.0
+	param set CA_ACT1_MAX 1.0
+	param set CA_ACT2_MAX 1.0
+	param set CA_ACT3_MAX 1.0
+
+	param set CA_ACT4_MAX 1.0
+	param set CA_ACT4_MIN 0.0
+
+	param set CA_ACT5_MAX 1.0
+	param set CA_ACT5_MIN -1.0
+	param set CA_ACT6_MAX 1.0
+	param set CA_ACT6_MIN -1.0
+	param set CA_ACT7_MAX 1.0
+	param set CA_ACT7_MIN -1.0
+
 fi
 
 set MAV_TYPE 22

--- a/ROMFS/px4fmu_common/init.d-posix/1040_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/1040_standard_vtol
@@ -67,5 +67,4 @@ fi
 
 set MAV_TYPE 22
 
-set MIXER_FILE etc/mixers-sitl/standard_vtol_sitl.main.mix
-set MIXER custom
+set MIXER standard_vtol

--- a/ROMFS/px4fmu_common/mixers/standard_vtol.main.mix
+++ b/ROMFS/px4fmu_common/mixers/standard_vtol.main.mix
@@ -1,0 +1,9 @@
+Control outputs
+A: 0
+A: 1
+A: 2
+A: 3
+A: 4
+A: 5
+A: 6
+A: 7

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocationSequentialDesaturation.cpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocationSequentialDesaturation.cpp
@@ -77,7 +77,8 @@ void ControlAllocationSequentialDesaturation::desaturateActuators(
 	actuator_sp = actuator_sp + 0.5f * gain * desaturation_vector;
 }
 
-ControlAllocation::ActuatorVector ControlAllocationSequentialDesaturation::getDesaturationVector(const ControlAxis &axis)
+ControlAllocation::ActuatorVector ControlAllocationSequentialDesaturation::getDesaturationVector(
+	const ControlAxis &axis)
 {
 	ActuatorVector ret;
 

--- a/src/modules/control_allocator/ControlAllocator.cpp
+++ b/src/modules/control_allocator/ControlAllocator.cpp
@@ -139,32 +139,19 @@ ControlAllocator::getEffectinvenessMatrix()
 	matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS> B;
 
 	switch (_param_ca_airframe.get()) {
+
 	case 0: {
-			if (_vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
+			// quad_w
+			const float B_quad_w[NUM_AXES][NUM_ACTUATORS] = {
 				// quad_w
-				const float B_quad_w[NUM_AXES][NUM_ACTUATORS] = {
-					{-0.5,  0.5,  0.5, -0.5, 0.f, 0.0f, 0.0f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
-					{ 0.5, -0.5,  0.5, -0.5, 0.f, 0.f, 0.f, 0.0f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
-					{ 0.28323701f,  0.28323701f, -0.28323701f, -0.28323701f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
-					{ 0.f,  0.f,  0.f,  0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
-					{ 0.f,  0.f,  0.f,  0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
-					{-0.25f, -0.25f, -0.25f, -0.25f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f}
-				};
-				B = matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS>(B_quad_w);
-
-			} else {
-				// fixed wing
-				const float B_fixed_wing[NUM_AXES][NUM_ACTUATORS] = {
-					{ 0.0, 0.0, 0.0, 0.0, 0.f, -0.5f, 0.5f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
-					{ 0.0, 0.0, 0.0, 0.0, 0.f, 0.f, 0.f, 0.5f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
-					{ 0.0, 0.0, 0.0, 0.0, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
-					{ 0.f,  0.f,  0.f,  0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
-					{ 0.f,  0.f,  0.f,  0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
-					{ 0.0f, 0.0f, 0.0f, 0.0f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f}
-				};
-				B = matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS>(B_fixed_wing);
-			}
-
+				{-0.5717536f,  0.43756646f,  0.5717536f, -0.43756646f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
+				{ 0.35355328f, -0.35355328f,  0.35355328f, -0.35355328f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
+				{ 0.28323701f,  0.28323701f, -0.28323701f, -0.28323701f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
+				{ 0.f,  0.f,  0.f,  0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
+				{ 0.f,  0.f,  0.f,  0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
+				{-0.25f, -0.25f, -0.25f, -0.25f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f}
+			};
+			B = matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS>(B_quad_w);
 			break;
 		}
 
@@ -179,6 +166,35 @@ ControlAllocator::getEffectinvenessMatrix()
 				{-0.166667f, -0.166667f, -0.166667f, -0.166667f, -0.166667f, -0.166667f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
 			};
 			B = matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS>(B_hexa_x);
+			break;
+		}
+
+	case 2: {
+			if (_vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
+				// standard_vtol_hover
+				const float B_standard_vtol_hover[NUM_AXES][NUM_ACTUATORS] = {
+					{-0.5,  0.5,  0.5, -0.5, 0.f, 0.0f, 0.0f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
+					{ 0.5, -0.5,  0.5, -0.5, 0.f, 0.f, 0.f, 0.0f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
+					{ 0.28323701f,  0.28323701f, -0.28323701f, -0.28323701f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
+					{ 0.f,  0.f,  0.f,  0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
+					{ 0.f,  0.f,  0.f,  0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
+					{-0.25f, -0.25f, -0.25f, -0.25f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f}
+				};
+				B = matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS>(B_standard_vtol_hover);
+
+			} else {
+				// standard_vtol_fixed_wing
+				const float B_standard_vtol_fixed_wing[NUM_AXES][NUM_ACTUATORS] = {
+					{ 0.0, 0.0, 0.0, 0.0, 0.f, -0.5f, 0.5f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
+					{ 0.0, 0.0, 0.0, 0.0, 0.f, 0.f, 0.f, 0.5f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
+					{ 0.0, 0.0, 0.0, 0.0, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
+					{ 0.f,  0.f,  0.f,  0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
+					{ 0.f,  0.f,  0.f,  0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
+					{ 0.0f, 0.0f, 0.0f, 0.0f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f}
+				};
+				B = matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS>(B_standard_vtol_fixed_wing);
+			}
+
 			break;
 		}
 

--- a/src/modules/control_allocator/ControlAllocator.hpp
+++ b/src/modules/control_allocator/ControlAllocator.hpp
@@ -63,6 +63,7 @@
 #include <uORB/topics/vehicle_torque_setpoint.h>
 #include <uORB/topics/vehicle_thrust_setpoint.h>
 #include <uORB/topics/vehicle_actuator_setpoint.h>
+#include <uORB/topics/vehicle_status.h>
 
 class ControlAllocator : public ModuleBase<ControlAllocator>, public ModuleParams, public px4::WorkItem
 {
@@ -102,6 +103,9 @@ private:
 	void publish_legacy_actuator_controls();
 	void publish_legacy_multirotor_motor_limits();
 
+	const matrix::Matrix<float, ControlAllocation::NUM_AXES, ControlAllocation::NUM_ACTUATORS>
+	getEffectinvenessMatrix();
+
 	static const uint8_t NUM_ACTUATORS = ControlAllocation::NUM_ACTUATORS;
 	static const uint8_t NUM_AXES = ControlAllocation::NUM_AXES;
 
@@ -126,12 +130,15 @@ private:
 	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};		/**< parameter updates subscription */
 	uORB::Subscription _battery_status_sub{ORB_ID(battery_status)};			/**< battery status subscription */
 	uORB::Subscription _airspeed_sub{ORB_ID(airspeed)};				/**< airspeed subscription */
+	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
 
 	matrix::Vector3f _torque_sp;
 	matrix::Vector3f _thrust_sp;
 
 	// float _battery_scale_factor{1.0f};
 	// float _airspeed_scale_factor{1.0f};
+
+	uint8_t _vehicle_type{0};	/**< see vehicle_status_s::vehicle_type */
 
 	perf_counter_t	_loop_perf;			/**< loop duration performance counter */
 

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -571,6 +571,10 @@ void Logger::add_default_topics()
 	add_topic("vehicle_global_position_groundtruth", 100);
 	add_topic("vehicle_local_position_groundtruth", 100);
 	add_topic("vehicle_roi");
+	add_topic("actuator_controls_4", 100);
+	add_topic("actuator_controls_5", 100);
+	add_topic("vehicle_torque_setpoint", 100);
+	add_topic("vehicle_thrust_setpoint", 100);
 
 	add_topic_multi("multirotor_motor_limits");
 

--- a/src/modules/mc_rate_control/MulticopterRateControl.cpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.cpp
@@ -238,7 +238,8 @@ MulticopterRateControl::Run()
 					math::superexpo(_manual_control_sp.r, _param_mc_acro_expo_y.get(), _param_mc_acro_supexpoy.get())};
 
 				_rates_sp = man_rate_sp.emult(_acro_rate_max);
-				_thrust_sp = _manual_control_sp.z;
+				_throttle_z_sp = _manual_control_sp.z;
+				_thrust_sp = Vector3f(0, 0, -_throttle_z_sp);
 
 				// publish rate setpoint
 				vehicle_rates_setpoint_s v_rates_sp{};
@@ -247,7 +248,7 @@ MulticopterRateControl::Run()
 				v_rates_sp.yaw = _rates_sp(2);
 				v_rates_sp.thrust_body[0] = 0.0f;
 				v_rates_sp.thrust_body[1] = 0.0f;
-				v_rates_sp.thrust_body[2] = -_thrust_sp;
+				v_rates_sp.thrust_body[2] = -_throttle_z_sp;
 				v_rates_sp.timestamp = hrt_absolute_time();
 
 				_v_rates_sp_pub.publish(v_rates_sp);
@@ -261,7 +262,8 @@ MulticopterRateControl::Run()
 				_rates_sp(0) = v_rates_sp.roll;
 				_rates_sp(1) = v_rates_sp.pitch;
 				_rates_sp(2) = v_rates_sp.yaw;
-				_thrust_sp = -v_rates_sp.thrust_body[2];
+				_throttle_z_sp = -v_rates_sp.thrust_body[2];
+				_thrust_sp = Vector3f(&v_rates_sp.thrust_body[0]);
 			}
 		}
 
@@ -346,7 +348,7 @@ MulticopterRateControl::publish_actuator_controls()
 	actuators.control[actuator_controls_s::INDEX_ROLL] = PX4_ISFINITE(act_control(0)) ? act_control(0) : 0.0f;
 	actuators.control[actuator_controls_s::INDEX_PITCH] = PX4_ISFINITE(act_control(1)) ? act_control(1) : 0.0f;
 	actuators.control[actuator_controls_s::INDEX_YAW] = PX4_ISFINITE(act_control(2)) ? act_control(2) : 0.0f;
-	actuators.control[actuator_controls_s::INDEX_THROTTLE] = PX4_ISFINITE(_thrust_sp) ? _thrust_sp : 0.0f;
+	actuators.control[actuator_controls_s::INDEX_THROTTLE] = PX4_ISFINITE(_throttle_z_sp) ? _throttle_z_sp : 0.0f;
 	actuators.control[actuator_controls_s::INDEX_LANDING_GEAR] = (float)_landing_gear.landing_gear;
 
 	// scale effort by battery status if enabled
@@ -407,9 +409,9 @@ MulticopterRateControl::publish_thrust_setpoint()
 	vehicle_thrust_setpoint_s v_thrust_sp = {};
 	v_thrust_sp.timestamp = hrt_absolute_time();
 	v_thrust_sp.timestamp_sample = _timestamp_sample;
-	v_thrust_sp.xyz[0] = 0.0f;
-	v_thrust_sp.xyz[1] = 0.0f;
-	v_thrust_sp.xyz[2] = (PX4_ISFINITE(-_thrust_sp)) ? (-_thrust_sp) : 0.0f;
+	v_thrust_sp.xyz[0] = (PX4_ISFINITE(_thrust_sp(0))) ? (_thrust_sp(0)) : 0.0f;
+	v_thrust_sp.xyz[1] = (PX4_ISFINITE(_thrust_sp(1))) ? (_thrust_sp(1)) : 0.0f;
+	v_thrust_sp.xyz[2] = (PX4_ISFINITE(_thrust_sp(2))) ? (_thrust_sp(2)) : 0.0f;
 
 	_vehicle_thrust_setpoint_pub.publish(v_thrust_sp);
 }

--- a/src/modules/mc_rate_control/MulticopterRateControl.cpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.cpp
@@ -383,9 +383,7 @@ MulticopterRateControl::publish_angular_acceleration_setpoint()
 	v_angular_accel_sp.xyz[1] = (PX4_ISFINITE(angular_accel_sp(1))) ? angular_accel_sp(1) : 0.0f;
 	v_angular_accel_sp.xyz[2] = (PX4_ISFINITE(angular_accel_sp(2))) ? angular_accel_sp(2) : 0.0f;
 
-	if (!_vehicle_status.is_vtol) {
-		_vehicle_angular_acceleration_setpoint_pub.publish(v_angular_accel_sp);
-	}
+	_vehicle_angular_acceleration_setpoint_pub.publish(v_angular_accel_sp);
 }
 
 void
@@ -400,9 +398,7 @@ MulticopterRateControl::publish_torque_setpoint()
 	v_torque_sp.xyz[1] = (PX4_ISFINITE(torque_sp(1))) ? torque_sp(1) : 0.0f;
 	v_torque_sp.xyz[2] = (PX4_ISFINITE(torque_sp(2))) ? torque_sp(2) : 0.0f;
 
-	if (!_vehicle_status.is_vtol) {
-		_vehicle_torque_setpoint_pub.publish(v_torque_sp);
-	}
+	_vehicle_torque_setpoint_pub.publish(v_torque_sp);
 }
 
 void
@@ -415,9 +411,7 @@ MulticopterRateControl::publish_thrust_setpoint()
 	v_thrust_sp.xyz[1] = 0.0f;
 	v_thrust_sp.xyz[2] = (PX4_ISFINITE(-_thrust_sp)) ? (-_thrust_sp) : 0.0f;
 
-	if (!_vehicle_status.is_vtol) {
-		_vehicle_thrust_setpoint_pub.publish(v_thrust_sp);
-	}
+	_vehicle_thrust_setpoint_pub.publish(v_thrust_sp);
 }
 
 int MulticopterRateControl::task_spawn(int argc, char *argv[])

--- a/src/modules/mc_rate_control/MulticopterRateControl.hpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.hpp
@@ -149,7 +149,8 @@ private:
 
 	matrix::Vector3f _rates_sp;			/**< angular rates setpoint */
 
-	float		_thrust_sp{0.0f};		/**< thrust setpoint */
+	matrix::Vector3f		_thrust_sp;		/**< thrust setpoint */
+	float 			_throttle_z_sp{0.0f};
 
 	bool _gear_state_initialized{false};		/**< true if the gear state has been initialized */
 

--- a/src/modules/mc_rate_control/MulticopterRateControl.hpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.hpp
@@ -147,10 +147,9 @@ private:
 	static constexpr const float initial_update_rate_hz = 1000.f; /**< loop update rate used for initialization */
 	float _loop_update_rate_hz{initial_update_rate_hz};          /**< current rate-controller loop update rate in [Hz] */
 
-	matrix::Vector3f _rates_sp;			/**< angular rates setpoint */
+	matrix::Vector3f _rates_sp;		/**< angular rates setpoint */
 
-	matrix::Vector3f		_thrust_sp;		/**< thrust setpoint */
-	float 			_throttle_z_sp{0.0f};
+	matrix::Vector3f _thrust_sp;		/**< thrust setpoint */
 
 	bool _gear_state_initialized{false};		/**< true if the gear state has been initialized */
 

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -313,6 +313,9 @@ void Standard::update_transition_state()
 		}
 	}
 
+
+	_v_att_sp->thrust_body[0] = _pusher_throttle;
+
 	mc_weight = math::constrain(mc_weight, 0.0f, 1.0f);
 
 	_mc_roll_weight = mc_weight;


### PR DESCRIPTION
Enables the standard vtol SITL module to use the new control allocation module.

Note: Currently control surfaces are not enabled during the transition, e.g. the effectiveness matrix does not container any entries for them.
The gazebo vtol model has a crazy high rolling moment to the right (created by the drag torque of the pusher rotor). Without the help of control surfaces the transition never completes as the vehicles yaws to the right and never reaches the target airspeed.
As a workaround for now you can decrease the drag torque of the pusher rotor, by reducing this number [here](https://github.com/PX4/sitl_gazebo/blob/master/models/standard_vtol/standard_vtol.sdf#L835)