### PR TITLE
beaglebone blue: add support for in tree bmp280 and mpu9250 drivers

### DIFF
--- a/boards/beaglebone/blue/src/board_config.h
+++ b/boards/beaglebone/blue/src/board_config.h
@@ -60,8 +60,11 @@
 /*
  * I2C busses
  */
-#define PX4_I2C_BUS_EXPANSION	1
+#define PX4_I2C_BUS_EXPANSION	2
 #define PX4_NUMBER_I2C_BUSES    1
+
+#define PX4_I2C_OBDEV_MPU9250   0x69
+#define PX4_I2C_OBDEV_BMP280    0x76
 
 #include <system_config.h>
 #include <px4_platform_common/board_common.h>

--- a/posix-configs/bbblue/px4.config
+++ b/posix-configs/bbblue/px4.config
@@ -52,8 +52,10 @@ param set BAT_V_DIV 		11.0
 dataman start
 
 df_bmp280_wrapper  start -D /dev/i2c-2
+#bmp280 -X start
 
 df_mpu9250_wrapper start
+#mpu9250 -X start
 # options:  -R rotation
 
 gps start -d /dev/ttyS2 -s -p ubx

--- a/posix-configs/bbblue/px4_fw.config
+++ b/posix-configs/bbblue/px4_fw.config
@@ -52,8 +52,10 @@ param set BAT_V_DIV 		11.0
 dataman start
 
 df_bmp280_wrapper  start -D /dev/i2c-2
+#bmp280 -X start
 
 df_mpu9250_wrapper start
+#mpu9250 -X start
 # options:  -R rotation
 
 gps start -d /dev/ttyS2 -s -p ubx


### PR DESCRIPTION
The beagle bone blue has an mpu9250 and bmp280 on /dev/i2c-2