### PR TITLE
[Two motor tailsitter]Controlling the servo through the output from the mc controller

### DIFF
--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -314,7 +314,7 @@ void Tailsitter::fill_actuator_outputs()
 
 	} else if (_vtol_schedule.flight_mode == vtol_mode::MC_MODE) {	
 		_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] =
-			_actuators_mc_in->control[actuator_controls_s::INDEX_ROLL];
+			_actuators_mc_in->control[actuator_controls_s::INDEX_YAW];
 		_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] =
 			_actuators_mc_in->control[actuator_controls_s::INDEX_PITCH];
 

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -312,6 +312,12 @@ void Tailsitter::fill_actuator_outputs()
 		_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] = 0;
 		_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] = 0;
 
+	} else if (_vtol_schedule.flight_mode == vtol_mode::MC_MODE) {	
+		_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] =
+			_actuators_mc_in->control[actuator_controls_s::INDEX_ROLL];
+		_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] =
+			_actuators_mc_in->control[actuator_controls_s::INDEX_PITCH];
+
 	} else {
 		_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] =
 			_actuators_fw_in->control[actuator_controls_s::INDEX_ROLL];


### PR DESCRIPTION
I understand that we use the output value from the FW controller to control the aileron in fixed-wing and transmission mode. But in MC mode, the output from the rotor controller should be used to control the aileron.


Now when tailsitter UAV is flying in the rotor state, the pitch / yaw control is through the output of the fw controller instead of the rotor controller output. This PR fixes this problem.


FYI： @RomanBapst  