### PR TITLE
[WIP] uORB::Publication automatically set timestamp

### DIFF
--- a/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
+++ b/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
@@ -533,9 +533,8 @@ Syslink::handle_raw(syslink_message_t *sys)
 
 		crtp_commander *cmd = (crtp_commander *) &c->data[0];
 
-		input_rc_s rc = {};
+		input_rc_s rc{};
 
-		rc.timestamp = hrt_absolute_time();
 		rc.timestamp_last_signal = rc.timestamp;
 		rc.channel_count = 5;
 		rc.rc_failsafe = false;

--- a/boards/emlid/navio2/navio_sysfs_rc_in/NavioSysRCInput.cpp
+++ b/boards/emlid/navio2/navio_sysfs_rc_in/NavioSysRCInput.cpp
@@ -152,7 +152,6 @@ void NavioSysRCInput::Run()
 	data.timestamp_last_signal = timestamp_sample;
 	data.channel_count = CHANNELS;
 	data.input_source = input_rc_s::RC_INPUT_SOURCE_PX4FMU_PPM;
-	data.timestamp = hrt_absolute_time();
 
 	_input_rc_pub.publish(data);
 	perf_count(_publish_interval_perf);

--- a/src/drivers/camera_capture/camera_capture.cpp
+++ b/src/drivers/camera_capture/camera_capture.cpp
@@ -195,7 +195,6 @@ CameraCapture::Run()
 			// Acknowledge the command
 			vehicle_command_ack_s command_ack{};
 
-			command_ack.timestamp = hrt_absolute_time();
 			command_ack.command = cmd.command;
 			command_ack.result = (uint8_t)vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED;
 			command_ack.target_system = cmd.source_system;

--- a/src/drivers/camera_trigger/camera_trigger.cpp
+++ b/src/drivers/camera_trigger/camera_trigger.cpp
@@ -494,7 +494,6 @@ void
 CameraTrigger::test()
 {
 	vehicle_command_s vcmd{};
-	vcmd.timestamp = hrt_absolute_time();
 	vcmd.param5 = 1.0;
 	vcmd.command = vehicle_command_s::VEHICLE_CMD_DO_DIGICAM_CONTROL;
 
@@ -701,7 +700,6 @@ CameraTrigger::Run()
 	if (updated && need_ack) {
 		vehicle_command_ack_s command_ack{};
 
-		command_ack.timestamp = hrt_absolute_time();
 		command_ack.command = cmd.command;
 		command_ack.result = (uint8_t)cmd_result;
 		command_ack.target_system = cmd.source_system;

--- a/src/drivers/differential_pressure/ms4525/ms4525_airspeed.cpp
+++ b/src/drivers/differential_pressure/ms4525/ms4525_airspeed.cpp
@@ -204,7 +204,6 @@ MEASAirspeed::collect()
 
 	differential_pressure_s report{};
 
-	report.timestamp = hrt_absolute_time();
 	report.error_count = perf_event_count(_comms_errors);
 	report.temperature = temperature;
 	report.differential_pressure_filtered_pa =  _filter.apply(diff_press_pa_raw) - _diff_pres_offset;

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -657,7 +657,6 @@ GPS::run()
 	while (!should_exit()) {
 
 		if (_fake_gps) {
-			_report_gps_pos.timestamp = hrt_absolute_time();
 			_report_gps_pos.lat = (int32_t)47.378301e7f;
 			_report_gps_pos.lon = (int32_t)8.538777e7f;
 			_report_gps_pos.alt = (int32_t)1200e3f;

--- a/src/drivers/irlock/irlock.cpp
+++ b/src/drivers/irlock/irlock.cpp
@@ -366,7 +366,6 @@ int IRLOCK::read_device()
 	// publish over uORB
 	if (report.num_targets > 0) {
 		irlock_report_s orb_report{};
-		orb_report.timestamp = report.timestamp;
 		orb_report.signature = report.targets[0].signature;
 		orb_report.pos_x     = report.targets[0].pos_x;
 		orb_report.pos_y     = report.targets[0].pos_y;

--- a/src/drivers/optical_flow/px4flow/px4flow.cpp
+++ b/src/drivers/optical_flow/px4flow/px4flow.cpp
@@ -303,7 +303,6 @@ PX4FLOW::collect()
 
 	optical_flow_s report{};
 
-	report.timestamp = hrt_absolute_time();
 	report.pixel_flow_x_integral = static_cast<float>(_frame_integral.pixel_flow_x_integral) / 10000.0f;//convert to radians
 	report.pixel_flow_y_integral = static_cast<float>(_frame_integral.pixel_flow_y_integral) / 10000.0f;//convert to radians
 	report.frame_count_since_last_readout = _frame_integral.frame_count_since_last_readout;

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -751,7 +751,6 @@ PX4IO::init()
 		if (reg & PX4IO_P_SETUP_ARMING_FORCE_FAILSAFE) {
 			mavlink_log_emergency(&_mavlink_log_pub, "IO is in failsafe, force failsafe");
 			/* send command to terminate flight via command API */
-			vcmd.timestamp = hrt_absolute_time();
 			vcmd.param1 = 1.0f; /* request flight termination */
 			vcmd.command = vehicle_command_s::VEHICLE_CMD_DO_FLIGHTTERMINATION;
 
@@ -783,7 +782,6 @@ PX4IO::init()
 		}
 
 		/* send command to arm system via command API */
-		vcmd.timestamp = hrt_absolute_time();
 		vcmd.param1 = 1.0f; /* request arming */
 		vcmd.param3 = 1234.f; /* mark the command coming from IO (for in-air restoring) */
 		vcmd.command = vehicle_command_s::VEHICLE_CMD_COMPONENT_ARM_DISARM;
@@ -1691,7 +1689,6 @@ PX4IO::io_handle_status(uint16_t status)
 	 * Get and handle the safety status
 	 */
 	safety_s safety{};
-	safety.timestamp = hrt_absolute_time();
 	safety.safety_switch_available = true;
 	safety.safety_off = (status & PX4IO_P_STATUS_FLAGS_SAFETY_OFF) ? true : false;
 	safety.override_available = _override_available;
@@ -1737,8 +1734,6 @@ void
 PX4IO::io_handle_vservo(uint16_t vservo, uint16_t vrssi)
 {
 	servorail_status_s servorail_status{};
-
-	servorail_status.timestamp = hrt_absolute_time();
 
 	/* voltage is scaled to mV */
 	servorail_status.voltage_v = vservo * 0.001f;
@@ -1818,8 +1813,6 @@ PX4IO::io_get_raw_rc_input(input_rc_s &input_rc)
 
 	_rc_chan_count = channel_count;
 
-	input_rc.timestamp = hrt_absolute_time();
-
 	input_rc.rc_ppm_frame_length = regs[PX4IO_P_RAW_RC_DATA];
 
 	if (!_analog_rc_rssi_stable) {
@@ -1888,9 +1881,8 @@ PX4IO::io_get_raw_rc_input(input_rc_s &input_rc)
 int
 PX4IO::io_publish_raw_rc()
 {
-
 	/* fetch values from IO */
-	input_rc_s	rc_val;
+	input_rc_s rc_val{};
 
 	/* set the RC status flag ORDER MATTERS! */
 	rc_val.rc_lost = !(_status & PX4IO_P_STATUS_FLAGS_RC_OK);
@@ -1945,7 +1937,6 @@ PX4IO::io_publish_pwm_outputs()
 	}
 
 	actuator_outputs_s outputs = {};
-	outputs.timestamp = hrt_absolute_time();
 	outputs.noutputs = _max_actuators;
 
 	/* convert from register format to float */
@@ -1966,7 +1957,6 @@ PX4IO::io_publish_pwm_outputs()
 	/* publish mixer status */
 	if (saturation_status.flags.valid) {
 		multirotor_motor_limits_s motor_limits{};
-		motor_limits.timestamp = hrt_absolute_time();
 		motor_limits.saturation_status = saturation_status.value;
 
 		_to_mixer_status.publish(motor_limits);

--- a/src/drivers/qshell/posix/qshell.cpp
+++ b/src/drivers/qshell/posix/qshell.cpp
@@ -99,7 +99,6 @@ int QShell::_send_cmd(std::vector<std::string> &argList)
 	strcpy((char *)qshell_req.cmd, cmd.c_str());
 	qshell_req.request_sequence = _current_sequence;
 
-	qshell_req.timestamp = hrt_absolute_time();
 	_qshell_req_pub.publish(qshell_req);
 
 	return 0;

--- a/src/drivers/qshell/qurt/qshell.cpp
+++ b/src/drivers/qshell/qurt/qshell.cpp
@@ -122,7 +122,6 @@ int QShell::main()
 				PX4_INFO("Ok executing command: %s", m_qshell_req.cmd);
 			}
 
-			retval.timestamp = hrt_absolute_time();
 			_qshell_retval_pub.publish(retval);
 
 		} else if (pret == 0) {

--- a/src/drivers/safety_button/SafetyButton.cpp
+++ b/src/drivers/safety_button/SafetyButton.cpp
@@ -146,14 +146,12 @@ SafetyButton::CheckPairingRequest(bool button_pressed)
 		led_control.color = led_control_s::COLOR_GREEN;
 		led_control.num_blinks = 1;
 		led_control.priority = 0;
-		led_control.timestamp = hrt_absolute_time();
 		_to_led_control.publish(led_control);
 
 		tune_control_s tune_control{};
 		tune_control.tune_id = TONE_NOTIFY_POSITIVE_TUNE;
 		tune_control.volume = tune_control_s::VOLUME_LEVEL_DEFAULT;
 		tune_control.tune_override = 0;
-		tune_control.timestamp = hrt_absolute_time();
 		_to_tune_control.publish(tune_control);
 
 		// reset state
@@ -214,7 +212,6 @@ SafetyButton::Run()
 		FlashButton();
 
 		safety_s safety{};
-		safety.timestamp = hrt_absolute_time();
 		safety.safety_switch_available = true;
 		safety.safety_off = _safety_btn_off || _safety_disabled;
 

--- a/src/drivers/telemetry/iridiumsbd/IridiumSBD.cpp
+++ b/src/drivers/telemetry/iridiumsbd/IridiumSBD.cpp
@@ -1107,8 +1107,6 @@ void IridiumSBD::publish_iridium_status()
 		_status.rx_session_pending = _rx_session_pending;
 	}
 
-	_status.timestamp = hrt_absolute_time();
-
 	// publish the status if it changed
 	if (need_to_publish) {
 		_iridiumsbd_status_pub.publish(_status);
@@ -1122,7 +1120,6 @@ void IridiumSBD::publish_subsystem_status()
 	const bool ok = _status.last_heartbeat > 0; // maybe at some point here an additional check should be made
 
 	if ((_info.present != present) || (_info.enabled != enabled) || (_info.ok != ok)) {
-		_info.timestamp = hrt_absolute_time();
 		_info.subsystem_type = subsystem_info_s::SUBSYSTEM_TYPE_SATCOM;
 		_info.present = present;
 		_info.enabled = enabled;

--- a/src/lib/avoidance/ObstacleAvoidanceTest.cpp
+++ b/src/lib/avoidance/ObstacleAvoidanceTest.cpp
@@ -72,7 +72,6 @@ TEST_F(ObstacleAvoidanceTest, oa_enabled_healthy)
 	TestObstacleAvoidance oa;
 
 	vehicle_trajectory_waypoint_s message = empty_trajectory_waypoint;
-	message.timestamp = hrt_absolute_time();
 	message.type = vehicle_trajectory_waypoint_s::MAV_TRAJECTORY_REPRESENTATION_WAYPOINTS;
 	message.waypoints[vehicle_trajectory_waypoint_s::POINT_0].position[0] = 2.6f;
 	message.waypoints[vehicle_trajectory_waypoint_s::POINT_0].position[1] = 2.4f;

--- a/src/lib/drivers/accelerometer/PX4Accelerometer.cpp
+++ b/src/lib/drivers/accelerometer/PX4Accelerometer.cpp
@@ -155,7 +155,6 @@ void PX4Accelerometer::update(hrt_abstime timestamp_sample, float x, float y, fl
 		report.x = val_calibrated(0);
 		report.y = val_calibrated(1);
 		report.z = val_calibrated(2);
-		report.timestamp = hrt_absolute_time();
 
 		_sensor_pub.publish(report);
 	}
@@ -178,7 +177,6 @@ void PX4Accelerometer::update(hrt_abstime timestamp_sample, float x, float y, fl
 		report.dt = integral_dt;
 		report.samples = _integrator_samples;
 		report.clip_count = _integrator_clipping;
-		report.timestamp = hrt_absolute_time();
 
 		_sensor_integrated_pub.publish(report);
 
@@ -219,7 +217,6 @@ void PX4Accelerometer::updateFIFO(const FIFOSample &sample)
 		report.x = val_calibrated(0);
 		report.y = val_calibrated(1);
 		report.z = val_calibrated(2);
-		report.timestamp = hrt_absolute_time();
 
 		_sensor_pub.publish(report);
 	}
@@ -282,7 +279,6 @@ void PX4Accelerometer::updateFIFO(const FIFOSample &sample)
 			report.samples = _integrator_fifo_samples;
 			report.clip_count = _integrator_clipping;
 
-			report.timestamp = hrt_absolute_time();
 			_sensor_integrated_pub.publish(report);
 
 			// update vibration metrics
@@ -308,7 +304,6 @@ void PX4Accelerometer::updateFIFO(const FIFOSample &sample)
 	memcpy(fifo.y, sample.y, sizeof(sample.y[0]) * N);
 	memcpy(fifo.z, sample.z, sizeof(sample.z[0]) * N);
 
-	fifo.timestamp = hrt_absolute_time();
 	_sensor_fifo_pub.publish(fifo);
 
 
@@ -331,7 +326,6 @@ void PX4Accelerometer::PublishStatus()
 		status.clipping[0] = _clipping[0];
 		status.clipping[1] = _clipping[1];
 		status.clipping[2] = _clipping[2];
-		status.timestamp = hrt_absolute_time();
 		_sensor_status_pub.publish(status);
 
 		_status_last_publish = status.timestamp;

--- a/src/lib/flight_tasks/FlightTasks.cpp
+++ b/src/lib/flight_tasks/FlightTasks.cpp
@@ -167,7 +167,6 @@ void FlightTasks::_updateCommand()
 
 	// send back acknowledgment
 	vehicle_command_ack_s command_ack{};
-	command_ack.timestamp = hrt_absolute_time();
 	command_ack.command = command.command;
 	command_ack.result = cmd_result;
 	command_ack.result_param1 = static_cast<int>(switch_result);

--- a/src/lib/flight_tasks/tasks/FlightTask/FlightTask.cpp
+++ b/src/lib/flight_tasks/tasks/FlightTask/FlightTask.cpp
@@ -84,7 +84,6 @@ const vehicle_local_position_setpoint_s FlightTask::getPositionSetpoint()
 {
 	/* fill position setpoint message */
 	vehicle_local_position_setpoint_s vehicle_local_position_setpoint{};
-	vehicle_local_position_setpoint.timestamp = hrt_absolute_time();
 
 	vehicle_local_position_setpoint.x = _position_setpoint(0);
 	vehicle_local_position_setpoint.y = _position_setpoint(1);

--- a/src/lib/flight_tasks/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/lib/flight_tasks/tasks/Orbit/FlightTaskOrbit.cpp
@@ -96,7 +96,6 @@ bool FlightTaskOrbit::applyCommandParameters(const vehicle_command_s &command)
 bool FlightTaskOrbit::sendTelemetry()
 {
 	orbit_status_s orbit_status{};
-	orbit_status.timestamp = hrt_absolute_time();
 	orbit_status.radius = math::signNoZero(_v) * _r;
 	orbit_status.frame = 0; // MAV_FRAME::MAV_FRAME_GLOBAL
 

--- a/src/modules/commander/Arming/ArmAuthorization/ArmAuthorization.cpp
+++ b/src/modules/commander/Arming/ArmAuthorization/ArmAuthorization.cpp
@@ -82,7 +82,6 @@ static uint8_t (*arm_check_method[ARM_AUTH_METHOD_LAST])() = {
 static void arm_auth_request_msg_send()
 {
 	vehicle_command_s vcmd{};
-	vcmd.timestamp = hrt_absolute_time();
 	vcmd.command = vehicle_command_s::VEHICLE_CMD_ARM_AUTHORIZATION_REQUEST;
 	vcmd.target_system = arm_parameters.struct_value.authorizer_system_id;
 

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -178,8 +178,6 @@ static bool send_vehicle_command(uint16_t cmd, float param1 = NAN, float param2 
 	vcmd.source_component = vehicle_status_sub.get().component_id;
 	vcmd.target_component = vehicle_status_sub.get().component_id;
 
-	vcmd.timestamp = hrt_absolute_time();
-
 	uORB::PublicationQueued<vehicle_command_s> vcmd_pub{ORB_ID(vehicle_command)};
 
 	return vcmd_pub.publish(vcmd);
@@ -797,7 +795,6 @@ Commander::handle_command(vehicle_status_s *status_local, const vehicle_command_
 					if (local_pos.xy_global && local_pos.z_global) {
 						/* use specified position */
 						home_position_s home{};
-						home.timestamp = hrt_absolute_time();
 
 						home.lat = lat;
 						home.lon = lon;
@@ -1083,7 +1080,6 @@ Commander::handle_command_motor_test(const vehicle_command_s &cmd)
 	}
 
 	test_motor_s test_motor{};
-	test_motor.timestamp = hrt_absolute_time();
 	test_motor.motor_number = (int)(cmd.param1 + 0.5f) - 1;
 	int throttle_type = (int)(cmd.param2 + 0.5f);
 
@@ -1138,8 +1134,6 @@ Commander::set_home_position()
 			// Set home position
 			home_position_s home{};
 
-			home.timestamp = hrt_absolute_time();
-
 			home.lat = gpos.lat;
 			home.lon = gpos.lon;
 			home.valid_hpos = true;
@@ -1180,8 +1174,6 @@ Commander::set_home_position_alt_only()
 		home_position_s home{};
 		home.alt = lpos.ref_alt;
 		home.valid_alt = true;
-
-		home.timestamp = hrt_absolute_time();
 
 		return _home_pub.update(home);
 	}
@@ -2209,7 +2201,6 @@ Commander::run()
 
 			update_control_mode();
 
-			status.timestamp = hrt_absolute_time();
 			_status_pub.publish(status);
 
 			switch ((PrearmedMode)_param_com_prearm_mode.get()) {
@@ -2243,15 +2234,12 @@ Commander::run()
 				break;
 			}
 
-			armed.timestamp = hrt_absolute_time();
 			_armed_pub.publish(armed);
 
 			/* publish internal state for logging purposes */
-			_internal_state.timestamp = hrt_absolute_time();
 			_commander_state_pub.publish(_internal_state);
 
 			/* publish vehicle_status_flags */
-			status_flags.timestamp = hrt_absolute_time();
 			_vehicle_status_flags_pub.publish(status_flags);
 		}
 
@@ -3012,8 +3000,6 @@ Commander::update_control_mode()
 {
 	vehicle_control_mode_s control_mode{};
 
-	control_mode.timestamp = hrt_absolute_time();
-
 	/* set vehicle_control_mode according to set_navigation_state */
 	control_mode.flag_armed = armed.armed;
 	control_mode.flag_external_manual_override_ok = (status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING
@@ -3241,12 +3227,10 @@ void answer_command(const vehicle_command_s &cmd, unsigned result,
 	/* publish ACK */
 	vehicle_command_ack_s command_ack{};
 
-	command_ack.timestamp = hrt_absolute_time();
 	command_ack.command = cmd.command;
 	command_ack.result = (uint8_t)result;
 	command_ack.target_system = cmd.source_system;
 	command_ack.target_component = cmd.source_component;
-
 
 	command_ack_pub.publish(command_ack);
 }

--- a/src/modules/events/send_event.cpp
+++ b/src/modules/events/send_event.cpp
@@ -120,7 +120,6 @@ void SendEvent::answer_command(const vehicle_command_s &cmd, unsigned result)
 {
 	/* publish ACK */
 	vehicle_command_ack_s command_ack{};
-	command_ack.timestamp = hrt_absolute_time();
 	command_ack.command = cmd.command;
 	command_ack.result = (uint8_t)result;
 	command_ack.target_system = cmd.source_system;

--- a/src/modules/events/status_display.cpp
+++ b/src/modules/events/status_display.cpp
@@ -95,8 +95,6 @@ void StatusDisplay::process()
 
 void StatusDisplay::publish()
 {
-	_led_control.timestamp = hrt_absolute_time();
-
 	_led_control_pub.publish(_led_control);
 }
 

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -640,9 +640,7 @@ void FixedwingAttitudeControl::Run()
 		_actuators.control[7] = _manual.aux3;
 
 		/* lazily publish the setpoint only once available */
-		_actuators.timestamp = hrt_absolute_time();
 		_actuators.timestamp_sample = _att.timestamp;
-		_actuators_airframe.timestamp = hrt_absolute_time();
 		_actuators_airframe.timestamp_sample = _att.timestamp;
 
 		/* Only publish if any of the proper modes are enabled */

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -339,8 +339,6 @@ FixedwingPositionControl::tecs_status_publish()
 	t.throttle_integ = _tecs.throttle_integ_state();
 	t.pitch_integ = _tecs.pitch_integ_state();
 
-	t.timestamp = hrt_absolute_time();
-
 	_tecs_status_pub.publish(t);
 }
 
@@ -363,8 +361,6 @@ FixedwingPositionControl::status_publish()
 
 	pos_ctrl_status.yaw_acceptance = NAN;
 
-	pos_ctrl_status.timestamp = hrt_absolute_time();
-
 	_pos_ctrl_status_pub.publish(pos_ctrl_status);
 }
 
@@ -378,8 +374,6 @@ FixedwingPositionControl::landing_status_publish()
 	pos_ctrl_landing_status.flare_length = _landingslope.flare_length();
 
 	pos_ctrl_landing_status.abort_landing = _land_abort;
-
-	pos_ctrl_landing_status.timestamp = hrt_absolute_time();
 
 	_pos_ctrl_landing_status_pub.publish(pos_ctrl_landing_status);
 }
@@ -1544,8 +1538,6 @@ FixedwingPositionControl::Run()
 		 * publish setpoint.
 		 */
 		if (control_position(curr_pos, ground_speed, _pos_sp_triplet.previous, _pos_sp_triplet.current, _pos_sp_triplet.next)) {
-			_att_sp.timestamp = hrt_absolute_time();
-
 			// add attitude setpoint offsets
 			_att_sp.roll_body += radians(_param_fw_rsp_off.get());
 			_att_sp.pitch_body += radians(_param_fw_psp_off.get());

--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -96,7 +96,6 @@ void LandDetector::Run()
 			_takeoff_time = now;
 		}
 
-		_land_detected.timestamp = hrt_absolute_time();
 		_land_detected.landed = landDetected;
 		_land_detected.freefall = freefallDetected;
 		_land_detected.maybe_landed = maybe_landedDetected;

--- a/src/modules/load_mon/load_mon.cpp
+++ b/src/modules/load_mon/load_mon.cpp
@@ -191,7 +191,6 @@ void LoadMon::_cpuload()
 	cpuload_s cpuload{};
 	cpuload.load = 1.0f - (float)interval_idletime / (float)interval;
 	cpuload.ram_usage = _ram_used();
-	cpuload.timestamp = hrt_absolute_time();
 
 	_cpuload_pub.publish(cpuload);
 }
@@ -273,7 +272,6 @@ void LoadMon::_stack_usage()
 		if (checked_task) {
 
 			task_stack_info.stack_free = stack_free;
-			task_stack_info.timestamp = hrt_absolute_time();
 
 			_task_stack_info_pub.publish(task_stack_info);
 

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -819,7 +819,6 @@ void Logger::run()
 						status.buffer_used_bytes = buffer_fill_count_file;
 						status.buffer_size_bytes = _writer.get_buffer_size_file(log_type);
 						status.num_messages = _num_subscriptions;
-						status.timestamp = hrt_absolute_time();
 						_logger_status_pub[i].publish(status);
 					}
 				}
@@ -1964,7 +1963,6 @@ void Logger::write_changed_parameters(LogType type)
 void Logger::ack_vehicle_command(vehicle_command_s *cmd, uint32_t result)
 {
 	vehicle_command_ack_s vehicle_command_ack = {};
-	vehicle_command_ack.timestamp = hrt_absolute_time();
 	vehicle_command_ack.command = cmd->command;
 	vehicle_command_ack.result = (uint8_t)result;
 	vehicle_command_ack.target_system = cmd->source_system;

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2611,8 +2611,6 @@ void Mavlink::publish_telemetry_status()
 
 	_tstatus.streams = _streams.size();
 
-	_tstatus.timestamp = hrt_absolute_time();
-
 	_telem_status_pub.publish(_tstatus);
 }
 

--- a/src/modules/mavlink/mavlink_parameters.cpp
+++ b/src/modules/mavlink/mavlink_parameters.cpp
@@ -262,7 +262,6 @@ MavlinkParametersManager::handle_message(const mavlink_message_t *msg)
 					_rc_param_map.valid[i] = true;
 				}
 
-				_rc_param_map.timestamp = hrt_absolute_time();
 				_rc_param_map_pub.publish(_rc_param_map);
 			}
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -104,7 +104,6 @@ MavlinkReceiver::acknowledge(uint8_t sysid, uint8_t compid, uint16_t command, ui
 {
 	vehicle_command_ack_s command_ack{};
 
-	command_ack.timestamp = hrt_absolute_time();
 	command_ack.command = command;
 	command_ack.result = result;
 	command_ack.target_system = sysid;
@@ -465,7 +464,7 @@ MavlinkReceiver::handle_message_command_int(mavlink_message_t *msg)
 
 template <class T>
 void MavlinkReceiver::handle_message_command_both(mavlink_message_t *msg, const T &cmd_mavlink,
-		const vehicle_command_s &vehicle_command)
+		vehicle_command_s &vehicle_command)
 {
 	bool target_ok = evaluate_target_ok(cmd_mavlink.command, cmd_mavlink.target_system, cmd_mavlink.target_component);
 	bool send_ack = true;

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -124,8 +124,7 @@ private:
 	 * Common method to handle both mavlink command types. T is one of mavlink_command_int_t or mavlink_command_long_t.
 	 */
 	template<class T>
-	void handle_message_command_both(mavlink_message_t *msg, const T &cmd_mavlink,
-					 const vehicle_command_s &vehicle_command);
+	void handle_message_command_both(mavlink_message_t *msg, const T &cmd_mavlink, vehicle_command_s &vehicle_command);
 
 	void handle_message(mavlink_message_t *msg);
 

--- a/src/modules/mavlink/mavlink_timesync.cpp
+++ b/src/modules/mavlink/mavlink_timesync.cpp
@@ -140,7 +140,6 @@ MavlinkTimesync::handle_message(const mavlink_message_t *msg)
 				// Publish status message
 				timesync_status_s tsync_status{};
 
-				tsync_status.timestamp = hrt_absolute_time();
 				tsync_status.remote_timestamp = tsync.tc1 / 1000ULL;
 				tsync_status.observed_offset = offset_us;
 				tsync_status.estimated_offset = (int64_t)_time_offset;

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -216,7 +216,6 @@ MulticopterAttitudeControl::generate_attitude_setpoint(float dt, bool reset_yaw_
 	q_sp.copyTo(attitude_setpoint.q_d);
 
 	attitude_setpoint.thrust_body[2] = -throttle_curve(_manual_control_sp.z);
-	attitude_setpoint.timestamp = hrt_absolute_time();
 
 	_vehicle_attitude_setpoint_pub.publish(attitude_setpoint);
 }
@@ -244,7 +243,6 @@ MulticopterAttitudeControl::publish_rates_setpoint()
 	v_rates_sp.thrust_body[0] = _v_att_sp.thrust_body[0];
 	v_rates_sp.thrust_body[1] = _v_att_sp.thrust_body[1];
 	v_rates_sp.thrust_body[2] = _v_att_sp.thrust_body[2];
-	v_rates_sp.timestamp = hrt_absolute_time();
 
 	_v_rates_sp_pub.publish(v_rates_sp);
 }

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -998,7 +998,6 @@ void MulticopterPositionControl::check_failure(bool task_failure, uint8_t nav_st
 void MulticopterPositionControl::send_vehicle_cmd_do(uint8_t nav_state)
 {
 	vehicle_command_s command{};
-	command.timestamp = hrt_absolute_time();
 	command.command = vehicle_command_s::VEHICLE_CMD_DO_SET_MODE;
 	command.param1 = (float)1; // base mode
 	command.param3 = (float)0; // sub mode

--- a/src/modules/mc_rate_control/MulticopterRateControl.cpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.cpp
@@ -183,7 +183,6 @@ MulticopterRateControl::Run()
 			//  limit landing gear update rate to 50 Hz
 			if (hrt_elapsed_time(&_landing_gear.timestamp) > 20_ms) {
 				_landing_gear.landing_gear = get_landing_gear_state();
-				_landing_gear.timestamp = hrt_absolute_time();
 				_landing_gear_pub.publish(_landing_gear);
 			}
 
@@ -223,7 +222,6 @@ MulticopterRateControl::Run()
 				v_rates_sp.thrust_body[0] = 0.0f;
 				v_rates_sp.thrust_body[1] = 0.0f;
 				v_rates_sp.thrust_body[2] = -_thrust_sp;
-				v_rates_sp.timestamp = hrt_absolute_time();
 
 				_v_rates_sp_pub.publish(v_rates_sp);
 			}
@@ -280,7 +278,6 @@ MulticopterRateControl::Run()
 			// publish rate controller status
 			rate_ctrl_status_s rate_ctrl_status{};
 			_rate_control.getRateControlStatus(rate_ctrl_status);
-			rate_ctrl_status.timestamp = hrt_absolute_time();
 			_controller_status_pub.publish(rate_ctrl_status);
 
 			// publish actuator controls
@@ -309,14 +306,12 @@ MulticopterRateControl::Run()
 				}
 			}
 
-			actuators.timestamp = hrt_absolute_time();
 			_actuators_0_pub.publish(actuators);
 
 		} else if (_v_control_mode.flag_control_termination_enabled) {
 			if (!_vehicle_status.is_vtol) {
 				// publish actuator controls
 				actuator_controls_s actuators{};
-				actuators.timestamp = hrt_absolute_time();
 				_actuators_0_pub.publish(actuators);
 			}
 		}

--- a/src/modules/navigator/gpsfailure.cpp
+++ b/src/modules/navigator/gpsfailure.cpp
@@ -84,7 +84,6 @@ GpsFailure::on_active()
 			/* Position controller does not run in this mode:
 			 * navigator has to publish an attitude setpoint */
 			vehicle_attitude_setpoint_s att_sp = {};
-			att_sp.timestamp = hrt_absolute_time();
 			att_sp.roll_body = math::radians(_param_nav_gpsf_r.get());
 			att_sp.pitch_body = math::radians(_param_nav_gpsf_p.get());
 			att_sp.thrust_body[0] = _param_nav_gpsf_tr.get();

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -441,8 +441,7 @@ MissionBlock::issue_command(const mission_item_s &item)
 		PX4_INFO("DO_SET_SERVO command");
 
 		// XXX: we should issue a vehicle command and handle this somewhere else
-		actuator_controls_s actuators = {};
-		actuators.timestamp = hrt_absolute_time();
+		actuator_controls_s actuators{};
 
 		// params[0] actuator number to be set 0..5 (corresponds to AUX outputs 1..6)
 		// params[1] new value for selected actuator in ms 900...2000

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -426,8 +426,6 @@ Navigator::run()
 					break;
 				}
 
-				_vroi.timestamp = hrt_absolute_time();
-
 				_vehicle_roi_pub.publish(_vroi);
 
 				publish_vehicle_command_ack(cmd, vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED);
@@ -447,7 +445,6 @@ Navigator::run()
 			last_geofence_check = hrt_absolute_time();
 			have_geofence_position_data = false;
 
-			_geofence_result.timestamp = hrt_absolute_time();
 			_geofence_result.geofence_action = _geofence.getGeofenceAction();
 			_geofence_result.home_required = _geofence.isHomeRequired();
 
@@ -925,7 +922,6 @@ void Navigator::fake_traffic(const char *callsign, float distance, float directi
 	// float vel_d = get_global_position()->vel_d;
 
 	transponder_report_s tr{};
-	tr.timestamp = hrt_absolute_time();
 	tr.icao_address = 1234;
 	tr.lat = lat; // Latitude, expressed as degrees
 	tr.lon = lon; // Longitude, expressed as degrees
@@ -1186,8 +1182,6 @@ int navigator_main(int argc, char *argv[])
 void
 Navigator::publish_mission_result()
 {
-	_mission_result.timestamp = hrt_absolute_time();
-
 	/* lazily publish the mission result only once available */
 	_mission_result_pub.publish(_mission_result);
 
@@ -1240,9 +1234,8 @@ Navigator::publish_vehicle_cmd(vehicle_command_s *vcmd)
 void
 Navigator::publish_vehicle_command_ack(const vehicle_command_s &cmd, uint8_t result)
 {
-	vehicle_command_ack_s command_ack = {};
+	vehicle_command_ack_s command_ack{};
 
-	command_ack.timestamp = hrt_absolute_time();
 	command_ack.command = cmd.command;
 	command_ack.target_system = cmd.source_system;
 	command_ack.target_component = cmd.source_component;

--- a/src/modules/rover_pos_control/RoverPositionControl.cpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.cpp
@@ -460,18 +460,12 @@ RoverPositionControl::run()
 					pos_ctrl_status.acceptance_radius = turn_distance;
 					pos_ctrl_status.yaw_acceptance = NAN;
 
-					pos_ctrl_status.timestamp = hrt_absolute_time();
-
 					_pos_ctrl_status_pub.publish(pos_ctrl_status);
-
 				}
 
 			} else if (!manual_mode && _control_mode.flag_control_velocity_enabled) {
-
 				control_velocity(current_velocity, _pos_sp_triplet);
-
 			}
-
 
 			perf_end(_loop_perf);
 		}
@@ -511,7 +505,6 @@ RoverPositionControl::run()
 			orb_copy(ORB_ID(sensor_combined), _sensor_combined_sub, &_sensor_combined);
 
 			//orb_copy(ORB_ID(vehicle_attitude), _vehicle_attitude_sub, &_vehicle_att);
-			_act_controls.timestamp = hrt_absolute_time();
 
 			/* Only publish if any of the proper modes are enabled */
 			if (_control_mode.flag_control_velocity_enabled ||

--- a/src/modules/sensors/vehicle_acceleration/VehicleAcceleration.cpp
+++ b/src/modules/sensors/vehicle_acceleration/VehicleAcceleration.cpp
@@ -247,7 +247,6 @@ void VehicleAcceleration::Run()
 				vehicle_acceleration_s v_acceleration;
 				v_acceleration.timestamp_sample = sensor_data.timestamp_sample;
 				accel.copyTo(v_acceleration.xyz);
-				v_acceleration.timestamp = hrt_absolute_time();
 				_vehicle_acceleration_pub.publish(v_acceleration);
 
 				_last_publish = v_acceleration.timestamp_sample;

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
@@ -288,14 +288,12 @@ void VehicleAngularVelocity::Run()
 					vehicle_angular_acceleration_s v_angular_acceleration;
 					v_angular_acceleration.timestamp_sample = sensor_data.timestamp_sample;
 					angular_acceleration.copyTo(v_angular_acceleration.xyz);
-					v_angular_acceleration.timestamp = hrt_absolute_time();
 					_vehicle_angular_acceleration_pub.publish(v_angular_acceleration);
 
 					// Publish vehicle_angular_velocity
 					vehicle_angular_velocity_s v_angular_velocity;
 					v_angular_velocity.timestamp_sample = sensor_data.timestamp_sample;
 					angular_velocity.copyTo(v_angular_velocity.xyz);
-					v_angular_velocity.timestamp = hrt_absolute_time();
 					_vehicle_angular_velocity_pub.publish(v_angular_velocity);
 
 					_last_publish = v_angular_velocity.timestamp_sample;

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -480,7 +480,6 @@ void Simulator::handle_message_landing_target(const mavlink_message_t *msg)
 	mavlink_msg_landing_target_decode(msg, &landing_target_mavlink);
 
 	irlock_report_s report{};
-	report.timestamp = hrt_absolute_time();
 	report.signature = landing_target_mavlink.target_num;
 	report.pos_x = landing_target_mavlink.angle_x;
 	report.pos_y = landing_target_mavlink.angle_y;
@@ -529,8 +528,6 @@ void Simulator::handle_message_rc_channels(const mavlink_message_t *msg)
 	rc_input.values[15] = rc_channels.chan16_raw;
 	rc_input.values[16] = rc_channels.chan17_raw;
 	rc_input.values[17] = rc_channels.chan18_raw;
-
-	rc_input.timestamp = hrt_absolute_time();
 
 	// publish message
 	_input_rc_pub.publish(rc_input);
@@ -963,7 +960,6 @@ int Simulator::publish_flow_topic(const mavlink_hil_optical_flow_t *flow_mavlink
 {
 	optical_flow_s flow = {};
 	flow.sensor_id = flow_mavlink->sensor_id;
-	flow.timestamp = hrt_absolute_time();;
 	flow.time_since_last_sonar_update = 0;
 	flow.frame_count_since_last_readout = 0; // ?
 	flow.integration_timespan = flow_mavlink->integration_time_us;
@@ -1111,7 +1107,6 @@ int Simulator::publish_odometry_topic(const mavlink_message_t *odom_mavlink)
 int Simulator::publish_distance_topic(const mavlink_distance_sensor_t *dist_mavlink)
 {
 	distance_sensor_s dist{};
-	dist.timestamp = hrt_absolute_time();
 	dist.min_distance = dist_mavlink->min_distance / 100.0f;
 	dist.max_distance = dist_mavlink->max_distance / 100.0f;
 	dist.current_distance = dist_mavlink->current_distance / 100.0f;

--- a/src/modules/temperature_compensation/TemperatureCompensationModule.cpp
+++ b/src/modules/temperature_compensation/TemperatureCompensationModule.cpp
@@ -244,7 +244,6 @@ void TemperatureCompensationModule::Run()
 						command_ack.result = vehicle_command_s::VEHICLE_CMD_RESULT_FAILED;
 					}
 
-					command_ack.timestamp = hrt_absolute_time();
 					command_ack.command = cmd.command;
 					command_ack.target_system = cmd.source_system;
 					command_ack.target_component = cmd.source_component;
@@ -271,8 +270,6 @@ void TemperatureCompensationModule::Run()
 
 	// publish sensor corrections if necessary
 	if (_corrections_changed) {
-		_corrections.timestamp = hrt_absolute_time();
-
 		_sensor_correction_pub.publish(_corrections);
 
 		_corrections_changed = false;
@@ -355,7 +352,6 @@ int TemperatureCompensationModule::custom_command(int argc, char *argv[])
 		}
 
 		vehicle_command_s vcmd{};
-		vcmd.timestamp = hrt_absolute_time();
 		vcmd.param1 = (float)((gyro_calib
 				       || calib_all) ? vehicle_command_s::PREFLIGHT_CALIBRATION_TEMPERATURE_CALIBRATION : NAN);
 		vcmd.param2 = NAN;

--- a/src/modules/temperature_compensation/temperature_calibration/task.cpp
+++ b/src/modules/temperature_compensation/temperature_calibration/task.cpp
@@ -337,7 +337,6 @@ int TemperatureCalibration::start()
 
 void TemperatureCalibration::publish_led_control(led_control_s &led_control)
 {
-	led_control.timestamp = hrt_absolute_time();
 	_led_control_pub.publish(led_control);
 }
 

--- a/src/modules/uORB/Publication.hpp
+++ b/src/modules/uORB/Publication.hpp
@@ -38,6 +38,7 @@
 
 #pragma once
 
+#include <drivers/drv_hrt.h>
 #include <px4_platform_common/defines.h>
 #include <systemlib/err.h>
 #include <uORB/uORB.h>
@@ -65,8 +66,20 @@ public:
 	 * Publish the struct
 	 * @param data The uORB message struct we are updating.
 	 */
-	bool publish(const T &data)
+	bool publish(T &data)
 	{
+		return publish(hrt_absolute_time(), data);
+	}
+
+	/**
+	 * Publish the struct
+	 * @param timestamp
+	 * @param data The uORB message struct we are updating.
+	 */
+	bool publish(const hrt_abstime &timestamp, T &data)
+	{
+		data.timestamp = timestamp;
+
 		if (_handle != nullptr) {
 			return (orb_publish(_meta, _handle, &data) == PX4_OK);
 

--- a/src/modules/uORB/PublicationMulti.hpp
+++ b/src/modules/uORB/PublicationMulti.hpp
@@ -38,6 +38,7 @@
 
 #pragma once
 
+#include <drivers/drv_hrt.h>
 #include <px4_platform_common/defines.h>
 #include <systemlib/err.h>
 #include <uORB/uORB.h>
@@ -70,8 +71,19 @@ public:
 	 * Publish the struct
 	 * @param data The uORB message struct we are updating.
 	 */
-	bool publish(const T &data)
+	bool publish(T &data)
 	{
+		return publish(hrt_absolute_time(), data);
+	}
+
+	/**
+	 * Publish the struct
+	 * @param data The uORB message struct we are updating.
+	 */
+	bool publish(const hrt_abstime timestamp, T &data)
+	{
+		data.timestamp = timestamp;
+
 		if (_handle != nullptr) {
 			return (orb_publish(_meta, _handle, &data) == PX4_OK);
 

--- a/src/modules/uORB/PublicationQueued.hpp
+++ b/src/modules/uORB/PublicationQueued.hpp
@@ -38,6 +38,7 @@
 
 #pragma once
 
+#include <drivers/drv_hrt.h>
 #include <px4_platform_common/defines.h>
 #include <systemlib/err.h>
 #include <uORB/uORB.h>
@@ -68,8 +69,10 @@ public:
 	 * Publish the struct
 	 * @param data The uORB message struct we are updating.
 	 */
-	bool publish(const T &data)
+	bool publish(T &data)
 	{
+		data.timestamp = hrt_absolute_time();
+
 		if (_handle != nullptr) {
 			return (orb_publish(_meta, _handle, &data) == PX4_OK);
 

--- a/src/modules/vmount/input_mavlink.cpp
+++ b/src/modules/vmount/input_mavlink.cpp
@@ -363,7 +363,6 @@ void InputMavlinkCmdMount::_ack_vehicle_command(vehicle_command_s *cmd)
 {
 	vehicle_command_ack_s vehicle_command_ack{};
 
-	vehicle_command_ack.timestamp = hrt_absolute_time();
 	vehicle_command_ack.command = cmd->command;
 	vehicle_command_ack.result = vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED;
 	vehicle_command_ack.target_system = cmd->source_system;

--- a/src/modules/vmount/output.cpp
+++ b/src/modules/vmount/output.cpp
@@ -70,7 +70,6 @@ void OutputBase::publish()
 		mount_orientation.attitude_euler_angle[i] = _angle_outputs[i];
 	}
 
-	mount_orientation.timestamp = hrt_absolute_time();
 	_mount_orientation_pub.publish(mount_orientation);
 }
 

--- a/src/modules/vmount/output_mavlink.cpp
+++ b/src/modules/vmount/output_mavlink.cpp
@@ -57,7 +57,6 @@ OutputMavlink::OutputMavlink(const OutputConfig &output_config)
 int OutputMavlink::update(const ControlData *control_data)
 {
 	vehicle_command_s vehicle_command{};
-	vehicle_command.timestamp = hrt_absolute_time();
 	vehicle_command.target_system = (uint8_t)_config.mavlink_sys_id;
 	vehicle_command.target_component = (uint8_t)_config.mavlink_comp_id;
 
@@ -66,7 +65,6 @@ int OutputMavlink::update(const ControlData *control_data)
 		_set_angle_setpoints(control_data);
 
 		vehicle_command.command = vehicle_command_s::VEHICLE_CMD_DO_MOUNT_CONFIGURE;
-		vehicle_command.timestamp = hrt_absolute_time();
 
 		if (control_data->type == ControlData::Type::Neutral) {
 			vehicle_command.param1 = vehicle_command_s::VEHICLE_MOUNT_MODE_NEUTRAL;

--- a/src/modules/vmount/output_rc.cpp
+++ b/src/modules/vmount/output_rc.cpp
@@ -66,7 +66,6 @@ int OutputRC::update(const ControlData *control_data)
 	_calculate_output_angles(t);
 
 	actuator_controls_s actuator_controls{};
-	actuator_controls.timestamp = hrt_absolute_time();
 	// _angle_outputs are in radians, actuator_controls are in [-1, 1]
 	actuator_controls.control[0] = (_angle_outputs[0] + _config.roll_offset) * _config.roll_scale;
 	actuator_controls.control[1] = (_angle_outputs[1] + _config.pitch_offset) * _config.pitch_scale;

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -154,7 +154,6 @@ VtolAttitudeControl::handle_command()
 
 		if (_vehicle_cmd.from_external) {
 			vehicle_command_ack_s command_ack{};
-			command_ack.timestamp = hrt_absolute_time();
 			command_ack.command = _vehicle_cmd.command;
 			command_ack.result = (uint8_t)vehicle_command_ack_s::VEHICLE_RESULT_ACCEPTED;
 			command_ack.target_system = _vehicle_cmd.source_system;
@@ -433,7 +432,6 @@ VtolAttitudeControl::Run()
 		_actuators_1_pub.publish(_actuators_out_1);
 
 		// Advertise/Publish vtol vehicle status
-		_vtol_vehicle_status.timestamp = hrt_absolute_time();
 		_vtol_vehicle_status_pub.publish(_vtol_vehicle_status);
 	}
 

--- a/src/systemcmds/led_control/led_control.cpp
+++ b/src/systemcmds/led_control/led_control.cpp
@@ -56,8 +56,6 @@ extern "C" {
 
 static void publish_led_control(led_control_s &led_control)
 {
-	led_control.timestamp = hrt_absolute_time();
-
 	uORB::PublicationQueued<led_control_s> led_control_pub{ORB_ID(led_control)};
 	led_control_pub.publish(led_control);
 }

--- a/src/systemcmds/motor_test/motor_test.cpp
+++ b/src/systemcmds/motor_test/motor_test.cpp
@@ -54,7 +54,6 @@ static void usage(const char *reason);
 void motor_test(unsigned channel, float value, uint8_t driver_instance, int timeout_ms)
 {
 	test_motor_s test_motor{};
-	test_motor.timestamp = hrt_absolute_time();
 	test_motor.motor_number = channel;
 	test_motor.value = value;
 	test_motor.action = value >= 0.f ? test_motor_s::ACTION_RUN : test_motor_s::ACTION_STOP;


### PR DESCRIPTION
WORK IN PROGRESS

The eventual goal is the `timestamp` field of a uORB messsage to be metadata that corresponds (atomically) with the message being published and available to the rest of the system. This is an incremental step in that direction that removes a lot of the current potential misuse. Things like setting the timestamp to an inappropriate value (like a much older sample timestamp passed through), setting it much earlier than actual publication, or even just forgetting to set it at all.

Ideally this would be pushed into the uORB::DeviceNode internals and the timestamp set in the same critical section as the message copy, however we're currently in an odd position with the timestamp not strictly required in every message. This needs to be revisited with ROS2 taken into account, including the possibility of directly into a `std_msgs/Header` equivalent.

For example in https://github.com/PX4/Firmware/pull/13955 the accel and gyro sensor message are updated to have a dedicated `timestamp_sample` field that we set as closely as possible to time corresponding to the contained data.