### PR TITLE
add negative for min to support tricycle landing gear

### DIFF
--- a/src/modules/fw_pos_control_l1/runway_takeoff/runway_takeoff_params.c
+++ b/src/modules/fw_pos_control_l1/runway_takeoff/runway_takeoff_params.c
@@ -95,7 +95,7 @@ PARAM_DEFINE_FLOAT(RWTO_MAX_THR, 1.0);
  * to takeoff is reached.
  *
  * @unit deg
- * @min 0.0
+ * @min -10.0
  * @max 20.0
  * @decimal 1
  * @increment 0.5


### PR DESCRIPTION
if we used tricycle landing gear, we need the wheel to  touch the ground to control the direction