### PR TITLE
ADC system refactor

### DIFF
--- a/boards/px4/raspberrypi/default.cmake
+++ b/boards/px4/raspberrypi/default.cmake
@@ -8,6 +8,7 @@ px4_add_board(
 	TOOLCHAIN arm-linux-gnueabihf
 	TESTING
 	DRIVERS
+		adc/ads1115
 		#barometer # all available barometer drivers
 		barometer/ms5611
 		batt_smbus

--- a/msg/adc_report.msg
+++ b/msg/adc_report.msg
@@ -1,3 +1,6 @@
 uint64 timestamp		# time since system start (microseconds)
-int16[12] channel_id		# ADC channel IDs, negative for non-existent
-float32[12] channel_value	# ADC channel value in volt, valid if channel ID is positive
+uint32 device_id		# unique device ID for the sensor that does not change between power cycles
+int16[12] channel_id		# ADC channel IDs, negative for non-existent, should be kept same as array index
+int32[12] raw_data		# ADC channel raw value, accept negative value, valid if channel ID is positive
+uint8[12] resolution		# ADC channel resolution, valid if channel ID is positive
+float32[12] scale		# ADC channel voltage scale, use to calculate LSB voltage(lsb=scale/resolution), valid if channel ID is positive

--- a/msg/adc_report.msg
+++ b/msg/adc_report.msg
@@ -2,5 +2,5 @@ uint64 timestamp		# time since system start (microseconds)
 uint32 device_id		# unique device ID for the sensor that does not change between power cycles
 int16[12] channel_id		# ADC channel IDs, negative for non-existent, should be kept same as array index
 int32[12] raw_data		# ADC channel raw value, accept negative value, valid if channel ID is positive
-uint8[12] resolution		# ADC channel resolution, valid if channel ID is positive
+uint16[12] resolution		# ADC channel resolution, valid if channel ID is positive
 float32[12] v_ref		# ADC channel voltage reference, use to calculate LSB voltage(lsb=scale/resolution), valid if channel ID is positive

--- a/msg/adc_report.msg
+++ b/msg/adc_report.msg
@@ -3,4 +3,4 @@ uint32 device_id		# unique device ID for the sensor that does not change between
 int16[12] channel_id		# ADC channel IDs, negative for non-existent, should be kept same as array index
 int32[12] raw_data		# ADC channel raw value, accept negative value, valid if channel ID is positive
 uint8[12] resolution		# ADC channel resolution, valid if channel ID is positive
-float32[12] scale		# ADC channel voltage scale, use to calculate LSB voltage(lsb=scale/resolution), valid if channel ID is positive
+float32[12] v_ref		# ADC channel voltage reference, use to calculate LSB voltage(lsb=scale/resolution), valid if channel ID is positive

--- a/msg/adc_report.msg
+++ b/msg/adc_report.msg
@@ -2,5 +2,5 @@ uint64 timestamp		# time since system start (microseconds)
 uint32 device_id		# unique device ID for the sensor that does not change between power cycles
 int16[12] channel_id		# ADC channel IDs, negative for non-existent, should be kept same as array index
 int32[12] raw_data		# ADC channel raw value, accept negative value, valid if channel ID is positive
-uint16[12] resolution		# ADC channel resolution, valid if channel ID is positive
+uint32[12] resolution		# ADC channel resolution, valid if channel ID is positive
 float32[12] v_ref		# ADC channel voltage reference, use to calculate LSB voltage(lsb=scale/resolution), valid if channel ID is positive

--- a/src/drivers/adc/ADC.cpp
+++ b/src/drivers/adc/ADC.cpp
@@ -139,6 +139,7 @@ void ADC::update_adc_report(hrt_abstime now)
 {
 	adc_report_s adc = {};
 	adc.timestamp = now;
+	adc.device_id = 0x00000000; // TODO: assign a proper dev_id
 
 	unsigned max_num = _channel_count;
 
@@ -148,7 +149,10 @@ void ADC::update_adc_report(hrt_abstime now)
 
 	for (unsigned i = 0; i < max_num; i++) {
 		adc.channel_id[i] = _samples[i].am_channel;
-		adc.channel_value[i] = _samples[i].am_data * 3.3f / px4_arch_adc_dn_fullcount();
+		adc.raw_data[i] = _samples[i].am_data;
+		adc.v_ref[i] = 3.3f;
+		adc.resolution[i] = px4_arch_adc_dn_fullcount();
+		//adc.channel_value[i] = _samples[i].am_data * 3.3f / px4_arch_adc_dn_fullcount();
 	}
 
 	_to_adc_report.publish(adc);

--- a/src/drivers/adc/ads1115/ADS1115.cpp
+++ b/src/drivers/adc/ads1115/ADS1115.cpp
@@ -5,6 +5,8 @@
 #include "ADS1115.h"
 #include <cassert>
 
+#include <stdio.h>
+
 ADS1115::ADS1115(I2C_Interface *interface) : _interface(interface)
 {
 
@@ -12,8 +14,8 @@ ADS1115::ADS1115(I2C_Interface *interface) : _interface(interface)
 
 int ADS1115::init()
 {
-	uint8_t config[2] = {0x00};
-	config[0] = CONFIG_HIGH_OS_START_SINGLE | CONFIG_HIGH_MUX_P0NG | CONFIG_HIGH_PGA_6144 | CONFIG_HIGH_MODE_SS;
+	uint8_t config[2] = {};
+	config[0] = CONFIG_HIGH_OS_NOACT | CONFIG_HIGH_MUX_P0NG | CONFIG_HIGH_PGA_6144 | CONFIG_HIGH_MODE_SS;
 	config[1] = CONFIG_LOW_DR_128SPS | CONFIG_LOW_COMP_MODE_TRADITIONAL | CONFIG_LOW_COMP_POL_RESET |
 		    CONFIG_LOW_COMP_LAT_NONE | CONFIG_LOW_COMP_QU_DISABLE;
 	_interface->writeReg(ADDRESSPOINTER_REG_CONFIG, config, 2);
@@ -22,7 +24,7 @@ int ADS1115::init()
 
 int ADS1115::setChannel(ADS1115::ChannelSelection ch)
 {
-	uint8_t buf[1] = {0x00};
+	uint8_t buf[2] = {};
 	uint8_t next_mux_reg = CONFIG_HIGH_MUX_P0NG;
 
 	switch (ch) {
@@ -48,7 +50,9 @@ int ADS1115::setChannel(ADS1115::ChannelSelection ch)
 	}
 
 	buf[0] = CONFIG_HIGH_OS_START_SINGLE | next_mux_reg | CONFIG_HIGH_PGA_6144 | CONFIG_HIGH_MODE_SS;
-	_interface->writeReg(ADDRESSPOINTER_REG_CONFIG, buf, 1);
+	buf[1] = CONFIG_LOW_DR_128SPS | CONFIG_LOW_COMP_MODE_TRADITIONAL | CONFIG_LOW_COMP_POL_RESET |
+		 CONFIG_LOW_COMP_LAT_NONE | CONFIG_LOW_COMP_QU_DISABLE;
+	_interface->writeReg(ADDRESSPOINTER_REG_CONFIG, buf, 2);    // must write whole register to take effect
 	return 0;
 }
 
@@ -56,14 +60,13 @@ bool ADS1115::isSampleReady()
 {
 	uint8_t buf[1] = {0x00};
 	_interface->readReg(ADDRESSPOINTER_REG_CONFIG, buf, 1); // Pull config register
-	return !(buf[0] & (uint8_t) 0x80);
+	return (buf[0] & (uint8_t) 0x80);
 }
 
 ADS1115::ChannelSelection ADS1115::getMeasurement(int16_t *value)
 {
 	uint8_t buf[2] = {0x00};
 	_interface->readReg(ADDRESSPOINTER_REG_CONFIG, buf, 1); // Pull config register
-
 	ChannelSelection channel;
 
 	switch ((buf[0] & (uint8_t) 0x70) >> 4) {
@@ -105,7 +108,6 @@ ADS1115::ChannelSelection ADS1115::cycleMeasure(int16_t *value)
 {
 	uint8_t buf[2] = {0x00};
 	_interface->readReg(ADDRESSPOINTER_REG_CONFIG, buf, 1); // Pull config register
-
 	ChannelSelection channel;
 	uint8_t next_mux_reg = CONFIG_HIGH_MUX_P0NG;
 
@@ -146,7 +148,8 @@ ADS1115::ChannelSelection ADS1115::cycleMeasure(int16_t *value)
 	}
 
 	buf[0] = CONFIG_HIGH_OS_START_SINGLE | next_mux_reg | CONFIG_HIGH_PGA_6144 | CONFIG_HIGH_MODE_SS;
-	_interface->writeReg(ADDRESSPOINTER_REG_CONFIG, buf, 1);
-
+	buf[1] = CONFIG_LOW_DR_128SPS | CONFIG_LOW_COMP_MODE_TRADITIONAL | CONFIG_LOW_COMP_POL_RESET |
+		 CONFIG_LOW_COMP_LAT_NONE | CONFIG_LOW_COMP_QU_DISABLE;
+	_interface->writeReg(ADDRESSPOINTER_REG_CONFIG, buf, 2);    // must write whole register to take effect
 	return channel;
 }

--- a/src/drivers/adc/ads1115/ADS1115.cpp
+++ b/src/drivers/adc/ads1115/ADS1115.cpp
@@ -1,0 +1,152 @@
+//
+// Created by salimterryli on 2020/1/8.
+//
+
+#include "ADS1115.h"
+#include <cassert>
+
+ADS1115::ADS1115(I2C_Interface *interface) : _interface(interface)
+{
+
+}
+
+int ADS1115::init()
+{
+	uint8_t config[2] = {0x00};
+	config[0] = CONFIG_HIGH_OS_START_SINGLE | CONFIG_HIGH_MUX_P0NG | CONFIG_HIGH_PGA_6144 | CONFIG_HIGH_MODE_SS;
+	config[1] = CONFIG_LOW_DR_128SPS | CONFIG_LOW_COMP_MODE_TRADITIONAL | CONFIG_LOW_COMP_POL_RESET |
+		    CONFIG_LOW_COMP_LAT_NONE | CONFIG_LOW_COMP_QU_DISABLE;
+	_interface->writeReg(ADDRESSPOINTER_REG_CONFIG, config, 2);
+	return 0;
+}
+
+int ADS1115::setChannel(ADS1115::ChannelSelection ch)
+{
+	uint8_t buf[1] = {0x00};
+	uint8_t next_mux_reg = CONFIG_HIGH_MUX_P0NG;
+
+	switch (ch) {
+	case A0:
+		next_mux_reg = CONFIG_HIGH_MUX_P0NG;
+		break;
+
+	case A1:
+		next_mux_reg = CONFIG_HIGH_MUX_P1NG;
+		break;
+
+	case A2:
+		next_mux_reg = CONFIG_HIGH_MUX_P2NG;
+		break;
+
+	case A3:
+		next_mux_reg = CONFIG_HIGH_MUX_P3NG;
+		break;
+
+	default:
+		assert(false);
+		break;
+	}
+
+	buf[0] = CONFIG_HIGH_OS_START_SINGLE | next_mux_reg | CONFIG_HIGH_PGA_6144 | CONFIG_HIGH_MODE_SS;
+	_interface->writeReg(ADDRESSPOINTER_REG_CONFIG, buf, 1);
+	return 0;
+}
+
+bool ADS1115::isSampleReady()
+{
+	uint8_t buf[1] = {0x00};
+	_interface->readReg(ADDRESSPOINTER_REG_CONFIG, buf, 1); // Pull config register
+	return !(buf[0] & (uint8_t) 0x80);
+}
+
+ADS1115::ChannelSelection ADS1115::getMeasurement(int16_t *value)
+{
+	uint8_t buf[2] = {0x00};
+	_interface->readReg(ADDRESSPOINTER_REG_CONFIG, buf, 1); // Pull config register
+
+	ChannelSelection channel;
+
+	switch ((buf[0] & (uint8_t) 0x70) >> 4) {
+	case 0x04:
+		channel = A0;
+		break;
+
+	case 0x05:
+		channel = A1;
+		break;
+
+	case 0x06:
+		channel = A2;
+		break;
+
+	case 0x07:
+		channel = A3;
+		break;
+
+	default:
+		return Invalid;
+	}
+
+	_interface->readReg(ADDRESSPOINTER_REG_CONVERSATION, buf, 2);
+	uint16_t raw_adc_val = buf[0] * 256 + buf[1];
+
+	if (raw_adc_val & (uint16_t) 0x8000) {     // Negetive value
+		raw_adc_val = ~raw_adc_val + 1;     // 2's complement
+		*value = -raw_adc_val;
+
+	} else {
+		*value = raw_adc_val;
+	}
+
+	return channel;
+}
+
+ADS1115::ChannelSelection ADS1115::cycleMeasure(int16_t *value)
+{
+	uint8_t buf[2] = {0x00};
+	_interface->readReg(ADDRESSPOINTER_REG_CONFIG, buf, 1); // Pull config register
+
+	ChannelSelection channel;
+	uint8_t next_mux_reg = CONFIG_HIGH_MUX_P0NG;
+
+	switch ((buf[0] & (uint8_t) 0x70) >> 4) {
+	case 0x04:
+		channel = A0;
+		next_mux_reg = CONFIG_HIGH_MUX_P1NG;
+		break;
+
+	case 0x05:
+		channel = A1;
+		next_mux_reg = CONFIG_HIGH_MUX_P2NG;
+		break;
+
+	case 0x06:
+		channel = A2;
+		next_mux_reg = CONFIG_HIGH_MUX_P3NG;
+		break;
+
+	case 0x07:
+		channel = A3;
+		next_mux_reg = CONFIG_HIGH_MUX_P0NG;
+		break;
+
+	default:
+		return Invalid;
+	}
+
+	_interface->readReg(ADDRESSPOINTER_REG_CONVERSATION, buf, 2);
+	uint16_t raw_adc_val = buf[0] * 256 + buf[1];
+
+	if (raw_adc_val & (uint16_t) 0x8000) {     // Negetive value
+		raw_adc_val = ~raw_adc_val + 1;     // 2's complement
+		*value = -raw_adc_val;
+
+	} else {
+		*value = raw_adc_val;
+	}
+
+	buf[0] = CONFIG_HIGH_OS_START_SINGLE | next_mux_reg | CONFIG_HIGH_PGA_6144 | CONFIG_HIGH_MODE_SS;
+	_interface->writeReg(ADDRESSPOINTER_REG_CONFIG, buf, 1);
+
+	return channel;
+}

--- a/src/drivers/adc/ads1115/ADS1115.h
+++ b/src/drivers/adc/ads1115/ADS1115.h
@@ -1,0 +1,113 @@
+//
+// Created by salimterryli on 2020/1/8.
+//
+
+#ifndef PX4_ADS1115_H
+#define PX4_ADS1115_H
+
+#include <cinttypes>
+
+#define ADDRESSPOINTER_REG_CONVERSATION    0x00
+#define ADDRESSPOINTER_REG_CONFIG    0x01
+#define ADDRESSPOINTER_REG_LO_THRESH    0x02
+#define ADDRESSPOINTER_REG_HI_THRESH    0x03
+#define CONVERSION_REG_RESET    0x00
+#define CONFIG_HIGH_OS_RESET    0x80
+#define CONFIG_HIGH_OS_NOACT    0x00
+#define CONFIG_HIGH_OS_START_SINGLE    0x80
+#define CONFIG_HIGH_MUX_RESET    0x00
+#define CONFIG_HIGH_MUX_P0N1    0x00
+#define CONFIG_HIGH_MUX_P0N3    0x10
+#define CONFIG_HIGH_MUX_P1N3    0x20
+#define CONFIG_HIGH_MUX_P2N3    0x30
+#define CONFIG_HIGH_MUX_P0NG    0x40
+#define CONFIG_HIGH_MUX_P1NG    0x50
+#define CONFIG_HIGH_MUX_P2NG    0x60
+#define CONFIG_HIGH_MUX_P3NG    0x70
+#define CONFIG_HIGH_PGA_RESET    0x02
+#define CONFIG_HIGH_PGA_6144    0x00
+#define CONFIG_HIGH_PGA_4096    0x02
+#define CONFIG_HIGH_PGA_2048    0x04
+#define CONFIG_HIGH_PGA_1024    0x06
+#define CONFIG_HIGH_PGA_0512    0x08
+#define CONFIG_HIGH_PGA_0256    0x0a
+#define CONFIG_HIGH_MODE_RESET    0x01
+#define CONFIG_HIGH_MODE_SS    0x01
+#define CONFIG_HIGH_MODE_CC    0x00
+
+#define CONFIG_LOW_DR_RESET    0x80
+#define CONFIG_LOW_DR_8SPS    0x00
+#define CONFIG_LOW_DR_16SPS    0x20
+#define CONFIG_LOW_DR_32SPS    0x40
+#define CONFIG_LOW_DR_64SPS    0x60
+#define CONFIG_LOW_DR_128SPS    0x80
+#define CONFIG_LOW_DR_250SPS    0xa0
+#define CONFIG_LOW_DR_475SPS    0xc0
+#define CONFIG_LOW_DR_860SPS    0xe0
+#define CONFIG_LOW_COMP_MODE_RESET    0x00
+#define CONFIG_LOW_COMP_MODE_TRADITIONAL    0x00
+#define CONFIG_LOW_COMP_MODE_WINDOW    0x10
+#define CONFIG_LOW_COMP_POL_RESET    0x00
+#define CONFIG_LOW_COMP_POL_ACTIVE_LOW    0x00
+#define CONFIG_LOW_COMP_POL_ACTIVE_HIGH    0x08
+#define CONFIG_LOW_COMP_LAT_DEFAULT    0x00
+#define CONFIG_LOW_COMP_LAT_NONE    0x00
+#define CONFIG_LOW_COMP_LAT_LATCH    0x04
+#define CONFIG_LOW_COMP_QU_DEFAULT    0x03
+#define CONFIG_LOW_COMP_QU_AFTER1    0x00
+#define CONFIG_LOW_COMP_QU_AFTER2    0x01
+#define CONFIG_LOW_COMP_QU_AFTER4    0x02
+#define CONFIG_LOW_COMP_QU_DISABLE    0x03
+
+class I2C_Interface
+{
+public:
+	virtual void readReg(uint8_t addr, uint8_t *buf, size_t len) = 0;
+
+	virtual void writeReg(uint8_t addr, uint8_t *buf, size_t len) = 0;
+};
+
+/*
+ * Logical part of ADS1115 driver
+ * This driver configure ADS1115 into 4 channels with gnd as baseline.
+ * Start each sample cycle by setting sample channel.
+ * PGA set to 6.144V
+ * SPS set to 128
+ * Valid output ranges from 0 to 32767 on each channel.
+ */
+class ADS1115
+{
+public:
+	ADS1115() = delete;
+	explicit ADS1115(I2C_Interface *interface);
+
+	enum ChannelSelection {
+		Invalid = -1, A0 = 0, A1, A2, A3
+	};
+
+	/* configure ads1115 into specific status */
+	int init();
+
+	/* set multiplexer to specific channel */
+	int setChannel(ChannelSelection ch);
+
+	/* return true if sample result is valid */
+	bool isSampleReady();
+
+	/*
+	 * get adc sample. return the channel being measured.
+	 * Invalid indicates sample failure.
+	 */
+	ChannelSelection getMeasurement(int16_t *value);
+
+	/*
+	 * get adc sample and automatically switch to next channel and start another measurement
+	 */
+	ChannelSelection cycleMeasure(int16_t *value);
+
+protected:
+	I2C_Interface *_interface;
+};
+
+
+#endif //PX4_ADS1115_H

--- a/src/drivers/adc/ads1115/CMakeLists.txt
+++ b/src/drivers/adc/ads1115/CMakeLists.txt
@@ -1,0 +1,41 @@
+############################################################################
+#
+#   Copyright (c) 2015-2017 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+px4_add_module(
+	MODULE drivers__ads1115
+	MAIN ads1115
+	COMPILE_FLAGS
+	SRCS
+		ads1115_main.cpp
+		ADS1115.cpp
+	DEPENDS
+	)

--- a/src/drivers/adc/ads1115/ads1115_main.cpp
+++ b/src/drivers/adc/ads1115/ads1115_main.cpp
@@ -1,33 +1,83 @@
 #include "ADS1115.h"
 #include <drivers/device/i2c.h>
+#include <px4_platform_common/module.h>
+#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
+#include <lib/perf/perf_counter.h>
+#include <uORB/Publication.hpp>
+#include <uORB/topics/adc_report.h>
+#include <drivers/drv_hrt.h>
+#include <px4_platform_common/getopt.h>
+
+#define ADS1115_DEFAULT_PATH "/dev/ads1115"
+
+using namespace time_literals;
 
 /* PX4 universal low-level driver wrapper for ADS1115 */
-class ADS1115_Drv : public device::I2C, public I2C_Interface
+class ADS1115_Drv : public device::I2C, public I2C_Interface, public ModuleBase<ADS1115_Drv>,
+	public px4::ScheduledWorkItem
 {
 public:
-	ADS1115_Drv(uint8_t bus, uint8_t address, const char *devname);
-	~ADS1115_Drv() override = default;
+	ADS1115_Drv(uint8_t bus, uint8_t address);
+	~ADS1115_Drv() override;
 	int init() override;
 
 	void readReg(uint8_t addr, uint8_t *buf, size_t len) override;
 
 	void writeReg(uint8_t addr, uint8_t *buf, size_t len) override;
 
+	/** @see ModuleBase */
+	static int task_spawn(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int custom_command(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int print_usage(const char *reason = nullptr);
+
 protected:
 	ADS1115 *_ads1115 = nullptr;
 
+	adc_report_s _adc_report = {};
+
 private:
+	void Run() override;
+
+	uORB::Publication<adc_report_s>		_to_adc_report{ORB_ID(adc_report)};
+
+	static const hrt_abstime	SAMPLE_INTERVAL{50_ms};
+
+	perf_counter_t			_cycle_perf;
+
+	int     _channel_cycle_count = 0;
 
 };
 
-ADS1115_Drv::ADS1115_Drv(uint8_t bus, uint8_t address, const char *devname) :
-	I2C("ads1115", devname, bus, address, 400000)
+ADS1115_Drv::ADS1115_Drv(uint8_t bus, uint8_t address) :
+	I2C("ADS1115", ADS1115_DEFAULT_PATH, bus, address, 400000),
+	ScheduledWorkItem(MODULE_NAME, px4::device_bus_to_wq(this->get_device_id())),
+	_cycle_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": single-sample"))
 {
 	_ads1115 = new ADS1115(this);
+
+	// TODO fill a vaild dev type
+	//this->_device_id.devid_s.devtype=0;
+
+	_adc_report.device_id = this->get_device_id();
 
 	if (_ads1115 == nullptr) {
 		PX4_ERR("ads1115 logical driver alloc failed");
 	}
+}
+
+ADS1115_Drv::~ADS1115_Drv()
+{
+	ScheduleClear();
+
+	if (_ads1115 != nullptr) {
+		delete _ads1115;
+	}
+
+	perf_free(_cycle_perf);
 }
 
 int ADS1115_Drv::init()
@@ -50,6 +100,10 @@ int ADS1115_Drv::init()
 		return ret;
 	}
 
+	_ads1115->setChannel(ADS1115::A0);  // prepare for the first measure.
+
+	ScheduleOnInterval(SAMPLE_INTERVAL / 4, SAMPLE_INTERVAL / 4);
+
 	return PX4_OK;
 }
 
@@ -66,7 +120,150 @@ void ADS1115_Drv::writeReg(uint8_t addr, uint8_t *buf, size_t len)
 	transfer(buffer, len + 1, nullptr, 0);
 }
 
+void ADS1115_Drv::Run()
+{
+	if (should_exit()) {
+		PX4_INFO("ADS1115 stopping.");
+		ScheduleClear();
+		exit_and_cleanup();
+		return;
+	}
+
+	lock();
+	perf_begin(_cycle_perf);
+
+	_adc_report.timestamp = hrt_absolute_time();
+
+	if (_ads1115->isSampleReady()) { // whether ADS1115 is ready to be read or not
+		int16_t buf;
+		ADS1115::ChannelSelection ch = _ads1115->cycleMeasure(&buf);
+		++_channel_cycle_count;
+
+		switch (ch) {
+		case ADS1115::A0:
+			_adc_report.channel_id[0] = 0;
+			_adc_report.raw_data[0] = buf;
+			_adc_report.resolution[0] = 32768;
+			_adc_report.v_ref[0] = 6.144f;
+			break;
+
+		case ADS1115::A1:
+			_adc_report.channel_id[1] = 1;
+			_adc_report.raw_data[1] = buf;
+			_adc_report.resolution[1] = 32768;
+			_adc_report.v_ref[1] = 6.144f;
+			break;
+
+		case ADS1115::A2:
+			_adc_report.channel_id[2] = 2;
+			_adc_report.raw_data[2] = buf;
+			_adc_report.resolution[2] = 32768;
+			_adc_report.v_ref[2] = 6.144f;
+			break;
+
+		case ADS1115::A3:
+			_adc_report.channel_id[3] = 3;
+			_adc_report.raw_data[3] = buf;
+			_adc_report.resolution[3] = 32768;
+			_adc_report.v_ref[3] = 6.144f;
+			break;
+
+		default:
+			PX4_DEBUG("ADS1115: undefined behaviour");
+			_ads1115->setChannel(ADS1115::A0);
+			--_channel_cycle_count;
+			break;
+		}
+
+		if (_channel_cycle_count == 4) { // ADS1115 has 4 channels
+			_channel_cycle_count = 0;
+			_to_adc_report.publish(_adc_report);
+		}
+
+	} else {
+		PX4_WARN("ADS1115 not ready!");
+	}
+
+	perf_end(_cycle_perf);
+	unlock();
+}
+
+int ADS1115_Drv::task_spawn(int argc, char **argv)
+{
+	ADS1115_Drv *instance;
+
+	uint8_t i2c_bus = 1;
+	uint8_t i2c_addr = 0x48;
+
+	int myoptind = 1;
+	int ch;
+	const char *myoptarg = nullptr;
+
+	while ((ch = px4_getopt(argc, argv, "a:b:", &myoptind, &myoptarg)) != EOF) {
+		switch (ch) {
+		case 'b':
+			i2c_bus = atoi(myoptarg);
+			break;
+
+		case 'a':
+			i2c_addr = atoi(myoptarg);
+			break;
+
+		default:
+			print_usage("unknown parameters");
+			return -EINVAL;
+		}
+	}
+
+	instance = new ADS1115_Drv(i2c_bus, i2c_addr);
+
+	if (instance) {
+		_object.store(instance);
+		_task_id = task_id_is_work_queue;
+
+		if (instance->init() == PX4_OK) {
+			return PX4_OK;
+		}
+
+	} else {
+		PX4_ERR("alloc failed");
+	}
+
+	delete instance;
+	_object.store(nullptr);
+	_task_id = -1;
+
+	return PX4_ERROR;
+}
+
+int ADS1115_Drv::custom_command(int argc, char **argv)
+{
+	return PX4_OK;
+}
+
+int ADS1115_Drv::print_usage(const char *reason)
+{
+	if (reason) {
+		PX4_WARN("%s\n", reason);
+	}
+
+	PRINT_MODULE_DESCRIPTION(
+		R"DESCR_STR(
+### Description
+ADS1115 driver.
+
+)DESCR_STR");
+
+    PRINT_MODULE_USAGE_NAME("ads1115", "driver");
+    PRINT_MODULE_USAGE_COMMAND("start");
+    PRINT_MODULE_USAGE_PARAM_INT('a',72,0,255,"device address on this bus",true);
+    PRINT_MODULE_USAGE_PARAM_INT('b',1,0,255,"bus that ADS1115 is connected to",true);
+    PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
+
+    return 0;
+}
+
 extern "C" int ads1115_main(int argc, char *argv[])
 {
-	return 0;
+	return ADS1115_Drv::main(argc,argv);
 }

--- a/src/drivers/adc/ads1115/ads1115_main.cpp
+++ b/src/drivers/adc/ads1115/ads1115_main.cpp
@@ -1,0 +1,77 @@
+#include "ADS1115.h"
+#include <drivers/device/i2c.h>
+
+/* PX4 universal low-level driver wrapper for ADS1115 */
+class ADS1115_Drv : public device::I2C, public I2C_Interface
+{
+public:
+	ADS1115_Drv(uint8_t bus, uint8_t address, const char *devname);
+	~ADS1115_Drv() override;
+	int init() override;
+
+	void readReg(uint8_t addr, uint8_t *buf, size_t len) override;
+
+	void writeReg(uint8_t addr, uint8_t *buf, size_t len) override;
+
+protected:
+	ADS1115 *_ads1115 = nullptr;
+
+private:
+
+};
+
+ADS1115_Drv::ADS1115_Drv(uint8_t bus, uint8_t address, const char *devname) :
+	I2C("ads1115", devname, bus, address, 400000)
+{
+	_ads1115 = new ADS1115(this);
+
+	if (_ads1115 == nullptr) {
+		PX4_ERR("ads1115 logical driver alloc failed");
+	}
+}
+
+ADS1115_Drv::~ADS1115_Drv()
+{
+	delete _ads1115;
+}
+
+int ADS1115_Drv::init()
+{
+	if (_ads1115 == nullptr) {
+		return -ENOMEM;
+	}
+
+	int ret = I2C::init();
+
+	if (ret != PX4_OK) {
+		PX4_ERR("I2C init failed");
+		return ret;
+	}
+
+	ret = _ads1115->init();
+
+	if (ret != PX4_OK) {
+		PX4_ERR("ADS1115 init failed");
+		return ret;
+	}
+
+	return PX4_OK;
+}
+
+void ADS1115_Drv::readReg(uint8_t addr, uint8_t *buf, size_t len)
+{
+	transfer(&addr, 1, buf, len);
+}
+
+void ADS1115_Drv::writeReg(uint8_t addr, uint8_t *buf, size_t len)
+{
+	uint8_t buffer[len + 1];
+	buffer[0] = addr;
+	memcpy(buffer + 1, buf, sizeof(uint8_t)*len);
+	transfer(buffer, len + 1, nullptr, 0);
+}
+
+extern "C" int ads1115_main(int argc, char *argv[])
+{
+	return 0;
+}

--- a/src/drivers/adc/ads1115/ads1115_main.cpp
+++ b/src/drivers/adc/ads1115/ads1115_main.cpp
@@ -6,7 +6,7 @@ class ADS1115_Drv : public device::I2C, public I2C_Interface
 {
 public:
 	ADS1115_Drv(uint8_t bus, uint8_t address, const char *devname);
-	~ADS1115_Drv() override;
+	~ADS1115_Drv() override = default;
 	int init() override;
 
 	void readReg(uint8_t addr, uint8_t *buf, size_t len) override;
@@ -28,11 +28,6 @@ ADS1115_Drv::ADS1115_Drv(uint8_t bus, uint8_t address, const char *devname) :
 	if (_ads1115 == nullptr) {
 		PX4_ERR("ads1115 logical driver alloc failed");
 	}
-}
-
-ADS1115_Drv::~ADS1115_Drv()
-{
-	delete _ads1115;
 }
 
 int ADS1115_Drv::init()

--- a/src/drivers/differential_pressure/adc_dp_wrapper/CMakeLists.txt
+++ b/src/drivers/differential_pressure/adc_dp_wrapper/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2018 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -30,9 +30,13 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 ############################################################################
-
-add_subdirectory(ets)
-add_subdirectory(ms4525)
-add_subdirectory(ms5525)
-add_subdirectory(sdp3x)
-add_subdirectory(adc_dp_wrapper)
+px4_add_module(
+	MODULE drivers__adc_dp_wrapper
+	MAIN adc_dp_wrapper
+	SRCS
+		adc_dp_wrapper_main.cpp
+	DEPENDS
+		git_ecl
+		ecl_airdata
+		AirspeedValidator
+)

--- a/src/drivers/differential_pressure/adc_dp_wrapper/adc_dp_wrapper_main.cpp
+++ b/src/drivers/differential_pressure/adc_dp_wrapper/adc_dp_wrapper_main.cpp
@@ -1,0 +1,217 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <drivers/drv_hrt.h>
+#include <drivers/drv_adc.h>
+#include <parameters/param.h>
+#include <perf/perf_counter.h>
+#include <px4_platform_common/module.h>
+#include <px4_platform_common/module_params.h>
+#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
+
+#include <uORB/Subscription.hpp>
+#include <uORB/topics/adc_report.h>
+#include <uORB/topics/parameter_update.h>
+#include <uORB/topics/differential_pressure.h>
+#include <uORB/Publication.hpp>
+#include <uORB/PublicationMulti.hpp>
+
+using namespace time_literals;
+
+static constexpr uint32_t SCHEDULE_INTERVAL{10_ms};	/**< The schedule interval in usec (100 Hz) */
+
+class ADC_DifferentialPressure_Wrapper : public ModuleBase<ADC_DifferentialPressure_Wrapper>, public ModuleParams,
+	public px4::ScheduledWorkItem
+{
+public:
+
+	ADC_DifferentialPressure_Wrapper();
+
+	~ADC_DifferentialPressure_Wrapper() override;
+
+	/** @see ModuleBase */
+	static int task_spawn(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int custom_command(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int print_usage(const char *reason = nullptr);
+
+private:
+
+	void Run() override;
+
+	void init();
+
+	perf_counter_t _perf_elapsed{};
+
+	differential_pressure_s _dp_report = {};
+
+	uORB::Subscription	_parameter_update_sub{ORB_ID(parameter_update)};				/**< notification of parameter updates */
+	uORB::Subscription	_adc_report_update_sub{ORB_ID(adc_report)};
+
+	uORB::PublicationMulti<differential_pressure_s>	_diff_pres_sub{ORB_ID(differential_pressure)};			/**< raw differential pressure subscription */
+
+	DEFINE_PARAMETERS(
+		(ParamInt<px4::params::ADC_DP_CH>) _param_input_channel,
+		(ParamInt<px4::params::ADC_DP_MAIN_ID>) _param_input_devid,
+
+		(ParamFloat<px4::params::SENS_DPRES_ANSC>) _param_dp_scale,
+		(ParamFloat<px4::params::SENS_DPRES_OFF>) _param_dp_offset
+	)
+
+};
+
+ADC_DifferentialPressure_Wrapper::ADC_DifferentialPressure_Wrapper():
+	ModuleParams(nullptr),
+	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::att_pos_ctrl)
+{
+	_perf_elapsed = perf_alloc(PC_ELAPSED, MODULE_NAME": elapsed");
+}
+
+ADC_DifferentialPressure_Wrapper::~ADC_DifferentialPressure_Wrapper()
+{
+	ScheduleClear();
+
+	perf_free(_perf_elapsed);
+}
+
+int
+ADC_DifferentialPressure_Wrapper::task_spawn(int argc, char *argv[])
+{
+	ADC_DifferentialPressure_Wrapper *dev = new ADC_DifferentialPressure_Wrapper();
+
+	if (!dev) {
+		PX4_ERR("alloc failed");
+		return PX4_ERROR;
+	}
+
+	_object.store(dev);
+
+	dev->init();
+
+	dev->ScheduleOnInterval(SCHEDULE_INTERVAL, 10000);
+	_task_id = task_id_is_work_queue;
+	return PX4_OK;
+
+}
+
+void
+ADC_DifferentialPressure_Wrapper::init()
+{
+	_dp_report.differential_pressure_filtered_pa = 2.5f;
+}
+
+void
+ADC_DifferentialPressure_Wrapper::Run()
+{
+	perf_begin(_perf_elapsed);
+
+	parameter_update_s param_update;
+
+	if (_parameter_update_sub.update(&param_update)) {
+		updateParams();
+	}
+
+	adc_report_s adc_report;
+
+	if (_adc_report_update_sub.update(&adc_report)) {   // only if adc report updated
+		int32_t dp_channel = _param_input_channel.get();
+
+		union {
+			int32_t i;
+			uint32_t u;
+		} u2i;
+		u2i.i = _param_input_devid.get();
+
+		if (adc_report.device_id == u2i.u) {   // if device_id match
+			float diff_pres_pa_raw = adc_report.raw_data[dp_channel]
+						 * adc_report.v_ref[dp_channel]
+						 / adc_report.resolution[dp_channel];
+			diff_pres_pa_raw = diff_pres_pa_raw * _param_dp_scale.get() / _param_dp_offset.get();
+
+			_dp_report.timestamp = adc_report.timestamp;
+			_dp_report.differential_pressure_raw_pa = diff_pres_pa_raw;
+			_dp_report.differential_pressure_filtered_pa = (_dp_report.differential_pressure_filtered_pa * 0.9f) +
+					(diff_pres_pa_raw * 0.1f);
+			_dp_report.temperature = -1000.0f;
+
+			_diff_pres_sub.publish(_dp_report);
+		}
+	}
+
+	perf_end(_perf_elapsed);
+
+	if (should_exit()) {
+		exit_and_cleanup();
+	}
+}
+
+int ADC_DifferentialPressure_Wrapper::custom_command(int argc, char *argv[])
+{
+	if (!is_running()) {
+		int ret = ADC_DifferentialPressure_Wrapper::task_spawn(argc, argv);
+
+		if (ret) {
+			return ret;
+		}
+	}
+
+	return print_usage("unknown command");
+}
+
+int ADC_DifferentialPressure_Wrapper::print_usage(const char *reason)
+{
+	if (reason) {
+		PX4_WARN("%s\n", reason);
+	}
+
+	PRINT_MODULE_DESCRIPTION(
+		R"DESCR_STR(
+### Description
+This module converts ADC result to differential pressure topic.
+
+)DESCR_STR");
+
+	PRINT_MODULE_USAGE_NAME("adc_dp_wrapper", "driver");
+	PRINT_MODULE_USAGE_COMMAND("start");
+	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
+
+	return 0;
+}
+
+extern "C" __EXPORT int adc_dp_wrapper_main(int argc, char *argv[])
+{
+	return ADC_DifferentialPressure_Wrapper::main(argc, argv);
+}

--- a/src/drivers/differential_pressure/adc_dp_wrapper/adc_dp_wrapper_params.c
+++ b/src/drivers/differential_pressure/adc_dp_wrapper/adc_dp_wrapper_params.c
@@ -1,0 +1,17 @@
+/**
+ * ADC to Differential Pressure: ADC device ID
+ *
+ * Which ADC backend the sensor is connected to.
+ *
+ * @group ADC to Differential Pressure
+ */
+PARAM_DEFINE_INT32(ADC_DP_MAIN_ID, 0);
+
+/**
+ * ADC to Differential Pressure: sensor input channel
+ *
+ * Which channel of ADC the sensor is connected to.
+ *
+ * @group ADC to Differential Pressure
+ */
+PARAM_DEFINE_INT32(ADC_DP_CH, 0);

--- a/src/drivers/rc_input/RCInput.hpp
+++ b/src/drivers/rc_input/RCInput.hpp
@@ -48,12 +48,14 @@
 #include <px4_platform_common/getopt.h>
 #include <px4_platform_common/log.h>
 #include <px4_platform_common/module.h>
+#include <px4_platform_common/module_params.h>
 #include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/adc_report.h>
 #include <uORB/topics/input_rc.h>
 #include <uORB/topics/vehicle_command.h>
+#include <uORB/topics/parameter_update.h>
 
 #include "crsf_telemetry.h"
 
@@ -61,7 +63,7 @@
 # include <systemlib/ppm_decode.h>
 #endif
 
-class RCInput : public ModuleBase<RCInput>, public px4::ScheduledWorkItem
+class RCInput : public ModuleBase<RCInput>, public px4::ScheduledWorkItem, public ModuleParams
 {
 public:
 
@@ -112,8 +114,14 @@ private:
 
 	static constexpr unsigned	_current_update_interval{4000}; // 250 Hz
 
+	uORB::Subscription	_parameter_update_sub{ORB_ID(parameter_update)};
 	uORB::Subscription	_vehicle_cmd_sub{ORB_ID(vehicle_command)};
 	uORB::Subscription	_adc_sub{ORB_ID(adc_report)};
+
+	DEFINE_PARAMETERS(
+		(ParamInt<px4::params::RC_RSSI_DEVID>) _param_rssi_dev_id,
+		(ParamInt<px4::params::RC_RSSI_CH>) _param_rssi_ch
+	)
 
 	input_rc_s	_rc_in{};
 

--- a/src/drivers/rc_input/rc_input_params.c
+++ b/src/drivers/rc_input/rc_input_params.c
@@ -1,0 +1,19 @@
+/**
+ * ADC Device ID for Analogue RC RSSI
+ *
+ * Which ADC backend the RSSI comes from.
+ * Invalid device ID will disable this function.
+ *
+ * @group RC Input
+ */
+PARAM_DEFINE_INT32(RC_RSSI_DEVID, -1);
+
+/**
+ * ADC Channel for RC RSSI
+ *
+ * Which ADC channel the RSSI comes from.
+ * A value of -1 disables RSSI function.
+ *
+ * @group RC Input
+ */
+PARAM_DEFINE_INT32(RC_RSSI_CH, -1);

--- a/src/modules/battery_status/CMakeLists.txt
+++ b/src/modules/battery_status/CMakeLists.txt
@@ -40,7 +40,6 @@ px4_add_module(
 	MODULE_CONFIG
 		module.yaml
 	DEPENDS
-		arch_adc
 		battery
 		conversion
 		drivers__device

--- a/src/modules/battery_status/analog_battery.cpp
+++ b/src/modules/battery_status/analog_battery.cpp
@@ -1,30 +1,10 @@
 #include <lib/battery/battery.h>
 #include "analog_battery.h"
 
-// Defaults to use if the parameters are not set
-#if BOARD_NUMBER_BRICKS > 0
-#if defined(BOARD_BATT_V_LIST) && defined(BOARD_BATT_I_LIST)
-static constexpr int   DEFAULT_V_CHANNEL[BOARD_NUMBER_BRICKS] = BOARD_BATT_V_LIST;
-static constexpr int   DEFAULT_I_CHANNEL[BOARD_NUMBER_BRICKS] = BOARD_BATT_I_LIST;
-#else
-static constexpr int   DEFAULT_V_CHANNEL[BOARD_NUMBER_BRICKS] = {0};
-static constexpr int   DEFAULT_I_CHANNEL[BOARD_NUMBER_BRICKS] = {0};
-#endif
-#else
-static constexpr int DEFAULT_V_CHANNEL[1] = {0};
-static constexpr int DEFAULT_I_CHANNEL[1] = {0};
-#endif
-
-static constexpr float DEFAULT_VOLTS_PER_COUNT = 3.3f / 4096.0f;
-
 AnalogBattery::AnalogBattery(int index, ModuleParams *parent) :
 	Battery(index, parent)
 {
 	char param_name[17];
-
-	_analog_param_handles.cnt_v_volt = param_find("BAT_CNT_V_VOLT");
-
-	_analog_param_handles.cnt_v_curr = param_find("BAT_CNT_V_CURR");
 
 	_analog_param_handles.v_offs_cur = param_find("BAT_V_OFFS_CURR");
 
@@ -34,8 +14,14 @@ AnalogBattery::AnalogBattery(int index, ModuleParams *parent) :
 	snprintf(param_name, sizeof(param_name), "BAT%d_A_PER_V", index);
 	_analog_param_handles.a_per_v = param_find(param_name);
 
-	snprintf(param_name, sizeof(param_name), "BAT%d_ADC_CHANNEL", index);
-	_analog_param_handles.adc_channel = param_find(param_name);
+	snprintf(param_name, sizeof(param_name), "BAT%d_ADC_V_CH", index);
+	_analog_param_handles.adc_v_channel = param_find(param_name);
+	snprintf(param_name, sizeof(param_name), "BAT%d_ADC_V_DEV", index);
+	_analog_param_handles.adc_v_devid = param_find(param_name);
+	snprintf(param_name, sizeof(param_name), "BAT%d_ADC_C_CH", index);
+	_analog_param_handles.adc_c_channel = param_find(param_name);
+	snprintf(param_name, sizeof(param_name), "BAT%d_ADC_C_DEV", index);
+	_analog_param_handles.adc_c_devid = param_find(param_name);
 
 	_analog_param_handles.v_div_old = param_find("BAT_V_DIV");
 	_analog_param_handles.a_per_v_old = param_find("BAT_A_PER_V");
@@ -46,78 +32,68 @@ void
 AnalogBattery::updateBatteryStatusRawADC(hrt_abstime timestamp, int32_t voltage_raw, int32_t current_raw,
 		bool selected_source, int priority, float throttle_normalized)
 {
-	float voltage_v = (voltage_raw * _analog_params.cnt_v_volt) * _analog_params.v_div;
-	float current_a = ((current_raw * _analog_params.cnt_v_curr) - _analog_params.v_offs_cur) * _analog_params.a_per_v;
+	float voltage_v = voltage_raw * _analog_params.v_div;
+	float current_a = (current_raw - _analog_params.v_offs_cur) * _analog_params.a_per_v;
 
 	bool connected = voltage_v > BOARD_ADC_OPEN_CIRCUIT_V &&
-			 (BOARD_ADC_OPEN_CIRCUIT_V <= BOARD_VALID_UV || is_valid());
+			 (BOARD_ADC_OPEN_CIRCUIT_V <= BOARD_VALID_UV);
 
 
 	Battery::updateBatteryStatus(timestamp, voltage_v, current_a, connected,
 				     selected_source, priority, throttle_normalized, _params.source == 0);
 }
 
-bool AnalogBattery::is_valid()
-{
-#ifdef BOARD_BRICK_VALID_LIST
-	bool valid[BOARD_NUMBER_BRICKS] = BOARD_BRICK_VALID_LIST;
-	return valid[_index - 1];
-#else
-	// TODO: Maybe return false instead?
-	return true;
-#endif
-}
 
 int AnalogBattery::get_voltage_channel()
 {
-	if (_analog_params.adc_channel >= 0) {
-		return _analog_params.adc_channel;
+	return _analog_params.adc_v_channel;
+}
 
-	} else {
-		return DEFAULT_V_CHANNEL[_index - 1];
-	}
+uint32_t AnalogBattery::get_voltage_deviceid()
+{
+	union {
+		int32_t i;
+		uint32_t u;
+	} u2i;
+	u2i.i = _analog_params.adc_v_devid;
+	return u2i.u;
 }
 
 int AnalogBattery::get_current_channel()
 {
-	// TODO: Possibly implement parameter for current sense channel
-	return DEFAULT_I_CHANNEL[_index - 1];
+	return _analog_params.adc_c_channel;
+}
+
+uint32_t AnalogBattery::get_current_deviceid()
+{
+	union {
+		int32_t i;
+		uint32_t u;
+	} u2i;
+	u2i.i = _analog_params.adc_c_devid;
+	return u2i.u;
 }
 
 void
 AnalogBattery::updateParams()
 {
-	if (_index == 1) {
+	if (_index == 1) {  // TODO: deprecate out-date parameters
 		migrateParam<float>(_analog_param_handles.v_div_old, _analog_param_handles.v_div, &_analog_params.v_div_old,
 				    &_analog_params.v_div, _first_parameter_update);
 		migrateParam<float>(_analog_param_handles.a_per_v_old, _analog_param_handles.a_per_v, &_analog_params.a_per_v_old,
 				    &_analog_params.a_per_v, _first_parameter_update);
-		migrateParam<int>(_analog_param_handles.adc_channel_old, _analog_param_handles.adc_channel,
-				  &_analog_params.adc_channel_old, &_analog_params.adc_channel, _first_parameter_update);
 
 	} else {
 		param_get(_analog_param_handles.v_div, &_analog_params.v_div);
 		param_get(_analog_param_handles.a_per_v, &_analog_params.a_per_v);
-		param_get(_analog_param_handles.adc_channel, &_analog_params.adc_channel);
 	}
 
-	param_get(_analog_param_handles.cnt_v_volt, &_analog_params.cnt_v_volt);
-	param_get(_analog_param_handles.cnt_v_curr, &_analog_params.cnt_v_curr);
+	param_get(_analog_param_handles.adc_v_devid, &_analog_params.adc_v_devid);
+	param_get(_analog_param_handles.adc_c_devid, &_analog_params.adc_c_devid);
+	param_get(_analog_param_handles.adc_v_channel, &_analog_params.adc_v_channel);
+	param_get(_analog_param_handles.adc_c_channel, &_analog_params.adc_c_channel);
+
 	param_get(_analog_param_handles.v_offs_cur, &_analog_params.v_offs_cur);
-
-	/* scaling of ADC ticks to battery voltage */
-	if (_analog_params.cnt_v_volt < 0.0f) {
-		/* apply scaling according to defaults if set to default */
-		_analog_params.cnt_v_volt = (BOARD_ADC_POS_REF_V_FOR_VOLTAGE_CHAN / px4_arch_adc_dn_fullcount());
-		param_set_no_notification(_analog_param_handles.cnt_v_volt, &_analog_params.cnt_v_volt);
-	}
-
-	/* scaling of ADC ticks to battery current */
-	if (_analog_params.cnt_v_curr < 0.0f) {
-		/* apply scaling according to defaults if set to default */
-		_analog_params.cnt_v_curr = (BOARD_ADC_POS_REF_V_FOR_CURRENT_CHAN / px4_arch_adc_dn_fullcount());
-		param_set_no_notification(_analog_param_handles.cnt_v_curr, &_analog_params.cnt_v_curr);
-	}
 
 	if (_analog_params.v_div <= 0.0f) {
 		/* apply scaling according to defaults if set to default */

--- a/src/modules/battery_status/analog_battery.h
+++ b/src/modules/battery_status/analog_battery.h
@@ -55,15 +55,19 @@ public:
 				       bool selected_source, int priority, float throttle_normalized);
 
 	/**
-	 * Whether the ADC channel for the voltage of this battery is valid.
-	 * Corresponds to BOARD_BRICK_VALID_LIST
+	 * Which ADC device is used for voltage reading of this battery
 	 */
-	bool is_valid();
+	uint32_t get_voltage_deviceid();
 
 	/**
 	 * Which ADC channel is used for voltage reading of this battery
 	 */
 	int get_voltage_channel();
+
+	/**
+	 * Which ADC device is used for current reading of this battery
+	 */
+	uint32_t get_current_deviceid();
 
 	/**
 	 * Which ADC channel is used for current reading of this battery
@@ -73,12 +77,13 @@ public:
 protected:
 
 	struct {
-		param_t cnt_v_volt;
-		param_t cnt_v_curr;
 		param_t v_offs_cur;
 		param_t v_div;
 		param_t a_per_v;
-		param_t adc_channel;
+		param_t adc_v_channel;
+		param_t adc_v_devid;
+		param_t adc_c_channel;
+		param_t adc_c_devid;
 
 		param_t v_div_old;
 		param_t a_per_v_old;
@@ -86,17 +91,18 @@ protected:
 	} _analog_param_handles;
 
 	struct {
-		float cnt_v_volt;
-		float cnt_v_curr;
 		float v_offs_cur;
 		float v_div;
 		float a_per_v;
-		int adc_channel;
+		int adc_v_channel;
+		int32_t adc_v_devid;
+		int adc_c_channel;
+		int32_t adc_c_devid;
 
 		float v_div_old;
 		float a_per_v_old;
 		int adc_channel_old;
 	} _analog_params;
 
-	virtual void updateParams() override;
+	void updateParams() override;
 };

--- a/src/modules/battery_status/analog_battery_params_common.c
+++ b/src/modules/battery_status/analog_battery_params_common.c
@@ -32,30 +32,6 @@
  ****************************************************************************/
 
 /**
- * Scaling from ADC counts to volt on the ADC input (battery voltage)
- *
- * This is not the battery voltage, but the intermediate ADC voltage.
- * A value of -1 signifies that the board defaults are used, which is
- * highly recommended.
- *
- * @group Battery Calibration
- * @decimal 8
- */
-PARAM_DEFINE_FLOAT(BAT_CNT_V_VOLT, -1.0f);
-
-/**
- * Scaling from ADC counts to volt on the ADC input (battery current)
- *
- * This is not the battery current, but the intermediate ADC voltage.
- * A value of -1 signifies that the board defaults are used, which is
- * highly recommended.
- *
- * @group Battery Calibration
- * @decimal 8
- */
-PARAM_DEFINE_FLOAT(BAT_CNT_V_CURR, -1.0);
-
-/**
  * Offset in volt as seen by the ADC input of the current sensor.
  *
  * This offset will be subtracted before calculating the battery

--- a/src/modules/battery_status/module.yaml
+++ b/src/modules/battery_status/module.yaml
@@ -9,7 +9,7 @@ parameters:
             description:
                 short: Battery ${i} voltage divider (V divider)
                 long: |
-                    This is the divider from battery ${i} voltage to 3.3V ADC voltage.
+                    This is the divider from battery ${i} voltage to ADC measured voltage.
                     If using e.g. Mauch power modules the value from the datasheet
                     can be applied straight here. A value of -1 means to use
                     the board default.
@@ -25,7 +25,7 @@ parameters:
             description:
                 short: Battery ${i} current per volt (A/V)
                 long: |
-                    The voltage seen by the 3.3V ADC multiplied by this factor
+                    The voltage seen by the ADC multiplied by this factor
                     will determine the battery current. A value of -1 means to use
                     the board default.
 
@@ -36,12 +36,47 @@ parameters:
             instance_start: 1
             default: [-1.0, -1.0]
 
-        BAT${i}_ADC_CHANNEL:
+        BAT${i}_ADC_V_CH:
             description:
-                short: Battery ${i} ADC Channel
+                short: Battery ${i} ADC Channel for voltage sensing
                 long: |
                     This parameter specifies the ADC channel used to monitor voltage of main power battery.
-                    A value of -1 means to use the board default.
+
+            type: int32
+            reboot_required: true
+            num_instances: *max_num_config_instances
+            instance_start: 1
+            default: [-1, -1]
+
+        BAT${i}_ADC_V_DEV:
+            description:
+                short: Battery ${i} ADC Device ID for voltage sensing
+                long: |
+                    This parameter specifies the ADC device used to monitor voltage of main power battery.
+
+            type: int32
+            reboot_required: true
+            num_instances: *max_num_config_instances
+            instance_start: 1
+            default: [-1, -1]
+
+        BAT${i}_ADC_C_CH:
+            description:
+                short: Battery ${i} ADC Channel for current sensing
+                long: |
+                    This parameter specifies the ADC channel used to monitor current of main power battery.
+
+            type: int32
+            reboot_required: true
+            num_instances: *max_num_config_instances
+            instance_start: 1
+            default: [-1, -1]
+
+        BAT${i}_ADC_C_DEV:
+            description:
+                short: Battery ${i} ADC Device ID for current sensing
+                long: |
+                    This parameter specifies the ADC device used to monitor current of main power battery.
 
             type: int32
             reboot_required: true


### PR DESCRIPTION
**Describe problem solved by this pull request**
Refactor adc. Moving adc out of DriverFramework. Aim to get a more flexible adc system.

**Describe your solution**
1. make `adc_report.msg` contains more useful information
2. reduce hard-coded macros
2. let adc data receptor decide which adc device and channel it make use of by parameters or any other way.

This adc system works like mpu9250 with similar deviceID management. It supports multiple adc drivers and support multiple adc subscriber.
ADC driver publish `adc_report`, analog battery/airspeed driver wrapper subscribe the uorb topic and pick up information they need.
Old architecture-specific call in `drv_adc.h` should be deprecated.

**Additional context**
WIP, support needed.
