### PR TITLE
free allocated variable by perf_alloc

### DIFF
--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -114,6 +114,7 @@ Navigator::Navigator() :
 
 Navigator::~Navigator()
 {
+	perf_free(_loop_perf);
 	orb_unsubscribe(_local_pos_sub);
 	orb_unsubscribe(_vehicle_status_sub);
 }


### PR DESCRIPTION
Free `_loop_perf` in deconstructor which was allocated in constructor.