### PR TITLE
PAW3902: fix mode change shutter thresholds

### DIFF
--- a/src/drivers/optical_flow/paw3902/PAW3902.cpp
+++ b/src/drivers/optical_flow/paw3902/PAW3902.cpp
@@ -603,7 +603,7 @@ PAW3902::Run()
 			// LowLight -> SuperLowLight
 			changeMode(Mode::SuperLowLight);
 
-		} else if ((shutter >= 0x0BB8)) {	// AND valid for 10 consecutive frames?
+		} else if ((shutter < 0x0BB8)) {	// AND valid for 10 consecutive frames?
 			// LowLight -> Bright
 			changeMode(Mode::Bright);
 		}
@@ -613,7 +613,7 @@ PAW3902::Run()
 	case Mode::SuperLowLight:
 
 		// SuperLowLight -> LowLight
-		if ((shutter >= 0x03E8)) { // AND valid for 10 consecutive frames?
+		if ((shutter < 0x03E8)) { // AND valid for 10 consecutive frames?
 			changeMode(Mode::LowLight);
 		}
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
Mode switching of PAW3903 wasn't working as expected

**Describe your solution**
Changed the shutter threshold logic according to datasheet

**Test data / coverage**
Tested that modes were stable after the change, but not flown or tested in low light

