### PR TITLE
land detector: fix ordering of hysteresis updates...

### DIFF
--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -145,13 +145,11 @@ void LandDetector::_update_params()
 
 void LandDetector::_update_state()
 {
-	/* when we are landed we also have ground contact for sure but only one output state can be true at a particular time
-	 * with higher priority for landed */
 	const hrt_abstime now_us = hrt_absolute_time();
 	_freefall_hysteresis.set_state_and_update(_get_freefall_state(), now_us);
-	_landed_hysteresis.set_state_and_update(_get_landed_state(), now_us);
-	_maybe_landed_hysteresis.set_state_and_update(_get_maybe_landed_state(), now_us);
 	_ground_contact_hysteresis.set_state_and_update(_get_ground_contact_state(), now_us);
+	_maybe_landed_hysteresis.set_state_and_update(_get_maybe_landed_state(), now_us);
+	_landed_hysteresis.set_state_and_update(_get_landed_state(), now_us);
 	_ground_effect_hysteresis.set_state_and_update(_get_ground_effect_state(), now_us);
 }
 


### PR DESCRIPTION
… to ensure we report LANDED only if also MAYBE LANDED and GROUND CONTACT, and MAYBE LANDED only if also GROUND CONTACT

With the existing ordering, `_landed_hysteresis.set_state_and_update(_get_landed_state(), now_us);` uses the `_maybe_landed_hysteresis` immediately before the latter is updated, which leads to `vehicle_land_detected` messages being published where
```
landed == true
maybe_landed == false
ground_contact == false
```

Similarly the following was possible
```
maybe_landed == true
ground_contact == false
```

This is a problem if users of `vehicle_land_detected` expect the logic of `landed only if maybe_landed only if ground_contact` to hold. E.g. `mc_pos_control` which only looks at `maybe_landed` and `ground_contact` to decide whether thrust should be cut to 0.