### PR TITLE
uorb_rtps_message_ids.yaml: onboard_computer_status to be received

### DIFF
--- a/msg/tools/uorb_rtps_message_ids.yaml
+++ b/msg/tools/uorb_rtps_message_ids.yaml
@@ -262,6 +262,7 @@ rtps:
     id: 115
   - msg: onboard_computer_status
     id: 116
+    receive: true
   - msg: cellular_status
     id: 117
   - msg: sensor_accel_fifo


### PR DESCRIPTION
Required to receive status messages from the companion computer through the micro-RTPS bridge.
