### PR TITLE
fix RPi upload

### DIFF
--- a/boards/px4/raspberrypi/cmake/upload.cmake
+++ b/boards/px4/raspberrypi/cmake/upload.cmake
@@ -31,7 +31,7 @@
 #
 ############################################################################
 
-if($ENV{AUTOPILOT_HOST})
+if(DEFINED ENV{AUTOPILOT_HOST})
 	set(AUTOPILOT_HOST $ENV{AUTOPILOT_HOST})
 else()
 	set(AUTOPILOT_HOST "raspberrypi")


### PR DESCRIPTION
**Describe problem solved by this pull request**
Fix cmake expression to detect whether AUTOPILOT_HOST is set or not correctly.

**Test data / coverage**
I issued `export AUTOPILOT_HOST=xxxxxx` to set the variable. It could not be detected by the old expression so I searched and found out the new one which works properly.

**Additional context**
Maybe Navio version of upload needs this change as well?
