### PR TITLE
Fix rover_sitl mixer call in CMakeLists.txt

### DIFF
--- a/ROMFS/px4fmu_common/mixers-sitl/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/mixers-sitl/CMakeLists.txt
@@ -34,7 +34,7 @@
 px4_add_romfs_files(
 	delta_wing_sitl.main.mix
 	plane_sitl.main.mix
-	over_sitl.main.mix
+	rover_sitl.main.mix
 	standard_vtol_sitl.main.mix
 	tiltrotor_sitl.main.mix
 )


### PR DESCRIPTION
Looks like a copying error. Quick fix.