### PR TITLE
navigator: fix VTOL RTL corner case

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -820,7 +820,7 @@ Mission::set_mission_items()
 
 				/* move to land wp as fixed wing */
 				if (_mission_item.nav_cmd == NAV_CMD_VTOL_LAND
-				    && _work_item_type == WORK_ITEM_TYPE_DEFAULT
+				    && (_work_item_type == WORK_ITEM_TYPE_DEFAULT || _work_item_type == WORK_ITEM_TYPE_TRANSITON_AFTER_TAKEOFF)
 				    && new_work_item_type == WORK_ITEM_TYPE_DEFAULT
 				    && !_navigator->get_land_detected()->landed) {
 


### PR DESCRIPTION
This fixes a corner case for VTOL RTL with RTL_TYPE 1.
RTL_TYPE 1 means that the VTOL skips all waypoints on RTL and jumps to the land waypoint at the end.

During a mission in fixedwing mode it will continue to fly in fixedwing mode and then do a transition before landing.

However, if RTL is engaged right at the moment of the front transition, the transition waypoint is not inserted and the VTOL will try to land in fixedwing mode at the mission land location.

This corner case is fixed in this patch by also considering the "transition after takeoff" state.

This was discovered by @sfuhrer and I did most debugging together with @sfuhrer.

Tested in SITL with `standard_vtol`.

The problem can be reproduced by requesting RTL right during the front transition of a mission (and with `RTL_TYPE` set to `1`.