### PR TITLE
tests: workaround against astyle 3.1 bug

### DIFF
--- a/src/systemcmds/tests/test_matrix.cpp
+++ b/src/systemcmds/tests/test_matrix.cpp
@@ -769,12 +769,14 @@ bool MatrixTest::pseudoInverseTests()
 		8.f, 9.f, 10.f, 11.f
 	};
 
+	// *INDENT-OFF*
 	float data0_check[12] = {
 		-0.3375f, -0.1f,  0.1375f,
 		-0.13333333f, -0.03333333f,  0.06666667f,
 		0.07083333f,  0.03333333f, -0.00416667f,
 		0.275f, 0.1f, -0.075f
 	};
+	// *INDENT-ON*
 
 	Matrix<float, 3, 4> A0(data0);
 	Matrix<float, 4, 3> A0_I = geninv(A0);
@@ -790,11 +792,13 @@ bool MatrixTest::pseudoInverseTests()
 		3.f, 7.f, 11.f
 	};
 
+	// *INDENT-OFF*
 	float data1_check[12] = {
 		-0.3375f, -0.13333333f,  0.07083333f,  0.275f,
 		-0.1f, -0.03333333f,  0.03333333f,  0.1f,
 		0.1375f,  0.06666667f, -0.00416667f, -0.075f
 	};
+	// *INDENT-ON*
 
 	Matrix<float, 4, 3> A1(data1);
 	Matrix<float, 3, 4> A1_I = geninv(A1);
@@ -808,11 +812,13 @@ bool MatrixTest::pseudoInverseTests()
 		4, 5, 6,
 		7, 8, 10
 	};
+	// *INDENT-OFF*
 	float data2_check[9] = {
 		-0.4f, -0.8f,  0.6f,
 		-0.4f,  4.2f, -2.4f,
 		0.6f, -2.8f,  1.6f
 	};
+	// *INDENT-ON*
 
 	SquareMatrix<float, 3> A2(data2);
 	SquareMatrix<float, 3> A2_I = inv(A2);


### PR DESCRIPTION
This prevents astyle 3.1 from changing these 3 matrices without a good reason.

Raised by @ItsTimmy.