### PR TITLE
stm32h7:Bootloader fix assertion caused by USB running

### DIFF
--- a/platforms/nuttx/src/bootloader/stm32h7/main.c
+++ b/platforms/nuttx/src/bootloader/stm32h7/main.c
@@ -311,6 +311,7 @@ board_deinit(void)
 
 #if INTERFACE_USB
 	px4_arch_configgpio(MK_GPIO_INPUT(GPIO_OTGFS_VBUS));
+	putreg32(RCC_AHB1RSTR_OTGFSRST, STM32_RCC_AHB1RSTR);
 #endif
 
 #if defined(BOARD_FORCE_BL_PIN_IN) && defined(BOARD_FORCE_BL_PIN_OUT)
@@ -342,7 +343,10 @@ board_deinit(void)
 #endif
 
 
-	/* disable the AHB peripheral clocks */
+
+	/* Clear any RSTR set above and disable the AHB peripheral clocks */
+
+	putreg32(0, STM32_RCC_AHB1RSTR);
 	putreg32(0, STM32_RCC_AHB1ENR);
 }
 


### PR DESCRIPTION
   USB was still running in transition to Firmware. This resets the USB
Fixes https://github.com/PX4/Firmware/issues/13614
@bkueng - Thank you for isolating the IRQ number!