### PR TITLE
FW: Allow counterclockwise loiter

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -854,7 +854,7 @@ FixedwingPositionControl::control_position(const Vector2f &curr_pos, const Vecto
 			float loiter_radius = pos_sp_curr.loiter_radius;
 			uint8_t loiter_direction = pos_sp_curr.loiter_direction;
 
-			if (pos_sp_curr.loiter_radius < 0.01f || pos_sp_curr.loiter_radius > -0.01f) {
+			if (fabsf(pos_sp_curr.loiter_radius) < FLT_EPSILON) {
 				loiter_radius = _parameters.loiter_radius;
 				loiter_direction = (loiter_radius > 0) ? 1 : -1;
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
There was a bug preventing us to set a loiter radius individually for each waypoint and to loiter counterclockwise.

**Describe your solution**
Fixed the check whether the radius is 0 or not.

**Test data / coverage**
Tested in sitl_gazebo with MAV_CMD_NAV_LOITER_UNLIMITED waypoints with param3 (radius) being set to 100.0 and -100.0.