### PR TITLE
uORB_tests: fix queue simulation and cleanup initializations

### DIFF
--- a/src/modules/uORB/uORB_tests/uORBTest_UnitTest.cpp
+++ b/src/modules/uORB/uORB_tests/uORBTest_UnitTest.cpp
@@ -74,7 +74,7 @@ int uORBTest::UnitTest::pubsublatency_main()
 	int test_multi_sub_medium = orb_subscribe_multi(ORB_ID(orb_test_medium), 0);
 	int test_multi_sub_large = orb_subscribe_multi(ORB_ID(orb_test_large), 0);
 
-	struct orb_test_large t;
+	orb_test_large t{};
 
 	/* clear all ready flags */
 	orb_copy(ORB_ID(orb_test), test_multi_sub, &t);
@@ -140,7 +140,7 @@ int uORBTest::UnitTest::pubsublatency_main()
 	orb_unsubscribe(test_multi_sub_large);
 
 	if (pubsubtest_print) {
-		char fname[32];
+		char fname[32] {};
 		sprintf(fname, PX4_STORAGEDIR"/uorb_timings%u.txt", timingsgroup);
 		FILE *f = fopen(fname, "w");
 
@@ -241,8 +241,8 @@ int uORBTest::UnitTest::test_unadvertise()
 	}
 
 	//try to advertise and see whether we get the right instance
-	int instance_test[4];
-	struct orb_test t;
+	int instance_test[4] {};
+	orb_test t{};
 
 	for (int i = 0; i < 4; ++i) {
 		_pfd[i] = orb_advertise_multi(ORB_ID(orb_multitest), &t, &instance_test[i], ORB_PRIO_MAX);
@@ -269,10 +269,11 @@ int uORBTest::UnitTest::test_single()
 {
 	test_note("try single-topic support");
 
-	struct orb_test t, u;
-	int sfd;
-	orb_advert_t ptopic;
-	bool updated;
+	orb_test t{};
+	orb_test u{};
+	int sfd = -1;
+	orb_advert_t ptopic{};
+	bool updated{false};
 
 	t.val = 0;
 	ptopic = orb_advertise(ORB_ID(orb_test), &t);
@@ -346,8 +347,9 @@ int uORBTest::UnitTest::test_multi()
 	/* this routine tests the multi-topic support */
 	test_note("try multi-topic support");
 
-	struct orb_test t {}, u {};
-	t.val = 0;
+	orb_test t{};
+	orb_test u{};
+
 	int instance0;
 	_pfd[0] = orb_advertise_multi(ORB_ID(orb_multitest), &t, &instance0, ORB_PRIO_MAX);
 
@@ -428,8 +430,6 @@ int uORBTest::UnitTest::test_multi()
 	return test_note("PASS multi-topic test");
 }
 
-
-
 int uORBTest::UnitTest::pub_test_multi2_entry(int argc, char *argv[])
 {
 	uORBTest::UnitTest &t = uORBTest::UnitTest::instance();
@@ -440,8 +440,8 @@ int uORBTest::UnitTest::pub_test_multi2_main()
 {
 	int data_next_idx = 0;
 	const int num_instances = 3;
-	orb_advert_t orb_pub[num_instances];
-	struct orb_test_medium data_topic;
+	orb_advert_t orb_pub[num_instances] {};
+	orb_test_medium data_topic{};
 
 	for (int i = 0; i < num_instances; ++i) {
 		orb_advert_t &pub = orb_pub[i];
@@ -458,7 +458,8 @@ int uORBTest::UnitTest::pub_test_multi2_main()
 
 	px4_usleep(100 * 1000);
 
-	int message_counter = 0, num_messages = 50 * num_instances;
+	int message_counter = 0;
+	int num_messages = 50 * num_instances;
 
 	while (message_counter++ < num_messages) {
 		px4_usleep(2); //make sure the timestamps are different
@@ -489,13 +490,12 @@ int uORBTest::UnitTest::pub_test_multi2_main()
 
 int uORBTest::UnitTest::test_multi2()
 {
-
 	test_note("Testing multi-topic 2 test (queue simulation)");
 	//test: first subscribe, then advertise
 
 	_thread_should_exit = false;
 	const int num_instances = 3;
-	int orb_data_fd[num_instances];
+	int orb_data_fd[num_instances] {-1, -1, -1};
 	int orb_data_next = 0;
 
 	for (int i = 0; i < num_instances; ++i) {
@@ -519,20 +519,15 @@ int uORBTest::UnitTest::test_multi2()
 
 	while (!_thread_should_exit) {
 
+		px4_usleep(1000);
+
 		bool updated = false;
 		int orb_data_cur_fd = orb_data_fd[orb_data_next];
 		orb_check(orb_data_cur_fd, &updated);
 
 		if (updated) {
-			struct orb_test_medium msg;
+			orb_test_medium msg{};
 			orb_copy(ORB_ID(orb_test_medium_multi), orb_data_cur_fd, &msg);
-
-// Relax timing requirement for Darwin CI system
-#ifdef __PX4_DARWIN
-			px4_usleep(10000);
-#else
-			px4_usleep(1000);
-#endif
 
 			if (last_time >= msg.time && last_time != 0) {
 				return test_fail("Timestamp not increasing! (%" PRIu64 " >= %" PRIu64 ")", last_time, msg.time);
@@ -540,7 +535,7 @@ int uORBTest::UnitTest::test_multi2()
 
 			last_time = msg.time;
 
-//			PX4_WARN("      got message (val=%i, idx=%i, t=%" PRIu64 ")", msg.val, orb_data_next, msg.time);
+			PX4_DEBUG("got message (val=%i, idx=%i, t=%" PRIu64 ")", msg.val, orb_data_next, msg.time);
 			orb_data_next = (orb_data_next + 1) % num_instances;
 		}
 	}
@@ -783,8 +778,8 @@ int uORBTest::UnitTest::test_queue_poll_notify()
 {
 	test_note("Testing orb queuing (poll & notify)");
 
-	struct orb_test_medium t;
-	int sfd;
+	orb_test_medium t{};
+	int sfd = -1;
 
 	if ((sfd = orb_subscribe(ORB_ID(orb_test_medium_queue_poll))) < 0) {
 		return test_fail("subscribe failed: %d", errno);
@@ -805,7 +800,7 @@ int uORBTest::UnitTest::test_queue_poll_notify()
 	}
 
 	int next_expected_val = 0;
-	px4_pollfd_struct_t fds[1];
+	px4_pollfd_struct_t fds[1] {};
 	fds[0].fd = sfd;
 	fds[0].events = POLLIN;
 

--- a/src/modules/uORB/uORB_tests/uORB_tests_main.cpp
+++ b/src/modules/uORB/uORB_tests/uORB_tests_main.cpp
@@ -61,13 +61,11 @@ uorb_tests_main(int argc, char *argv[])
 		int rc = t.test();
 
 		if (rc == OK) {
-			fprintf(stdout, "  [uORBTest] \t\tPASS\n");
-			fflush(stdout);
+			PX4_INFO("PASS");
 			return 0;
 
 		} else {
-			fprintf(stderr, "  [uORBTest] \t\tFAIL\n");
-			fflush(stderr);
+			PX4_ERR("FAIL");
 			return -1;
 		}
 	}


### PR DESCRIPTION
This fixes the current failure.

![image](https://user-images.githubusercontent.com/84712/70473398-f8d3b380-1a9e-11ea-8979-0ded127af33f.png)
