### PR TITLE
Add camera_capture module build to raspberry pi cross.cmake.

### DIFF
--- a/boards/px4/raspberrypi/cross.cmake
+++ b/boards/px4/raspberrypi/cross.cmake
@@ -26,6 +26,7 @@ px4_add_board(
 
 	MODULES
 		attitude_estimator_q
+		camera_capture
 		camera_feedback
 		commander
 		dataman


### PR DESCRIPTION
**Describe problem solved by this pull request**
It appears that adding `camera_capture` to RaspberryPi cross.cmake was inadvertently missed.  This PR simply adds `camera_capture` to the module build list for rpi.

**Additional context**
See comments by @SalimTerryLi [here](https://github.com/PX4/Firmware/commit/e951531b12917b5855725bc5ac7e1d5c75482dc5#commitcomment-36226469)
