### PR TITLE
collision_prevention: don't unadvertise mavlink_log in destructor

### DIFF
--- a/src/lib/collision_prevention/CollisionPrevention.cpp
+++ b/src/lib/collision_prevention/CollisionPrevention.cpp
@@ -87,14 +87,6 @@ CollisionPrevention::CollisionPrevention(ModuleParams *parent) :
 	}
 }
 
-CollisionPrevention::~CollisionPrevention()
-{
-	//unadvertise publishers
-	if (_mavlink_log_pub != nullptr) {
-		orb_unadvertise(_mavlink_log_pub);
-	}
-}
-
 hrt_abstime CollisionPrevention::getTime()
 {
 	return hrt_absolute_time();

--- a/src/lib/collision_prevention/CollisionPrevention.hpp
+++ b/src/lib/collision_prevention/CollisionPrevention.hpp
@@ -65,11 +65,10 @@ class CollisionPrevention : public ModuleParams
 {
 public:
 	CollisionPrevention(ModuleParams *parent);
-
-	virtual ~CollisionPrevention();
+	~CollisionPrevention() override = default;
 
 	/**
-	 * Returs true if Collision Prevention is running
+	 * Returns true if Collision Prevention is running
 	 */
 	bool is_active();
 


### PR DESCRIPTION
With the way flight tasks currently works we probably shouldn't be unadvertising mavlink_log in the CollisionPrevention destructor. CollisionPrevention is constructed/destructed corresponding with mode changes in and out of POSCTL. The `mavlink_log` ORB message is used systemwide