### PR TITLE
[Trivial] commander_params: remove duplicate rc override title

### DIFF
--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -630,7 +630,6 @@ PARAM_DEFINE_INT32(COM_ARM_MAG_ANG, 30);
 PARAM_DEFINE_INT32(COM_ARM_MAG_STR, 1);
 
 /**
- * Enable RC stick override of auto modes
  * Enable RC stick override of auto or offboard modes
  *
  * Moving the RC sticks gives control back to the pilot in manual position mode immediately when:


### PR DESCRIPTION
**Describe problem solved by this pull request**
Follow up fix for https://github.com/PX4/Firmware/pull/13618#discussion_r364840683

I merged the duplicate title because the pr was from a private fork branch and already delayed a lot.
