### PR TITLE
platforms: split posix hrt for qurt

### DIFF
--- a/platforms/common/include/px4_platform_common/posix.h
+++ b/platforms/common/include/px4_platform_common/posix.h
@@ -136,13 +136,4 @@ __EXPORT const char 	*px4_get_device_names(unsigned int *handle);
 __EXPORT void		px4_show_topics(void);
 __EXPORT const char 	*px4_get_topic_names(unsigned int *handle);
 
-#ifndef __PX4_QURT
-/*
- * The UNIX epoch system time following the system clock
- */
-__EXPORT uint64_t	hrt_system_time(void);
-
-
-#endif
-
 __END_DECLS

--- a/platforms/qurt/src/px4/common/CMakeLists.txt
+++ b/platforms/qurt/src/px4/common/CMakeLists.txt
@@ -40,7 +40,7 @@ set(QURT_LAYER_SRCS
 	px4_qurt_impl.cpp
 	px4_qurt_tasks.cpp
 	lib_crc32.c
-	${PX4_SOURCE_DIR}/platforms/posix/src/px4/common/drv_hrt.cpp
+	drv_hrt.cpp
 	qurt_stubs.c
 	main.cpp
 	shmem_qurt.cpp

--- a/src/drivers/drv_hrt.h
+++ b/src/drivers/drv_hrt.h
@@ -185,8 +185,6 @@ __EXPORT extern void	hrt_init(void);
 
 #ifdef __PX4_POSIX
 
-__EXPORT extern hrt_abstime hrt_reset(void);
-
 __EXPORT extern hrt_abstime hrt_absolute_time_offset(void);
 
 #endif


### PR DESCRIPTION
This keeps the per platform libraries contained to their respective directories and minimizes the ifdef mess.