### PR TITLE
Fix check for negative scaled lat lon on VEHICLE_CMD_DO_REPOSITION 

### DIFF
--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -268,8 +268,8 @@ Navigator::run()
 				if (PX4_ISFINITE(cmd.param5) && PX4_ISFINITE(cmd.param6)) {
 
 					// Position change with optional altitude change
-					rep->current.lat = (cmd.param5 < 1000) ? cmd.param5 : cmd.param5 / (double)1e7;
-					rep->current.lon = (cmd.param6 < 1000) ? cmd.param6 : cmd.param6 / (double)1e7;
+					rep->current.lat = cmd.param5;
+					rep->current.lon = cmd.param6;
 
 					if (PX4_ISFINITE(cmd.param7)) {
 						rep->current.alt = cmd.param7;
@@ -323,8 +323,8 @@ Navigator::run()
 				}
 
 				if (PX4_ISFINITE(cmd.param5) && PX4_ISFINITE(cmd.param6)) {
-					rep->current.lat = (cmd.param5 < 1000) ? cmd.param5 : cmd.param5 / (double)1e7;
-					rep->current.lon = (cmd.param6 < 1000) ? cmd.param6 : cmd.param6 / (double)1e7;
+					rep->current.lat = cmd.param5;
+					rep->current.lon = cmd.param6;
 
 				} else {
 					// If one of them is non-finite, reset both


### PR DESCRIPTION
**Describe problem solved by this pull request**
as described on 'VEHICLE_CMD_DO_REPOSITION scaling check invalid for negative lat/lon #11364:

VEHICLE_CMD_DO_REPOSITION attempts to do a sanity check to handle both scaled and unscaled lat/lon. If the lat or lon are over 1000, the value is assumed to be scaled and divided down. However, this check is not valid for locations south of the equator or west of the meridian because the values will be negative and therefore below 1000

**Describe possible alternatives**
add flag on COMMAND_LONG to tell if the location is scaled.

**Test data / coverage**
Simulation

**Additional context**
The check will still fail in case of scaled location that happen to be on the narrow band in the meridian/equator of +-1000.
this fix is partial for now, and still solves most of the cases.
