### PR TITLE
Migrate MulticoperLandDetector mpc_xxx params to ModuleParams inherit…

### DIFF
--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -96,21 +96,6 @@ private:
 	/** Time interval in us in which wider acceptance thresholds are used after landed. */
 	static constexpr hrt_abstime LAND_DETECTOR_LAND_PHASE_TIME_US = 2_s;
 
-	/** Handles for interesting parameters. **/
-	struct {
-		param_t minThrottle;
-		param_t hoverThrottle;
-		param_t minManThrottle;
-		param_t landSpeed;
-	} _paramHandle{};
-
-	struct {
-		float minThrottle;
-		float hoverThrottle;
-		float minManThrottle;
-		float landSpeed;
-	} _params{};
-
 	uORB::Subscription _actuator_controls_sub{ORB_ID(actuator_controls_0)};
 	uORB::Subscription _battery_sub{ORB_ID(battery_status)};
 	uORB::Subscription _vehicle_acceleration_sub{ORB_ID(vehicle_acceleration)};
@@ -139,7 +124,11 @@ private:
 		(ParamFloat<px4::params::LNDMC_LOW_T_THR>)  _param_lndmc_low_t_thr,
 		(ParamFloat<px4::params::LNDMC_ROT_MAX>)    _param_lndmc_rot_max,
 		(ParamFloat<px4::params::LNDMC_XY_VEL_MAX>) _param_lndmc_xy_vel_max,
-		(ParamFloat<px4::params::LNDMC_Z_VEL_MAX>)  _param_lndmc_z_vel_max
+		(ParamFloat<px4::params::LNDMC_Z_VEL_MAX>)  _param_lndmc_z_vel_max,
+		(ParamFloat<px4::params::MPC_LAND_SPEED>)   _param_mpc_land_speed,
+		(ParamFloat<px4::params::MPC_MANTHR_MIN>)   _param_mpc_manthr_min,
+		(ParamFloat<px4::params::MPC_THR_MIN>)      _param_mpc_thr_min,
+		(ParamFloat<px4::params::MPC_THR_HOVER>)    _param_mpc_thr_hover
 	);
 };
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
This PR migrates remaining params in the `MulticopterLanddetector` module to inherit from the `ModuleParams` class.

**Test data / coverage**
Flight tested on a 250 racer, pixhawk 4 mini (fmu-v5).  Flight behavior is unchanged, land detection performs as expected.  Flight log: https://logs.px4.io/plot_app?log=cf75b11b-b4ef-47d9-8f93-e49d462bbb4f

Let me know if you have any questions on this PR!  Thanks!