### PR TITLE
Move mag downsampling to ECL lib

### DIFF
--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -185,12 +185,6 @@ private:
 	// Initialise time stamps used to send sensor data to the EKF and for logging
 	uint8_t _invalid_mag_id_count = 0;	///< number of times an invalid magnetomer device ID has been detected
 
-	// Used to down sample magnetometer data
-	float _mag_data_sum[3] = {};			///< summed magnetometer readings (Gauss)
-	uint64_t _mag_time_sum_ms = 0;		///< summed magnetoemter time stamps (mSec)
-	uint8_t _mag_sample_count = 0;		///< number of magnetometer measurements summed during downsampling
-	int32_t _mag_time_ms_last_used = 0;	///< time stamp of the last averaged magnetometer measurement sent to the EKF (mSec)
-
 	// Used to down sample barometer data
 	float _balt_data_sum = 0.0f;			///< summed pressure altitude readings (m)
 	uint64_t _balt_time_sum_ms = 0;		///< summed pressure altitude time stamps (mSec)
@@ -828,33 +822,7 @@ void Ekf2::Run()
 					PX4_INFO("Mag sensor ID changed to %i", _param_ekf2_magbias_id.get());
 				}
 
-				// If the time last used by the EKF is less than specified, then accumulate the
-				// data and push the average when the specified interval is reached.
-				_mag_time_sum_ms += magnetometer.timestamp / 1000;
-				_mag_sample_count++;
-				_mag_data_sum[0] += magnetometer.magnetometer_ga[0];
-				_mag_data_sum[1] += magnetometer.magnetometer_ga[1];
-				_mag_data_sum[2] += magnetometer.magnetometer_ga[2];
-				int32_t mag_time_ms = _mag_time_sum_ms / _mag_sample_count;
-
-				if ((mag_time_ms - _mag_time_ms_last_used) > _params->sensor_interval_min_ms) {
-					const float mag_sample_count_inv = 1.0f / _mag_sample_count;
-					// calculate mean of measurements and correct for learned bias offsets
-					float mag_data_avg_ga[3] = {_mag_data_sum[0] *mag_sample_count_inv - _param_ekf2_magbias_x.get(),
-								    _mag_data_sum[1] *mag_sample_count_inv - _param_ekf2_magbias_y.get(),
-								    _mag_data_sum[2] *mag_sample_count_inv - _param_ekf2_magbias_z.get()
-								   };
-
-					_ekf.setMagData(1000 * (uint64_t)mag_time_ms, mag_data_avg_ga);
-
-					_mag_time_ms_last_used = mag_time_ms;
-					_mag_time_sum_ms = 0;
-					_mag_sample_count = 0;
-					_mag_data_sum[0] = 0.0f;
-					_mag_data_sum[1] = 0.0f;
-					_mag_data_sum[2] = 0.0f;
-				}
-
+				_ekf.setMagData(magnetometer.timestamp, magnetometer.magnetometer_ga);
 				ekf2_timestamps.vehicle_magnetometer_timestamp_rel = (int16_t)((int64_t)magnetometer.timestamp / 100 -
 						(int64_t)ekf2_timestamps.timestamp / 100);
 			}

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -822,7 +822,12 @@ void Ekf2::Run()
 					PX4_INFO("Mag sensor ID changed to %i", _param_ekf2_magbias_id.get());
 				}
 
-				_ekf.setMagData(magnetometer.timestamp, magnetometer.magnetometer_ga);
+				float magnetometer_ga [3];
+				magnetometer_ga[0] = magnetometer.magnetometer_ga[0] - _param_ekf2_magbias_x.get();
+				magnetometer_ga[1] = magnetometer.magnetometer_ga[1] - _param_ekf2_magbias_y.get();
+				magnetometer_ga[2] = magnetometer.magnetometer_ga[2] - _param_ekf2_magbias_z.get();
+
+				_ekf.setMagData(magnetometer.timestamp, magnetometer_ga);
 				ekf2_timestamps.vehicle_magnetometer_timestamp_rel = (int16_t)((int64_t)magnetometer.timestamp / 100 -
 						(int64_t)ekf2_timestamps.timestamp / 100);
 			}


### PR DESCRIPTION
ECL should handle the down sampling the sensor data to match its limitation in buffer size. This PR brings the down sampling of the magnetometer data to ECL. Previously this was done on the Firmware side.

**Log Replay:**
Before
![before](https://user-images.githubusercontent.com/23532607/72619383-6811b280-393d-11ea-8369-c2ccc0b061bc.png)
[Log}(https://review.px4.io/plot_app?log=aadaf2b7-82a0-4beb-8e77-8cd8f4b7b7e7)

After
![after](https://user-images.githubusercontent.com/23532607/72619392-6ea02a00-393d-11ea-91e2-1742e8c3972e.png)
[Log](https://review.px4.io/plot_app?log=3adc3ef8-2676-449f-a15c-cb502fdd35dc)

Related ECL PR: https://github.com/PX4/ecl/pull/712