### PR TITLE
Rover hold/loiter

### DIFF
--- a/src/modules/rover_pos_control/RoverPositionControl.hpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.hpp
@@ -99,10 +99,11 @@ public:
 	void run() override;
 
 private:
-	uORB::Publication<position_controller_status_s>	_pos_ctrl_status_pub{ORB_ID(position_controller_status)};
-	uORB::Publication<actuator_controls_s>		_actuator_controls_pub{ORB_ID(actuator_controls_0)};
 
-	int		_control_mode_sub{-1};			/**< control mode subscription */
+	uORB::Publication<position_controller_status_s>	_pos_ctrl_status_pub{ORB_ID(position_controller_status)};  /**< navigation capabilities publication */
+	uORB::Publication<actuator_controls_s>		_actuator_controls_pub{ORB_ID(actuator_controls_0)};  /**< actuator controls publication */
+
+	int		_control_mode_sub{-1};		/**< control mode subscription */
 	int		_global_pos_sub{-1};
 	int		_local_pos_sub{-1};
 	int		_manual_control_sub{-1};		/**< notification of manual control updates */
@@ -113,15 +114,15 @@ private:
 
 	uORB::Subscription	_parameter_update_sub{ORB_ID(parameter_update)};
 
-	manual_control_setpoint_s		_manual{};			/**< r/c channel data */
+	manual_control_setpoint_s		_manual{};			    /**< r/c channel data */
 	position_setpoint_triplet_s		_pos_sp_triplet{};		/**< triplet of mission items */
 	vehicle_attitude_setpoint_s		_att_sp{};			/**< attitude setpoint > */
 	vehicle_control_mode_s			_control_mode{};		/**< control mode */
 	vehicle_global_position_s		_global_pos{};			/**< global vehicle position */
 	vehicle_local_position_s		_local_pos{};			/**< global vehicle position */
-	actuator_controls_s			_act_controls{};		/**< direct control of actuators */
-	vehicle_attitude_s			_vehicle_att{};
-	sensor_combined_s			_sensor_combined{};
+	actuator_controls_s				_act_controls{};		/**< direct control of actuators */
+	vehicle_attitude_s				_vehicle_att{};
+	sensor_combined_s				_sensor_combined{};
 
 	SubscriptionData<vehicle_acceleration_s>		_vehicle_acceleration_sub{ORB_ID(vehicle_acceleration)};
 
@@ -138,12 +139,19 @@ private:
 
 	ECL_L1_Pos_Controller				_gnd_control;
 
-	bool _waypoint_reached{false};
-
 	enum UGV_POSCTRL_MODE {
 		UGV_POSCTRL_MODE_AUTO,
 		UGV_POSCTRL_MODE_OTHER
 	} _control_mode_current{UGV_POSCTRL_MODE_OTHER};			///< used to check the mode in the last control loop iteration. Use to check if the last iteration was in the same mode.
+
+
+	enum POS_CTRLSTATES {
+		GOTO_WAYPOINT,
+		STOPPING
+	} _pos_ctrl_state {STOPPING};			/// Position control state machine
+
+	/* previous waypoint */
+	matrix::Vector2f _prev_wp{0.0f, 0.0f};
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::GND_L1_PERIOD>) _param_l1_period,
@@ -165,7 +173,8 @@ private:
 		(ParamFloat<px4::params::GND_THR_CRUISE>) _param_throttle_cruise,
 
 		(ParamFloat<px4::params::GND_WHEEL_BASE>) _param_wheel_base,
-		(ParamFloat<px4::params::GND_MAX_ANG>) _param_max_turn_angle
+		(ParamFloat<px4::params::GND_MAX_ANG>) _param_max_turn_angle,
+		(ParamFloat<px4::params::NAV_LOITER_RAD>) _param_nav_loiter_rad	/**< loiter radius for Rover */
 	)
 
 	/**


### PR DESCRIPTION
This is my first pull request, so unsure as to whether I should  raise an Issue before creating a pull request, but I'm hoping that this explanation will be sufficiently clear, any feedback welcome. 

**Describe problem solved by this pull request**
When using HOLD/LOITER the rover would not hold position but instead circle/oscillate around the hold position. This was caused by the fact that the current algorithm sets velocity to zero when distance to waypoint is under a certain threshold, the vehicle would decelerate, but not enough to stop before it once again exceeded the threshold. At this point it would then try to return to the hold position and the process would repeat. 

**Describe your solution**
In the proposed solution once the distance to the waypoint is under a threshold the velocity is set to zero until a new position waypoint is requested that is more than the threshold distance away from the previous waypoint. This way the vehicle always stops.

**Test data / coverage**
This was tested with both px4_sitl and a pixhawk4 rover running the  Aion RObotics R1 UGV (Tank type/Differential drive)


