### PR TITLE
mavlink and land_detector airspeed timeout fixes

### DIFF
--- a/src/modules/land_detector/FixedwingLandDetector.cpp
+++ b/src/modules/land_detector/FixedwingLandDetector.cpp
@@ -55,6 +55,11 @@ void FixedwingLandDetector::_update_topics()
 {
 	LandDetector::_update_topics();
 	_airspeed_sub.update(&_airspeed);
+
+	// zero airspeed on timeout
+	if (hrt_elapsed_time(&_airspeed.timestamp) > 1_s) {
+		_airspeed = airspeed_s{};
+	}
 }
 
 bool FixedwingLandDetector::_get_landed_state()

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -1432,8 +1432,15 @@ protected:
 		updated |= _airspeed_sub->update(&_airspeed_time, &airspeed);
 
 		if (updated) {
-			mavlink_vfr_hud_t msg = {};
-			msg.airspeed = airspeed.indicated_airspeed_m_s;
+			mavlink_vfr_hud_t msg{};
+
+			if (hrt_elapsed_time(&airspeed.timestamp) < 1_s) {
+				msg.airspeed = airspeed.indicated_airspeed_m_s;
+
+			} else {
+				msg.airspeed = NAN;
+			}
+
 			msg.groundspeed = sqrtf(pos.vx * pos.vx + pos.vy * pos.vy);
 			msg.heading = math::degrees(wrap_2pi(pos.yaw));
 


### PR DESCRIPTION
This PR updates mavlink VFR_HUD and the fixed wing land detector to handle airspeed data timeout, rather than continuing to use old data. These cases should probably be updated to use airspeed_validated, but this is a quick fix for now.

https://github.com/PX4/Firmware/issues/13697