### PR TITLE
reverse adding 'master' build for deploy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -714,7 +714,7 @@ pipeline {
           }
           when {
             anyOf {
-              branch 'master'
+              //branch 'master'
               branch 'pr-jenkins' // for testing
             }
           }


### PR DESCRIPTION
Looks like we need `six`. Fix in https://github.com/PX4/containers/pull/231#pullrequestreview-341178000.
