### PR TITLE
Kakutef7: fix baro startup

### DIFF
--- a/boards/holybro/kakutef7/init/rc.board_sensors
+++ b/boards/holybro/kakutef7/init/rc.board_sensors
@@ -12,7 +12,7 @@ then
 fi
 
 # Internal Baro
-bmp280 -I start
+bmp280 start
 
 # Possible external compasses
 ist8310 -C -b 1 start


### PR DESCRIPTION
The bmp280 is on the expansion bus (that is both internal & external)

Fixes regression from 92559f7a858b7a82f1cf541b0a00d6f8a6285f7f.