### PR TITLE
Remove MPC_ACC_HOR_ESTM parameter

### DIFF
--- a/src/lib/flight_tasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
+++ b/src/lib/flight_tasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
@@ -101,16 +101,8 @@ void FlightTaskManualPosition::_scaleSticks()
 		// Allow for a minimum of 0.3 m/s for repositioning
 		_velocity_scale = fmaxf(_velocity_scale, 0.3f);
 
-	} else if (stick_xy.length() > 0.5f) {
-		// raise the limit at a constant rate up to the user specified value
-
-		if (_velocity_scale < _constraints.speed_xy) {
-			_velocity_scale += _deltatime * _param_mpc_acc_hor_estm.get();
-
-		} else {
-			_velocity_scale = _constraints.speed_xy;
-
-		}
+	} else {
+		_velocity_scale = _constraints.speed_xy;
 	}
 
 	_velocity_scale = fminf(_computeVelXYGroundDist(), _velocity_scale);

--- a/src/lib/flight_tasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
+++ b/src/lib/flight_tasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
@@ -84,20 +84,19 @@ void FlightTaskManualPosition::_scaleSticks()
 	FlightTaskManualAltitude::_scaleSticks();
 
 	/* Constrain length of stick inputs to 1 for xy*/
-	Vector2f stick_xy(&_sticks_expo(0));
+	Vector2f stick_xy = _sticks_expo.slice<2, 1>(0, 0);
 
-	float mag = math::constrain(stick_xy.length(), 0.0f, 1.0f);
+	const float mag = math::constrain(stick_xy.length(), 0.0f, 1.0f);
 
 	if (mag > FLT_EPSILON) {
 		stick_xy = stick_xy.normalized() * mag;
 	}
 
-	// scale the stick inputs
-	if (PX4_ISFINITE(_sub_vehicle_local_position.get().vxy_max)) {
-		// estimator provides vehicle specific max
+	const float max_speed_from_estimator = _sub_vehicle_local_position.get().vxy_max;
 
+	if (PX4_ISFINITE(max_speed_from_estimator)) {
 		// use the minimum of the estimator and user specified limit
-		_velocity_scale = fminf(_constraints.speed_xy, _sub_vehicle_local_position.get().vxy_max);
+		_velocity_scale = fminf(_constraints.speed_xy, max_speed_from_estimator);
 		// Allow for a minimum of 0.3 m/s for repositioning
 		_velocity_scale = fmaxf(_velocity_scale, 0.3f);
 
@@ -119,8 +118,7 @@ void FlightTaskManualPosition::_scaleSticks()
 						     Vector2f(_velocity));
 	}
 
-	_velocity_setpoint(0) = vel_sp_xy(0);
-	_velocity_setpoint(1) = vel_sp_xy(1);
+	_velocity_setpoint.xy() = vel_sp_xy;
 }
 
 float FlightTaskManualPosition::_computeVelXYGroundDist()

--- a/src/lib/flight_tasks/tasks/ManualPosition/FlightTaskManualPosition.hpp
+++ b/src/lib/flight_tasks/tasks/ManualPosition/FlightTaskManualPosition.hpp
@@ -67,8 +67,7 @@ protected:
 					(ParamFloat<px4::params::MPC_VEL_MANUAL>) _param_mpc_vel_manual,
 					(ParamFloat<px4::params::MPC_LAND_VEL_XY>) _param_mpc_land_vel_xy,
 					(ParamFloat<px4::params::MPC_ACC_HOR_MAX>) _param_mpc_acc_hor_max,
-					(ParamFloat<px4::params::MPC_HOLD_MAX_XY>) _param_mpc_hold_max_xy,
-					(ParamFloat<px4::params::MPC_ACC_HOR_ESTM>) _param_mpc_acc_hor_estm
+					(ParamFloat<px4::params::MPC_HOLD_MAX_XY>) _param_mpc_hold_max_xy
 				       )
 private:
 	float _computeVelXYGroundDist();

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -506,21 +506,6 @@ PARAM_DEFINE_FLOAT(MPC_ACC_HOR, 3.0f);
 PARAM_DEFINE_FLOAT(MPC_DEC_HOR_SLOW, 5.0f);
 
 /**
- * Horizontal acceleration in manual modes when te estimator speed limit is removed.
- * If full stick is being applied and the estimator stops demanding a speed limit,
- * which it had been before (e.g if GPS is gained while flying on optical flow/vision only),
- * the vehicle will accelerate at this rate until the normal position control speed is achieved.
- *
- * @unit m/s/s
- * @min 0.2
- * @max 2.0
- * @increment 0.1
- * @decimal 1
- * @group Multicopter Position Control
- */
-PARAM_DEFINE_FLOAT(MPC_ACC_HOR_ESTM, 0.5f);
-
-/**
  * Maximum vertical acceleration in velocity controlled modes upward
  *
  * @unit m/s/s


### PR DESCRIPTION
Remove [MPC_ACC_HOR_ESTM](https://dev.px4.io/master/en/advanced/parameter_reference.html#MPC_ACC_HOR_ESTM)

This was used back in time when no soothing was done to avoid large steps when the estimator stops sending a maximum velocity (e.g.:GPS gained during optical flow flight). Since smoothing is applied later, this is not required anymore.

This fixes the issue found by @PX4/testflights  https://github.com/PX4/Firmware/pull/13561#issuecomment-564531310