### PR TITLE
delete module's redundant print_status()

### DIFF
--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -475,13 +475,6 @@ int BATT_SMBUS::manufacturer_name(uint8_t *man_name, const uint8_t length)
 	return result;
 }
 
-int BATT_SMBUS::print_status()
-{
-	PX4_INFO("Running");
-	print_message(_last_report);
-	return 0;
-}
-
 int BATT_SMBUS::manufacturer_read(const uint16_t cmd_code, void *data, const unsigned length)
 {
 	uint8_t code = BATT_SMBUS_MANUFACTURER_BLOCK_ACCESS;

--- a/src/drivers/batt_smbus/batt_smbus.h
+++ b/src/drivers/batt_smbus/batt_smbus.h
@@ -141,9 +141,6 @@ public:
 	/** @see ModuleBase */
 	static int task_spawn(int argc, char *argv[]);
 
-	/** @see ModuleBase::print_status() */
-	int print_status() override;
-
 	/**
 	 * @brief Reads data from flash.
 	 * @param address The address to start the read from.

--- a/src/drivers/distance_sensor/pga460/pga460.cpp
+++ b/src/drivers/distance_sensor/pga460/pga460.cpp
@@ -464,12 +464,6 @@ void PGA460::print_diagnostics(const uint8_t diagnostic_byte)
 	}
 }
 
-int PGA460::print_status()
-{
-	PX4_INFO("Distance: %2.2f", (double)_previous_valid_report_distance);
-	return PX4_OK;
-}
-
 int PGA460::print_usage(const char *reason)
 {
 	if (reason) {

--- a/src/drivers/distance_sensor/pga460/pga460.h
+++ b/src/drivers/distance_sensor/pga460/pga460.h
@@ -268,11 +268,6 @@ public:
 	void print_diagnostics(const uint8_t diagnostic_byte);
 
 	/**
-	 * Diagnostics - print some basic information about the driver.
-	 */
-	int print_status() override;
-
-	/**
 	 * @brief Reads the threshold registers.
 	 * @return Returns true if the threshold registers are set to default
 	 */

--- a/src/drivers/safety_button/SafetyButton.cpp
+++ b/src/drivers/safety_button/SafetyButton.cpp
@@ -200,14 +200,6 @@ SafetyButton::custom_command(int argc, char *argv[])
 }
 
 int
-SafetyButton::print_status()
-{
-	PX4_INFO("Safety State (from button): %s", _safety_btn_off ? "off" : "on");
-
-	return 0;
-}
-
-int
 SafetyButton::print_usage(const char *reason)
 {
 	if (reason) {

--- a/src/drivers/safety_button/SafetyButton.hpp
+++ b/src/drivers/safety_button/SafetyButton.hpp
@@ -62,9 +62,6 @@ public:
 	/** @see ModuleBase */
 	static int print_usage(const char *reason = nullptr);
 
-	/** @see ModuleBase::print_status() */
-	int print_status() override;
-
 	void Run() override;
 
 	int Start();

--- a/src/modules/airspeed_selector/airspeed_selector_main.cpp
+++ b/src/modules/airspeed_selector/airspeed_selector_main.cpp
@@ -90,8 +90,6 @@ public:
 	/* run the main loop */
 	void Run() override;
 
-	int print_status() override;
-
 private:
 	static constexpr int MAX_NUM_AIRSPEED_SENSORS = 3; /**< Support max 3 airspeed sensors */
 	enum airspeed_index {
@@ -588,19 +586,6 @@ int AirspeedModule::custom_command(int argc, char *argv[])
 	}
 
 	return print_usage("unknown command");
-}
-
-int AirspeedModule::print_status()
-{
-	perf_print_counter(_perf_elapsed);
-
-	int instance = 0;
-	uORB::SubscriptionData<airspeed_validated_s> est{ORB_ID(airspeed_validated), (uint8_t)instance};
-	est.update();
-	PX4_INFO("Number of airspeed sensors: %i", _number_of_airspeed_sensors);
-	print_message(est.get());
-
-	return 0;
 }
 
 int AirspeedModule::print_usage(const char *reason)

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -736,13 +736,6 @@ int FixedwingAttitudeControl::custom_command(int argc, char *argv[])
 	return print_usage("unknown command");
 }
 
-int FixedwingAttitudeControl::print_status()
-{
-	PX4_INFO("Running");
-	perf_print_counter(_loop_perf);
-	return 0;
-}
-
 int FixedwingAttitudeControl::print_usage(const char *reason)
 {
 	if (reason) {

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
@@ -88,9 +88,6 @@ public:
 	/** @see ModuleBase */
 	static int print_usage(const char *reason = nullptr);
 
-	/** @see ModuleBase::print_status() */
-	int print_status() override;
-
 	void Run() override;
 
 	bool init();

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1953,13 +1953,6 @@ int FixedwingPositionControl::custom_command(int argc, char *argv[])
 	return print_usage("unknown command");
 }
 
-int FixedwingPositionControl::print_status()
-{
-	PX4_INFO("Running");
-	perf_print_counter(_loop_perf);
-	return 0;
-}
-
 int FixedwingPositionControl::print_usage(const char *reason)
 {
 	if (reason) {

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -145,9 +145,6 @@ public:
 
 	bool init();
 
-	/** @see ModuleBase::print_status() */
-	int print_status() override;
-
 private:
 	orb_advert_t	_mavlink_log_pub{nullptr};
 

--- a/src/modules/load_mon/load_mon.cpp
+++ b/src/modules/load_mon/load_mon.cpp
@@ -84,9 +84,6 @@ public:
 	/** @see ModuleBase */
 	static int print_usage(const char *reason = nullptr);
 
-	/** @see ModuleBase::print_status() */
-	int print_status() override;
-
 	void start();
 
 private:
@@ -306,13 +303,6 @@ void LoadMon::_stack_usage()
 	_stack_task_index = task_index + 1;
 }
 #endif
-
-int LoadMon::print_status()
-{
-	PX4_INFO("running");
-	perf_print_counter(_stack_perf);
-	return 0;
-}
 
 int LoadMon::print_usage(const char *reason)
 {

--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -78,9 +78,6 @@ public:
 	/** @see ModuleBase */
 	static int print_usage(const char *reason = nullptr);
 
-	/** @see ModuleBase::print_status() */
-	int print_status() override;
-
 	void Run() override;
 
 	bool init();

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -378,15 +378,6 @@ int MulticopterAttitudeControl::task_spawn(int argc, char *argv[])
 	return PX4_ERROR;
 }
 
-int MulticopterAttitudeControl::print_status()
-{
-	PX4_INFO("Running");
-
-	perf_print_counter(_loop_perf);
-
-	return 0;
-}
-
 int MulticopterAttitudeControl::custom_command(int argc, char *argv[])
 {
 	return print_usage("unknown command");

--- a/src/modules/mc_rate_control/MulticopterRateControl.cpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.cpp
@@ -356,15 +356,6 @@ int MulticopterRateControl::task_spawn(int argc, char *argv[])
 	return PX4_ERROR;
 }
 
-int MulticopterRateControl::print_status()
-{
-	PX4_INFO("Running");
-
-	perf_print_counter(_loop_perf);
-
-	return 0;
-}
-
 int MulticopterRateControl::custom_command(int argc, char *argv[])
 {
 	return print_usage("unknown command");

--- a/src/modules/mc_rate_control/MulticopterRateControl.hpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.hpp
@@ -75,9 +75,6 @@ public:
 	/** @see ModuleBase */
 	static int print_usage(const char *reason = nullptr);
 
-	/** @see ModuleBase::print_status() */
-	int print_status() override;
-
 	void Run() override;
 
 	bool init();

--- a/src/modules/rc_update/rc_update.cpp
+++ b/src/modules/rc_update/rc_update.cpp
@@ -512,15 +512,6 @@ RCUpdate::task_spawn(int argc, char *argv[])
 }
 
 int
-RCUpdate::print_status()
-{
-	PX4_INFO("Running");
-	perf_print_counter(_loop_perf);
-
-	return 0;
-}
-
-int
 RCUpdate::custom_command(int argc, char *argv[])
 {
 	return print_usage("unknown command");

--- a/src/modules/rc_update/rc_update.h
+++ b/src/modules/rc_update/rc_update.h
@@ -87,9 +87,6 @@ public:
 	void Run() override;
 	bool init();
 
-	/** @see ModuleBase::print_status() */
-	int print_status() override;
-
 private:
 
 	/**

--- a/src/modules/sih/sih.cpp
+++ b/src/modules/sih/sih.cpp
@@ -55,11 +55,6 @@
 using namespace math;
 using namespace matrix;
 
-int Sih::print_status()
-{
-	PX4_INFO("Running");
-	return 0;
-}
 
 int Sih::custom_command(int argc, char *argv[])
 {

--- a/src/modules/sih/sih.hpp
+++ b/src/modules/sih/sih.hpp
@@ -79,9 +79,6 @@ public:
 	/** @see ModuleBase::run() */
 	void run() override;
 
-	/** @see ModuleBase::print_status() */
-	int print_status() override;
-
 	static float generate_wgn();    // generate white Gaussian noise sample
 
 	// generate white Gaussian noise sample as a 3D vector with specified std

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -463,14 +463,6 @@ VtolAttitudeControl::custom_command(int argc, char *argv[])
 }
 
 int
-VtolAttitudeControl::print_status()
-{
-	PX4_INFO("Running");
-	perf_print_counter(_loop_perf);
-	return PX4_OK;
-}
-
-int
 VtolAttitudeControl::print_usage(const char *reason)
 {
 	if (reason) {

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -106,9 +106,6 @@ public:
 
 	bool init();
 
-	/** @see ModuleBase::print_status() */
-	int print_status() override;
-
 	bool is_fixed_wing_requested();
 	void abort_front_transition(const char *reason);
 


### PR DESCRIPTION
We can already get the running status from the base class and the other information is either provided via perf or orb.