### PR TITLE
Tools: fix 'Assistive technology not found error'

### DIFF
--- a/Tools/jmavsim_run.sh
+++ b/Tools/jmavsim_run.sh
@@ -68,11 +68,11 @@ fi
 ant create_run_jar copy_res
 cd out/production
 
-java -XX:GCTimeRatio=20 -Djava.ext.dirs= -jar jmavsim_run.jar $device $extra_args
+java -XX:GCTimeRatio=20 -Djava.ext.dirs= -Djavax.accessibility.assistive_technologies=" " -jar jmavsim_run.jar $device $extra_args
 ret=$?
 if [ $ret -ne 0 -a $ret -ne 130 ]; then # 130 is Ctrl-C
 	# if the start of java fails, it's probably because the GC option is not
 	# understood. Try starting without it
-	java -Djava.ext.dirs= -jar jmavsim_run.jar $device $extra_args
+	java -Djava.ext.dirs= -Djavax.accessibility.assistive_technologies=" " -jar jmavsim_run.jar $device $extra_args
 fi
 


### PR DESCRIPTION
On Ubuntu we often saw the error
```
Assistive technology not found AWTError when starting jMAVSim.
```

This should be fixed by appending this cli argument to java.

As suggested in https://github.com/PX4/containers/issues/206 by @zwn.