### PR TITLE
use default stack size of 2048, fixes stack check failure

### DIFF
--- a/src/drivers/barometer/bmp388/CMakeLists.txt
+++ b/src/drivers/barometer/bmp388/CMakeLists.txt
@@ -34,10 +34,6 @@
 px4_add_module(
 	MODULE drivers__barometer__bmp388
 	MAIN bmp388
-	COMPILE_FLAGS
-		-Wno-cast-align # TODO: fix and enable
-	STACK_MAIN
-		1200
 	SRCS
 		bmp388_spi.cpp
 		bmp388_i2c.cpp


### PR DESCRIPTION
**Describe problem solved by this pull request**
Fixes stack size error found using stackcheck build during debug session with David S.

**Describe your solution**
Use default module stack size of 2048 specified by px4_add_module.cmake
