### PR TITLE
px4_simple_app: UPdate copyright to last modification

### DIFF
--- a/src/examples/px4_simple_app/px4_simple_app.c
+++ b/src/examples/px4_simple_app/px4_simple_app.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2016 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2019 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions


### PR DESCRIPTION
This just updates the copyright for px4_simple_app to 2019 (last update). The 2016 marker looks bad in the example docs.

@bkueng Can you please merge as well as approve if you OK with this.