### PR TITLE
Tests: Speed up boot

### DIFF
--- a/src/modules/simulator/simulator.cpp
+++ b/src/modules/simulator/simulator.cpp
@@ -163,7 +163,7 @@ extern "C" {
 					break;
 
 				} else {
-					system_sleep(1);
+					system_usleep(100);
 				}
 			}
 

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -667,7 +667,7 @@ void Simulator::poll_for_MAVLink_messages()
 				break;
 
 			} else {
-				system_sleep(1);
+				system_usleep(100);
 			}
 		}
 


### PR DESCRIPTION
The previous boot configuration took at minimum one second to boot. This is in particular significant in tests when the system is often started and stopped.
