### PR TITLE
github actions: temporarily disable SITL Tests (Code Coverage)

### DIFF
--- a/.github/workflows/sitl_tests_coverage.yml
+++ b/.github/workflows/sitl_tests_coverage.yml
@@ -14,8 +14,9 @@ jobs:
       run: update-alternatives --install /usr/bin/python python /usr/bin/python3 10
     - name: Install psutil
       run: pip3 install psutil
-    - name: Run simulation tests
-      run: make tests_integration_coverage
+# TODO: disabled 2019-01-09 due to failures
+#    - name: Run simulation tests
+#      run: make tests_integration_coverage
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:


### PR DESCRIPTION
Github actions SITL Tests (Code Coverage) started failing after the recent ECL update (https://github.com/PX4/Firmware/pull/13883).

Disabling until we find and fix the problem.
https://github.com/PX4/Firmware/issues/13884