### PR TITLE
Support multi vehicle simulation for fixed wing in gazebo SITL

### DIFF
--- a/Tools/gazebo_sitl_multiple_run.sh
+++ b/Tools/gazebo_sitl_multiple_run.sh
@@ -29,7 +29,7 @@ done
 num_vehicles=${NUM_VEHICLES:=3}
 export PX4_SIM_MODEL=${VEHICLE_MODEL:=iris}
 
-if [ "$PX4_SIM_MODEL" != "iris" ]
+if [ "$PX4_SIM_MODEL" != "iris" ] & [ "$PX4_SIM_MODEL" != "plane" ]
 then
 	echo "Currently only iris vehicle model is supported!"
 	exit 1

--- a/Tools/gazebo_sitl_multiple_run.sh
+++ b/Tools/gazebo_sitl_multiple_run.sh
@@ -69,7 +69,7 @@ while [ $n -lt $num_vehicles ]; do
 	gz sdf -p  /tmp/${PX4_SIM_MODEL}_${n}.urdf > /tmp/${PX4_SIM_MODEL}_${n}.sdf
 	echo "Spawning ${PX4_SIM_MODEL}_${n}"
 
-	gz model --spawn-file=/tmp/${PX4_SIM_MODEL}_${n}.sdf --model-name=${PX4_SIM_MODEL}_${n} -x 0.0 -y ${n} -z 0.0
+	gz model --spawn-file=/tmp/${PX4_SIM_MODEL}_${n}.sdf --model-name=${PX4_SIM_MODEL}_${n} -x 0.0 -y $((2*${n})) -z 0.0
 
 	popd &>/dev/null
 

--- a/Tools/gazebo_sitl_multiple_run.sh
+++ b/Tools/gazebo_sitl_multiple_run.sh
@@ -66,9 +66,10 @@ while [ $n -lt $num_vehicles ]; do
 		rotors_description_dir:=${src_path}/Tools/sitl_gazebo/models/rotors_description mavlink_udp_port:=$(($mavlink_udp_port+$n)) \
 		mavlink_tcp_port:=$(($mavlink_tcp_port+$n))  -o /tmp/${PX4_SIM_MODEL}_${n}.urdf
 
+	gz sdf -p  /tmp/${PX4_SIM_MODEL}_${n}.urdf > /tmp/${PX4_SIM_MODEL}_${n}.sdf
 	echo "Spawning ${PX4_SIM_MODEL}_${n}"
 
-	gz model --spawn-file=/tmp/${PX4_SIM_MODEL}_${n}.urdf --model-name=${PX4_SIM_MODEL}_${n} -x 0.0 -y ${n} -z 0.0
+	gz model --spawn-file=/tmp/${PX4_SIM_MODEL}_${n}.sdf --model-name=${PX4_SIM_MODEL}_${n} -x 0.0 -y ${n} -z 0.0
 
 	popd &>/dev/null
 

--- a/Tools/gazebo_sitl_multiple_run.sh
+++ b/Tools/gazebo_sitl_multiple_run.sh
@@ -31,7 +31,7 @@ export PX4_SIM_MODEL=${VEHICLE_MODEL:=iris}
 
 if [ "$PX4_SIM_MODEL" != "iris" ] & [ "$PX4_SIM_MODEL" != "plane" ]
 then
-	echo "Currently only iris vehicle model is supported!"
+	echo "Currently only iris and plane vehicle model is supported!"
 	exit 1
 fi
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
Since the plane model is defined as a sdf format, it was not possible to launch multivehicle simulation, as it relies on xacro macros to generate sdf files.

**Describe your solution**
This enables https://github.com/PX4/sitl_gazebo/pull/385 and spawns the vehicles from the sdf file rather than froma urdf file as done previously. This is more consistent on what was being done for the iris in PX4/sitl_gazebo

**Test data / coverage**
Video: 
[![Video](https://img.youtube.com/vi/aEzFKPMEfjc/0.jpg)](https://youtu.be/aEzFKPMEfjc "Hovering done")