### PR TITLE
Takeoff: check if the desired velocity is finite when generating the takeoff velocity ramp

### DIFF
--- a/src/modules/mc_pos_control/Takeoff/Takeoff.cpp
+++ b/src/modules/mc_pos_control/Takeoff/Takeoff.cpp
@@ -37,6 +37,7 @@
 
 #include "Takeoff.hpp"
 #include <mathlib/mathlib.h>
+#include <px4_defines.h>
 
 void Takeoff::generateInitialRampValue(const float hover_thrust, float velocity_p_gain)
 {
@@ -115,6 +116,10 @@ float Takeoff::updateRamp(const float dt, const float takeoff_desired_vz)
 	}
 
 	if (_takeoff_state == TakeoffState::rampup) {
+		if (!PX4_ISFINITE(takeoff_desired_vz)) {
+			return _takeoff_ramp_vz;
+		}
+
 		if (_takeoff_ramp_time > dt) {
 			_takeoff_ramp_vz += (takeoff_desired_vz - _takeoff_ramp_vz_init) * dt / _takeoff_ramp_time;
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
Drone takes off, executes an auto mission, lands, but never detects landing, instead keeps high thrust indefinitely.

When the mission starts (with a command) the flight task doesn't update for one iteration (#13971 #13668). If this happens while the takeoff state machine is in state `rampup`, the controller constraints remain NAN as initialized and `Takeoff::updateRamp` would set `_takeoff_ramp_vz` to NAN. With `_takeoff_ramp_vz` being NAN, the takeoff state machine can not leave the `rampup` state which leads to `limit_thrust_during_landing` never being called and thrust never set to 0, even though ground contact is true. `Maybe landed` requires low thrust, so `landed` is never detected.

![Screenshot from 2020-01-17 20-05-06](https://user-images.githubusercontent.com/35773661/72638900-bdad8580-3964-11ea-8bb0-871544abb80b.png)

**Describe your solution**
Proposed solution is to check whether the constraint that is used in ramp computation is NAN. While it is NAN the ramp is not updated.
