### PR TITLE
jMAVSim: Accept AdoptOpenJDK on macOS

### DIFF
--- a/Tools/jmavsim_run.sh
+++ b/Tools/jmavsim_run.sh
@@ -60,7 +60,7 @@ fi
 if [ "$(uname)" == "Darwin" ]; then
     bold=$(tput bold)
     normal=$(tput sgr0)
-    if ! /usr/libexec/java_home -V 2>&1 | grep --quiet "Java SE 8" ; then
+    if ! /usr/libexec/java_home -V 2>&1 | grep --quiet "1.8\|Java SE 8" ; then
         echo "${bold}You need to have Java 8 installed for macOS, for more info, see:${normal}"
         echo "${bold}https://github.com/PX4/jMAVSim/issues/81${normal}"
         exit 1

--- a/Tools/jmavsim_run.sh
+++ b/Tools/jmavsim_run.sh
@@ -62,7 +62,7 @@ if [ "$(uname)" == "Darwin" ]; then
     normal=$(tput sgr0)
     if ! /usr/libexec/java_home -V 2>&1 | grep --quiet "1.8\|Java SE 8" ; then
         echo "${bold}You need to have Java 8 installed for macOS, for more info, see:${normal}"
-        echo "${bold}https://github.com/PX4/jMAVSim/issues/81${normal}"
+        echo "${bold}https://dev.px4.io/master/en/simulation/jmavsim.html#macos${normal}"
         exit 1
     fi
     export JAVA_HOME=`/usr/libexec/java_home -v 1.8`


### PR DESCRIPTION
This works with AdoptOpenJDK installed via brew:
```
brew tap adoptopenjdk/openjdk
brew cask install adoptopenjdk8
```

```
java -version
openjdk version "1.8.0_232"
OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_232-b09)
OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.232-b09, mixed mode)
```
