### PR TITLE
VTOL: instantly do VTOL mode changes if landed and disarmed

### DIFF
--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -159,7 +159,8 @@ void Standard::update_vtol_state()
 			float x_vel = vel(0);
 
 			if (time_since_trans_start > _params->back_trans_duration ||
-			    (_local_pos->v_xy_valid && x_vel <= _params->mpc_xy_cruise)) {
+			    (_local_pos->v_xy_valid && x_vel <= _params->mpc_xy_cruise) ||
+			    can_transition_on_ground()) {
 				_vtol_schedule.flight_mode = vtol_mode::MC_MODE;
 			}
 


### PR DESCRIPTION
This is closely related to https://github.com/PX4/Firmware/pull/13676.

**Describe problem solved by this pull request**
This PR makes VTOL transitions having immediate effect if landed and disarmed. 
Currently, It the groundspeed v_xy is invalid, the vehicle stays for the duration of VT_B_TRANS_DUR in the transition mode, even if not flying. The user usually doesn't notice this, as the groundstation only displays if MC or FW, and transition phases belong to the MC vehicle state (also not optimal, but different topic).

**Test data / coverage**
Bench tested.

**Additional context**
Before this PR: 
![image](https://user-images.githubusercontent.com/26798987/70438409-0b91bc80-1a8e-11ea-9658-e2789c474e7d.png)
After this PR:
![image](https://user-images.githubusercontent.com/26798987/70439278-f0c04780-1a8f-11ea-9d6b-c9a03fa4ab09.png)

Only changed for standard VTOL so far, probably should also be applied to tiltrotor and tailsitters.

@RomanBapst do you know what was the reason to enable immediate transitions to FW on the ground [see here](https://github.com/PX4/Firmware/blob/904ab16558272939f15a4ce90255783a761dc1f9/src/modules/vtol_att_control/standard.cpp#L200), but not for transitions to MC?