### PR TITLE
Fixed digital power module validity check

### DIFF
--- a/src/drivers/adc/ADC.cpp
+++ b/src/drivers/adc/ADC.cpp
@@ -209,8 +209,8 @@ void ADC::update_system_power(hrt_abstime now)
 	system_power.usb_valid  = system_power.usb_connected;
 #endif
 
+#if defined(BOARD_BRICK_VALID_LIST)
 	/* The valid signals (HW dependent) are associated with each brick */
-#if !defined(BOARD_NUMBER_DIGITAL_BRICKS)
 	bool  valid_chan[BOARD_NUMBER_BRICKS] = BOARD_BRICK_VALID_LIST;
 	system_power.brick_valid = 0;
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
When using the INA226 digital power module (For example, with the v5x) and the driver added in https://github.com/PX4/Firmware/pull/12673, the vehicle would fail the pre-flight check (`Arming denied! Check battery`). This is because, in the `system_power` uORB topic, the `brick_valid` field was not being properly set. This PR is a quick fix to make sure it is set. A more proper fix would be to completely restructure the power management system. But that will presumably be a large undertaking, so this quick fix will allow the v5x to fly in the meantime.

**Describe your solution**
I changed the ADC driver. Before, it would only set the `brick_valid` flags if the digital power module is not configured in the board configuration. However, at least on the v5x, power module validity is checked in the same way as the v5 (using one digital GPIO pin for each power source). So, I enabled the validity check even if there are digital power modules available.

**Describe possible alternatives**
A complete restructure of the power management system would presumably separate the validity checks and other functionality from the ADC driver. The ADC driver should probably just publish raw ADC readings, and not bother with interpreting them. However, as previously mentioned, this will probably be a large project.

**Test data / coverage**
Tested on both v5 and v5x: Armed successfully when a battery is plugged in, and correctly denied arming when there is no battery.
