### PR TITLE
prevent vmount from publishing mount orientation if smart gimbal is a…

### DIFF
--- a/src/modules/vmount/vmount.cpp
+++ b/src/modules/vmount/vmount.cpp
@@ -357,7 +357,12 @@ static int vmount_thread_main(int argc, char *argv[])
 				break;
 			}
 
-			thread_data.output_obj->publish();
+			//only publish the mount orientation if the mode is not mavlink
+			//if the gimbal speaks mavlink it publishes its own orientation
+			if (params.mnt_mode_out != 1) { // 1 = MAVLINK
+				thread_data.output_obj->publish();
+			}
+
 
 		} else {
 			//wait for parameter changes. We still need to wake up regularily to check for thread exit requests


### PR DESCRIPTION
Problem:
Smart gimbals send a mount orientation message which is very accurate and forwarded to the groundstation. If vmount is used, vmount also publishes a mount orientation which is an approximative guess. These messages conflict in the groundstation.

Solution:
We assume that if the vmount output_mode is mavlink, then a smart gimbal is attached which will supply its own mount orientation message. So in this case vmount will not send out the apprximated orientation.
