### PR TITLE
CI: Jenkins: move "Cppcheck" stage to ROS Melodic container

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -378,7 +378,7 @@ pipeline {
         stage('Cppcheck') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2020-01-13'
+              image 'px4io/px4-dev-ros-melodic:2020-01-13'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }


### PR DESCRIPTION
*Cppcheck* Jenkins stage runs `cppcheck-htmlreport`, which requires Python 2 `pygments` (not Python 3). Since we install it on the ROS containers, we can move this stage to the `melodic` container.