### PR TITLE
[ECL] Full variance usage of vision data

### DIFF
--- a/msg/vehicle_odometry.msg
+++ b/msg/vehicle_odometry.msg
@@ -17,7 +17,7 @@ uint8 COVARIANCE_MATRIX_YAWRATE_VARIANCE=20
 
 # Position and linear velocity frame of reference constants
 uint8 LOCAL_FRAME_NED=0         # NED earth-fixed frame
-uint8 LOCAL_FRAME_ENU=1         # ENU earth-fixed frame
+uint8 LOCAL_FRAME_FRD=1         # FRD earth-fixed frame, heading different to NED
 uint8 LOCAL_FRAME_OTHER=2       # Not aligned with the std frames of reference
 
 # Position and linear velocity local frame of reference

--- a/msg/vehicle_odometry.msg
+++ b/msg/vehicle_odometry.msg
@@ -17,7 +17,7 @@ uint8 COVARIANCE_MATRIX_YAWRATE_VARIANCE=20
 
 # Position and linear velocity frame of reference constants
 uint8 LOCAL_FRAME_NED=0         # NED earth-fixed frame
-uint8 LOCAL_FRAME_FRD=1         # FRD earth-fixed frame, heading different to NED
+uint8 LOCAL_FRAME_FRD=1         # FRD earth-fixed frame, arbitrary heading reference
 uint8 LOCAL_FRAME_OTHER=2       # Not aligned with the std frames of reference
 
 # Position and linear velocity local frame of reference

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -1110,7 +1110,9 @@ void Ekf2::Run()
 				// velocity measurement error from ev_data or parameters
 				float param_evv_noise_var = sq(_param_ekf2_evv_noise.get());
 
-				if (!_param_ekf2_ev_noise_md.get() && PX4_ISFINITE(_ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_VX_VARIANCE])) {
+				if (!_param_ekf2_ev_noise_md.get() && PX4_ISFINITE(_ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_VX_VARIANCE])
+				    && PX4_ISFINITE(_ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_VY_VARIANCE])
+				    && PX4_ISFINITE(_ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_VZ_VARIANCE])) {
 					ev_data.velVar(0) = fmaxf(param_evv_noise_var, _ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_VX_VARIANCE]);
 					ev_data.velVar(1) = fmaxf(param_evv_noise_var, _ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_VY_VARIANCE]);
 					ev_data.velVar(2) = fmaxf(param_evv_noise_var, _ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_VZ_VARIANCE]);
@@ -1129,13 +1131,15 @@ void Ekf2::Run()
 				float param_evp_noise_var = sq(_param_ekf2_evp_noise.get());
 
 				// position measurement error from ev_data or parameters
-				if (!_param_ekf2_ev_noise_md.get() && PX4_ISFINITE(_ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_X_VARIANCE])) {
+				if (!_param_ekf2_ev_noise_md.get() && PX4_ISFINITE(_ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_X_VARIANCE])
+				    && PX4_ISFINITE(_ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_Y_VARIANCE])
+				    && PX4_ISFINITE(_ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_Z_VARIANCE])) {
 					ev_data.posVar(0) = fmaxf(param_evp_noise_var, _ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_X_VARIANCE]);
 					ev_data.posVar(1) = fmaxf(param_evp_noise_var, _ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_Y_VARIANCE]);
 					ev_data.posVar(2) = fmaxf(param_evp_noise_var, _ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_Z_VARIANCE]);
 
 				} else {
-					ev_data.posVar.setAll(_param_ekf2_evp_noise.get());
+					ev_data.posVar.setAll(param_evp_noise_var);
 				}
 			}
 

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -171,6 +171,8 @@ private:
 	 */
 	float filter_altitude_ellipsoid(float amsl_hgt);
 
+	inline float sq(float x) { return x * x; };
+
 	const bool 	_replay_mode;			///< true when we use replay data from a log
 
 	// time slip monitoring
@@ -1106,14 +1108,15 @@ void Ekf2::Run()
 				ev_data.vel(2) = _ev_odom.vz;
 
 				// velocity measurement error from ev_data or parameters
+				float param_evv_noise_var = sq(_param_ekf2_evv_noise.get());
+
 				if (!_param_ekf2_ev_noise_md.get() && PX4_ISFINITE(_ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_VX_VARIANCE])) {
-					ev_data.velErr = fmaxf(_param_ekf2_evv_noise.get(),
-							       sqrtf(fmaxf(_ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_VX_VARIANCE],
-									   fmaxf(_ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_VY_VARIANCE],
-											   _ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_VZ_VARIANCE]))));
+					ev_data.velVar(0) = fmaxf(param_evv_noise_var, _ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_VX_VARIANCE]);
+					ev_data.velVar(1) = fmaxf(param_evv_noise_var, _ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_VY_VARIANCE]);
+					ev_data.velVar(2) = fmaxf(param_evv_noise_var, _ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_VZ_VARIANCE]);
 
 				} else {
-					ev_data.velErr = _param_ekf2_evv_noise.get();
+					ev_data.velVar.setAll(param_evv_noise_var);
 				}
 			}
 
@@ -1123,17 +1126,16 @@ void Ekf2::Run()
 				ev_data.pos(1) = _ev_odom.y;
 				ev_data.pos(2) = _ev_odom.z;
 
+				float param_evp_noise_var = sq(_param_ekf2_evp_noise.get());
+
 				// position measurement error from ev_data or parameters
 				if (!_param_ekf2_ev_noise_md.get() && PX4_ISFINITE(_ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_X_VARIANCE])) {
-					ev_data.posErr = fmaxf(_param_ekf2_evp_noise.get(),
-							       sqrtf(fmaxf(_ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_X_VARIANCE],
-									   _ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_Y_VARIANCE])));
-					ev_data.hgtErr = fmaxf(_param_ekf2_evp_noise.get(),
-							       sqrtf(_ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_Z_VARIANCE]));
+					ev_data.posVar(0) = fmaxf(param_evp_noise_var, _ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_X_VARIANCE]);
+					ev_data.posVar(1) = fmaxf(param_evp_noise_var, _ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_Y_VARIANCE]);
+					ev_data.posVar(2) = fmaxf(param_evp_noise_var, _ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_Z_VARIANCE]);
 
 				} else {
-					ev_data.posErr = _param_ekf2_evp_noise.get();
-					ev_data.hgtErr = _param_ekf2_evp_noise.get();
+					ev_data.posVar.setAll(_param_ekf2_evp_noise.get());
 				}
 			}
 
@@ -1142,21 +1144,18 @@ void Ekf2::Run()
 				ev_data.quat = matrix::Quatf(_ev_odom.q);
 
 				// orientation measurement error from ev_data or parameters
-				if (!_param_ekf2_ev_noise_md.get()
-				    && PX4_ISFINITE(_ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_YAW_VARIANCE])) {
-					ev_data.angErr = fmaxf(_param_ekf2_eva_noise.get(),
-							       sqrtf(_ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_YAW_VARIANCE]));
+				float param_eva_noise_var = sq(_param_ekf2_eva_noise.get());
+
+				if (!_param_ekf2_ev_noise_md.get() && PX4_ISFINITE(_ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_YAW_VARIANCE])) {
+					ev_data.angVar = fmaxf(param_eva_noise_var, _ev_odom.pose_covariance[_ev_odom.COVARIANCE_MATRIX_YAW_VARIANCE]);
 
 				} else {
-					ev_data.angErr = _param_ekf2_eva_noise.get();
+					ev_data.angVar = param_eva_noise_var;
 				}
 			}
 
-			// only set data if all positions and orientation are valid
-			if (ev_data.posErr < ep_max_std_dev && ev_data.angErr < eo_max_std_dev) {
-				// use timestamp from external computer, clocks are synchronized when using MAVROS
-				_ekf.setExtVisionData(_ev_odom.timestamp, &ev_data);
-			}
+			// use timestamp from external computer, clocks are synchronized when using MAVROS
+			_ekf.setExtVisionData(_ev_odom.timestamp, &ev_data);
 
 			ekf2_timestamps.visual_odometry_timestamp_rel = (int16_t)((int64_t)_ev_odom.timestamp / 100 -
 					(int64_t)ekf2_timestamps.timestamp / 100);

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -1177,8 +1177,8 @@ void Ekf2::Run()
 				// we can only use the landing target if it has a fixed position and  a valid velocity estimate
 				if (landing_target_pose.is_static && landing_target_pose.rel_vel_valid) {
 					// velocity of vehicle relative to target has opposite sign to target relative to vehicle
-					float velocity[2] = { -landing_target_pose.vx_rel, -landing_target_pose.vy_rel};
-					float variance[2] = {landing_target_pose.cov_vx_rel, landing_target_pose.cov_vy_rel};
+					matrix::Vector3f velocity { -landing_target_pose.vx_rel, -landing_target_pose.vy_rel, 0.0f};
+					matrix::Vector3f variance {landing_target_pose.cov_vx_rel, landing_target_pose.cov_vy_rel, 0.0f};
 					_ekf.setAuxVelData(landing_target_pose.timestamp, velocity, variance);
 				}
 			}

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -712,7 +712,7 @@ PARAM_DEFINE_FLOAT(EKF2_MIN_RNG, 0.1f);
 PARAM_DEFINE_INT32(EKF2_EV_NOISE_MD, 0);
 
 /**
- * Measurement noise for vision position observations used when the vision system does not supply error estimates
+ * Measurement noise for vision position observations used to lower bound or replace the uncertainty included in the message
  *
  * @group EKF2
  * @min 0.01
@@ -722,7 +722,7 @@ PARAM_DEFINE_INT32(EKF2_EV_NOISE_MD, 0);
 PARAM_DEFINE_FLOAT(EKF2_EVP_NOISE, 0.1f);
 
 /**
- * Measurement noise for vision velocity observations used when the vision system does not supply error estimates
+ * Measurement noise for vision velocity observations used to lower bound or replace the uncertainty included in the message
  *
  * @group EKF2
  * @min 0.01
@@ -732,7 +732,7 @@ PARAM_DEFINE_FLOAT(EKF2_EVP_NOISE, 0.1f);
 PARAM_DEFINE_FLOAT(EKF2_EVV_NOISE, 0.1f);
 
 /**
- * Measurement noise for vision angle observations used when the vision system does not supply error estimates
+ * Measurement noise for vision angle observations used to lower bound or replace the uncertainty included in the message
  *
  * @group EKF2
  * @min 0.01


### PR DESCRIPTION
This adapts the interface to ECL EKF to support the use of all variance information in the visual_odometry message. More information can be found in the [ECL PR](https://github.com/PX4/ecl/pull/680).

This needs recently added function of Matrix. Therefore, it is also updating Matrix to newest version.

In addition, it is adding the missing transformation of the linear velocity covariances to local frame. This was undone before and therefore not completely correct. 

Testing:
Run estimation on vehicle, which does not have a true full covariance. But it still shows that the vision estimation is not broken by this PR. [Log](https://review.px4.io/plot_app?log=dec270d7-076b-46d6-b6e0-f1a4b2ed0cda)