### PR TITLE
px4_work_queue: increase hp_default stack 1800 -> 1900 bytes

### DIFF
--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
@@ -66,7 +66,7 @@ static constexpr wq_config_t I2C4{"wq:I2C4", 1400, -12};
 
 static constexpr wq_config_t att_pos_ctrl{"wq:att_pos_ctrl", 6600, -11}; // PX4 att/pos controllers, highest priority after sensors
 
-static constexpr wq_config_t hp_default{"wq:hp_default", 1800, -12};
+static constexpr wq_config_t hp_default{"wq:hp_default", 1900, -12};
 
 static constexpr wq_config_t uavcan{"uavcan", 2400, -13};
 


### PR DESCRIPTION
 - fixes https://github.com/PX4/Firmware/issues/13691

![image](https://user-images.githubusercontent.com/84712/70456670-936ecb00-1a7c-11ea-9c1e-e86da552a8f5.png)
https://logs.px4.io/plot_app?log=a8662dfc-e6f1-453a-9c9d-8ca576b93340

I'll backport this for v1.10 as well.