### PR TITLE
Use correct params for DO_MOUNT_CONTROL

### DIFF
--- a/src/modules/vmount/input_mavlink.cpp
+++ b/src/modules/vmount/input_mavlink.cpp
@@ -303,7 +303,7 @@ int InputMavlinkCmdMount::update_impl(unsigned int timeout_ms, ControlData **con
 						break;
 
 					case vehicle_command_s::VEHICLE_MOUNT_MODE_GPS_POINT:
-						control_data_set_lon_lat((double)vehicle_command.param2, (double)vehicle_command.param1, vehicle_command.param3);
+						control_data_set_lon_lat((double)vehicle_command.param6, (double)vehicle_command.param5, vehicle_command.param4);
 
 						*control_data = &_control_data;
 						break;


### PR DESCRIPTION
**Describe problem solved by this pull request**
If MAV_MOUNT_MODE is GPS_POINT, the mavlink documentation recommends to
use params5-7. In the current implementation params1-3 were used
instead.

**Describe possible alternatives**
An alternative would be to get rid of the lon/lat/alt parameters for DO_MOUNT_CONTROL and rely on DO_SET_ROI_LOCATION instead.