### PR TITLE
[WIP] Refactoring of linux_pwm_out

### DIFF
--- a/boards/px4/raspberrypi/cross.cmake
+++ b/boards/px4/raspberrypi/cross.cmake
@@ -12,6 +12,7 @@ px4_add_board(
 		#barometer # all available barometer drivers
 		batt_smbus
 		camera_trigger
+		camera_capture
 		differential_pressure # all available differential pressure drivers
 		distance_sensor # all available distance sensor drivers
 		gps
@@ -19,14 +20,13 @@ px4_add_board(
 		#magnetometer # all available magnetometer drivers
 		pwm_out_sim
 		#telemetry # all available telemetry drivers
-
 		linux_pwm_out
+		linux_pwm_output
 		linux_sbus
 		rpi_rc_in
 
 	MODULES
 		attitude_estimator_q
-		camera_capture
 		camera_feedback
 		commander
 		dataman

--- a/posix-configs/rpi/test.config
+++ b/posix-configs/rpi/test.config
@@ -1,0 +1,30 @@
+#!/bin/sh
+# PX4 commands need the 'px4-' prefix in bash.
+# (px4-alias.sh is expected to be in the PATH)
+. px4-alias.sh
+
+uorb start
+param load
+param set MAV_BROADCAST 1
+dataman start
+
+linux_pwm_output start pca9685 -a 64 -b 1
+#linux_pwm_output start debug -asdf 0
+mixer load /dev/linux_pwm_out_wrapper ROMFS/px4fmu_common/mixers/quad_x.main.mix
+mixer append /dev/linux_pwm_out_wrapper ROMFS/px4fmu_common/mixers/quad_x.main.mix
+
+sensors start
+commander start
+navigator start
+ekf2 start
+sleep 1
+
+fw_att_control start
+fw_pos_control_l1 start
+land_detector start fixedwing
+
+mavlink start -x -u 14556 -r 1000000
+
+logger start -t -b 200
+
+mavlink boot_complete

--- a/src/drivers/linux_pwm_output/CMakeLists.txt
+++ b/src/drivers/linux_pwm_output/CMakeLists.txt
@@ -1,0 +1,50 @@
+############################################################################
+#
+#   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+px4_add_module(
+	MODULE drivers__linux_pwm_output
+	MAIN linux_pwm_output
+	COMPILE_FLAGS
+	SRCS
+		linux_pwm_output.cpp
+		PWMDeviceBase.cpp
+
+		device_debug.cpp
+		PCA9685.cpp
+		navio_sysfs.cpp
+		ocpoc_mmap.cpp
+		bbblue_pwm_rc.cpp
+	DEPENDS
+		mixer
+		mixer_module
+		output_limit
+	)

--- a/src/drivers/linux_pwm_output/PCA9685.cpp
+++ b/src/drivers/linux_pwm_output/PCA9685.cpp
@@ -1,0 +1,226 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ * Original Author      : Georgi Todorov
+ * Edited by	: Tord Wessman
+ * Created on  : Nov 22, 2013
+ * Rewrite	   : Fan.zhang  421395590@qq.com
+ * Updated on  : Mar 2, 2017
+ * Integrate   : SalimTerryLi<lhf2613@gmail.com>
+ ****************************************************************************/
+
+#include <sys/ioctl.h>
+#include <linux/i2c-dev.h>
+#include <cstdio>      /* Standard I/O functions */
+#include <fcntl.h>
+#include <cinttypes>
+#include <cerrno>
+
+#include "PCA9685.h"
+
+#include <px4_log.h>
+
+using namespace linux_pwm_output;
+
+int PCA9685::deviceConfigure(int argc, char **argv)
+{
+	int ret = 0;
+	int ch;
+	opterr = 0; // turn off parse error output
+
+	while ((ch = getopt(argc, argv, "a:b:")) != -1) {
+		switch (ch) {
+		case 'a':
+			_Addr = atoi(optarg);
+			break;
+
+		case 'b':
+			_Bus = atoi(optarg);
+			break;
+
+		case '?':
+			PX4_WARN("Unsupported arg: %c", optopt);
+			ret = -EINVAL;
+
+		default:
+			break;
+		}
+	}
+
+	return ret;
+}
+
+int PCA9685::init(int bus, int address)
+{
+	_fd = open_fd(bus, address);
+
+	if (_fd == -1) {
+		return -EINVAL;
+	}
+
+	reset();
+
+	usleep(1000 * 100);
+	/* 200HZ for 12bit Resolution, supported by most of the esc's */
+	setFreq(_Freq);
+	usleep(1000 * 1000);
+	return 0;
+}
+
+int PCA9685::updatePWM(const uint16_t *outputs, unsigned num_outputs)
+{
+	if (num_outputs > 16) {
+		num_outputs = 16;
+	}
+
+	for (uint16_t i = 0; i < num_outputs; ++i) {
+		setPWM(i, outputs[i]);
+	}
+
+	return 0;
+}
+
+PCA9685::~PCA9685()
+{
+	reset();
+
+	if (_fd >= 0) {
+		close(_fd);
+	}
+}
+
+void PCA9685::reset()
+{
+	if (_fd != -1) {
+		write_byte(_fd, MODE1, 0x00); //Normal mode
+		write_byte(_fd, MODE2, 0x04); //Normal mode
+	}
+}
+
+int PCA9685::setFreq(int freq)
+{
+	if (_fd != -1) {
+		_Freq = freq;
+		uint8_t prescale = (CLOCK_FREQ / MAX_PWM_RES / freq)  - 1;
+		//printf ("Setting prescale value to: %d\n", prescale);
+		//printf ("Using Frequency: %d\n", freq);
+
+		uint8_t oldmode = read_byte(_fd, MODE1);
+		uint8_t newmode = (oldmode & 0x7F) | 0x10;    //sleep
+		write_byte(_fd, MODE1, newmode);        // go to sleep
+		write_byte(_fd, PRE_SCALE, prescale);
+		write_byte(_fd, MODE1, oldmode);
+		usleep(10 * 1000);
+		write_byte(_fd, MODE1, oldmode | 0x80);
+		return PX4_OK;
+	}
+
+	return -EINVAL;
+}
+
+
+void PCA9685::setPWM(uint8_t led, int value)
+{
+	setPWM(led, 0, value * _Freq * MAX_PWM_RES / 1000000);
+}
+
+void PCA9685::setPWM(uint8_t led, int on_value, int off_value)
+{
+	if (_fd != -1) {
+		write_byte(_fd, LED0_ON_L + LED_MULTIPLYER * led, on_value & 0xFF);
+
+		write_byte(_fd, LED0_ON_H + LED_MULTIPLYER * led, on_value >> 8);
+
+		write_byte(_fd, LED0_OFF_L + LED_MULTIPLYER * led, off_value & 0xFF);
+
+		write_byte(_fd, LED0_OFF_H + LED_MULTIPLYER * led, off_value >> 8);
+	}
+
+}
+
+uint8_t PCA9685::read_byte(int fd, uint8_t address)
+{
+
+	uint8_t buf[1];
+	buf[0] = address;
+
+	if (write(fd, buf, 1) != 1) {
+		return -1;
+	}
+
+	if (read(fd, buf, 1) != 1) {
+		return -1;
+	}
+
+	return buf[0];
+}
+
+void PCA9685::write_byte(int fd, uint8_t address, uint8_t data)
+{
+	uint8_t buf[2];
+	buf[0] = address;
+	buf[1] = data;
+
+	if (write(fd, buf, sizeof(buf)) != sizeof(buf)) {
+		PX4_ERR("Write failed (%i)", errno);
+	}
+}
+
+int PCA9685::open_fd(int bus, int address)
+{
+	int fd;
+	char bus_file[64];
+	snprintf(bus_file, sizeof(bus_file), "/dev/i2c-%d", bus);
+
+	if ((fd = open(bus_file, O_RDWR)) < 0) {
+		PX4_ERR("Couldn't open I2C Bus %d [open_fd():open %d]", bus, errno);
+		return -1;
+	}
+
+	if (ioctl(fd, I2C_SLAVE, address) < 0) {
+		PX4_ERR("I2C slave %d failed [open_fd():ioctl %d]", address, errno);
+		return -1;
+	}
+
+	return fd;
+}
+
+int PCA9685::deviceInit()
+{
+	return init(_Bus, _Addr);
+}
+
+int PCA9685::deviceDeinit()
+{
+	reset();
+	return close(_fd);
+}

--- a/src/drivers/linux_pwm_output/PCA9685.h
+++ b/src/drivers/linux_pwm_output/PCA9685.h
@@ -1,0 +1,140 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ * Original Author      : Georgi Todorov
+ * Edited by	: Tord Wessman
+ * Created on  : Nov 22, 2013
+ * Rewrite	   : Fan.zhang  421395590@qq.com
+ * Updated on  : Mar 2, 2017
+ * Integrate   : SalimTerryLi<lhf2613@gmail.com>
+ ****************************************************************************/
+
+#pragma once
+#include <cinttypes>
+#include "PWMDeviceBase.h"
+
+namespace linux_pwm_output
+{
+
+// Register Definitions
+// 寄存器定义
+#define MODE1 0x00			//Mode  register  1
+#define MODE2 0x01			//Mode  register  2
+#define SUBADR1 0x02		//I2C-bus subaddress 1
+#define SUBADR2 0x03		//I2C-bus subaddress 2
+#define SUBADR3 0x04		//I2C-bus subaddress 3
+#define ALLCALLADR 0x05     //LED All Call I2C-bus address
+#define LED0 0x6			//LED0 start register
+#define LED0_ON_L 0x6		//LED0 output and brightness control byte 0
+#define LED0_ON_H 0x7		//LED0 output and brightness control byte 1
+#define LED0_OFF_L 0x8		//LED0 output and brightness control byte 2
+#define LED0_OFF_H 0x9		//LED0 output and brightness control byte 3
+#define LED_MULTIPLYER 4	// For the other 15 channels
+#define ALLLED_ON_L 0xFA    //load all the LEDn_ON registers, byte 0 (turn 0-7 channels on)
+#define ALLLED_ON_H 0xFB	//load all the LEDn_ON registers, byte 1 (turn 8-15 channels on)
+#define ALLLED_OFF_L 0xFC	//load all the LEDn_OFF registers, byte 0 (turn 0-7 channels off)
+#define ALLLED_OFF_H 0xFD	//load all the LEDn_OFF registers, byte 1 (turn 8-15 channels off)
+#define PRE_SCALE 0xFE		//prescaler for output frequency
+#define MAX_PWM_RES 4096        //Resolution 4096=12bit 分辨率，按2的阶乘计算，12bit为4096
+#define CLOCK_FREQ 25000000.0 //25MHz default osc clock
+
+//! Main class that exports features for PCA9685 chip
+class PCA9685 : public PWMDeviceBase
+{
+public:
+	int deviceConfigure(int argc, char **argv) override;
+
+	int deviceInit() override;
+
+	int deviceDeinit() override;
+
+	int updatePWM(const uint16_t *outputs, unsigned num_outputs) override;
+
+	int setFreq(int freq) override;
+
+	PCA9685() = default;
+
+	~PCA9685() override;
+
+
+protected:
+	int _Bus = 1;
+	int _Addr = 0x40;
+	int _Freq = 50;
+
+	int init(int bus, int address);
+
+	/** Sets PCA9685 mode to 00 */
+	void reset();
+
+	/**
+	 * PWM a single channel with custom on time.
+	 * send pwm vale to led(channel)
+	 * @param channel
+	 * @param on_value 0-4095 value to turn on the pulse
+	 * @param off_value 0-4095 value to turn off the pulse
+	 */
+	void setPWM(uint8_t channel, int on_value, int off_value);
+
+	/**
+	 * send pwm value to led(channel),
+	 * value should be range of 0-4095
+	 */
+	void setPWM(uint8_t channel, int value);
+
+private:
+	int _fd = -1; ///< I2C device file descriptor
+
+	/**
+	 * Read a single byte from PCA9685
+	 * @param fd file descriptor for I/O
+	 * @param address register address to read from
+	 * @return read byte
+	 */
+	uint8_t read_byte(int fd, uint8_t address);
+
+	/**
+	 *  Write a single byte to PCA9685
+	 * @param fd file descriptor for I/O
+	 * @param address register address to write to
+	 * @param data 8 bit data to write
+	 */
+	void write_byte(int fd, uint8_t address, uint8_t data);
+
+	/**
+	 * Open device file for PCA9685 I2C bus
+	 * @return fd returns the file descriptor number or -1 on error
+	 */
+	int open_fd(int bus, int address);
+};
+
+}

--- a/src/drivers/linux_pwm_output/PWMDeviceBase.cpp
+++ b/src/drivers/linux_pwm_output/PWMDeviceBase.cpp
@@ -1,0 +1,52 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2012-2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+//
+// Created by salimterryli on 2019/12/7.
+//
+
+#include "PWMDeviceBase.h"
+
+int PWMDeviceBase::deviceUsage()
+{
+	PRINT_MODULE_USAGE_PARAM_STRING('d', nullptr, "/dev/i2c-1|/sys/class/pwm/pwmchip0|..",
+					"set device filename: pca9685,navio2", true);
+	PRINT_MODULE_USAGE_PARAM_INT('b', 1, 0, 255,
+				     "set bus: pca9685", true);
+	PRINT_MODULE_USAGE_PARAM_INT('a', 0x40, 0, 255,
+				     "set bus address(Dec 64=hex 0x40): pca9685", true);
+	PRINT_MODULE_USAGE_PARAM_INT('n', 16, 0, 16,
+				     "number of output channels: navio2,ocpoc_mmap", true);
+
+	return PX4_OK;
+}

--- a/src/drivers/linux_pwm_output/PWMDeviceBase.h
+++ b/src/drivers/linux_pwm_output/PWMDeviceBase.h
@@ -1,0 +1,86 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2012-2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+//
+// Created by salimterryli on 2019/12/7.
+//
+
+#ifndef PX4_PWMDEVICEBASE_H
+#define PX4_PWMDEVICEBASE_H
+
+#include <px4_platform_common/module.h>
+#include <cerrno>
+#include <unistd.h>
+
+class PWMDeviceBase
+{
+public:
+	virtual ~PWMDeviceBase() = default;
+	/*
+	 * Called to generate command line usage.
+	 * Add new usage description here.
+	 */
+	static int deviceUsage();
+	/*
+	 * Called to parse command line arguments.
+	 */
+	virtual int deviceConfigure(int argc, char **argv) = 0;
+	/*
+	 * Called when pwm driver is required to init.
+	 * @params: Passed from command line.
+	 */
+	virtual int deviceInit() = 0;
+
+	/*
+	 * Called when pwm driver is going to be destroyed.
+	 */
+	virtual int deviceDeinit() = 0;
+
+	/*
+	 * Called when pwm pulses should be updated.
+	 */
+	virtual int updatePWM(const uint16_t *outputs, unsigned num_outputs) = 0;
+
+	/*
+	 * Called to set pwm frequency.
+	 */
+	virtual int setFreq(int freq) = 0;
+
+protected:
+
+private:
+
+};
+
+
+#endif //PX4_PWMDEVICEBASE_H

--- a/src/drivers/linux_pwm_output/bbblue_pwm_rc.cpp
+++ b/src/drivers/linux_pwm_output/bbblue_pwm_rc.cpp
@@ -1,0 +1,131 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+#include <cstdint>
+
+#ifdef __PX4_POSIX_BBBLUE
+
+#include <fcntl.h>
+#include <errno.h>
+#include <px4_platform_common/log.h>
+
+#include <robotcontrol.h>
+#include <board_config.h>
+
+#include "bbblue_pwm_rc.h"
+
+using namespace linux_pwm_output;
+
+BBBlueRcPWMOut::BBBlueRcPWMOut(int max_num_outputs) : _num_outputs(max_num_outputs)
+{
+	if (_num_outputs > MAX_NUM_PWM) {
+		PX4_WARN("number of outputs too large. Setting to %i", MAX_NUM_PWM);
+		_num_outputs = MAX_NUM_PWM;
+	}
+}
+
+BBBlueRcPWMOut::~BBBlueRcPWMOut()
+{
+	rc_cleaning();
+}
+
+int BBBlueRcPWMOut::init()
+{
+	rc_init();
+
+	return 0;
+}
+
+int BBBlueRcPWMOut::send_output_pwm(const uint16_t *pwm, int num_outputs)
+{
+	if (num_outputs > _num_outputs) {
+		num_outputs = _num_outputs;
+	}
+
+	int ret = 0;
+
+	// pwm[ch] is duty_cycle in us
+	for (int ch = 0; ch < num_outputs; ++ch) {
+		ret += rc_servo_send_pulse_us(ch + 1, pwm[ch]); // converts to 1-based channel #
+	}
+
+	return ret;
+}
+
+
+int linux_pwm_output::BBBlueRcPWMOut::deviceConfigure(int argc, char **argv)
+{
+	int ret = 0;
+	int ch;
+	optind = 1;
+	opterr = 0; // turn off parse error output
+
+	while ((ch = getopt(argc, argv, "d:")) != -1) {
+		switch (ch) {
+		case 'n':
+			_num_outputs = atoi(optarg);
+			_num_outputs = _num_outputs > MAX_NUM_PWM ? MAX_NUM_PWM : _num_outputs;
+			break;
+
+		case '?':
+			PX4_WARN("Unsupported arg: %c", optopt);
+			ret = -EINVAL;
+
+		default:
+			break;
+		}
+	}
+
+	return ret;
+}
+
+int linux_pwm_output::BBBlueRcPWMOut::deviceInit()
+{
+	return init();
+}
+
+int linux_pwm_output::BBBlueRcPWMOut::deviceDeinit()
+{
+	return 0;
+}
+
+int linux_pwm_output::BBBlueRcPWMOut::updatePWM(const uint16_t *outputs, unsigned num_outputs)
+{
+	return send_output_pwm(outputs, (int)num_outputs);
+}
+
+int linux_pwm_output::BBBlueRcPWMOut::setFreq(int freq)
+{
+	return 0;
+}
+
+#endif  // __PX4_POSIX_BBBLUE

--- a/src/drivers/linux_pwm_output/bbblue_pwm_rc.h
+++ b/src/drivers/linux_pwm_output/bbblue_pwm_rc.h
@@ -1,0 +1,75 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "PWMDeviceBase.h"
+
+namespace linux_pwm_output
+{
+
+/**
+ ** class BBBlueRcPWMOut
+ * PWM output class for BeagleBone Blue with Robotics Cape Library
+ *
+ * Ref: https://github.com/StrawsonDesign/Robotics_Cape_Installer
+ *      http://www.strawsondesign.com/#!manual-servos
+ */
+class BBBlueRcPWMOut : public PWMDeviceBase
+{
+public:
+	BBBlueRcPWMOut() = default;
+	~BBBlueRcPWMOut() override ;
+
+	int init();
+
+	int send_output_pwm(const uint16_t *pwm, int num_outputs);
+
+	int deviceConfigure(int argc, char **argv) override;
+
+	int deviceInit() override;
+
+	int deviceDeinit() override;
+
+	int updatePWM(const uint16_t *outputs, unsigned num_outputs) override;
+
+	int setFreq(int freq) override;
+
+private:
+	static const int MAX_NUM_PWM = 8;
+	static const int MIN_FREQUENCY_PWM = 40;
+
+	int _num_outputs = MAX_NUM_PWM;
+};
+
+}

--- a/src/drivers/linux_pwm_output/device_debug.cpp
+++ b/src/drivers/linux_pwm_output/device_debug.cpp
@@ -1,0 +1,88 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2012-2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file device_debug.cpp
+ * Example driver
+ * This driver will dump all messages passed to it.
+ *
+ * @author SalimTerryLi <lhf2613@gmail.com>
+ */
+
+#include "device_debug.h"
+
+int device_debug::deviceConfigure(int argc, char **argv)
+{
+	PX4_INFO("dump cmdline args:");
+	int ch;
+	optind = 1; // reset scan index
+	opterr = 0; // turn off parse error output
+
+	while ((ch = getopt(argc, argv, "abcdefghijklmnopqrstuvwxyz:")) != -1) {
+		PX4_INFO("arg: %c", ch);
+	}
+
+	optind = 1; // reset scan index
+	PX4_INFO("dump complete");
+	return 0;
+}
+
+int device_debug::deviceInit()
+{
+	PX4_INFO("driver init");
+	return 0;
+}
+
+int device_debug::deviceDeinit()
+{
+	PX4_INFO("driver removed");
+	return 0;
+}
+
+int device_debug::setFreq(int freq)
+{
+	PX4_INFO("set pwm frequency: %d", freq);
+	return 0;
+}
+
+int device_debug::updatePWM(const uint16_t *outputs, unsigned num_outputs)
+{
+	printf("PWM:");
+
+	for (uint16_t i = 0; i < num_outputs; i++) {
+		printf(" %.4d", outputs[i]);
+	}
+
+	printf("\n");
+	return 0;
+}

--- a/src/drivers/linux_pwm_output/device_debug.h
+++ b/src/drivers/linux_pwm_output/device_debug.h
@@ -1,0 +1,63 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2012-2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+//
+// Created by salimterryli on 2019/12/8.
+//
+
+#ifndef PX4_DEVICE_DEBUG_H
+#define PX4_DEVICE_DEBUG_H
+
+#include "PWMDeviceBase.h"
+
+class device_debug: public PWMDeviceBase
+{
+public:
+	device_debug() = default;
+
+	~device_debug() override = default;
+
+	int deviceConfigure(int argc, char **argv) override;
+
+	int deviceInit() override;
+
+	int deviceDeinit() override;
+
+	int updatePWM(const uint16_t *outputs, unsigned num_outputs) override;
+
+	int setFreq(int freq) override;
+
+};
+
+
+#endif //PX4_DEVICE_DEBUG_H

--- a/src/drivers/linux_pwm_output/linux_pwm_output.cpp
+++ b/src/drivers/linux_pwm_output/linux_pwm_output.cpp
@@ -1,0 +1,575 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2012-2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file linux_pwm_output.cpp
+ * Base class to manage all PWM devices which run on Linux platform such as RPi
+ * Implemented CDev framework only makes mixer files loaded in a different way
+ * I don't think this can be the final solution.
+ *
+ * @author SalimTerryLi <lhf2613@gmail.com>
+ */
+
+#include <px4_log.h>
+#include <drivers/device/device.h>
+#include <lib/mixer_module/mixer_module.hpp>
+#include <px4_platform_common/module.h>
+#include <lib/perf/perf_counter.h>
+#include <drivers/drv_mixer.h>
+
+#include "PWMDeviceBase.h"
+
+#include "device_debug.h"
+#include "PCA9685.h"
+#include "navio_sysfs.h"
+#include "ocpoc_mmap.h"
+#include "bbblue_pwm_rc.h"
+
+#define LINUX_PWM_OUTPUT_CHANNELS   16
+#define LINUXPWM_DEVICE_PATH	"/dev/linux_pwm_out_wrapper"
+
+using namespace linux_pwm_output;
+
+class LinuxPWMOutWrapper : public cdev::CDev, public ModuleBase<LinuxPWMOutWrapper>, public OutputModuleInterface
+{
+public:
+
+	LinuxPWMOutWrapper();
+	~LinuxPWMOutWrapper() override ;
+
+	int init() override;
+
+	int ioctl(cdev::file_t *filep, int cmd, unsigned long arg) override;
+
+	void mixerChanged() override;
+
+	/** @see ModuleBase */
+	static int task_spawn(int argc, char *argv[]);
+	/** @see ModuleBase */
+	static int custom_command(int argc, char *argv[]);
+	/** @see ModuleBase */
+	static int print_usage(const char *reason = nullptr);
+
+	bool updateOutputs(bool stop_motors, uint16_t *outputs, unsigned num_outputs,
+			   unsigned num_control_groups_updated) override;
+
+	LinuxPWMOutWrapper(const LinuxPWMOutWrapper &) = delete;
+	LinuxPWMOutWrapper operator=(const LinuxPWMOutWrapper &) = delete;
+
+private:
+	perf_counter_t	_cycle_perf;
+
+	void Run() override;
+
+protected:
+	void updateParams() override;
+
+	void updatePWMParams();
+
+	PWMDeviceBase *pwmDevice = nullptr; // driver handle.
+
+	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)}; // param handle
+
+	MixingOutput _mixing_output{LINUX_PWM_OUTPUT_CHANNELS, *this, MixingOutput::SchedulingPolicy::Auto, true};
+
+private:
+
+};
+
+LinuxPWMOutWrapper::LinuxPWMOutWrapper() :
+	CDev(LINUXPWM_DEVICE_PATH),
+	OutputModuleInterface(MODULE_NAME, px4::wq_configurations::hp_default),
+	_cycle_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": cycle"))
+{
+	_mixing_output.setAllMinValues(PWM_DEFAULT_MIN);
+	_mixing_output.setAllMaxValues(PWM_DEFAULT_MAX);
+}
+
+LinuxPWMOutWrapper::~LinuxPWMOutWrapper()
+{
+	if (pwmDevice != nullptr) { // normally this should not be called.
+		PX4_DEBUG("Destruction of LinuxPWMOutWrapper without pwmDevice unloaded!");
+		pwmDevice->deviceDeinit(); // force stop
+		delete pwmDevice;
+		pwmDevice = nullptr;
+	}
+
+	perf_free(_cycle_perf);
+}
+
+int LinuxPWMOutWrapper::init()
+{
+	int ret = CDev::init();
+
+	if (ret != PX4_OK) {
+		return ret;
+	}
+
+	ret = pwmDevice->deviceInit();
+
+	if (ret != PX4_OK) {
+		return ret;
+	}
+
+	updatePWMParams();
+
+	ScheduleNow();
+
+	return PX4_OK;
+}
+
+void LinuxPWMOutWrapper::updateParams()
+{
+	updatePWMParams();
+	ModuleParams::updateParams();
+}
+
+// TODO add support for trim value.
+void LinuxPWMOutWrapper::updatePWMParams()
+{
+	// update pwm params
+	const char *pname_format_main_max = "PWM_MAIN_MAX%d";
+	const char *pname_format_main_min = "PWM_MAIN_MIN%d";
+	const char *pname_format_main_fail = "PWM_MAIN_FAIL%d";
+	const char *pname_format_main_dis = "PWM_MAIN_DIS%d";
+	const char *pname_format_main_rev = "PWM_MAIN_REV%d";
+	//const char *pname_format_main_trim="PWM_MAIN_TRIM%d";
+	const char *pname_format_aux_max = "PWM_AUX_MAX%d";
+	const char *pname_format_aux_min = "PWM_AUX_MIN%d";
+	const char *pname_format_aux_fail = "PWM_AUX_FAIL%d";
+	const char *pname_format_aux_dis = "PWM_AUX_DIS%d";
+	const char *pname_format_aux_rev = "PWM_AUX_REV%d";
+	//const char *pname_format_aux_trim="PWM_AUX_TRIM%d";
+
+	//int16_t trim_values[LINUX_PWM_OUTPUT_CHANNELS] = {};
+
+	param_t param_h = param_find("PWM_MAX");
+
+	if (param_h != PARAM_INVALID) {
+		int32_t pval = 0;
+		param_get(param_h, &pval);
+		_mixing_output.setAllMaxValues(pval);
+
+	} else {
+		PX4_ERR("PARAM_INVALID: %s", "PWM_MAX");
+	}
+
+	param_h = param_find("PWM_MIN");
+
+	if (param_h != PARAM_INVALID) {
+		int32_t pval = 0;
+		param_get(param_h, &pval);
+		_mixing_output.setAllMinValues(pval);
+
+	} else {
+		PX4_ERR("PARAM_INVALID: %s", "PWM_MIN");
+	}
+
+	param_h = param_find("PWM_RATE");
+
+	if (param_h != PARAM_INVALID) {
+		int32_t pval = 0;
+		param_get(param_h, &pval);
+
+		if (pwmDevice->setFreq(pval) != PX4_OK) {
+			PX4_ERR("failed to set pwm frequency");
+		}
+
+	} else {
+		PX4_ERR("PARAM_INVALID: %s", "PWM_RATE");
+	}
+
+	for (int i = 0; i < 8; i++) {
+		char pname[16];
+
+		sprintf(pname, pname_format_main_max, i + 1);
+		param_h = param_find(pname);
+
+		if (param_h != PARAM_INVALID) {
+			int32_t pval = 0;
+			param_get(param_h, &pval);
+
+			if (pval != -1) {
+				_mixing_output.maxValue(i) = pval;
+			}
+
+		} else {
+			PX4_ERR("PARAM_INVALID: %s", pname);
+		}
+
+		sprintf(pname, pname_format_main_min, i + 1);
+		param_h = param_find(pname);
+
+		if (param_h != PARAM_INVALID) {
+			int32_t pval = 0;
+			param_get(param_h, &pval);
+
+			if (pval != -1) {
+				_mixing_output.minValue(i) = pval;
+			}
+
+		} else {
+			PX4_ERR("PARAM_INVALID: %s", pname);
+		}
+
+		sprintf(pname, pname_format_main_fail, i + 1);
+		param_h = param_find(pname);
+
+		if (param_h != PARAM_INVALID) {
+			int32_t pval = 0;
+			param_get(param_h, &pval);
+
+			if (pval != -1) {
+				_mixing_output.failsafeValue(i) = pval;
+			}
+
+		} else {
+			PX4_ERR("PARAM_INVALID: %s", pname);
+		}
+
+		sprintf(pname, pname_format_main_dis, i + 1);
+		param_h = param_find(pname);
+
+		if (param_h != PARAM_INVALID) {
+			int32_t pval = 0;
+			param_get(param_h, &pval);
+
+			if (pval != -1) {
+				_mixing_output.disarmedValue(i) = pval;
+			}
+
+		} else {
+			PX4_ERR("PARAM_INVALID: %s", pname);
+		}
+
+		sprintf(pname, pname_format_main_rev, i + 1);
+		param_h = param_find(pname);
+
+		if (param_h != PARAM_INVALID) {
+			uint16_t &reverse_pwm_mask = _mixing_output.reverseOutputMask();
+			int32_t pval = 0;
+			param_get(param_h, &pval);
+			reverse_pwm_mask &= (0xfffe << i);  // clear this bit
+			reverse_pwm_mask |= (((uint16_t)(pval != 0)) << i); // set to new val
+
+		} else {
+			PX4_ERR("PARAM_INVALID: %s", pname);
+		}
+
+		sprintf(pname, pname_format_aux_max, i + 1);
+		param_h = param_find(pname);
+
+		if (param_h != PARAM_INVALID) {
+			int32_t pval = 0;
+			param_get(param_h, &pval);
+
+			if (pval != -1) {
+				_mixing_output.maxValue(i + 8) = pval;
+			}
+
+		} else {
+			PX4_ERR("PARAM_INVALID: %s", pname);
+		}
+
+		sprintf(pname, pname_format_aux_min, i + 1);
+		param_h = param_find(pname);
+
+		if (param_h != PARAM_INVALID) {
+			int32_t pval = 0;
+			param_get(param_h, &pval);
+
+			if (pval != -1) {
+				_mixing_output.minValue(i + 8) = pval;
+			}
+
+		} else {
+			PX4_ERR("PARAM_INVALID: %s", pname);
+		}
+
+		sprintf(pname, pname_format_aux_fail, i + 1);
+		param_h = param_find(pname);
+
+		if (param_h != PARAM_INVALID) {
+			int32_t pval = 0;
+			param_get(param_h, &pval);
+
+			if (pval != -1) {
+				_mixing_output.failsafeValue(i + 8) = pval;
+			}
+
+		} else {
+			PX4_ERR("PARAM_INVALID: %s", pname);
+		}
+
+		sprintf(pname, pname_format_aux_dis, i + 1);
+		param_h = param_find(pname);
+
+		if (param_h != PARAM_INVALID) {
+			int32_t pval = 0;
+			param_get(param_h, &pval);
+
+			if (pval != -1) {
+				_mixing_output.disarmedValue(i + 8) = pval;
+			}
+
+		} else {
+			PX4_ERR("PARAM_INVALID: %s", pname);
+		}
+
+		sprintf(pname, pname_format_aux_rev, i + 1);
+		param_h = param_find(pname);
+
+		if (param_h != PARAM_INVALID) {
+			uint16_t &reverse_pwm_mask = _mixing_output.reverseOutputMask();
+			int32_t pval = 0;
+			param_get(param_h, &pval);
+			reverse_pwm_mask &= (0xfffe << (i + 8)); // clear this bit
+			reverse_pwm_mask |= (((uint16_t)(pval != 0)) << (i + 8)); // set to new val
+
+		} else {
+			PX4_ERR("PARAM_INVALID: %s", pname);
+		}
+
+		/*sprintf(pname, pname_format_main_trim, i + 1);
+		param_h = param_find(pname);
+		if (param_h != PARAM_INVALID) {
+		    float pval = 0.0f;
+		    param_get(param_h, &pval);
+		    trim_values[i] = (int16_t)(10000 * pval);
+		}else {
+		    PX4_ERR("PARAM_INVALID: %s",pname);
+		}
+
+		sprintf(pname, pname_format_aux_trim, i + 1);
+		param_h = param_find(pname);
+		if (param_h != PARAM_INVALID) {
+		    float pval = 0.0f;
+		    param_get(param_h, &pval);
+		    trim_values[i+8] = (int16_t)(10000 * pval);
+		}else {
+		    PX4_ERR("PARAM_INVALID: %s",pname);
+		}*/
+	}
+
+	/*unsigned n_out = _mixing_output.mixers()->set_trims(trim_values, LINUX_PWM_OUTPUT_CHANNELS);
+	PX4_DEBUG("set %d trims", n_out);*/
+
+}
+
+bool LinuxPWMOutWrapper::updateOutputs(bool stop_motors, uint16_t *outputs, unsigned num_outputs,
+				       unsigned num_control_groups_updated)
+{
+	return pwmDevice->updatePWM(outputs, num_outputs);;
+}
+
+// TODO
+void LinuxPWMOutWrapper::Run()
+{
+	if (should_exit()) {
+		ScheduleClear();
+		_mixing_output.unregister();
+
+		pwmDevice->deviceDeinit();
+		delete pwmDevice;
+		pwmDevice = nullptr;
+
+		exit_and_cleanup();
+		return;
+	}
+
+	perf_begin(_cycle_perf);
+
+	_mixing_output.update();
+
+	// check for parameter updates
+	if (_parameter_update_sub.updated()) {
+		// clear update
+		parameter_update_s pupdate;
+		_parameter_update_sub.copy(&pupdate);
+
+		// update parameters from storage
+		updateParams();
+	}
+
+	_mixing_output.updateSubscriptions(true);
+
+	perf_end(_cycle_perf);
+}
+
+// TODO
+int LinuxPWMOutWrapper::ioctl(cdev::file_t *filep, int cmd, unsigned long arg)
+{
+	int ret = OK;
+	PX4_INFO("linux_pwm ioctl cmd: %d, arg: %ld", cmd, arg);
+
+	lock();
+
+	switch (cmd) {
+	case MIXERIOCRESET:
+		_mixing_output.resetMixerThreadSafe();
+
+		break;
+
+	case MIXERIOCLOADBUF: {
+			const char *buf = (const char *)arg;
+			unsigned buflen = strlen(buf);
+
+			ret = _mixing_output.loadMixerThreadSafe(buf, buflen);
+
+			break;
+		}
+
+	default:
+		ret = -ENOTTY;
+		break;
+	}
+
+	unlock();
+
+	if (ret == -ENOTTY) {
+		ret = CDev::ioctl(filep, cmd, arg);
+	}
+
+	return ret;
+}
+
+int LinuxPWMOutWrapper::print_usage(const char *reason)
+{
+	if (reason) {
+		PX4_WARN("%s\n", reason);
+	}
+
+	PRINT_MODULE_DESCRIPTION(
+		R"DESCR_STR(
+### Description
+This module is responsible for generate pwm pulse on Linux based device such as RPi.
+
+It listens on the actuator_controls topics, does the mixing and writes the PWM outputs.
+
+### Implementation
+By default the module runs on a work queue with a callback on the uORB actuator_controls topic.
+
+### Examples
+It is typically started with:
+$ linux_pwm start debug -a -b 2
+
+Use the `mixer` command to load mixer files.
+)DESCR_STR");
+
+    PRINT_MODULE_USAGE_NAME("linux_pwm_output", "driver");
+    PRINT_MODULE_USAGE_COMMAND_DESCR("start debug", "Use debug_driver as pwm destination");
+    PRINT_MODULE_USAGE_COMMAND_DESCR("start navio2", "Use NAVIO2 as pwm destination");
+    PRINT_MODULE_USAGE_COMMAND_DESCR("start pca9685", "Use pca9685 as pwm destination");
+    PRINT_MODULE_USAGE_COMMAND_DESCR("start ocpoc_mmap", "Use ocpoc_mmap as pwm destination");
+    PRINT_MODULE_USAGE_COMMAND_DESCR("start bbblue_rc", "Use bbblue_rc as pwm destination");
+    PRINT_MODULE_USAGE_PARAM_COMMENT("");
+    PWMDeviceBase::deviceUsage();
+    PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
+
+    return 0;
+}
+
+int LinuxPWMOutWrapper::custom_command(int argc, char **argv) {
+    return PX4_OK;
+}
+
+int LinuxPWMOutWrapper::task_spawn(int argc, char **argv) {
+
+    auto *instance = new LinuxPWMOutWrapper();
+
+    if (instance!=nullptr) {
+        _object.store(instance);
+        _task_id = task_id_is_work_queue;
+
+        // Detect device type
+        // TODO load each device
+        if(argc>=2) {
+            const char *verb = argv[1];
+            if (!strcmp(verb, "debug")) {
+                instance->pwmDevice=new device_debug();
+            }else if (!strcmp(verb, "navio2")) {
+                instance->pwmDevice=new NavioSysfsPWMOut();
+            }else if (!strcmp(verb, "pca9685")) {
+                instance->pwmDevice=new PCA9685();
+            }else if (!strcmp(verb, "ocpoc_mmap")) {
+                instance->pwmDevice=new OcpocMmapPWMOut();
+            }else if (!strcmp(verb, "bbblue_rc")) {
+                //instance->pwmDevice=new BBBlueRcPWMOut(); // cannot find a previous implement
+            }else{
+                PX4_ERR("unknown device");
+                goto deviceNotLoaded;
+            }
+        } else{
+            PX4_ERR("device not declared");
+            goto deviceNotLoaded;
+        }
+
+        if(instance->pwmDevice == nullptr) {
+            PX4_ERR("pwmDevice alloc failed");
+            goto deviceNotLoaded;
+        }
+        if(instance->pwmDevice->deviceConfigure(argc-1, argv+1) != PX4_OK){
+            PX4_ERR("failed to configure driver from cmd line arguments");
+            goto deviceCfgFailed;
+        }
+
+        if (instance->init() == PX4_OK) {
+            return PX4_OK;
+        } else {
+            PX4_ERR("driver init failed");
+        }
+
+        deviceCfgFailed:
+        delete (instance->pwmDevice); // also delete the true driver
+        instance->pwmDevice=nullptr;
+        deviceNotLoaded:
+        delete instance;
+        _object.store(nullptr);
+        _task_id = -1;
+    } else {
+        PX4_ERR("alloc failed");
+    }
+
+    return PX4_ERROR;
+}
+
+// TODO add support for trim value.
+void LinuxPWMOutWrapper::mixerChanged() {
+    OutputModuleInterface::mixerChanged();
+}
+
+extern "C" __EXPORT int linux_pwm_output_main(int argc, char *argv[]);
+
+int linux_pwm_output_main(int argc, char *argv[]){
+	return LinuxPWMOutWrapper::main(argc, argv);
+}

--- a/src/drivers/linux_pwm_output/navio_sysfs.cpp
+++ b/src/drivers/linux_pwm_output/navio_sysfs.cpp
@@ -1,0 +1,190 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "navio_sysfs.h"
+
+#include <fcntl.h>
+#include <cerrno>
+#include <unistd.h>
+#include <px4_platform_common/log.h>
+
+using namespace linux_pwm_output;
+
+NavioSysfsPWMOut::~NavioSysfsPWMOut()
+{
+	for (int i = 0; i < MAX_NUM_PWM; ++i) {
+		if (_pwm_fd[i] != -1) {
+			::close(_pwm_fd[i]);
+		}
+	}
+}
+
+int NavioSysfsPWMOut::init()
+{
+	int i;
+	char path[128];
+
+	for (i = 0; i < _pwm_num; ++i) {
+		::snprintf(path, sizeof(path), "%s/export", _device);
+
+		if (pwm_write_sysfs(path, i) < 0) {
+			PX4_ERR("PWM export failed");
+		}
+	}
+
+	for (i = 0; i < _pwm_num; ++i) {
+		::snprintf(path, sizeof(path), "%s/pwm%u/enable", _device, i);
+
+		if (pwm_write_sysfs(path, 1) < 0) {
+			PX4_ERR("PWM enable failed");
+		}
+	}
+
+	for (i = 0; i < _pwm_num; ++i) {
+		::snprintf(path, sizeof(path), "%s/pwm%u/period", _device, i);
+
+		if (pwm_write_sysfs(path, (int)1e9 / FREQUENCY_PWM)) {
+			PX4_ERR("PWM period failed");
+		}
+	}
+
+	for (i = 0; i < _pwm_num; ++i) {
+		::snprintf(path, sizeof(path), "%s/pwm%u/duty_cycle", _device, i);
+		_pwm_fd[i] = ::open(path, O_WRONLY | O_CLOEXEC);
+
+		if (_pwm_fd[i] == -1) {
+			PX4_ERR("PWM: Failed to open duty_cycle.");
+			return -errno;
+		}
+	}
+
+	return 0;
+}
+
+int NavioSysfsPWMOut::send_output_pwm(const uint16_t *pwm, int num_outputs)
+{
+	char data[16];
+
+	if (num_outputs > _pwm_num) {
+		num_outputs = _pwm_num;
+	}
+
+	int ret = 0;
+
+	//convert this to duty_cycle in ns
+	for (int i = 0; i < num_outputs; ++i) {
+		int n = ::snprintf(data, sizeof(data), "%u", pwm[i] * 1000);
+		int write_ret = ::write(_pwm_fd[i], data, n);
+
+		if (n != write_ret) {
+			ret = -1;
+		}
+	}
+
+	return ret;
+}
+
+int NavioSysfsPWMOut::pwm_write_sysfs(char *path, int value)
+{
+	int fd = ::open(path, O_WRONLY | O_CLOEXEC);
+	int n;
+	char data[16];
+
+	if (fd == -1) {
+		return -errno;
+	}
+
+	n = ::snprintf(data, sizeof(data), "%u", value);
+
+	if (n > 0) {
+		n = ::write(fd, data, n);	// This n is not used, but to avoid a compiler error.
+	}
+
+	::close(fd);
+
+	return 0;
+}
+
+int NavioSysfsPWMOut::FREQUENCY_PWM = 400;
+
+int NavioSysfsPWMOut::deviceConfigure(int argc, char **argv)
+{
+	int ret = 0;
+	int ch;
+	optind = 1;
+	opterr = 0; // turn off parse error output
+
+	while ((ch = getopt(argc, argv, "d:")) != -1) {
+		switch (ch) {
+		case 'd':
+			strncpy(_device, optarg, 64);
+			break;
+
+		case 'n':
+			_pwm_num = atoi(optarg);
+			_pwm_num = _pwm_num > MAX_NUM_PWM ? MAX_NUM_PWM : _pwm_num;
+			break;
+
+		case '?':
+			PX4_WARN("Unsupported arg: %c", optopt);
+			ret = -EINVAL;
+
+		default:
+			break;
+		}
+	}
+
+	return ret;
+}
+
+int NavioSysfsPWMOut::deviceInit()
+{
+	return init();
+}
+
+int NavioSysfsPWMOut::deviceDeinit()
+{
+	return 0;
+}
+
+int NavioSysfsPWMOut::updatePWM(const uint16_t *outputs, unsigned num_outputs)
+{
+	return send_output_pwm(outputs, num_outputs);
+}
+
+int NavioSysfsPWMOut::setFreq(int freq)
+{
+	FREQUENCY_PWM = freq;
+	//init(); // TODO should update pwm frequency here?
+	return 0;
+}

--- a/src/drivers/linux_pwm_output/navio_sysfs.h
+++ b/src/drivers/linux_pwm_output/navio_sysfs.h
@@ -1,0 +1,77 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "PWMDeviceBase.h"
+
+namespace linux_pwm_output
+{
+
+/**
+ ** class NavioSysfsPWMOut
+ * PWM output class for Navio Sysfs
+ */
+class NavioSysfsPWMOut : public PWMDeviceBase
+{
+public:
+	NavioSysfsPWMOut() = default;
+	~NavioSysfsPWMOut() override;
+
+	int init();
+
+	int send_output_pwm(const uint16_t *pwm, int num_outputs);
+
+	int deviceConfigure(int argc, char **argv) override;
+
+	int deviceInit() override;
+
+	int deviceDeinit() override;
+
+	int updatePWM(const uint16_t *outputs, unsigned num_outputs) override;
+
+	int setFreq(int freq) override;
+
+private:
+	int pwm_write_sysfs(char *path, int value);
+
+	static const int MAX_NUM_PWM = 14;
+	static int FREQUENCY_PWM;
+
+	int _pwm_fd[MAX_NUM_PWM] = {};
+	int _pwm_num = MAX_NUM_PWM;
+
+	char _device[64] = "/sys/class/pwm/pwmchip0";
+};
+
+}

--- a/src/drivers/linux_pwm_output/ocpoc_mmap.cpp
+++ b/src/drivers/linux_pwm_output/ocpoc_mmap.cpp
@@ -1,0 +1,139 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "ocpoc_mmap.h"
+
+#include <px4_platform_common/log.h>
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+using namespace linux_pwm_output;
+
+#define RCOUT_ZYNQ_PWM_BASE	    0x43c00000
+static const int TICK_PER_US   =  50;
+static const int FREQUENCY_PWM = 400;
+static const int TICK_PER_S  = 50000000;
+
+OcpocMmapPWMOut::~OcpocMmapPWMOut()
+{
+	if (_shared_mem_cmd) {
+		munmap((void *)_shared_mem_cmd, 0x1000);
+	}
+}
+
+unsigned long OcpocMmapPWMOut::freq2tick(uint16_t freq_hz)
+{
+	unsigned long duty = TICK_PER_S / (unsigned long)freq_hz;
+	return duty;
+}
+
+int OcpocMmapPWMOut::init()
+{
+	uint32_t mem_fd = open(_device, O_RDWR | O_SYNC);
+	_shared_mem_cmd = (struct pwm_cmd *) mmap(0, 0x1000, PROT_READ | PROT_WRITE,
+			  MAP_SHARED, mem_fd, RCOUT_ZYNQ_PWM_BASE);
+	close(mem_fd);
+
+	if (_shared_mem_cmd == nullptr) {
+		PX4_ERR("initialize pwm pointer failed.");
+		return -1;
+	}
+
+	for (unsigned i = 0; i < _num_outputs; ++i) {
+		_shared_mem_cmd->periodhi[i].period   =  freq2tick(FREQUENCY_PWM);
+		_shared_mem_cmd->periodhi[i].hi = freq2tick(FREQUENCY_PWM) / 2;
+		PX4_DEBUG("Output values: %d, %d", _shared_mem_cmd->periodhi[i].period, _shared_mem_cmd->periodhi[i].hi);
+	}
+
+	return 0;
+}
+
+int OcpocMmapPWMOut::updatePWM(const uint16_t *outputs, unsigned num_outputs)
+{
+	if (num_outputs > _num_outputs) {
+		num_outputs = _num_outputs;
+	}
+
+	//convert this to duty_cycle in ns
+	for (unsigned i = 0; i < num_outputs; ++i) {
+		//n = ::asprintf(&data, "%u", pwm[i] * 1000);
+		//::write(_pwm_fd[i], data, n);
+		_shared_mem_cmd->periodhi[i].hi = TICK_PER_US * outputs[i];
+		//printf("ch:%d, val:%d*%d ", ch, period_us, TICK_PER_US);
+	}
+
+	return 0;
+}
+
+int OcpocMmapPWMOut::deviceConfigure(int argc, char **argv)
+{
+	int ret = 0;
+	int ch;
+	optind = 1;
+	opterr = 0; // turn off parse error output
+
+	while ((ch = getopt(argc, argv, "a:b:")) != -1) {
+		switch (ch) {
+		case 'n':
+			_num_outputs = atoi(optarg);
+			_num_outputs = _num_outputs > MAX_ZYNQ_PWMS ? MAX_ZYNQ_PWMS : _num_outputs;
+			break;
+
+		case '?':
+			PX4_WARN("Unsupported arg: %c", optopt);
+			ret = -EINVAL;
+
+		default:
+			break;
+		}
+	}
+
+	return ret;
+}
+
+int OcpocMmapPWMOut::deviceInit()
+{
+	return init();
+}
+
+int OcpocMmapPWMOut::deviceDeinit()
+{
+	return 0;
+}
+
+int OcpocMmapPWMOut::setFreq(int freq)
+{
+	return 0;
+}

--- a/src/drivers/linux_pwm_output/ocpoc_mmap.h
+++ b/src/drivers/linux_pwm_output/ocpoc_mmap.h
@@ -1,0 +1,83 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "PWMDeviceBase.h"
+
+namespace linux_pwm_output
+{
+
+/**
+ ** class OcpocMmapPWMOut
+ * PWM output class for Aerotenna OcPoC via mmap
+ */
+class OcpocMmapPWMOut : public PWMDeviceBase
+{
+public:
+	OcpocMmapPWMOut() = default;
+	~OcpocMmapPWMOut() override;
+
+	int init();
+
+	int deviceConfigure(int argc, char **argv) override;
+
+	int deviceInit() override;
+
+	int deviceDeinit() override;
+
+	int updatePWM(const uint16_t *outputs, unsigned num_outputs) override;
+
+	int setFreq(int freq) override;
+
+private:
+	static unsigned long freq2tick(uint16_t freq_hz);
+
+	static constexpr int MAX_ZYNQ_PWMS = 8;	/**< maximum number of pwm channels */
+
+	// Period|Hi 32 bits each
+	struct s_period_hi {
+		uint32_t period;
+		uint32_t hi;
+	};
+
+	struct pwm_cmd {
+		struct s_period_hi periodhi[MAX_ZYNQ_PWMS];
+	};
+
+	volatile struct pwm_cmd *_shared_mem_cmd = nullptr;
+	static constexpr const char *_device = "/dev/mem";
+	unsigned _num_outputs = 8;
+};
+
+}


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by this pull request**
Make more pwm related parameters on Linux based boards can be configured. New driver is called `linux_pwm_output` but `linux_pwm_out` is not removed.

**Describe your solution**
Take px4fmu as the reference and completely rewrite the driver.

**Test data / coverage**
Test passed on RPi with debug and pca9685 mode. The actual pwm pulse each channel outputed is examined  with gazebo_plane simulator in debug mode. Due to hardware limitation I cannot test for other hardware solutions.

**Additional context**
Currently it does not support parameters related to trim value to be configured due to some very strange problems. Other parameters can be configured and take effect immediately without rebooting required. This will cause heavy load when parameters changed but not very significant compared to the computing power from RPi #13635 

Now the mixer file should be loaded by `mixer` command. (Some [comments](https://github.com/PX4/Firmware/blob/505e922b08cb64066b0ac4cd401489655713165f/src/systemcmds/mixer/mixer.cpp#L120) should be changed.)

This driver assume that there are 16 channels in no difference. Parameters like PWM_MAIN_XXXn are treated for the first 8 channels and others with AUX mark are treated for 9~16 channels. [Discuss](https://discuss.px4.io/t/parameter-implements-about-pwm-output/14113)

It is able to be merged but also can be kept as WIP for further development. But I'm not able to make improvements to hardware solutions except for RPi with PCA9685.