### PR TITLE
Wrong comment in GPS.cpp

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -418,7 +418,7 @@ void GPS::handleInjectDataTopic()
 	bool updated = false;
 
 	// Limit maximum number of GPS injections to 6 since usually
-	// GPS injections should consist of 1-4 packets (GPS, Glonass, Baidu, Galileo).
+	// GPS injections should consist of 1-4 packets (GPS, Glonass, BeiDou, Galileo).
 	// Looking at 6 packets thus guarantees, that at least a full injection
 	// data set is evaluated.
 	const size_t max_num_injections = 6;


### PR DESCRIPTION
'BeiDou' is a navigation satellite system from China, while 'Baidu' is a search engine.
So it is supposed to change it from 'Baidu' to 'BeiDou'.

**Describe problem solved by this pull request**
Wrong comment about navigation systems.

**Describe your solution**
 Change from 'Baidu' to 'BeiDou'.

References:
https://en.wikipedia.org/wiki/BeiDou
https://en.wikipedia.org/wiki/Baidu
