### PR TITLE
msg: urtps: change the topic Data Type name to match expected on ROS2

### DIFF
--- a/msg/templates/urtps/Publisher.cpp.em
+++ b/msg/templates/urtps/Publisher.cpp.em
@@ -95,13 +95,20 @@ bool @(topic)_Publisher::init()
     if(mp_participant == nullptr)
         return false;
 
+@[if ros2_distro and (ros2_distro == "dashing" or ros2_distro == "eloquent")]@
+    // Type name should match the expected type name on ROS2
+    // Note: the change is being done here since the 'fastrtpsgen' example
+    // generator does not allow to change the type naming on the template
+    @(topic)DataType.setName("@(package)::msg::dds_::@(topic)_");
+@[end if]@
+
     // Register the type
-    Domain::registerType(mp_participant, static_cast<TopicDataType*>(&myType));
+    Domain::registerType(mp_participant, static_cast<TopicDataType*>(&@(topic)DataType));
 
     // Create Publisher
     PublisherAttributes Wparam;
     Wparam.topic.topicKind = NO_KEY;
-    Wparam.topic.topicDataType = myType.getName();  //This type MUST be registered
+    Wparam.topic.topicDataType = @(topic)DataType.getName();
 @[if ros2_distro]@
 @[    if ros2_distro == "ardent"]@
     Wparam.qos.m_partition.push_back("rt");

--- a/msg/templates/urtps/Publisher.h.em
+++ b/msg/templates/urtps/Publisher.h.em
@@ -111,15 +111,15 @@ private:
     } m_listener;
 @[if 1.5 <= fastrtpsgen_version <= 1.7]@
 @[    if ros2_distro]@
-    @(package)::msg::dds_::@(topic)_PubSubType myType;
+    @(package)::msg::dds_::@(topic)_PubSubType @(topic)DataType;
 @[    else]@
-    @(topic)_PubSubType myType;
+    @(topic)_PubSubType @(topic)DataType;
 @[    end if]@
 @[else]@
 @[    if ros2_distro]@
-    @(package)::msg::@(topic)PubSubType myType;
+    @(package)::msg::@(topic)PubSubType @(topic)DataType;
 @[    else]@
-    @(topic)PubSubType myType;
+    @(topic)PubSubType @(topic)DataType;
 @[    end if]@
 @[end if]@
 };

--- a/msg/templates/urtps/Subscriber.cpp.em
+++ b/msg/templates/urtps/Subscriber.cpp.em
@@ -94,13 +94,21 @@ bool @(topic)_Subscriber::init(uint8_t topic_ID, std::condition_variable* t_send
     if(mp_participant == nullptr)
             return false;
 
+@[if ros2_distro and (ros2_distro == "dashing" or ros2_distro == "eloquent")]@
+    // Type name should match the expected type name on ROS2
+    // Note: the change is being done here since the 'fastrtpsgen' example
+    // generator does not allow to change the type naming on the template of
+    // "*PubSubTypes.cpp" file
+    @(topic)DataType.setName("@(package)::msg::dds_::@(topic)_");
+@[end if]@
+
     //Register the type
-    Domain::registerType(mp_participant, static_cast<TopicDataType*>(&myType));
+    Domain::registerType(mp_participant, static_cast<TopicDataType*>(&@(topic)DataType));
 
     // Create Subscriber
     SubscriberAttributes Rparam;
     Rparam.topic.topicKind = NO_KEY;
-    Rparam.topic.topicDataType = myType.getName(); //Must be registered before the creation of the subscriber
+    Rparam.topic.topicDataType = @(topic)DataType.getName();
 @[if ros2_distro]@
 @[    if ros2_distro == "ardent"]@
     Rparam.qos.m_partition.push_back("rt");

--- a/msg/templates/urtps/Subscriber.h.em
+++ b/msg/templates/urtps/Subscriber.h.em
@@ -142,15 +142,15 @@ private:
     } m_listener;
 @[if 1.5 <= fastrtpsgen_version <= 1.7]@
 @[    if ros2_distro]@
-    @(package)::msg::dds_::@(topic)_PubSubType myType;
+    @(package)::msg::dds_::@(topic)_PubSubType @(topic)DataType;
 @[    else]@
-    @(topic)_PubSubType myType;
+    @(topic)_PubSubType @(topic)DataType;
 @[    end if]@
 @[else]@
 @[    if ros2_distro]@
-    @(package)::msg::@(topic)PubSubType myType;
+    @(package)::msg::@(topic)PubSubType @(topic)DataType;
 @[    else]@
-    @(topic)PubSubType myType;
+    @(topic)PubSubType @(topic)DataType;
 @[    end if]@
 @[end if]@
 };


### PR DESCRIPTION
**Describe problem solved by this pull request**
This change allows that our micro-RTPS agent communicates with ROS 2 Dashing (Eloquent not tested yet).

**Describe your solution**
Most of the problem was presented and followed in https://github.com/eProsima/Fast-RTPS/issues/829. The issue is that the topic data type name that is generated by `fastrtpsgen`, set in the `<msg_name>PubSubTypes.cpp` files, doesn't match the expected type name of the ROS 2 participant topics. So the solution taken was to directly "reset" the type naming on both Publisher and Subscriber source code.

Thumbs up for @ldg810 for finding and pointing https://answers.ros.org/question/319723/use-ros2-fastrtps-with-standalone-fastrtps-programs/ in https://github.com/eProsima/Fast-RTPS/issues/829, which allowed me to fix this. Thanks @ldg810!

**Describe possible alternatives**
If we find a way of adjusting the naming being set [here](https://github.com/eProsima/Fast-RTPS-Gen/blob/master/src/main/java/com/eprosima/fastrtps/idl/templates/RTPSPubSubTypeSource.stg#L71) by an argument passed through the generator, this could be used instead of the default `scopedname`.

@richiware is this possible by any means? I understand that the scope is built based on the directory structure, but `rosidl_generate_interfaces()` puts the generated IDL's under `px4_msgs/msg/`, while this wasn't a problem for `rosidl_generate_dds_interfaces()`, since the generated IDL's where put under `px4_msgs/msg/dds_fastrtps`, which in return would get you the right scope name.

If the above is not possible, one way I am seeing is to create a temp dir and copy the IDL files for it so to generate the code with the right scope.

**Test data / coverage**
Tested with `px4_ros_com` and SITL with UDP.

FYI @thomasgubler @jkflying.