### PR TITLE
mavlink_receiver: Set distance_sensor id field equal to mavlink msg

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -700,7 +700,7 @@ MavlinkReceiver::handle_message_distance_sensor(mavlink_message_t *msg)
 	ds.q[3]             = dist_sensor.quaternion[3];
 	ds.signal_quality   = -1; // TODO: A dist_sensor.signal_quality field is missing from the mavlink message definition.
 	ds.type             = dist_sensor.type;
-	ds.id               = MAV_DISTANCE_SENSOR_LASER;
+	ds.id               = dist_sensor.id;
 	ds.orientation      = dist_sensor.orientation;
 
 	_distance_sensor_pub.publish(ds);


### PR DESCRIPTION
The id field should be copied from the mavlink message, not
simply set to MAV_DISTANCE_SENSOR_LASER (which is 0).

**Describe problem solved by this pull request**
If you send a `DISTANCE_SENSOR` mavlink message to PX4, the ID of that message gets overwritten by a zero, so you lose the ID information.
The id data seems to be unused within the firmware, so this doesn't allow any new functionality, as far as I can tell, but it fixes this one thing
that will become a problem the day distance sensor IDs start being used, for those who get distance sensor data from outside px4 (ROS, for instance).

**Describe your solution**
Copy the `id` field from the incoming mavlink message to the `id` field of the created uorb message.

**Describe possible alternatives**
None really.

**Test data / coverage**
Tested by staring at the code.

**Additional context**
None.
