### PR TITLE
Position Control Refactoring Part 5

### DIFF
--- a/src/lib/flight_tasks/tasks/AutoMapper/FlightTaskAutoMapper.cpp
+++ b/src/lib/flight_tasks/tasks/AutoMapper/FlightTaskAutoMapper.cpp
@@ -65,7 +65,7 @@ bool FlightTaskAutoMapper::update()
 	// vehicle exits idle.
 
 	if (_type_previous == WaypointType::idle) {
-		_thrust_setpoint = Vector3f(NAN, NAN, NAN);
+		_thrust_setpoint.setNaN();
 	}
 
 	// during mission and reposition, raise the landing gears but only
@@ -112,8 +112,8 @@ void FlightTaskAutoMapper::_reset()
 void FlightTaskAutoMapper::_generateIdleSetpoints()
 {
 	// Send zero thrust setpoint
-	_position_setpoint = Vector3f(NAN, NAN, NAN); // Don't require any position/velocity setpoints
-	_velocity_setpoint = Vector3f(NAN, NAN, NAN);
+	_position_setpoint.setNaN(); // Don't require any position/velocity setpoints
+	_velocity_setpoint.setNaN();
 	_thrust_setpoint.zero();
 }
 

--- a/src/lib/flight_tasks/tasks/AutoMapper2/FlightTaskAutoMapper2.cpp
+++ b/src/lib/flight_tasks/tasks/AutoMapper2/FlightTaskAutoMapper2.cpp
@@ -57,7 +57,7 @@ bool FlightTaskAutoMapper2::update()
 	// vehicle exits idle.
 
 	if (_type_previous == WaypointType::idle) {
-		_thrust_setpoint = Vector3f(NAN, NAN, NAN);
+		_thrust_setpoint.setNaN();
 	}
 
 	// during mission and reposition, raise the landing gears but only
@@ -120,8 +120,8 @@ void FlightTaskAutoMapper2::_reset()
 void FlightTaskAutoMapper2::_prepareIdleSetpoints()
 {
 	// Send zero thrust setpoint
-	_position_setpoint = Vector3f(NAN, NAN, NAN); // Don't require any position/velocity setpoints
-	_velocity_setpoint = Vector3f(NAN, NAN, NAN);
+	_position_setpoint.setNaN(); // Don't require any position/velocity setpoints
+	_velocity_setpoint.setNaN();
 	_thrust_setpoint.zero();
 }
 

--- a/src/lib/flight_tasks/tasks/FlightTask/FlightTask.cpp
+++ b/src/lib/flight_tasks/tasks/FlightTask/FlightTask.cpp
@@ -105,11 +105,11 @@ const vehicle_local_position_setpoint_s FlightTask::getPositionSetpoint()
 
 void FlightTask::_resetSetpoints()
 {
-	_position_setpoint.setAll(NAN);
-	_velocity_setpoint.setAll(NAN);
-	_acceleration_setpoint.setAll(NAN);
-	_jerk_setpoint.setAll(NAN);
-	_thrust_setpoint.setAll(NAN);
+	_position_setpoint.setNaN();
+	_velocity_setpoint.setNaN();
+	_acceleration_setpoint.setNaN();
+	_jerk_setpoint.setNaN();
+	_thrust_setpoint.setNaN();
 	_yaw_setpoint = _yawspeed_setpoint = NAN;
 }
 

--- a/src/lib/flight_tasks/tasks/FlightTask/FlightTask.hpp
+++ b/src/lib/flight_tasks/tasks/FlightTask/FlightTask.hpp
@@ -168,10 +168,9 @@ public:
 					const matrix::Vector3f &thrust_sp) {_velocity_setpoint_feedback = vel_sp; _thrust_setpoint_feedback = thrust_sp; }
 
 protected:
-
-	uORB::SubscriptionData<vehicle_local_position_s>	_sub_vehicle_local_position{ORB_ID(vehicle_local_position)};
-	uORB::SubscriptionData<vehicle_attitude_s>		_sub_attitude{ORB_ID(vehicle_attitude)};
-	uORB::SubscriptionData<home_position_s> 		_sub_home_position{ORB_ID(home_position)};
+	uORB::SubscriptionData<vehicle_local_position_s> _sub_vehicle_local_position{ORB_ID(vehicle_local_position)};
+	uORB::SubscriptionData<vehicle_attitude_s> _sub_attitude{ORB_ID(vehicle_attitude)};
+	uORB::SubscriptionData<home_position_s> _sub_home_position{ORB_ID(home_position)};
 
 	/** Reset all setpoints to NAN */
 	void _resetSetpoints();
@@ -201,18 +200,18 @@ protected:
 
 	/* Time abstraction */
 	static constexpr uint64_t _timeout = 500000; /**< maximal time in us before a loop or data times out */
-	float _time = 0; /**< passed time in seconds since the task was activated */
-	float _deltatime = 0; /**< passed time in seconds since the task was last updated */
-	hrt_abstime _time_stamp_activate = 0; /**< time stamp when task was activated */
-	hrt_abstime _time_stamp_current = 0; /**< time stamp at the beginning of the current task update */
-	hrt_abstime _time_stamp_last = 0; /**< time stamp when task was last updated */
+	float _time{}; /**< passed time in seconds since the task was activated */
+	float _deltatime{}; /**< passed time in seconds since the task was last updated */
+	hrt_abstime _time_stamp_activate{}; /**< time stamp when task was activated */
+	hrt_abstime _time_stamp_current{}; /**< time stamp at the beginning of the current task update */
+	hrt_abstime _time_stamp_last{}; /**< time stamp when task was last updated */
 
 	/* Current vehicle state */
 	matrix::Vector3f _position; /**< current vehicle position */
 	matrix::Vector3f _velocity; /**< current vehicle velocity */
-	float _yaw = 0.f; /**< current vehicle yaw heading */
-	float _dist_to_bottom = 0.f; /**< current height above ground level */
-	float _dist_to_ground = 0.f; /**< equals _dist_to_bottom if valid, height above home otherwise */
+	float _yaw{}; /**< current vehicle yaw heading */
+	float _dist_to_bottom{}; /**< current height above ground level */
+	float _dist_to_ground{}; /**< equals _dist_to_bottom if valid, height above home otherwise */
 
 	/**
 	 * Setpoints which the position controller has to execute.
@@ -227,20 +226,20 @@ protected:
 	matrix::Vector3f _acceleration_setpoint;
 	matrix::Vector3f _jerk_setpoint;
 	matrix::Vector3f _thrust_setpoint;
-	float _yaw_setpoint;
-	float _yawspeed_setpoint;
+	float _yaw_setpoint{};
+	float _yawspeed_setpoint{};
 
 	matrix::Vector3f _velocity_setpoint_feedback;
 	matrix::Vector3f _thrust_setpoint_feedback;
 
 	/* Counters for estimator local position resets */
 	struct {
-		uint8_t xy = 0;
-		uint8_t vxy = 0;
-		uint8_t z = 0;
-		uint8_t vz = 0;
-		uint8_t quat = 0;
-	} _reset_counters;
+		uint8_t xy;
+		uint8_t vxy;
+		uint8_t z;
+		uint8_t vz;
+		uint8_t quat;
+	} _reset_counters{};
 
 	/**
 	 * Vehicle constraints.

--- a/src/lib/flight_tasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.hpp
+++ b/src/lib/flight_tasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.hpp
@@ -52,7 +52,6 @@ public:
 	void reActivate() override;
 
 protected:
-
 	virtual void _updateSetpoints() override;
 
 	/** Reset position or velocity setpoints in case of EKF reset event */
@@ -66,7 +65,6 @@ protected:
 	)
 
 private:
-
 	void checkSetpoints(vehicle_local_position_setpoint_s &setpoints);
 
 	void _updateTrajConstraints();

--- a/src/lib/flight_tasks/tasks/ManualPositionSmooth/FlightTaskManualPositionSmooth.cpp
+++ b/src/lib/flight_tasks/tasks/ManualPositionSmooth/FlightTaskManualPositionSmooth.cpp
@@ -65,5 +65,4 @@ void FlightTaskManualPositionSmooth::_updateSetpoints()
 
 	/* Check for altitude lock*/
 	_updateAltitudeLock();
-
 }

--- a/src/lib/flight_tasks/tasks/Transition/FlightTaskTransition.cpp
+++ b/src/lib/flight_tasks/tasks/Transition/FlightTaskTransition.cpp
@@ -69,7 +69,7 @@ void FlightTaskTransition::updateAccelerationEstimate()
 	if (!PX4_ISFINITE(_acceleration_setpoint(0)) ||
 	    !PX4_ISFINITE(_acceleration_setpoint(1)) ||
 	    !PX4_ISFINITE(_acceleration_setpoint(2))) {
-		_acceleration_setpoint.setAll(0.f);
+		_acceleration_setpoint.setZero();
 	}
 
 	_velocity_prev = _velocity;
@@ -78,11 +78,8 @@ void FlightTaskTransition::updateAccelerationEstimate()
 bool FlightTaskTransition::update()
 {
 	// level wings during the transition, altitude should be controlled
-	_thrust_setpoint(0) = _thrust_setpoint(1) = 0.0f;
-	_thrust_setpoint(2) = NAN;
-	_position_setpoint *= NAN;
-	_velocity_setpoint *= NAN;
 	_position_setpoint(2) = _transition_altitude;
+	_thrust_setpoint.xy() = matrix::Vector2f(0.f, 0.f);
 
 	updateAccelerationEstimate();
 

--- a/src/modules/mc_pos_control/PositionControl/ControlMath.cpp
+++ b/src/modules/mc_pos_control/PositionControl/ControlMath.cpp
@@ -1,7 +1,6 @@
-
 /****************************************************************************
  *
- *   Copyright (C) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (C) 2018 - 2019 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,46 +41,46 @@
 #include <mathlib/mathlib.h>
 
 using namespace matrix;
+
 namespace ControlMath
 {
 void thrustToAttitude(const Vector3f &thr_sp, const float yaw_sp, vehicle_attitude_setpoint_s &att_sp)
 {
-	att_sp.yaw_body = yaw_sp;
+	bodyzToAttitude(-thr_sp, yaw_sp, att_sp);
+	att_sp.thrust_body[2] = -thr_sp.length();
+}
 
-	// desired body_z axis = -normalize(thrust_vector)
-	Vector3f body_x, body_y, body_z;
-
-	if (thr_sp.length() > 0.00001f) {
-		body_z = -thr_sp.normalized();
-
-	} else {
-		// no thrust, set Z axis to safe value
-		body_z = Vector3f(0.f, 0.f, 1.f);
+void bodyzToAttitude(Vector3f body_z, const float yaw_sp, vehicle_attitude_setpoint_s &att_sp)
+{
+	// zero vector, no direction, set safe level value
+	if (body_z.norm_squared() < FLT_EPSILON) {
+		body_z(2) = 1.f;
 	}
 
+	body_z.normalize();
+
 	// vector of desired yaw direction in XY plane, rotated by PI/2
-	Vector3f y_C(-sinf(att_sp.yaw_body), cosf(att_sp.yaw_body), 0.0f);
+	Vector3f y_C(-sinf(yaw_sp), cosf(yaw_sp), 0.0f);
 
-	if (fabsf(body_z(2)) > 0.000001f) {
-		// desired body_x axis, orthogonal to body_z
-		body_x = y_C % body_z;
+	// desired body_x axis, orthogonal to body_z
+	Vector3f body_x = y_C % body_z;
 
-		// keep nose to front while inverted upside down
-		if (body_z(2) < 0.0f) {
-			body_x = -body_x;
-		}
+	// keep nose to front while inverted upside down
+	if (body_z(2) < 0.0f) {
+		body_x = -body_x;
+	}
 
-		body_x.normalize();
-
-	} else {
+	if (fabsf(body_z(2)) < 0.000001f) {
 		// desired thrust is in XY plane, set X downside to construct correct matrix,
 		// but yaw component will not be used actually
 		body_x.zero();
 		body_x(2) = 1.0f;
 	}
 
+	body_x.normalize();
+
 	// desired body_y axis
-	body_y = body_z % body_x;
+	Vector3f body_y = body_z % body_x;
 
 	Dcmf R_sp;
 
@@ -92,7 +91,7 @@ void thrustToAttitude(const Vector3f &thr_sp, const float yaw_sp, vehicle_attitu
 		R_sp(i, 2) = body_z(i);
 	}
 
-	//copy quaternion setpoint to attitude setpoint topic
+	// copy quaternion setpoint to attitude setpoint topic
 	Quatf q_sp = R_sp;
 	q_sp.copyTo(att_sp.q_d);
 	att_sp.q_d_valid = true;
@@ -101,7 +100,7 @@ void thrustToAttitude(const Vector3f &thr_sp, const float yaw_sp, vehicle_attitu
 	Eulerf euler = R_sp;
 	att_sp.roll_body = euler(0);
 	att_sp.pitch_body = euler(1);
-	att_sp.thrust_body[2] = -thr_sp.length();
+	att_sp.yaw_body = euler(2);
 }
 
 Vector2f constrainXY(const Vector2f &v0, const Vector2f &v1, const float &max)

--- a/src/modules/mc_pos_control/PositionControl/ControlMath.hpp
+++ b/src/modules/mc_pos_control/PositionControl/ControlMath.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (C) 2018 - 2019 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,12 +47,18 @@ namespace ControlMath
 {
 /**
  * Converts thrust vector and yaw set-point to a desired attitude.
- * @param thr_sp a 3D vector
+ * @param thr_sp desired 3D thrust vector
  * @param yaw_sp the desired yaw
- * @return vehicle_attitude_setpoints_s structure
+ * @param att_sp attitude setpoint to fill
  */
-void thrustToAttitude(const matrix::Vector3f &thr_sp, const float yaw_sp,
-		      vehicle_attitude_setpoint_s &attitude_setpoint);
+void thrustToAttitude(const matrix::Vector3f &thr_sp, const float yaw_sp, vehicle_attitude_setpoint_s &att_sp);
+/**
+ * Converts a body z vector and yaw set-point to a desired attitude.
+ * @param body_z a world frame 3D vector in direction of the desired body z axis
+ * @param yaw_sp the desired yaw setpoint
+ * @param att_sp attitude setpoint to fill
+ */
+void bodyzToAttitude(matrix::Vector3f body_z, const float yaw_sp, vehicle_attitude_setpoint_s &att_sp);
 
 /**
  * Outputs the sum of two vectors but respecting the limits and priority.

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
@@ -71,18 +71,8 @@ void PositionControl::setState(const PositionControlStates &states)
 	_vel_dot = states.acceleration;
 }
 
-void PositionControl::_setCtrlFlag(bool value)
-{
-	for (int i = 0; i <= 2; i++) {
-		_ctrl_pos[i] = _ctrl_vel[i] = value;
-	}
-}
-
 bool PositionControl::setInputSetpoint(const vehicle_local_position_setpoint_s &setpoint)
 {
-	// by default we use the entire position-velocity control-loop pipeline (flag only for logging purpose)
-	_setCtrlFlag(true);
-
 	_pos_sp = Vector3f(setpoint.x, setpoint.y, setpoint.z);
 	_vel_sp = Vector3f(setpoint.vx, setpoint.vy, setpoint.vz);
 	_acc_sp = Vector3f(setpoint.acceleration);
@@ -180,7 +170,6 @@ bool PositionControl::_interfaceMapping()
 			// Velocity controller is active without position control.
 			// Set integral states and setpoints to 0
 			_pos_sp(i) = _pos(i) = 0.0f;
-			_ctrl_pos[i] = false; // position control-loop is not used
 
 			// thrust setpoint is not supported in velocity control
 			_thr_sp(i) = NAN;
@@ -196,7 +185,6 @@ bool PositionControl::_interfaceMapping()
 			// Set all integral states and setpoints to 0
 			_pos_sp(i) = _pos(i) = 0.0f;
 			_vel_sp(i) = _vel(i) = 0.0f;
-			_ctrl_pos[i] = _ctrl_vel[i] = false; // position/velocity control loop is not used
 
 			// Reset the Integral term.
 			_vel_int(i) = 0.0f;
@@ -243,7 +231,6 @@ bool PositionControl::_interfaceMapping()
 		// 70% of throttle range between min and hover
 		_thr_sp(2) = -(_lim_thr_min + (_hover_thrust - _lim_thr_min) * 0.7f);
 		// position and velocity control-loop is currently unused (flag only for logging purpose)
-		_setCtrlFlag(false);
 	}
 
 	return !(failsafe);

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
@@ -113,7 +113,6 @@ void PositionControl::setConstraints(const vehicle_constraints_s &constraints)
 void PositionControl::update(const float dt)
 {
 	if (_skip_controller) {
-
 		// Already received a valid thrust set-point.
 		// Limit the thrust vector.
 		float thr_mag = _thr_sp.length();
@@ -129,11 +128,11 @@ void PositionControl::update(const float dt)
 		_pos_sp = _pos;
 		_vel_sp = _vel;
 		_acc_sp = _vel_dot;
-
-	} else {
-		_positionControl();
-		_velocityControl(dt);
+		return;
 	}
+
+	_positionControl();
+	_velocityControl(dt);
 }
 
 bool PositionControl::_interfaceMapping()

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
@@ -117,9 +117,7 @@ void PositionControl::setConstraints(const vehicle_constraints_s &constraints)
 		_constraints.speed_down = _lim_vel_down;
 	}
 
-	if (!PX4_ISFINITE(constraints.speed_xy) || !(constraints.speed_xy < _lim_vel_horizontal)) {
-		_constraints.speed_xy = _lim_vel_horizontal;
-	}
+	// ignore _constraints.speed_xy TODO: remove it completely as soon as no task uses it anymore to avoid confusion
 }
 
 void PositionControl::update(const float dt)

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
@@ -105,17 +105,15 @@ void PositionControl::setConstraints(const vehicle_constraints_s &constraints)
 
 	// For safety check if adjustable constraints are below global constraints. If they are not stricter than global
 	// constraints, then just use global constraints for the limits.
-
-	if (!PX4_ISFINITE(constraints.tilt)
-	    || !(constraints.tilt < _lim_tilt)) {
+	if (!PX4_ISFINITE(constraints.tilt) || (constraints.tilt > _lim_tilt)) {
 		_constraints.tilt = _lim_tilt;
 	}
 
-	if (!PX4_ISFINITE(constraints.speed_up) || !(constraints.speed_up < _lim_vel_up)) {
+	if (!PX4_ISFINITE(constraints.speed_up) || (constraints.speed_up > _lim_vel_up)) {
 		_constraints.speed_up = _lim_vel_up;
 	}
 
-	if (!PX4_ISFINITE(constraints.speed_down) || !(constraints.speed_down < _lim_vel_down)) {
+	if (!PX4_ISFINITE(constraints.speed_down) || (constraints.speed_down > _lim_vel_down)) {
 		_constraints.speed_down = _lim_vel_down;
 	}
 

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
@@ -36,9 +36,9 @@
  */
 
 #include "PositionControl.hpp"
+#include "ControlMath.hpp"
 #include <float.h>
 #include <mathlib/mathlib.h>
-#include <ControlMath.hpp>
 #include <px4_platform_common/defines.h>
 
 using namespace matrix;

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
@@ -42,7 +42,6 @@
 #include <matrix/matrix/math.hpp>
 #include <uORB/topics/vehicle_attitude_setpoint.h>
 #include <uORB/topics/vehicle_constraints.h>
-#include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_local_position_setpoint.h>
 
 struct PositionControlStates {

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
@@ -159,27 +159,6 @@ public:
 	void resetIntegral() { _vel_int.setZero(); }
 
 	/**
-	 * 	Get the
-	 * 	@see _vel_sp
-	 * 	@return The velocity set-point that was executed in the control-loop. Nan if velocity control-loop was skipped.
-	 */
-	const matrix::Vector3f getVelSp() const
-	{
-		matrix::Vector3f vel_sp{};
-
-		for (int i = 0; i <= 2; i++) {
-			if (_ctrl_vel[i]) {
-				vel_sp(i) = _vel_sp(i);
-
-			} else {
-				vel_sp(i) = NAN;
-			}
-		}
-
-		return vel_sp;
-	}
-
-	/**
 	 * Get the controllers output local position setpoint
 	 * These setpoints are the ones which were executed on including PID output and feed-forward.
 	 * The acceleration or thrust setpoints can be used for attitude control.
@@ -204,7 +183,6 @@ private:
 
 	void _positionControl(); ///< Position proportional control
 	void _velocityControl(const float dt); ///< Velocity PID control
-	void _setCtrlFlag(bool value); /**< set control-loop flags (only required for logging) */
 
 	// Gains
 	matrix::Vector3f _gain_pos_p; ///< Position control proportional gain
@@ -240,6 +218,4 @@ private:
 	float _yawspeed_sp{}; /** desired yaw-speed */
 
 	bool _skip_controller{false}; /**< skips position/velocity controller. true for stabilized mode */
-	bool _ctrl_pos[3] = {true, true, true}; /**< True if the control-loop for position was used */
-	bool _ctrl_vel[3] = {true, true, true}; /**< True if the control-loop for velocity was used */
 };

--- a/src/modules/mc_pos_control/PositionControl/PositionControlTest.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControlTest.cpp
@@ -102,9 +102,9 @@ public:
 
 	void runController()
 	{
-		_position_control.updateConstraints(_contraints);
-		_position_control.updateSetpoint(_input_setpoint);
-		_position_control.generateThrustYawSetpoint(.1f);
+		_position_control.setConstraints(_contraints);
+		_position_control.setInputSetpoint(_input_setpoint);
+		_position_control.update(.1f);
 		_position_control.getLocalPositionSetpoint(_output_setpoint);
 		_position_control.getAttitudeSetpoint(_attitude);
 	}

--- a/src/modules/mc_pos_control/PositionControl/PositionControlTest.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControlTest.cpp
@@ -133,7 +133,7 @@ public:
 	}
 };
 
-TEST_F(PositionControlBasicDirectionTest, PositionControlDirectionP)
+TEST_F(PositionControlBasicDirectionTest, PositionDirection)
 {
 	_input_setpoint.x = .1f;
 	_input_setpoint.y = .1f;
@@ -142,7 +142,7 @@ TEST_F(PositionControlBasicDirectionTest, PositionControlDirectionP)
 	checkDirection();
 }
 
-TEST_F(PositionControlBasicDirectionTest, VelocityControlDirection)
+TEST_F(PositionControlBasicDirectionTest, VelocityDirection)
 {
 	_input_setpoint.vx = .1f;
 	_input_setpoint.vy = .1f;
@@ -151,7 +151,7 @@ TEST_F(PositionControlBasicDirectionTest, VelocityControlDirection)
 	checkDirection();
 }
 
-TEST_F(PositionControlBasicTest, PositionControlMaxTilt)
+TEST_F(PositionControlBasicTest, TiltLimit)
 {
 	_input_setpoint.x = 10.f;
 	_input_setpoint.y = 10.f;
@@ -171,7 +171,7 @@ TEST_F(PositionControlBasicTest, PositionControlMaxTilt)
 	EXPECT_LE(angle, .50001f);
 }
 
-TEST_F(PositionControlBasicTest, PositionControlMaxVelocity)
+TEST_F(PositionControlBasicTest, VelocityLimit)
 {
 	_input_setpoint.x = 10.f;
 	_input_setpoint.y = 10.f;
@@ -183,7 +183,7 @@ TEST_F(PositionControlBasicTest, PositionControlMaxVelocity)
 	EXPECT_LE(abs(_output_setpoint.vz), 1.f);
 }
 
-TEST_F(PositionControlBasicTest, PositionControlThrustLimit)
+TEST_F(PositionControlBasicTest, ThrustLimit)
 {
 	_input_setpoint.x = 10.f;
 	_input_setpoint.y = 10.f;
@@ -196,7 +196,7 @@ TEST_F(PositionControlBasicTest, PositionControlThrustLimit)
 	EXPECT_GE(_attitude.thrust_body[2], -0.9f);
 }
 
-TEST_F(PositionControlBasicTest, PositionControlFailsafeInput)
+TEST_F(PositionControlBasicTest, FailsafeInput)
 {
 	_input_setpoint.vz = .7f;
 	_input_setpoint.acceleration[0] = _input_setpoint.acceleration[1] = 0.f;
@@ -208,4 +208,40 @@ TEST_F(PositionControlBasicTest, PositionControlFailsafeInput)
 	EXPECT_GT(_output_setpoint.thrust[2], -.5f);
 	EXPECT_GT(_attitude.thrust_body[2], -.5f);
 	EXPECT_LE(_attitude.thrust_body[2], -.1f);
+}
+
+TEST_F(PositionControlBasicTest, InputCombinationsPosition)
+{
+	_input_setpoint.x = .1f;
+	_input_setpoint.y = .2f;
+	_input_setpoint.z = .3f;
+
+	runController();
+	EXPECT_EQ(_output_setpoint.x, .1f);
+	EXPECT_EQ(_output_setpoint.y, .2f);
+	EXPECT_EQ(_output_setpoint.z, .3f);
+	EXPECT_FALSE(isnan(_output_setpoint.vx));
+	EXPECT_FALSE(isnan(_output_setpoint.vy));
+	EXPECT_FALSE(isnan(_output_setpoint.vz));
+	EXPECT_FALSE(isnan(_output_setpoint.thrust[0]));
+	EXPECT_FALSE(isnan(_output_setpoint.thrust[1]));
+	EXPECT_FALSE(isnan(_output_setpoint.thrust[2]));
+}
+
+TEST_F(PositionControlBasicTest, InputCombinationsPositionVelocity)
+{
+	_input_setpoint.vx = .1f;
+	_input_setpoint.vy = .2f;
+	_input_setpoint.z = .3f; // altitude
+
+	runController();
+	// EXPECT_TRUE(isnan(_output_setpoint.x));
+	// EXPECT_TRUE(isnan(_output_setpoint.y));
+	EXPECT_EQ(_output_setpoint.z, .3f);
+	EXPECT_EQ(_output_setpoint.vx, .1f);
+	EXPECT_EQ(_output_setpoint.vy, .2f);
+	EXPECT_FALSE(isnan(_output_setpoint.vz));
+	EXPECT_FALSE(isnan(_output_setpoint.thrust[0]));
+	EXPECT_FALSE(isnan(_output_setpoint.thrust[1]));
+	EXPECT_FALSE(isnan(_output_setpoint.thrust[2]));
 }

--- a/src/modules/mc_pos_control/Takeoff/CMakeLists.txt
+++ b/src/modules/mc_pos_control/Takeoff/CMakeLists.txt
@@ -34,9 +34,7 @@
 px4_add_library(Takeoff
 	Takeoff.cpp
 )
-target_include_directories(Takeoff
-	PUBLIC
-	${CMAKE_CURRENT_SOURCE_DIR}
-)
+target_include_directories(Takeoff PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(Takeoff PUBLIC hysteresis)
 
 px4_add_unit_gtest(SRC TakeoffTest.cpp LINKLIBS Takeoff)

--- a/src/modules/mc_pos_control/Takeoff/Takeoff.hpp
+++ b/src/modules/mc_pos_control/Takeoff/Takeoff.hpp
@@ -59,8 +59,8 @@ public:
 	~Takeoff() = default;
 
 	// initialize parameters
-	void setTakeoffRampTime(const float seconds) { _takeoff_ramp_time = seconds; }
 	void setSpoolupTime(const float seconds) { _spoolup_time_hysteresis.set_hysteresis_time_from(false, (hrt_abstime)(seconds * (float)1_s)); }
+	void setTakeoffRampTime(const float seconds) { _takeoff_ramp_time = seconds; }
 
 	/**
 	 * Calculate a vertical velocity to initialize the takeoff ramp
@@ -93,9 +93,9 @@ public:
 private:
 	TakeoffState _takeoff_state = TakeoffState::disarmed;
 
+	systemlib::Hysteresis _spoolup_time_hysteresis{false}; /**< becomes true MPC_SPOOLUP_TIME seconds after the vehicle was armed */
+
 	float _takeoff_ramp_time = 0.f;
 	float _takeoff_ramp_vz_init = 0.f;
 	float _takeoff_ramp_vz = 0.f;
-
-	systemlib::Hysteresis _spoolup_time_hysteresis{false}; /**< becomes true MPC_SPOOLUP_TIME seconds after the vehicle was armed */
 };

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -67,8 +67,8 @@
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/vehicle_trajectory_waypoint.h>
 
-#include <PositionControl.hpp>
-#include "Takeoff.hpp"
+#include "PositionControl/PositionControl.hpp"
+#include "Takeoff/Takeoff.hpp"
 
 #include <float.h>
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -609,8 +609,7 @@ MulticopterPositionControl::Run()
 				setpoint.yaw = _states.yaw;
 				setpoint.yawspeed = 0.f;
 				// prevent any integrator windup
-				_control.resetIntegralXY();
-				_control.resetIntegralZ();
+				_control.resetIntegral();
 				// reactivate the task which will reset the setpoint to current state
 				_flight_tasks.reActivate();
 			}
@@ -624,20 +623,18 @@ MulticopterPositionControl::Run()
 				limit_altitude(setpoint);
 			}
 
-			// Update states, setpoints and constraints.
-			_control.updateConstraints(constraints);
-			_control.updateState(_states);
+			// Run position control
+			_control.setState(_states);
+			_control.setConstraints(constraints);
 
-			// update position controller setpoints
-			if (!_control.updateSetpoint(setpoint)) {
-				warn_rate_limited("Position-Control Setpoint-Update failed");
+			if (!_control.setInputSetpoint(setpoint)) {
+				warn_rate_limited("PositionControl: invalid setpoints");
 				failsafe(setpoint, _states, true, !was_in_failsafe);
-				_control.updateSetpoint(setpoint);
+				_control.setInputSetpoint(setpoint);
 				constraints = FlightTask::empty_constraints;
 			}
 
-			// Generate desired thrust and yaw.
-			_control.generateThrustYawSetpoint(_dt);
+			_control.update(_dt);
 
 			// Fill local position, velocity and thrust setpoint.
 			// This message contains setpoints where each type of setpoint is either the input to the PositionController
@@ -660,8 +657,7 @@ MulticopterPositionControl::Run()
 			local_pos_sp.vz = PX4_ISFINITE(_control.getVelSp()(2)) ? _control.getVelSp()(2) : setpoint.vz;
 
 			// Publish local position setpoint
-			// This message will be used by other modules (such as Landdetector) to determine
-			// vehicle intention.
+			// This message will be used by other modules (such as Landdetector) to determine vehicle intention.
 			_local_pos_sp_pub.publish(local_pos_sp);
 
 			// Inform FlightTask about the input and output of the velocity controller
@@ -691,10 +687,8 @@ MulticopterPositionControl::Run()
 			// if there's any change in landing gear setpoint publish it
 			if (gear.landing_gear != _old_landing_gear_position
 			    && gear.landing_gear != landing_gear_s::GEAR_KEEP) {
-
-				_landing_gear.landing_gear = gear.landing_gear;
 				_landing_gear.timestamp = time_stamp_now;
-
+				_landing_gear.landing_gear = gear.landing_gear;
 				_landing_gear_pub.publish(_landing_gear);
 			}
 
@@ -940,8 +934,7 @@ MulticopterPositionControl::limit_thrust_during_landing(vehicle_attitude_setpoin
 		Quatf(AxisAngle<float>(0, 0, _states.yaw)).copyTo(setpoint.q_d);
 		setpoint.yaw_sp_move_rate = 0.f;
 		// prevent any position control integrator windup
-		_control.resetIntegralXY();
-		_control.resetIntegralZ();
+		_control.resetIntegral();
 	}
 }
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -652,9 +652,6 @@ MulticopterPositionControl::Run()
 			local_pos_sp.x = setpoint.x;
 			local_pos_sp.y = setpoint.y;
 			local_pos_sp.z = setpoint.z;
-			local_pos_sp.vx = PX4_ISFINITE(_control.getVelSp()(0)) ? _control.getVelSp()(0) : setpoint.vx;
-			local_pos_sp.vy = PX4_ISFINITE(_control.getVelSp()(1)) ? _control.getVelSp()(1) : setpoint.vy;
-			local_pos_sp.vz = PX4_ISFINITE(_control.getVelSp()(2)) ? _control.getVelSp()(2) : setpoint.vz;
 
 			// Publish local position setpoint
 			// This message will be used by other modules (such as Landdetector) to determine vehicle intention.
@@ -662,7 +659,8 @@ MulticopterPositionControl::Run()
 
 			// Inform FlightTask about the input and output of the velocity controller
 			// This is used to properly initialize the velocity setpoint when onpening the position loop (position unlock)
-			_flight_tasks.updateVelocityControllerIO(_control.getVelSp(), Vector3f(local_pos_sp.thrust));
+			_flight_tasks.updateVelocityControllerIO(Vector3f(local_pos_sp.vx, local_pos_sp.vy, local_pos_sp.vz),
+					Vector3f(local_pos_sp.thrust));
 
 			vehicle_attitude_setpoint_s attitude_setpoint{};
 			attitude_setpoint.timestamp = time_stamp_now;


### PR DESCRIPTION
**Describe problem solved by this pull request**
This is part 5 of the refactoring from the monster pr #12072 and should be easy to understand and review since the diff is manageable.

**Describe your solution**
- Switched naming and definition order of the `PositionControl` library to a clear interface best shown in the unit test for it: https://github.com/PX4/Firmware/blob/6bd543156eab2ccfe639e90d9214e2e0128daa09/src/modules/mc_pos_control/PositionControl/PositionControlTest.cpp#L105-L109 with better doxygen descriptions and internal naming.
- Simplified constraints checks above global limit e.g. `!(constraints.tilt < _lim_tilt)` to `(constraints.tilt > _lim_tilt)`.
- When working on https://github.com/PX4/Firmware/pull/13224 I was told we should rather write full include paths if they are in a subfolder of the same module such that it's more clear where the libreries are located even though cmake can do it all for you. That's why I also adapted the position control local includes to e.g. `#include "PositiopnControl/PositionControl.hpp"`.
- Added a takeoff unit test for basic functionality of states and ramp. It's harder to cover all corner cases but at least we see if it directly breaks.
- Replaced all  `= Vector3f(NAN, NAN, NAN);` with `.setNaN();`, initialized all `FlightTask` members with `{}`.
- Simplified `thrustToAttitude()` implementation.
- `constraints.speed_xy` is not used in the controller for a long time so I remove the processing to avoid confusion. Once tasks don't use it internally for communicating speeds accross inheritance anymore we can get rid of the message field.
- Remove control flags logic for correct logging, adding unit tests to make sure it's still correct.
- Removing the `skip_controller` flag is not yet possible with the old `_interfaceMapping()` but this will be replaced in the next pr.

**Test data / coverage**
SITL hover goto tested and unit tests pass.

**Additional context**
Part 4 that goes before this: #13347
