### PR TITLE
Debug ekf log replays with gdb in vscode

### DIFF
--- a/platforms/posix/Debug/launch.json.in
+++ b/platforms/posix/Debug/launch.json.in
@@ -291,5 +291,65 @@
                 ]
             }
         },
+        {
+            "name": "EKF replay",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${command:cmake.launchTargetPath}",
+            "args": [
+                "${workspaceFolder}/ROMFS/px4fmu_common",
+                "-s",
+                "etc/init.d-posix/rcS",
+                "-t",
+                "${workspaceFolder}/test_data"
+            ],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/build/px4_sitl_default/tmp",
+            "environment": [
+                {
+                    "name": "replay",
+                    "value": "${input:setReplayLog}"
+                },
+                {
+                    "name": "replay_mode",
+                    "value": "ekf2"
+                }
+            ],
+            "externalConsole": false,
+            "preLaunchTask": "gazebo iris",
+            "postDebugTask": "gazebo kill",
+            "linux": {
+                "MIMode": "gdb",
+                "externalConsole": false,
+                "setupCommands": [
+                    {
+                        "description": "Enable pretty-printing for gdb",
+                        "text": "-enable-pretty-printing",
+                        "ignoreFailures": true
+                    },
+                    {
+                        "description": "PX4 ignore wq signals",
+                        "text": "handle SIGCONT nostop noprint nopass",
+                        "ignoreFailures": true
+                    }
+                ]
+            },
+            "osx": {
+                "MIMode": "lldb",
+                "externalConsole": true,
+                "setupCommands": [
+                    {
+                        "text": "pro hand -p true -s false -n false SIGCONT",
+                    }
+                ]
+            }
+        },
+    ],
+    "inputs": [
+        {
+          "type": "promptString",
+          "id": "setReplayLog",
+          "description": "Input the path to ulog file",
+        }
     ]
 }


### PR DESCRIPTION
This PR extends the debug options in Visual Studio Code. It adds the option of convenient gdb debugging during EKF log replays. 

*How to use it:*
- Copy the absolute path to your log file to your clipboard.
- Choose EKf replay target and press the play button.
![Screenshot from 2019-12-15 13-38-57](https://user-images.githubusercontent.com/23532607/70862756-ad0e8780-1f40-11ea-9fd7-09b1e73fd276.png)

- Prompt for log file path appears. Tip or paste absolute path to log file. Press enter and enjoy debugging.
![Screenshot from 2019-12-15 13-39-32](https://user-images.githubusercontent.com/23532607/70862788-227a5800-1f41-11ea-83b6-fc1e383b6157.png)

FYI @dagar @priseborough @RomanBapst @bresch 