### PR TITLE
Added cli check for ism330dlc startup to prevent hardfault

### DIFF
--- a/src/drivers/imu/st/ism330dlc/ism330dlc_main.cpp
+++ b/src/drivers/imu/st/ism330dlc/ism330dlc_main.cpp
@@ -132,6 +132,11 @@ extern "C" __EXPORT int ism330dlc_main(int argc, char *argv[])
 		}
 	}
 
+	if (myoptind >= argc) {
+		ism330dlc::usage();
+		return -1;
+	}
+
 	const char *verb = argv[myoptind];
 
 	if (!strcmp(verb, "start")) {


### PR DESCRIPTION
If ism033dlc driver is started without any options, the fmu hard faults. 