### PR TITLE
Don't sleep in middle of mavlink message reception

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2717,18 +2717,8 @@ MavlinkReceiver::Run()
 
 		if (poll(&fds[0], 1, timeout) > 0) {
 			if (_mavlink->get_protocol() == Protocol::SERIAL) {
-
-				/*
-				 * to avoid reading very small chunks wait for data before reading
-				 * this is designed to target one message, so >20 bytes at a time
-				 */
-				const unsigned character_count = 20;
-
 				/* non-blocking read. read may return negative values */
-				if ((nread = ::read(fds[0].fd, buf, sizeof(buf))) < (ssize_t)character_count) {
-					const unsigned sleeptime = character_count * 1000000 / (_mavlink->get_baudrate() / 10);
-					px4_usleep(sleeptime);
-				}
+				nread = ::read(fds[0].fd, buf, sizeof(buf));
 			}
 
 #if defined(MAVLINK_UDP)


### PR DESCRIPTION
**Describe problem solved by this pull request**
During investigation of an external timesync module, it was discovered that it took a significant amount of time for the firmware to respond to a timesync message:
![IMG_20191219_120808](https://user-images.githubusercontent.com/1746276/71180582-c120f480-2272-11ea-9d32-524917eea5fb.jpg)
In this case, 4.5ms, which is an eternity to decode a 25 byte mavlink message, get the system time, then encode and queue a new 25 byte mavlink message.

Further investigation found that there is a sleep in the mavlink decode. NB: the sleep would be expected to be called at the end of any message that had less than 20 bytes from the final `read()`, not just for incomplete messages.

The sleep is requested to be for ~200uS at 921600 baud, but in reality sleeps between 1.0 - 2.5mS. This is critical, as the parser has not handled the data yet, and the message maybe be completely received. Due to the longer-than-requested sleep, it could also miss other data coming in on the serial port afterwards, necessitating larger RX buffers.

![Screenshot_20191219_143953](https://user-images.githubusercontent.com/1746276/71180925-7784d980-2273-11ea-8144-b9cdf94d3248.png)

![Screenshot_20191219_143803](https://user-images.githubusercontent.com/1746276/71180902-6fc53500-2273-11ea-806a-b91b8e3bc062.png)

**Describe your solution**
Completely removing the sleep fixes a large part of this delay.
Round trip time of the timesync message before:
![Screenshot_20191219_143911](https://user-images.githubusercontent.com/1746276/71180775-2543b880-2273-11ea-9ab0-c0e0098811ac.png)

After:
![Screenshot_20191219_144752](https://user-images.githubusercontent.com/1746276/71180788-2aa10300-2273-11ea-9d5f-f4d0ddea0717.png)

**Test data / coverage**
Once concern is increased CPU usage.

CPU usage with 1kHz timesync messages being sent, before:
![Screenshot_20191219_144330](https://user-images.githubusercontent.com/1746276/71181282-21646600-2274-11ea-88cb-0ccda9c08741.png)

After
![Screenshot_20191219_144641](https://user-images.githubusercontent.com/1746276/71181370-4b1d8d00-2274-11ea-8005-e0cf79b1181b.png)

**Additional context**
@bkueng @julianoes  would love some feedback, maybe I've missed something here.
@MaEtUgR since you seemed interested.