### PR TITLE
px4_work_queue: revert inherited sched attr and run wq:manager and max priority

### DIFF
--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
@@ -64,21 +64,21 @@ static constexpr wq_config_t I2C2{"wq:I2C2", 1400, -10};
 static constexpr wq_config_t I2C3{"wq:I2C3", 1400, -11};
 static constexpr wq_config_t I2C4{"wq:I2C4", 1400, -12};
 
-static constexpr wq_config_t att_pos_ctrl{"wq:att_pos_ctrl", 6600, -11}; // PX4 att/pos controllers, highest priority after sensors
+static constexpr wq_config_t att_pos_ctrl{"wq:att_pos_ctrl", 6600, -13}; // PX4 att/pos controllers, highest priority after sensors
 
-static constexpr wq_config_t hp_default{"wq:hp_default", 1900, -12};
+static constexpr wq_config_t hp_default{"wq:hp_default", 1900, -14};
 
-static constexpr wq_config_t uavcan{"uavcan", 2400, -13};
+static constexpr wq_config_t uavcan{"wq:uavcan", 2400, -15};
 
-static constexpr wq_config_t UART0{"wq:UART0", 1400, -14};
-static constexpr wq_config_t UART1{"wq:UART1", 1400, -15};
-static constexpr wq_config_t UART2{"wq:UART2", 1400, -16};
-static constexpr wq_config_t UART3{"wq:UART3", 1400, -17};
-static constexpr wq_config_t UART4{"wq:UART4", 1400, -18};
-static constexpr wq_config_t UART5{"wq:UART5", 1400, -19};
-static constexpr wq_config_t UART6{"wq:UART6", 1400, -20};
-static constexpr wq_config_t UART7{"wq:UART7", 1400, -21};
-static constexpr wq_config_t UART8{"wq:UART8", 1400, -22};
+static constexpr wq_config_t UART0{"wq:UART0", 1400, -16};
+static constexpr wq_config_t UART1{"wq:UART1", 1400, -17};
+static constexpr wq_config_t UART2{"wq:UART2", 1400, -18};
+static constexpr wq_config_t UART3{"wq:UART3", 1400, -19};
+static constexpr wq_config_t UART4{"wq:UART4", 1400, -20};
+static constexpr wq_config_t UART5{"wq:UART5", 1400, -21};
+static constexpr wq_config_t UART6{"wq:UART6", 1400, -22};
+static constexpr wq_config_t UART7{"wq:UART7", 1400, -23};
+static constexpr wq_config_t UART8{"wq:UART8", 1400, -24};
 
 static constexpr wq_config_t lp_default{"wq:lp_default", 1700, -50};
 

--- a/platforms/common/px4_work_queue/WorkQueueManager.cpp
+++ b/platforms/common/px4_work_queue/WorkQueueManager.cpp
@@ -270,14 +270,6 @@ WorkQueueManagerRun(int, char **)
 #if defined(ENABLE_LOCKSTEP_SCHEDULER)
 			int ret_setschedpolicy = pthread_attr_setschedpolicy(&attr, SCHED_RR);
 #else
-
-			// don't inherit attributes from parent thread
-			int ret_setinheritsched = pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED);
-
-			if (ret_setinheritsched != 0) {
-				PX4_ERR("failed to set inherit-scheduler attribute PTHREAD_EXPLICIT_SCHED (%i)", ret_setinheritsched);
-			}
-
 			int ret_setschedpolicy = pthread_attr_setschedpolicy(&attr, SCHED_FIFO);
 #endif
 
@@ -327,7 +319,7 @@ WorkQueueManagerStart()
 
 		int task_id = px4_task_spawn_cmd("wq:manager",
 						 SCHED_DEFAULT,
-						 PX4_WQ_HP_BASE,
+						 SCHED_PRIORITY_MAX,
 						 1280,
 						 (px4_main_t)&WorkQueueManagerRun,
 						 nullptr);


### PR DESCRIPTION
More discoveries about pthread consistentcy across all supported platforms and platform configurations (running privileged or not, ulimit settings, etc).

 - setting PTHREAD_EXPLICIT_SCHED was necessary on linux to create WQ
threads with priorities relative to max
 - we can't rely pthread_attr_setinheritsched everywhere as it's
dependent on system ulimit configuration or running privileged
 - instead we create the wq:manager at the maximum desired priority and
allow each WQ thread to have a relative priority
