### PR TITLE
vscode debug minor improvements

### DIFF
--- a/.vscode/cmake-variants.yaml
+++ b/.vscode/cmake-variants.yaml
@@ -6,6 +6,16 @@ CONFIG:
       buildType: RelWithDebInfo
       settings:
         CONFIG: px4_sitl_default
+    px4_sitl_replay:
+      short: px4_sitl_replay
+      buildType: RelWithDebInfo
+      settings:
+        CONFIG: px4_sitl_replay
+    px4_sitl_test:
+      short: px4_sitl_test
+      buildType: RelWithDebInfo
+      settings:
+        CONFIG: px4_sitl_test
     px4_fmu-v2_default:
       short: px4_fmu-v2_default
       buildType: MinSizeRel
@@ -46,6 +56,11 @@ CONFIG:
       buildType: MinSizeRel
       settings:
         CONFIG: av_x-v1_default
+    holybro_durandal-v1_default:
+      short: holybro_durandal-v1
+      buildType: MinSizeRel
+      settings:
+        CONFIG: holybro_durandal-v1_default
     intel_aerofc-v1_default:
       short: intel_aerofc-v1_default
       buildType: MinSizeRel
@@ -66,8 +81,3 @@ CONFIG:
       buildType: MinSizeRel
       settings:
         CONFIG: nxp_fmuk66-v3_default
-    holybro_durandal-v1_default:
-      short: holybro_durandal-v1
-      buildType: MinSizeRel
-      settings:
-        CONFIG: holybro_durandal-v1_default

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,7 +21,7 @@
                         "${workspaceFolder}/test_data"
                 ],
                 "stopAtEntry": false,
-                "cwd": "${workspaceFolder}/build/px4_sitl_default/tmp",
+                "cwd": "${command:cmake.buildDirectory}/tmp",
                 "environment": [
                         {
                                 "name": "PX4_SIM_MODEL",

--- a/boards/px4/sitl/replay.cmake
+++ b/boards/px4/sitl/replay.cmake
@@ -1,0 +1,25 @@
+
+px4_add_board(
+	PLATFORM posix
+	VENDOR px4
+	MODEL sitl
+	LABEL replay
+	MODULES
+		ekf2
+		logger
+		replay
+	SYSTEMCMDS
+		param
+		perf
+		reboot
+		shutdown
+		topic_listener
+		ver
+		work_queue
+	)
+
+message(STATUS "Building with uorb publisher rules support")
+add_definitions(-DORB_USE_PUBLISHER_RULES)
+
+message(STATUS "Building without lockstep for replay")
+set(ENABLE_LOCKSTEP_SCHEDULER no)

--- a/boards/px4/sitl/test.cmake
+++ b/boards/px4/sitl/test.cmake
@@ -5,7 +5,6 @@ px4_add_board(
 	MODEL sitl
 	LABEL test
 	TESTING
-
 	DRIVERS
 		#barometer # all available barometer drivers
 		#batt_smbus
@@ -20,8 +19,8 @@ px4_add_board(
 		#telemetry # all available telemetry drivers
 		tone_alarm
 		#uavcan
-
 	MODULES
+		airspeed_selector
 		attitude_estimator_q
 		camera_feedback
 		commander
@@ -30,7 +29,6 @@ px4_add_board(
 		events
 		fw_att_control
 		fw_pos_control_l1
-		rover_pos_control
 		land_detector
 		landing_target_estimator
 		load_mon
@@ -38,27 +36,26 @@ px4_add_board(
 		logger
 		mavlink
 		mc_att_control
-		mc_rate_control
 		mc_pos_control
+		mc_rate_control
 		navigator
-		replay
 		rc_update
+		replay
+		rover_pos_control
 		sensors
+		#sih
 		simulator
 		vmount
 		vtol_att_control
-		airspeed_selector
-
 	SYSTEMCMDS
-		#bl_update
 		#config
 		#dumpfile
 		dyn
 		esc_calib
-		#hardfault_log
 		led_control
 		mixer
 		motor_ramp
+		motor_test
 		#mtd
 		#nshterm
 		param
@@ -73,16 +70,17 @@ px4_add_board(
 		tune_control
 		ver
 		work_queue
-
 	EXAMPLES
 		bottle_drop # OBC challenge
 		dyn_hello # dynamically loading modules example
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		#hwtest # Hardware test
+		#matlab_csv_serial
 		px4_mavlink_debug # Tutorial code from http://dev.px4.io/en/debug/debug_values.html
 		px4_simple_app # Tutorial code from http://dev.px4.io/en/apps/hello_sky.html
 		rover_steering_control # Rover example app
+		uuv_example_app
 	)
 
 set(config_sitl_viewer jmavsim CACHE STRING "viewer for sitl")

--- a/platforms/posix/Debug/launch_replay.json.in
+++ b/platforms/posix/Debug/launch_replay.json.in
@@ -1,0 +1,63 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "EKF2 replay",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${command:cmake.launchTargetPath}",
+            "args": [
+                "${workspaceFolder}/ROMFS/px4fmu_common",
+                "-s",
+                "etc/init.d-posix/rcS",
+                "-t",
+                "${workspaceFolder}/test_data"
+            ],
+            "stopAtEntry": false,
+            "cwd": "${command:cmake.buildDirectory}/tmp",
+            "environment": [
+                {
+                    "name": "replay",
+                    "value": "${input:setReplayLog}"
+                },
+                {
+                    "name": "replay_mode",
+                    "value": "ekf2"
+                }
+            ],
+            "externalConsole": false,
+            "linux": {
+                "MIMode": "gdb",
+                "externalConsole": false,
+                "setupCommands": [
+                    {
+                        "description": "Enable pretty-printing for gdb",
+                        "text": "-enable-pretty-printing",
+                        "ignoreFailures": true
+                    },
+                    {
+                        "description": "PX4 ignore wq signals",
+                        "text": "handle SIGCONT nostop noprint nopass",
+                        "ignoreFailures": true
+                    }
+                ]
+            },
+            "osx": {
+                "MIMode": "lldb",
+                "externalConsole": true,
+                "setupCommands": [
+                    {
+                        "text": "pro hand -p true -s false -n false SIGCONT",
+                    }
+                ]
+            }
+        },
+    ],
+    "inputs": [
+        {
+          "type": "promptString",
+          "id": "setReplayLog",
+          "description": "Input the path to ulog file",
+        }
+    ]
+}

--- a/platforms/posix/Debug/launch_sim.json.in
+++ b/platforms/posix/Debug/launch_sim.json.in
@@ -14,7 +14,7 @@
                 "${workspaceFolder}/test_data"
             ],
             "stopAtEntry": false,
-            "cwd": "${workspaceFolder}/build/px4_sitl_default/tmp",
+            "cwd": "${command:cmake.buildDirectory}/tmp",
             "environment": [
                 {
                     "name": "PX4_SIM_MODEL",
@@ -63,7 +63,7 @@
                 "${workspaceFolder}/test_data"
             ],
             "stopAtEntry": false,
-            "cwd": "${workspaceFolder}/build/px4_sitl_default/tmp",
+            "cwd": "${command:cmake.buildDirectory}/tmp",
             "environment": [
                 {
                     "name": "PX4_SIM_MODEL",
@@ -112,7 +112,7 @@
                 "${workspaceFolder}/test_data"
             ],
             "stopAtEntry": false,
-            "cwd": "${workspaceFolder}/build/px4_sitl_default/tmp",
+            "cwd": "${command:cmake.buildDirectory}/tmp",
             "environment": [
                 {
                     "name": "PX4_SIM_MODEL",
@@ -161,7 +161,7 @@
                 "${workspaceFolder}/test_data"
             ],
             "stopAtEntry": false,
-            "cwd": "${workspaceFolder}/build/px4_sitl_default/tmp",
+            "cwd": "${command:cmake.buildDirectory}/tmp",
             "environment": [
                 {
                     "name": "PX4_SIM_MODEL",
@@ -210,7 +210,7 @@
                 "${workspaceFolder}/test_data"
             ],
             "stopAtEntry": false,
-            "cwd": "${workspaceFolder}/build/px4_sitl_default/tmp",
+            "cwd": "${command:cmake.buildDirectory}/tmp",
             "environment": [
                 {
                     "name": "PX4_SIM_MODEL",
@@ -258,7 +258,7 @@
                 "${workspaceFolder}/test_data"
             ],
             "stopAtEntry": false,
-            "cwd": "${workspaceFolder}/build/px4_sitl_default/tmp",
+            "cwd": "${command:cmake.buildDirectory}/tmp",
             "environment": [
                 {
                     "name": "PX4_SIM_MODEL",
@@ -290,66 +290,6 @@
                     }
                 ]
             }
-        },
-        {
-            "name": "EKF replay",
-            "type": "cppdbg",
-            "request": "launch",
-            "program": "${command:cmake.launchTargetPath}",
-            "args": [
-                "${workspaceFolder}/ROMFS/px4fmu_common",
-                "-s",
-                "etc/init.d-posix/rcS",
-                "-t",
-                "${workspaceFolder}/test_data"
-            ],
-            "stopAtEntry": false,
-            "cwd": "${workspaceFolder}/build/px4_sitl_default/tmp",
-            "environment": [
-                {
-                    "name": "replay",
-                    "value": "${input:setReplayLog}"
-                },
-                {
-                    "name": "replay_mode",
-                    "value": "ekf2"
-                }
-            ],
-            "externalConsole": false,
-            "preLaunchTask": "gazebo iris",
-            "postDebugTask": "gazebo kill",
-            "linux": {
-                "MIMode": "gdb",
-                "externalConsole": false,
-                "setupCommands": [
-                    {
-                        "description": "Enable pretty-printing for gdb",
-                        "text": "-enable-pretty-printing",
-                        "ignoreFailures": true
-                    },
-                    {
-                        "description": "PX4 ignore wq signals",
-                        "text": "handle SIGCONT nostop noprint nopass",
-                        "ignoreFailures": true
-                    }
-                ]
-            },
-            "osx": {
-                "MIMode": "lldb",
-                "externalConsole": true,
-                "setupCommands": [
-                    {
-                        "text": "pro hand -p true -s false -n false SIGCONT",
-                    }
-                ]
-            }
-        },
-    ],
-    "inputs": [
-        {
-          "type": "promptString",
-          "id": "setReplayLog",
-          "description": "Input the path to ulog file",
         }
     ]
 }

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -103,4 +103,8 @@ add_custom_target(list_vmd_make_targets
 	)
 
 # vscode launch.json
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Debug/launch.json.in ${PX4_SOURCE_DIR}/.vscode/launch.json COPYONLY)
+if(${PX4_BOARD_LABEL} MATCHES "replay")
+	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Debug/launch_replay.json.in ${PX4_SOURCE_DIR}/.vscode/launch.json COPYONLY)
+else()
+	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Debug/launch_sim.json.in ${PX4_SOURCE_DIR}/.vscode/launch.json COPYONLY)
+endif()


### PR DESCRIPTION
This is a small follow up on https://github.com/PX4/Firmware/pull/13749.

There was potential confusion between px4_sitl_default built in replay mode or not. To get around this I introduced a stripped down px4_sitl_replay config. Then the vscode launch is split to be appropriate for either replay or simulation.

 - create new px4_sitl_replay config specifically for replay
 - split posix launch.json for simulation and replay
 - ekf2 replay don't launch gazebo
 - add px4_sitl_test cmake variant
 - px4_sitl_test bring into sync with px4_sitl_default
 - vscode replace hard coded build path with cmake setting


