### PR TITLE
Fix velocity state usage in multicopter position control

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -462,7 +462,7 @@ MulticopterPositionControl::set_vehicle_states(const float &vel_sp_z)
 		_vel_y_deriv.update(0.0f);
 	}
 
-	if (PX4_ISFINITE(_local_pos.vz)) {
+	if (PX4_ISFINITE(_local_pos.vz) && _local_pos.v_z_valid) {
 		_states.velocity(2) = _local_pos.vz;
 
 		if (PX4_ISFINITE(vel_sp_z) && fabsf(vel_sp_z) > FLT_EPSILON && PX4_ISFINITE(_local_pos.z_deriv)) {

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -456,10 +456,9 @@ MulticopterPositionControl::set_vehicle_states(const float &vel_sp_z)
 	} else {
 		_states.velocity(0) = _states.velocity(1) = NAN;
 		_states.acceleration(0) = _states.acceleration(1) = NAN;
-
-		// since no valid velocity, update derivate with 0
-		_vel_x_deriv.update(0.0f);
-		_vel_y_deriv.update(0.0f);
+		// reset derivatives to prevent acceleration spikes when regaining velocity
+		_vel_x_deriv.reset();
+		_vel_y_deriv.reset();
 	}
 
 	if (PX4_ISFINITE(_local_pos.vz) && _local_pos.v_z_valid) {
@@ -476,9 +475,8 @@ MulticopterPositionControl::set_vehicle_states(const float &vel_sp_z)
 
 	} else {
 		_states.velocity(2) = _states.acceleration(2) = NAN;
-		// since no valid velocity, update derivate with 0
-		_vel_z_deriv.update(0.0f);
-
+		// reset derivative to prevent acceleration spikes when regaining velocity
+		_vel_z_deriv.reset();
 	}
 }
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -462,13 +462,7 @@ MulticopterPositionControl::set_vehicle_states(const float &vel_sp_z)
 		_vel_y_deriv.update(0.0f);
 	}
 
-	if (_param_mpc_alt_mode.get() && _local_pos.dist_bottom_valid && PX4_ISFINITE(_local_pos.dist_bottom_rate)) {
-		// terrain following
-		_states.velocity(2) = -_local_pos.dist_bottom_rate;
-		_states.acceleration(2) = _vel_z_deriv.update(-_states.velocity(2));
-
-	} else if (PX4_ISFINITE(_local_pos.vz)) {
-
+	if (PX4_ISFINITE(_local_pos.vz)) {
 		_states.velocity(2) = _local_pos.vz;
 
 		if (PX4_ISFINITE(vel_sp_z) && fabsf(vel_sp_z) > FLT_EPSILON && PX4_ISFINITE(_local_pos.z_deriv)) {


### PR DESCRIPTION
**Describe problem solved by this pull request**
We had a crash while using terrain following and I found out that the vertical velocity estimate of the EKF is getting ignored in that configuration. This was introduced in https://github.com/PX4/Firmware/commit/bf4ac7a9d639f26fc7557345a219ffd1bec04764 and I couldn't find a viable use case for doing that at least with the current implementation. Maybe it was rather experimental back then maybe @Stifael could give us some insights.

**Describe your solution**
While fixing the above root problem I changed three things (3 commits with detailed descriptions):
1. Still use the vertical velocity estimate from the estimator in terrain following and do not override it with the dist_bottom_rate.
1. Do not use the vertical velocity estimate if it's flagged invalid. A bug I realized while comparing to the horizontal velocity case in the same function. This probably never showed up because the vertical velocity is almost always valid but in case it's not it would be fatal to feed position control with it.
1. Reset the velocity derivatives instead of updating them with zero to avoid spikes when regaining the velocity estimate. I found that bug while looking at the update calls since we had the derivative spike problem before with timing issues when switching modes in #13522.

**Test data / coverage**
Not tested at all yet, I have to follow up with reports. Reveiws and tests are welcome.

**Additional context**
Here's a screenshot where you see the distance being reported too high up because of this bug: https://github.com/PX4/ecl/pull/706 and since terrain following was enabled the wrong dist_bottom rate was used before the changes in this pr and made the drone go vertically unstable and cut thrust to idle:
![dist_bottom_rate](https://user-images.githubusercontent.com/4668506/72212747-d0bce300-3496-11ea-924a-546e8cc0acaa.PNG)
