### PR TITLE
VTOL tiltrotor tilt ("pusher") support in hover

### DIFF
--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -317,9 +317,7 @@ void Standard::update_mc_state()
 {
 	VtolType::update_mc_state();
 
-	VtolType::pusher_assist();
-
-	_pusher_throttle = _forward_thrust;
+	_pusher_throttle = VtolType::pusher_assist();
 }
 
 void Standard::update_fw_state()

--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -69,8 +69,6 @@ private:
 	struct {
 		float pusher_ramp_dt;
 		float back_trans_ramp;
-		float down_pitch_max;
-		float forward_thrust_scale;
 		float pitch_setpoint_offset;
 		float reverse_output;
 		float reverse_delay;
@@ -79,8 +77,6 @@ private:
 	struct {
 		param_t pusher_ramp_dt;
 		param_t back_trans_ramp;
-		param_t down_pitch_max;
-		param_t forward_thrust_scale;
 		param_t pitch_setpoint_offset;
 		param_t reverse_output;
 		param_t reverse_delay;

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -401,6 +401,7 @@ float Tiltrotor::thrust_compensation_for_tilt()
 	compensated_tilt = compensated_tilt < 0.0f ? 0.0f : compensated_tilt;
 	compensated_tilt = compensated_tilt > 0.5f ? 0.5f : compensated_tilt;
 
-	return _v_att_sp->thrust_body[2] / cosf(compensated_tilt * M_PI_2_F);
+	// increase vertical thrust by 1/cos(tilt), limmit to [0,1]
+	return math::constrain(_v_att_sp->thrust_body[2] / cosf(compensated_tilt * M_PI_2_F), 0.0f, 1.0f);
 
 }

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -395,11 +395,10 @@ void Tiltrotor::fill_actuator_outputs()
 
 float Tiltrotor::thrust_compensation_for_tilt()
 {
-
 	// only compensate for tilt angle up to 0.5 * max tilt
 	float compensated_tilt = math::constrain(_tilt_control, 0.0f, 0.5f);
 
-	// increase vertical thrust by 1/cos(tilt), limmit to [0,1]
-	return math::constrain(_v_att_sp->thrust_body[2] / cosf(compensated_tilt * M_PI_2_F), 0.0f, 1.0f);
+	// increase vertical thrust by 1/cos(tilt), limmit to [-1,0]
+	return math::constrain(_v_att_sp->thrust_body[2] / cosf(compensated_tilt * M_PI_2_F), -1.0f, 0.0f);
 
 }

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -397,9 +397,7 @@ float Tiltrotor::thrust_compensation_for_tilt()
 {
 
 	// only compensate for tilt angle up to 0.5 * max tilt
-	float compensated_tilt = _tilt_control;
-	compensated_tilt = compensated_tilt < 0.0f ? 0.0f : compensated_tilt;
-	compensated_tilt = compensated_tilt > 0.5f ? 0.5f : compensated_tilt;
+	float compensated_tilt = math::constrain(_tilt_control, 0.0f, 0.5f);
 
 	// increase vertical thrust by 1/cos(tilt), limmit to [0,1]
 	return math::constrain(_v_att_sp->thrust_body[2] / cosf(compensated_tilt * M_PI_2_F), 0.0f, 1.0f);

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -207,11 +207,9 @@ void Tiltrotor::update_mc_state()
 {
 	VtolType::update_mc_state();
 
-	VtolType::pusher_assist();
+	_tilt_control = VtolType::pusher_assist();
 
-	_tilt_control = _forward_thrust;
-
-	Tiltrotor::thrust_compensation_for_tilt();
+	_v_att_sp->thrust_body[2] = Tiltrotor::thrust_compensation_for_tilt();
 }
 
 void Tiltrotor::update_fw_state()
@@ -395,7 +393,7 @@ void Tiltrotor::fill_actuator_outputs()
  * Increase combined thrust of MC propellers if motors are tilted. Assumes that all MC motors are tilted equally.
  */
 
-void Tiltrotor::thrust_compensation_for_tilt()
+float Tiltrotor::thrust_compensation_for_tilt()
 {
 
 	// only compensate for tilt angle up to 0.5 * max tilt
@@ -403,7 +401,6 @@ void Tiltrotor::thrust_compensation_for_tilt()
 	compensated_tilt = compensated_tilt < 0.0f ? 0.0f : compensated_tilt;
 	compensated_tilt = compensated_tilt > 0.5f ? 0.5f : compensated_tilt;
 
-	float thrust_new = _v_att_sp->thrust_body[2] / cosf(compensated_tilt * M_PI_2_F);
+	return _v_att_sp->thrust_body[2] / cosf(compensated_tilt * M_PI_2_F);
 
-	_v_att_sp->thrust_body[2] = thrust_new;
 }

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -207,8 +207,11 @@ void Tiltrotor::update_mc_state()
 {
 	VtolType::update_mc_state();
 
-	// make sure motors are not tilted
-	_tilt_control = _params_tiltrotor.tilt_mc;
+	VtolType::pusher_assist();
+
+	_tilt_control = _forward_thrust;
+
+	Tiltrotor::thrust_compensation_for_tilt();
 }
 
 void Tiltrotor::update_fw_state()
@@ -386,4 +389,21 @@ void Tiltrotor::fill_actuator_outputs()
 		_actuators_out_1->control[actuator_controls_s::INDEX_YAW] =
 			_actuators_fw_in->control[actuator_controls_s::INDEX_YAW];
 	}
+}
+
+/*
+ * Increase combined thrust of MC propellers if motors are tilted. Assumes that all MC motors are tilted equally.
+ */
+
+void Tiltrotor::thrust_compensation_for_tilt()
+{
+
+	// only compensate for tilt angle up to 0.5 * max tilt
+	float compensated_tilt = _tilt_control;
+	compensated_tilt = compensated_tilt < 0.0f ? 0.0f : compensated_tilt;
+	compensated_tilt = compensated_tilt > 0.5f ? 0.5f : compensated_tilt;
+
+	float thrust_new = _v_att_sp->thrust_body[2] / cosf(compensated_tilt * M_PI_2_F);
+
+	_v_att_sp->thrust_body[2] = thrust_new;
 }

--- a/src/modules/vtol_att_control/tiltrotor.h
+++ b/src/modules/vtol_att_control/tiltrotor.h
@@ -58,6 +58,7 @@ public:
 	void update_mc_state() override;
 	void update_fw_state() override;
 	void waiting_on_tecs() override;
+	void thrust_compensation_for_tilt();
 
 private:
 

--- a/src/modules/vtol_att_control/tiltrotor.h
+++ b/src/modules/vtol_att_control/tiltrotor.h
@@ -58,7 +58,7 @@ public:
 	void update_mc_state() override;
 	void update_fw_state() override;
 	void waiting_on_tecs() override;
-	void thrust_compensation_for_tilt();
+	float thrust_compensation_for_tilt();
 
 private:
 

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -86,6 +86,9 @@ VtolAttitudeControl::VtolAttitudeControl() :
 	_params_handles.diff_thrust = param_find("VT_FW_DIFTHR_EN");
 	_params_handles.diff_thrust_scale = param_find("VT_FW_DIFTHR_SC");
 
+	_params_handles.down_pitch_max = param_find("VT_DWN_PITCH_MAX");
+	_params_handles.forward_thrust_scale = param_find("VT_FWD_THRUST_SC");
+
 	/* fetch initial parameter values */
 	parameters_update();
 
@@ -271,6 +274,13 @@ VtolAttitudeControl::parameters_update()
 
 	param_get(_params_handles.diff_thrust_scale, &v);
 	_params.diff_thrust_scale = math::constrain(v, -1.0f, 1.0f);
+
+	/* maximum down pitch allowed */
+	param_get(_params_handles.down_pitch_max, &v);
+	_params.down_pitch_max = math::radians(v);
+
+	/* scale for fixed wing thrust used for forward acceleration in multirotor mode */
+	param_get(_params_handles.forward_thrust_scale, &_params.forward_thrust_scale);
 
 	// make sure parameters are feasible, require at least 1 m/s difference between transition and blend airspeed
 	_params.airspeed_blend = math::min(_params.airspeed_blend, _params.transition_airspeed - 1.0f);

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -201,6 +201,8 @@ private:
 		param_t fw_motors_off;
 		param_t diff_thrust;
 		param_t diff_thrust_scale;
+		param_t down_pitch_max;
+		param_t forward_thrust_scale;
 	} _params_handles{};
 
 	/* for multicopters it is usual to have a non-zero idle speed of the engines

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -434,8 +434,7 @@ float VtolType::pusher_assist()
 
 		forward_thrust = (sinf(-pitch_down) - sinf(_params->down_pitch_max)) * _params->forward_thrust_scale;
 		// limit forward actuation to [0, 0.9]
-		forward_thrust = forward_thrust < 0.0f ? 0.0f : forward_thrust;
-		forward_thrust = forward_thrust > 0.9f ? 0.9f : forward_thrust;
+		forward_thrust = math::constrain(forward_thrust, 0.0f, 0.9f);
 
 		// return the vehicle to level position
 		float pitch_new = 0.0f;

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -70,6 +70,8 @@ struct Params {
 	int32_t fw_motors_off;			/**< bitmask of all motors that should be off in fixed wing mode */
 	int32_t diff_thrust;
 	float diff_thrust_scale;
+	float down_pitch_max;
+	float forward_thrust_scale;
 };
 
 // Has to match 1:1 msg/vtol_vehicle_status.msg
@@ -163,6 +165,10 @@ public:
 	 */
 	bool can_transition_on_ground();
 
+	/**
+	 * Pusher assist in hover (pusher/pull for standard VTOL, motor tilt for tiltrotor)
+	 */
+	void pusher_assist();
 
 
 	mode get_mode() {return _vtol_mode;}
@@ -215,6 +221,8 @@ protected:
 	hrt_abstime _tecs_running_ts = 0;
 
 	motor_state _motor_state = motor_state::DISABLED;
+
+	float _forward_thrust = 0.0f; // normalized pusher throttle (standard VTOL) or tilt (tiltrotor)
 
 
 

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -168,7 +168,7 @@ public:
 	/**
 	 * Pusher assist in hover (pusher/pull for standard VTOL, motor tilt for tiltrotor)
 	 */
-	void pusher_assist();
+	float pusher_assist();
 
 
 	mode get_mode() {return _vtol_mode;}
@@ -221,8 +221,6 @@ protected:
 	hrt_abstime _tecs_running_ts = 0;
 
 	motor_state _motor_state = motor_state::DISABLED;
-
-	float _forward_thrust = 0.0f; // normalized pusher throttle (standard VTOL) or tilt (tiltrotor)
 
 
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
This PR enables the controller for tiltrotor VTOL to use tilting of the motors to accelerate forward (similar as the standard VTOL can use its pusher/pull motor to do so).

**Test data / coverage**
Initial testing looked promising, but need to do some more as I've changed the thrust compensation when tilting is applied. 
Also needs to be tested on a standard VTOL to check for regressions.

This a video of the first flight: https://drive.google.com/file/d/1gHhwEUxHKgazkDOrzRixyPfx4gMYRJ-x/view?usp=sharing
It was with flying in altitude mode (I've enabled pusher/tilt assist also in altitude mode to test this PR - do you think it's a good idea to enable that in general @RomanBapst ?).

