### PR TITLE
mavlink battery_status: report actual cell voltages

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -737,10 +737,12 @@ protected:
 				}
 
 				static constexpr int mavlink_cells_max = (sizeof(bat_msg.voltages) / sizeof(bat_msg.voltages[0]));
+				static constexpr int uorb_cells_max =
+					(sizeof(battery_status.voltage_cell_v) / sizeof(battery_status.voltage_cell_v[0]));
 
 				for (int cell = 0; cell < mavlink_cells_max; cell++) {
-					if ((battery_status.cell_count > 0) && (cell < battery_status.cell_count) && battery_status.connected) {
-						bat_msg.voltages[cell] = (battery_status.voltage_v / battery_status.cell_count) * 1000.0f;
+					if (battery_status.connected && (cell < battery_status.cell_count) && (cell < uorb_cells_max)) {
+						bat_msg.voltages[cell] = battery_status.voltage_cell_v[cell] * 1000.0f;
 
 					} else {
 						bat_msg.voltages[cell] = UINT16_MAX;


### PR DESCRIPTION
**Describe problem solved by this pull request**
There are battery drivers that can report individual cell voltages, there's also the array in the uORB battery status message `battery_status.voltage_cell_v[0]` for internal communication and logging of the voltages but over MAVLink you always only get the total voltage devided by the cell count. I honestly don't know how this can be useful...

**Describe your solution**
I'm filling the MAVLink message with the individual cell voltages of the uORB message such that if you know them they get reported to the ground station. In the worst case you don't know them but then it's misleading to just have average information while one cell is silently dying, that's what the cell voltage information is useful for.

**Test data / coverage**
Bench tested with a battery supporting cell voltage reading.
