### PR TITLE
Jenkins: compile px4_io-v2_default directly and archive

### DIFF
--- a/.ci/Jenkinsfile-compile
+++ b/.ci/Jenkinsfile-compile
@@ -29,6 +29,7 @@ pipeline {
 
           def nuttx_builds_archive = [
             target: [
+                     "px4_io-v2_default",
                      "px4_fmu-v2_default", "px4_fmu-v2_fixedwing", "px4_fmu-v2_lpe", "px4_fmu-v2_multicopter", "px4_fmu-v2_rover", "px4_fmu-v2_test",
                      "px4_fmu-v3_default",
                      "px4_fmu-v4_default",


### PR DESCRIPTION
This is primarily for convenient flash comparison (bloaty) later.