### PR TITLE
Add access token to build_tests.yml

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -8,6 +8,8 @@ jobs:
     container: px4io/px4-dev-base-bionic:2019-10-24
     steps:
     - uses: actions/checkout@v1
+      with:
+        token: ${{ secrets.ACCESS_TOKEN }}
     - name: check_format
       env:
         CI: true

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -10,6 +10,7 @@ jobs:
     - uses: actions/checkout@v1
       with:
         token: ${{ secrets.ACCESS_TOKEN }}
+        submodules: true
     - name: check_format
       env:
         CI: true


### PR DESCRIPTION
This is necessary to enable GH Actions for downstream adopters.