### PR TITLE
logger: Add support for logging only on bat power

### DIFF
--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -338,6 +338,7 @@ private:
 	param_t						_log_utc_offset{PARAM_INVALID};
 	param_t						_log_dirs_max{PARAM_INVALID};
 	param_t						_mission_log{PARAM_INVALID};
+	param_t						_boot_bat_only{PARAM_INVALID};
 };
 
 } //namespace logger

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -268,6 +268,12 @@ private:
 	bool initialize_topics(MissionLogType mission_log_mode);
 
 	/**
+	 * Determines if log-from-boot should be disabled, based on the value of SDLOG_BOOT_BAT and the battery status.
+	 * @return true if log-from-boot should be disabled
+	 */
+	bool get_disable_boot_logging();
+
+	/**
 	 * check current arming state or aux channel and start/stop logging if state changed and according to
 	 * configured params.
 	 * @param vehicle_status_sub

--- a/src/modules/logger/params.c
+++ b/src/modules/logger/params.c
@@ -67,6 +67,21 @@ PARAM_DEFINE_INT32(SDLOG_UTC_OFFSET, 0);
 PARAM_DEFINE_INT32(SDLOG_MODE, 0);
 
 /**
+ * Battery-only Logging
+ *
+ * When enabled, logging will not start from boot if battery power is not detected
+ * (e.g. powered via USB on a test bench). This prevents extraneous flight logs from
+ * being created during bench testing.
+ *
+ * Note that this only applies to log-from-boot modes. This has no effect on arm-based
+ * modes.
+ *
+ * @boolean
+ * @group SD Logging
+ */
+PARAM_DEFINE_INT32(SDLOG_BOOT_BAT, 0);
+
+/**
  * Mission Log
  *
  * If enabled, a small additional "mission" log file will be written to the SD card.


### PR DESCRIPTION
Will not start logging from boot if battery is not connected.

**Problem**
For the logging modes that cause logger to start at boot (boot until disarm or boot until shutdown), a log is started every time the FCU is powered. This includes connecting to the FCU over USB for firmware updates, parameter modifications, or other non-flight modifications. This causes the creation of logs in scenarios where they are most likely unneeded, which clutters up the log space.

**Solution**
Introduce a parameter (`SDLOG_BOOT_BAT`) that when enabled, prevents logs from being started from boot if a battery is not connected.

**Note**
Only works for the first battery instance. If FCU has second power connector that is used instead, this will not work as-is.