### PR TITLE
Fix Unit Test Float Accuracy

### DIFF
--- a/src/lib/collision_prevention/CollisionPreventionTest.cpp
+++ b/src/lib/collision_prevention/CollisionPreventionTest.cpp
@@ -313,7 +313,7 @@ TEST_F(CollisionPreventionTest, testPurgeOldData)
 		if (i < 6) {
 			// THEN: If the data is new enough, the velocity setpoint should stay the same as the input
 			// Note: direction will change slightly due to guidance
-			EXPECT_EQ(original_setpoint.norm(), modified_setpoint.norm());
+			EXPECT_FLOAT_EQ(original_setpoint.norm(), modified_setpoint.norm());
 
 		} else {
 			// THEN: If the data is expired, the velocity setpoint should be cut down to zero because there is no data
@@ -381,7 +381,7 @@ TEST_F(CollisionPreventionTest, testNoRangeData)
 		if (i < 5) {
 			// THEN: If the data is new enough, the velocity setpoint should stay the same as the input
 			// Note: direction will change slightly due to guidance
-			EXPECT_EQ(original_setpoint.norm(), modified_setpoint.norm());
+			EXPECT_FLOAT_EQ(original_setpoint.norm(), modified_setpoint.norm());
 
 		} else {
 			// THEN: If the data is expired, the velocity setpoint should be cut down to zero because there is no data
@@ -1008,8 +1008,8 @@ TEST_F(CollisionPreventionTest, adaptSetpointDirection_flat_minimum)
 
 	//THEN: the setpoint direction should be modified correctly
 	EXPECT_EQ(sp_index, 2);
-	EXPECT_FLOAT_EQ(setpoint_dir(0), 0.93969262);
-	EXPECT_FLOAT_EQ(setpoint_dir(1), 0.34202012);
+	EXPECT_FLOAT_EQ(setpoint_dir(0), 0.93969262f);
+	EXPECT_FLOAT_EQ(setpoint_dir(1), 0.34202012f);
 }
 
 TEST_F(CollisionPreventionTest, overlappingSensors)

--- a/src/lib/flight_tasks/tasks/Utility/ManualVelocitySmoothingXYTest.cpp
+++ b/src/lib/flight_tasks/tasks/Utility/ManualVelocitySmoothingXYTest.cpp
@@ -58,9 +58,9 @@ TEST_F(ManualVelocitySmoothingXYTest, setGet)
 	_smoothing.setMaxVel(5.f);
 
 	// THEN: We should be able to get them back
-	EXPECT_EQ(_smoothing.getMaxJerk(), 11.f);
-	EXPECT_EQ(_smoothing.getMaxAccel(), 7.f);
-	EXPECT_EQ(_smoothing.getMaxVel(), 5.f);
+	EXPECT_FLOAT_EQ(_smoothing.getMaxJerk(), 11.f);
+	EXPECT_FLOAT_EQ(_smoothing.getMaxAccel(), 7.f);
+	EXPECT_FLOAT_EQ(_smoothing.getMaxVel(), 5.f);
 }
 
 TEST_F(ManualVelocitySmoothingXYTest, getCurrentState)

--- a/src/lib/flight_tasks/tasks/Utility/VelocitySmoothingTest.cpp
+++ b/src/lib/flight_tasks/tasks/Utility/VelocitySmoothingTest.cpp
@@ -172,9 +172,9 @@ TEST_F(VelocitySmoothingTest, testZeroSetpoint)
 
 	// THEN: All the trajectories should still be zero
 	for (int i = 0; i < 3; i++) {
-		EXPECT_EQ(_trajectories[i].getCurrentJerk(), 0.f);
-		EXPECT_EQ(_trajectories[i].getCurrentAcceleration(), 0.f);
-		EXPECT_EQ(_trajectories[i].getCurrentVelocity(), 0.f);
-		EXPECT_EQ(_trajectories[i].getCurrentPosition(), 0.f);
+		EXPECT_FLOAT_EQ(_trajectories[i].getCurrentJerk(), 0.f);
+		EXPECT_FLOAT_EQ(_trajectories[i].getCurrentAcceleration(), 0.f);
+		EXPECT_FLOAT_EQ(_trajectories[i].getCurrentVelocity(), 0.f);
+		EXPECT_FLOAT_EQ(_trajectories[i].getCurrentPosition(), 0.f);
 	}
 }

--- a/src/lib/parameters/ParameterTest.cpp
+++ b/src/lib/parameters/ParameterTest.cpp
@@ -59,7 +59,7 @@ TEST_F(ParameterTest, testParamReadWrite)
 
 	// THEN it should be successful and have the default value
 	EXPECT_EQ(0, status);
-	EXPECT_EQ(-1, value);
+	EXPECT_FLOAT_EQ(-1.f, value);
 
 	// WHEN: we set the parameter
 	value = 42.f;
@@ -74,7 +74,7 @@ TEST_F(ParameterTest, testParamReadWrite)
 
 	// THEN: it should be exactly the value we set
 	EXPECT_EQ(0, status);
-	EXPECT_EQ(42.f, value2);
+	EXPECT_FLOAT_EQ(42.f, value2);
 }
 
 
@@ -99,8 +99,8 @@ TEST_F(ParameterTest, testUorbSendReceive)
 
 	// AND: the values we got should be the same
 	EXPECT_EQ(message.timestamp, obstacle_distance.timestamp);
-	EXPECT_EQ(message.min_distance, obstacle_distance.min_distance);
-	EXPECT_EQ(message.max_distance, obstacle_distance.max_distance);
+	EXPECT_FLOAT_EQ(message.min_distance, obstacle_distance.min_distance);
+	EXPECT_FLOAT_EQ(message.max_distance, obstacle_distance.max_distance);
 
 	// AND: all the bytes should be equal
 	EXPECT_EQ(0, memcmp(&message, &obstacle_distance, sizeof(message)));

--- a/src/modules/mc_pos_control/PositionControl/ControlMathTest.cpp
+++ b/src/modules/mc_pos_control/PositionControl/ControlMathTest.cpp
@@ -43,38 +43,38 @@ TEST(ControlMathTest, ThrottleAttitudeMapping)
 {
 	/* expected: zero roll, zero pitch, zero yaw, full thr mag
 	 * reason: thrust pointing full upward */
-	Vector3f thr{0.0f, 0.0f, -1.0f};
-	float yaw = 0.0f;
+	Vector3f thr{0.f, 0.f, -1.f};
+	float yaw = 0.f;
 	vehicle_attitude_setpoint_s att{};
 	thrustToAttitude(thr, yaw, att);
-	EXPECT_FLOAT_EQ(att.roll_body, 0.0f);
-	EXPECT_FLOAT_EQ(att.pitch_body, 0.0f);
-	EXPECT_FLOAT_EQ(att.yaw_body, 0.0f);
+	EXPECT_FLOAT_EQ(att.roll_body, 0.f);
+	EXPECT_FLOAT_EQ(att.pitch_body, 0.f);
+	EXPECT_FLOAT_EQ(att.yaw_body, 0.f);
 	EXPECT_FLOAT_EQ(att.thrust_body[2], -1.f);
 
 	/* expected: same as before but with 90 yaw
 	 * reason: only yaw changed */
 	yaw = M_PI_2_F;
 	thrustToAttitude(thr, yaw, att);
-	EXPECT_FLOAT_EQ(att.roll_body, 0.0f);
-	EXPECT_FLOAT_EQ(att.pitch_body, 0.0f);
+	EXPECT_FLOAT_EQ(att.roll_body, 0.f);
+	EXPECT_FLOAT_EQ(att.pitch_body, 0.f);
 	EXPECT_FLOAT_EQ(att.yaw_body, M_PI_2_F);
 	EXPECT_FLOAT_EQ(att.thrust_body[2], -1.f);
 
 	/* expected: same as before but roll 180
 	 * reason: thrust points straight down and order Euler
 	 * order is: 1. roll, 2. pitch, 3. yaw */
-	thr = Vector3f(0.0f, 0.0f, 1.0f);
+	thr = Vector3f(0.f, 0.f, 1.f);
 	thrustToAttitude(thr, yaw, att);
 	EXPECT_FLOAT_EQ(att.roll_body, -M_PI_F);
-	EXPECT_FLOAT_EQ(att.pitch_body, 0.0f);
+	EXPECT_FLOAT_EQ(att.pitch_body, 0.f);
 	EXPECT_FLOAT_EQ(att.yaw_body, M_PI_2_F);
 	EXPECT_FLOAT_EQ(att.thrust_body[2], -1.f);
 }
 
 TEST(ControlMathTest, ConstrainXYPriorities)
 {
-	const float max = 5.0f;
+	const float max = 5.f;
 	// v0 already at max
 	Vector2f v0(max, 0);
 	Vector2f v1(v0(1), -v0(0));
@@ -87,17 +87,17 @@ TEST(ControlMathTest, ConstrainXYPriorities)
 	v0.zero();
 	v_r = constrainXY(v0, v1, max);
 	EXPECT_FLOAT_EQ(v_r(1), -max);
-	EXPECT_FLOAT_EQ(v_r(0), 0.0f);
+	EXPECT_FLOAT_EQ(v_r(0), 0.f);
 
-	v0 = Vector2f(0.5f, 0.5f);
-	v1 = Vector2f(0.5f, -0.5f);
+	v0 = Vector2f(.5f, .5f);
+	v1 = Vector2f(.5f, -.5f);
 	v_r = constrainXY(v0, v1, max);
 	const float diff = Vector2f(v_r - (v0 + v1)).length();
-	EXPECT_FLOAT_EQ(diff, 0.0f);
+	EXPECT_FLOAT_EQ(diff, 0.f);
 
 	// v0 and v1 exceed max and are perpendicular
-	v0 = Vector2f(4.0f, 0.0f);
-	v1 = Vector2f(0.0f, -4.0f);
+	v0 = Vector2f(4.f, 0.f);
+	v1 = Vector2f(0.f, -4.f);
 	v_r = constrainXY(v0, v1, max);
 	EXPECT_FLOAT_EQ(v_r(0), v0(0));
 	EXPECT_GT(v_r(0), 0);
@@ -127,53 +127,53 @@ TEST(ControlMathTest, CrossSphereLine)
 	 *
 	 *
 	 * On trajectory --+----o----1----+--------2/3---+-- */
-	const Vector3f prev = Vector3f(0.0f, 0.0f, 0.0f);
-	const Vector3f curr = Vector3f(0.0f, 0.0f, 2.0f);
+	const Vector3f prev = Vector3f(0.f, 0.f, 0.f);
+	const Vector3f curr = Vector3f(0.f, 0.f, 2.f);
 	Vector3f res;
 	bool retval = false;
 
 	// on line, near, before previous waypoint
-	retval = cross_sphere_line(Vector3f(0.0f, 0.0f, -0.5f), 1.0f, prev, curr, res);
+	retval = cross_sphere_line(Vector3f(0.f, 0.f, -.5f), 1.f, prev, curr, res);
 	EXPECT_TRUE(retval);
 	EXPECT_EQ(res, Vector3f(0.f, 0.f, 0.5f));
 
 	// on line, near, before target waypoint
-	retval = cross_sphere_line(Vector3f(0.0f, 0.0f, 1.0f), 1.0f, prev, curr, res);
+	retval = cross_sphere_line(Vector3f(0.f, 0.f, 1.f), 1.f, prev, curr, res);
 	EXPECT_TRUE(retval);
 	EXPECT_EQ(res, Vector3f(0.f, 0.f, 2.f));
 
 	// on line, near, after target waypoint
-	retval = cross_sphere_line(Vector3f(0.0f, 0.0f, 2.5f), 1.0f, prev, curr, res);
+	retval = cross_sphere_line(Vector3f(0.f, 0.f, 2.5f), 1.f, prev, curr, res);
 	EXPECT_TRUE(retval);
 	EXPECT_EQ(res, Vector3f(0.f, 0.f, 2.f));
 
 	// near, before previous waypoint
-	retval = cross_sphere_line(Vector3f(0.0f, 0.5f, -0.5f), 1.0f, prev, curr, res);
+	retval = cross_sphere_line(Vector3f(0.f, .5f, -.5f), 1.f, prev, curr, res);
 	EXPECT_TRUE(retval);
-	EXPECT_EQ(res, Vector3f(0.f, 0.f, 0.366025388f));
+	EXPECT_EQ(res, Vector3f(0.f, 0.f, .366025388f));
 
 	// near, before target waypoint
-	retval = cross_sphere_line(Vector3f(0.0f, 0.5f, 1.0f), 1.0f, prev, curr, res);
+	retval = cross_sphere_line(Vector3f(0.f, .5f, 1.f), 1.f, prev, curr, res);
 	EXPECT_TRUE(retval);
 	EXPECT_EQ(res, Vector3f(0.f, 0.f, 1.866025448f));
 
 	// near, after target waypoint
-	retval = ControlMath::cross_sphere_line(matrix::Vector3f(0.0f, 0.5f, 2.5f), 1.0f, prev, curr, res);
+	retval = ControlMath::cross_sphere_line(matrix::Vector3f(0.f, .5f, 2.5f), 1.f, prev, curr, res);
 	EXPECT_TRUE(retval);
 	EXPECT_EQ(res, Vector3f(0.f, 0.f, 2.f));
 
 	// far, before previous waypoint
-	retval = ControlMath::cross_sphere_line(matrix::Vector3f(0.0f, 2.0f, -0.5f), 1.0f, prev, curr, res);
+	retval = ControlMath::cross_sphere_line(matrix::Vector3f(0.f, 2.f, -.5f), 1.f, prev, curr, res);
 	EXPECT_FALSE(retval);
 	EXPECT_EQ(res, Vector3f());
 
 	// far, before target waypoint
-	retval = ControlMath::cross_sphere_line(matrix::Vector3f(0.0f, 2.0f, 1.0f), 1.0f, prev, curr, res);
+	retval = ControlMath::cross_sphere_line(matrix::Vector3f(0.f, 2.f, 1.f), 1.f, prev, curr, res);
 	EXPECT_FALSE(retval);
 	EXPECT_EQ(res, Vector3f(0.f, 0.f, 1.f));
 
 	// far, after target waypoint
-	retval = ControlMath::cross_sphere_line(matrix::Vector3f(0.0f, 2.0f, 2.5f), 1.0f, prev, curr, res);
+	retval = ControlMath::cross_sphere_line(matrix::Vector3f(0.f, 2.f, 2.5f), 1.f, prev, curr, res);
 	EXPECT_FALSE(retval);
 	EXPECT_EQ(res, Vector3f(0.f, 0.f, 2.f));
 }

--- a/src/modules/mc_pos_control/PositionControl/ControlMathTest.cpp
+++ b/src/modules/mc_pos_control/PositionControl/ControlMathTest.cpp
@@ -135,45 +135,45 @@ TEST(ControlMathTest, CrossSphereLine)
 	// on line, near, before previous waypoint
 	retval = cross_sphere_line(Vector3f(0.0f, 0.0f, -0.5f), 1.0f, prev, curr, res);
 	EXPECT_TRUE(retval);
-	EXPECT_TRUE(matrix::isEqual(res, Vector3f(0.f, 0.f, 0.5f)));
+	EXPECT_EQ(res, Vector3f(0.f, 0.f, 0.5f));
 
 	// on line, near, before target waypoint
 	retval = cross_sphere_line(Vector3f(0.0f, 0.0f, 1.0f), 1.0f, prev, curr, res);
 	EXPECT_TRUE(retval);
-	EXPECT_TRUE(matrix::isEqual(res, Vector3f(0.f, 0.f, 2.f)));
+	EXPECT_EQ(res, Vector3f(0.f, 0.f, 2.f));
 
 	// on line, near, after target waypoint
 	retval = cross_sphere_line(Vector3f(0.0f, 0.0f, 2.5f), 1.0f, prev, curr, res);
 	EXPECT_TRUE(retval);
-	EXPECT_TRUE(matrix::isEqual(res, Vector3f(0.f, 0.f, 2.f)));
+	EXPECT_EQ(res, Vector3f(0.f, 0.f, 2.f));
 
 	// near, before previous waypoint
 	retval = cross_sphere_line(Vector3f(0.0f, 0.5f, -0.5f), 1.0f, prev, curr, res);
 	EXPECT_TRUE(retval);
-	EXPECT_TRUE(matrix::isEqual(res, Vector3f(0.f, 0.f, 0.366025388f)));
+	EXPECT_EQ(res, Vector3f(0.f, 0.f, 0.366025388f));
 
 	// near, before target waypoint
 	retval = cross_sphere_line(Vector3f(0.0f, 0.5f, 1.0f), 1.0f, prev, curr, res);
 	EXPECT_TRUE(retval);
-	EXPECT_TRUE(matrix::isEqual(res, Vector3f(0.f, 0.f, 1.866025448f)));
+	EXPECT_EQ(res, Vector3f(0.f, 0.f, 1.866025448f));
 
 	// near, after target waypoint
 	retval = ControlMath::cross_sphere_line(matrix::Vector3f(0.0f, 0.5f, 2.5f), 1.0f, prev, curr, res);
 	EXPECT_TRUE(retval);
-	EXPECT_TRUE(matrix::isEqual(res, Vector3f(0.f, 0.f, 2.f)));
+	EXPECT_EQ(res, Vector3f(0.f, 0.f, 2.f));
 
 	// far, before previous waypoint
 	retval = ControlMath::cross_sphere_line(matrix::Vector3f(0.0f, 2.0f, -0.5f), 1.0f, prev, curr, res);
 	EXPECT_FALSE(retval);
-	EXPECT_TRUE(matrix::isEqual(res, Vector3f()));
+	EXPECT_EQ(res, Vector3f());
 
 	// far, before target waypoint
 	retval = ControlMath::cross_sphere_line(matrix::Vector3f(0.0f, 2.0f, 1.0f), 1.0f, prev, curr, res);
 	EXPECT_FALSE(retval);
-	EXPECT_TRUE(matrix::isEqual(res, Vector3f(0.f, 0.f, 1.f)));
+	EXPECT_EQ(res, Vector3f(0.f, 0.f, 1.f));
 
 	// far, after target waypoint
 	retval = ControlMath::cross_sphere_line(matrix::Vector3f(0.0f, 2.0f, 2.5f), 1.0f, prev, curr, res);
 	EXPECT_FALSE(retval);
-	EXPECT_TRUE(matrix::isEqual(res, Vector3f(0.f, 0.f, 2.f)));
+	EXPECT_EQ(res, Vector3f(0.f, 0.f, 2.f));
 }

--- a/src/modules/mc_pos_control/PositionControl/PositionControlTest.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControlTest.cpp
@@ -43,24 +43,24 @@ TEST(PositionControlTest, EmptySetpoint)
 
 	vehicle_local_position_setpoint_s output_setpoint{};
 	position_control.getLocalPositionSetpoint(output_setpoint);
-	EXPECT_EQ(output_setpoint.x, 0.f);
-	EXPECT_EQ(output_setpoint.y, 0.f);
-	EXPECT_EQ(output_setpoint.z, 0.f);
-	EXPECT_EQ(output_setpoint.yaw, 0.f);
-	EXPECT_EQ(output_setpoint.yawspeed, 0.f);
-	EXPECT_EQ(output_setpoint.vx, 0.f);
-	EXPECT_EQ(output_setpoint.vy, 0.f);
-	EXPECT_EQ(output_setpoint.vz, 0.f);
+	EXPECT_FLOAT_EQ(output_setpoint.x, 0.f);
+	EXPECT_FLOAT_EQ(output_setpoint.y, 0.f);
+	EXPECT_FLOAT_EQ(output_setpoint.z, 0.f);
+	EXPECT_FLOAT_EQ(output_setpoint.yaw, 0.f);
+	EXPECT_FLOAT_EQ(output_setpoint.yawspeed, 0.f);
+	EXPECT_FLOAT_EQ(output_setpoint.vx, 0.f);
+	EXPECT_FLOAT_EQ(output_setpoint.vy, 0.f);
+	EXPECT_FLOAT_EQ(output_setpoint.vz, 0.f);
 	EXPECT_EQ(Vector3f(output_setpoint.acceleration), Vector3f(0.f, 0.f, 0.f));
 	EXPECT_EQ(Vector3f(output_setpoint.jerk), Vector3f(0.f, 0.f, 0.f));
 	EXPECT_EQ(Vector3f(output_setpoint.thrust), Vector3f(0, 0, 0));
 
 	vehicle_attitude_setpoint_s attitude{};
 	position_control.getAttitudeSetpoint(attitude);
-	EXPECT_EQ(attitude.roll_body, 0.f);
-	EXPECT_EQ(attitude.pitch_body, 0.f);
-	EXPECT_EQ(attitude.yaw_body, 0.f);
-	EXPECT_EQ(attitude.yaw_sp_move_rate, 0.f);
+	EXPECT_FLOAT_EQ(attitude.roll_body, 0.f);
+	EXPECT_FLOAT_EQ(attitude.pitch_body, 0.f);
+	EXPECT_FLOAT_EQ(attitude.yaw_body, 0.f);
+	EXPECT_FLOAT_EQ(attitude.yaw_sp_move_rate, 0.f);
 	EXPECT_EQ(Quatf(attitude.q_d), Quatf(1.f, 0.f, 0.f, 0.f));
 	//EXPECT_EQ(attitude.q_d_valid, false); // TODO should not be true when there was no control
 	EXPECT_EQ(Vector3f(attitude.thrust_body), Vector3f(0.f, 0.f, 0.f));
@@ -68,7 +68,7 @@ TEST(PositionControlTest, EmptySetpoint)
 	EXPECT_EQ(attitude.pitch_reset_integral, false);
 	EXPECT_EQ(attitude.yaw_reset_integral, false);
 	EXPECT_EQ(attitude.fw_control_yaw, false);
-	EXPECT_EQ(attitude.apply_flaps, 0.f);//vehicle_attitude_setpoint_s::FLAPS_OFF); // TODO why no reference?
+	EXPECT_FLOAT_EQ(attitude.apply_flaps, 0.f);//vehicle_attitude_setpoint_s::FLAPS_OFF); // TODO why no reference?
 }
 
 class PositionControlBasicTest : public ::testing::Test
@@ -190,8 +190,8 @@ TEST_F(PositionControlBasicTest, ThrustLimit)
 	_input_setpoint.z = -10.f;
 
 	runController();
-	EXPECT_EQ(_attitude.thrust_body[0], 0.f);
-	EXPECT_EQ(_attitude.thrust_body[1], 0.f);
+	EXPECT_FLOAT_EQ(_attitude.thrust_body[0], 0.f);
+	EXPECT_FLOAT_EQ(_attitude.thrust_body[1], 0.f);
 	EXPECT_LT(_attitude.thrust_body[2], -.1f);
 	EXPECT_GE(_attitude.thrust_body[2], -0.9f);
 }
@@ -202,8 +202,8 @@ TEST_F(PositionControlBasicTest, FailsafeInput)
 	_input_setpoint.acceleration[0] = _input_setpoint.acceleration[1] = 0.f;
 
 	runController();
-	EXPECT_EQ(_attitude.thrust_body[0], 0.f);
-	EXPECT_EQ(_attitude.thrust_body[1], 0.f);
+	EXPECT_FLOAT_EQ(_attitude.thrust_body[0], 0.f);
+	EXPECT_FLOAT_EQ(_attitude.thrust_body[1], 0.f);
 	EXPECT_LT(_output_setpoint.thrust[2], -.1f);
 	EXPECT_GT(_output_setpoint.thrust[2], -.5f);
 	EXPECT_GT(_attitude.thrust_body[2], -.5f);
@@ -217,9 +217,9 @@ TEST_F(PositionControlBasicTest, InputCombinationsPosition)
 	_input_setpoint.z = .3f;
 
 	runController();
-	EXPECT_EQ(_output_setpoint.x, .1f);
-	EXPECT_EQ(_output_setpoint.y, .2f);
-	EXPECT_EQ(_output_setpoint.z, .3f);
+	EXPECT_FLOAT_EQ(_output_setpoint.x, .1f);
+	EXPECT_FLOAT_EQ(_output_setpoint.y, .2f);
+	EXPECT_FLOAT_EQ(_output_setpoint.z, .3f);
 	EXPECT_FALSE(isnan(_output_setpoint.vx));
 	EXPECT_FALSE(isnan(_output_setpoint.vy));
 	EXPECT_FALSE(isnan(_output_setpoint.vz));
@@ -237,9 +237,9 @@ TEST_F(PositionControlBasicTest, InputCombinationsPositionVelocity)
 	runController();
 	// EXPECT_TRUE(isnan(_output_setpoint.x));
 	// EXPECT_TRUE(isnan(_output_setpoint.y));
-	EXPECT_EQ(_output_setpoint.z, .3f);
-	EXPECT_EQ(_output_setpoint.vx, .1f);
-	EXPECT_EQ(_output_setpoint.vy, .2f);
+	EXPECT_FLOAT_EQ(_output_setpoint.z, .3f);
+	EXPECT_FLOAT_EQ(_output_setpoint.vx, .1f);
+	EXPECT_FLOAT_EQ(_output_setpoint.vy, .2f);
 	EXPECT_FALSE(isnan(_output_setpoint.vz));
 	EXPECT_FALSE(isnan(_output_setpoint.thrust[0]));
 	EXPECT_FALSE(isnan(_output_setpoint.thrust[1]));

--- a/src/modules/mc_pos_control/Takeoff/TakeoffTest.cpp
+++ b/src/modules/mc_pos_control/Takeoff/TakeoffTest.cpp
@@ -66,11 +66,11 @@ TEST(TakeoffTest, RegularTakeoffRamp)
 
 	// armed, not landed, want takeoff, ramping up
 	takeoff.updateTakeoffState(true, false, true, 1.f, false, 4_s);
-	EXPECT_EQ(takeoff.updateRamp(.5f, 1.5f), 0.f);
-	EXPECT_EQ(takeoff.updateRamp(.5f, 1.5f), .5f);
-	EXPECT_EQ(takeoff.updateRamp(.5f, 1.5f), 1.f);
-	EXPECT_EQ(takeoff.updateRamp(.5f, 1.5f), 1.5f);
-	EXPECT_EQ(takeoff.updateRamp(.5f, 1.5f), 1.5f);
+	EXPECT_FLOAT_EQ(takeoff.updateRamp(.5f, 1.5f), 0.f);
+	EXPECT_FLOAT_EQ(takeoff.updateRamp(.5f, 1.5f), .5f);
+	EXPECT_FLOAT_EQ(takeoff.updateRamp(.5f, 1.5f), 1.f);
+	EXPECT_FLOAT_EQ(takeoff.updateRamp(.5f, 1.5f), 1.5f);
+	EXPECT_FLOAT_EQ(takeoff.updateRamp(.5f, 1.5f), 1.5f);
 
 	// armed, not landed, want takeoff, rampup time passed
 	takeoff.updateTakeoffState(true, false, true, 1.f, false, 6500_ms);


### PR DESCRIPTION
**Describe problem solved by this pull request**
This is the follow-up pr after the findings in https://github.com/PX4/Firmware/pull/13776#issuecomment-568592420. The original pr was created to prevent potential failing tests because of small rounding errors.

**Describe your solution**
- All vector/matrix/quaternion equality tests use EXPECT_EQ() because gtest calls the `matrix::operator==()` which calls `matrix::isEqual()` with the default element-wise comparison accuracy of `1e-4`.
- Consistently use short float literal notation in `ControlMathTest` e.g. `0.f` and `.1f`.
- Use `EXPECT_FLOAT_EQ` for all float equality tests

**Describe possible alternatives**
Reviewers please tell me if `EXPECT_FLOAT_EQ` has any downsides like e.g. if bitwise checks make more sense for uORB transfer checks.

**Additional context**
https://github.com/PX4/Firmware/pull/13776
