### PR TITLE
tiltrotor SITL config: increase transition time from 1.5 to 5 seconds

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/1042_tiltrotor
+++ b/ROMFS/px4fmu_common/init.d-posix/1042_tiltrotor
@@ -33,7 +33,7 @@ then
 	param set NAV_ACC_RAD 5
 	param set NAV_LOITER_RAD 80
 
-	param set VT_F_TRANS_DUR 1.5
+	param set VT_F_TRANS_DUR 5.0
 	param set VT_F_TRANS_THR 0.75
 	param set VT_TILT_FW 3.1415
 	param set VT_TILT_TRANS 1.2


### PR DESCRIPTION
I think this [commit ](https://github.com/PX4/Firmware/commit/273988c124d68031c300dcdcac1c4b4150d432de) has unintentionally reduced the front transition time for the SITL tiltrotor config from 5 to 1.5 seconds. This is too short and leads to rough front transitions.