### PR TITLE
Add upload command support for Raspberry Pi build.

### DIFF
--- a/boards/px4/raspberrypi/cmake/upload.cmake
+++ b/boards/px4/raspberrypi/cmake/upload.cmake
@@ -1,0 +1,6 @@
+add_custom_target(upload
+        COMMAND rsync -arh --progress ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} ${PX4_SOURCE_DIR}/posix-configs/rpi/*.config ${PX4_SOURCE_DIR}/ROMFS pi@"$ENV{AUTOPILOT_HOST}":/home/pi/px4
+	DEPENDS px4
+	COMMENT "uploading px4"
+	USES_TERMINAL
+	)


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by this pull request**
Sub-command 'upload' has been missing for a long time. This will bring back support for `make px4_raspberrypi_xxx upload`.

**Describe your solution**
Add the upload.cmake file.

**Describe possible alternatives**
None.

**Test data / coverage**
Successfully uploaded.

**Additional context**
It is related to emlid/navio2 board and the implement there is not in correct format.
