### PR TITLE
IMU drivers using FIFOs increase max length to 16 and sync similar implementations

### DIFF
--- a/msg/sensor_accel_fifo.msg
+++ b/msg/sensor_accel_fifo.msg
@@ -8,6 +8,6 @@ float32 scale
 
 uint8 samples		# number of valid samples
 
-int16[8] x		# acceleration in the NED X board axis in m/s/s
-int16[8] y		# acceleration in the NED Y board axis in m/s/s
-int16[8] z		# acceleration in the NED Z board axis in m/s/s
+int16[16] x		# acceleration in the NED X board axis in m/s/s
+int16[16] y		# acceleration in the NED Y board axis in m/s/s
+int16[16] z		# acceleration in the NED Z board axis in m/s/s

--- a/msg/sensor_gyro_fifo.msg
+++ b/msg/sensor_gyro_fifo.msg
@@ -8,6 +8,6 @@ float32 scale
 
 uint8 samples		# number of valid samples
 
-int16[8] x		# angular velocity in the NED X board axis in rad/s
-int16[8] y		# angular velocity in the NED Y board axis in rad/s
-int16[8] z		# angular velocity in the NED Z board axis in rad/s
+int16[16] x		# angular velocity in the NED X board axis in rad/s
+int16[16] y		# angular velocity in the NED Y board axis in rad/s
+int16[16] z		# angular velocity in the NED Z board axis in rad/s

--- a/src/drivers/imu/invensense/icm20602/ICM20602.cpp
+++ b/src/drivers/imu/invensense/icm20602/ICM20602.cpp
@@ -121,37 +121,31 @@ bool ICM20602::Init()
 
 bool ICM20602::Reset()
 {
-	for (int i = 0; i < 5; i++) {
-		// PWR_MGMT_1: Device Reset
-		// CLKSEL[2:0] must be set to 001 to achieve full gyroscope performance.
-		RegisterWrite(Register::PWR_MGMT_1, PWR_MGMT_1_BIT::DEVICE_RESET);
-		usleep(1000);
+	// PWR_MGMT_1: Device Reset
+	// CLKSEL[2:0] must be set to 001 to achieve full gyroscope performance.
+	RegisterWrite(Register::PWR_MGMT_1, PWR_MGMT_1_BIT::DEVICE_RESET);
+	usleep(1000);
 
-		// PWR_MGMT_1: CLKSEL[2:0] must be set to 001 to achieve full gyroscope performance.
-		RegisterWrite(Register::PWR_MGMT_1, PWR_MGMT_1_BIT::CLKSEL_0);
-		usleep(1000);
+	// PWR_MGMT_1: CLKSEL[2:0] must be set to 001 to achieve full gyroscope performance.
+	RegisterWrite(Register::PWR_MGMT_1, PWR_MGMT_1_BIT::CLKSEL_0);
+	usleep(1000);
 
-		// ACCEL_CONFIG: Accel 16 G range
-		RegisterSetBits(Register::ACCEL_CONFIG, ACCEL_CONFIG_BIT::ACCEL_FS_SEL_16G);
-		_px4_accel.set_scale(CONSTANTS_ONE_G / 2048);
-		_px4_accel.set_range(16.0f * CONSTANTS_ONE_G);
+	// ACCEL_CONFIG: Accel 16 G range
+	RegisterSetBits(Register::ACCEL_CONFIG, ACCEL_CONFIG_BIT::ACCEL_FS_SEL_16G);
+	_px4_accel.set_scale(CONSTANTS_ONE_G / 2048);
+	_px4_accel.set_range(16.0f * CONSTANTS_ONE_G);
 
-		// GYRO_CONFIG: Gyro 2000 degrees/second
-		RegisterSetBits(Register::GYRO_CONFIG, GYRO_CONFIG_BIT::FS_SEL_2000_DPS);
-		_px4_gyro.set_scale(math::radians(1.0f / 16.4f));
-		_px4_gyro.set_range(math::radians(2000.0f));
+	// GYRO_CONFIG: Gyro 2000 degrees/second
+	RegisterSetBits(Register::GYRO_CONFIG, GYRO_CONFIG_BIT::FS_SEL_2000_DPS);
+	_px4_gyro.set_scale(math::radians(1.0f / 16.4f));
+	_px4_gyro.set_range(math::radians(2000.0f));
 
-		const bool reset_done = !(RegisterRead(Register::PWR_MGMT_1) & PWR_MGMT_1_BIT::DEVICE_RESET);
-		const bool clksel_done = (RegisterRead(Register::PWR_MGMT_1) & PWR_MGMT_1_BIT::CLKSEL_0);
-		const bool data_ready = (RegisterRead(Register::INT_STATUS) & INT_STATUS_BIT::DATA_RDY_INT);
+	// reset done once data is ready
+	const bool reset_done = !(RegisterRead(Register::PWR_MGMT_1) & PWR_MGMT_1_BIT::DEVICE_RESET);
+	const bool clksel_done = (RegisterRead(Register::PWR_MGMT_1) & PWR_MGMT_1_BIT::CLKSEL_0);
+	const bool data_ready = (RegisterRead(Register::INT_STATUS) & INT_STATUS_BIT::DATA_RDY_INT);
 
-		// reset done once data is ready
-		if (reset_done && clksel_done && data_ready) {
-			return true;
-		}
-	}
-
-	return false;
+	return reset_done && clksel_done && data_ready;
 }
 
 void ICM20602::ResetFIFO()
@@ -322,8 +316,8 @@ void ICM20602::Run()
 		perf_count(_fifo_empty_perf);
 		return;
 
-	} else if (samples > 32) {
-		// not a real overflow, but something went wrong
+	} else if (samples > 16) {
+		// not technically an overflow, but more samples than we expected
 		perf_count(_fifo_overflow_perf);
 		ResetFIFO();
 		return;
@@ -337,13 +331,13 @@ void ICM20602::Run()
 	}
 
 	// Transfer data
-	struct ICM_Report {
+	struct TransferBuffer {
 		uint8_t cmd;
-		FIFO::DATA f[32]; // max 32 samples
+		FIFO::DATA f[16]; // max 16 samples
 	};
-	static_assert(sizeof(ICM_Report) == (sizeof(uint8_t) + 32 * sizeof(FIFO::DATA))); // ensure no struct padding
+	static_assert(sizeof(TransferBuffer) == (sizeof(uint8_t) + 16 * sizeof(FIFO::DATA))); // ensure no struct padding
 
-	ICM_Report *report = (ICM_Report *)_dma_data_buffer;
+	TransferBuffer *report = (TransferBuffer *)_dma_data_buffer;
 	const size_t transfer_size = math::min(samples * sizeof(FIFO::DATA) + 1, FIFO::SIZE);
 	memset(report, 0, transfer_size);
 	report->cmd = static_cast<uint8_t>(Register::FIFO_R_W) | DIR_READ;

--- a/src/drivers/imu/invensense/icm20602/ICM20602.hpp
+++ b/src/drivers/imu/invensense/icm20602/ICM20602.hpp
@@ -65,7 +65,6 @@ public:
 	void PrintInfo();
 
 private:
-
 	int probe() override;
 
 	static int DataReadyInterruptCallback(int irq, void *context, void *arg);

--- a/src/drivers/imu/invensense/icm20608-g/ICM20608G.cpp
+++ b/src/drivers/imu/invensense/icm20608-g/ICM20608G.cpp
@@ -121,37 +121,31 @@ bool ICM20608G::Init()
 
 bool ICM20608G::Reset()
 {
-	for (int i = 0; i < 5; i++) {
-		// PWR_MGMT_1: Device Reset
-		// CLKSEL[2:0] must be set to 001 to achieve full gyroscope performance.
-		RegisterWrite(Register::PWR_MGMT_1, PWR_MGMT_1_BIT::DEVICE_RESET);
-		usleep(1000);
+	// PWR_MGMT_1: Device Reset
+	// CLKSEL[2:0] must be set to 001 to achieve full gyroscope performance.
+	RegisterWrite(Register::PWR_MGMT_1, PWR_MGMT_1_BIT::DEVICE_RESET);
+	usleep(1000);
 
-		// PWR_MGMT_1: CLKSEL[2:0] must be set to 001 to achieve full gyroscope performance.
-		RegisterWrite(Register::PWR_MGMT_1, PWR_MGMT_1_BIT::CLKSEL_0);
-		usleep(1000);
+	// PWR_MGMT_1: CLKSEL[2:0] must be set to 001 to achieve full gyroscope performance.
+	RegisterWrite(Register::PWR_MGMT_1, PWR_MGMT_1_BIT::CLKSEL_0);
+	usleep(1000);
 
-		// ACCEL_CONFIG: Accel 16 G range
-		RegisterSetBits(Register::ACCEL_CONFIG, ACCEL_CONFIG_BIT::ACCEL_FS_SEL_16G);
-		_px4_accel.set_scale(CONSTANTS_ONE_G / 2048);
-		_px4_accel.set_range(16.0f * CONSTANTS_ONE_G);
+	// ACCEL_CONFIG: Accel 16 G range
+	RegisterSetBits(Register::ACCEL_CONFIG, ACCEL_CONFIG_BIT::ACCEL_FS_SEL_16G);
+	_px4_accel.set_scale(CONSTANTS_ONE_G / 2048);
+	_px4_accel.set_range(16.0f * CONSTANTS_ONE_G);
 
-		// GYRO_CONFIG: Gyro 2000 degrees/second
-		RegisterSetBits(Register::GYRO_CONFIG, GYRO_CONFIG_BIT::FS_SEL_2000_DPS);
-		_px4_gyro.set_scale(math::radians(1.0f / 16.4f));
-		_px4_gyro.set_range(math::radians(2000.0f));
+	// GYRO_CONFIG: Gyro 2000 degrees/second
+	RegisterSetBits(Register::GYRO_CONFIG, GYRO_CONFIG_BIT::FS_SEL_2000_DPS);
+	_px4_gyro.set_scale(math::radians(1.0f / 16.4f));
+	_px4_gyro.set_range(math::radians(2000.0f));
 
-		const bool reset_done = !(RegisterRead(Register::PWR_MGMT_1) & PWR_MGMT_1_BIT::DEVICE_RESET);
-		const bool clksel_done = (RegisterRead(Register::PWR_MGMT_1) & PWR_MGMT_1_BIT::CLKSEL_0);
-		const bool data_ready = (RegisterRead(Register::INT_STATUS) & INT_STATUS_BIT::DATA_RDY_INT);
+	// reset done once data is ready
+	const bool reset_done = !(RegisterRead(Register::PWR_MGMT_1) & PWR_MGMT_1_BIT::DEVICE_RESET);
+	const bool clksel_done = (RegisterRead(Register::PWR_MGMT_1) & PWR_MGMT_1_BIT::CLKSEL_0);
+	const bool data_ready = (RegisterRead(Register::INT_STATUS) & INT_STATUS_BIT::DATA_RDY_INT);
 
-		// reset done once data is ready
-		if (reset_done && clksel_done && data_ready) {
-			return true;
-		}
-	}
-
-	return false;
+	return reset_done && clksel_done && data_ready;
 }
 
 void ICM20608G::ResetFIFO()
@@ -298,8 +292,8 @@ void ICM20608G::Run()
 		perf_count(_fifo_empty_perf);
 		return;
 
-	} else if (samples > 32) {
-		// not a real overflow, but something went wrong
+	} else if (samples > 16) {
+		// not technically an overflow, but more samples than we expected
 		perf_count(_fifo_overflow_perf);
 		ResetFIFO();
 		return;
@@ -313,13 +307,13 @@ void ICM20608G::Run()
 	}
 
 	// Transfer data
-	struct ICM_Report {
+	struct TransferBuffer {
 		uint8_t cmd;
-		FIFO::DATA f[32]; // max 32 samples
+		FIFO::DATA f[16]; // max 16 samples
 	};
-	static_assert(sizeof(ICM_Report) == (sizeof(uint8_t) + 32 * sizeof(FIFO::DATA))); // ensure no struct padding
+	static_assert(sizeof(TransferBuffer) == (sizeof(uint8_t) + 16 * sizeof(FIFO::DATA))); // ensure no struct padding
 
-	ICM_Report *report = (ICM_Report *)_dma_data_buffer;
+	TransferBuffer *report = (TransferBuffer *)_dma_data_buffer;
 	const size_t transfer_size = math::min(samples * sizeof(FIFO::DATA) + 1, FIFO::SIZE);
 	memset(report, 0, transfer_size);
 	report->cmd = static_cast<uint8_t>(Register::FIFO_R_W) | DIR_READ;

--- a/src/drivers/imu/st/ism330dlc/ISM330DLC.hpp
+++ b/src/drivers/imu/st/ism330dlc/ISM330DLC.hpp
@@ -48,7 +48,6 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/ecl/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/px4_config.h>
 #include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
 
 using ST_ISM330DLC::Register;
@@ -57,38 +56,35 @@ class ISM330DLC : public device::SPI, public px4::ScheduledWorkItem
 {
 public:
 	ISM330DLC(int bus, uint32_t device, enum Rotation rotation = ROTATION_NONE);
-	virtual ~ISM330DLC();
+	~ISM330DLC() override;
 
-	bool		Init();
-	void		Start();
-	void		Stop();
-	bool		Reset();
-	void		PrintInfo();
-
-protected:
-	virtual int	probe();
+	bool Init();
+	void Start();
+	void Stop();
+	bool Reset();
+	void PrintInfo();
 
 private:
+	int probe() override;
 
-	static int	DataReadyInterruptCallback(int irq, void *context, void *arg);
-	void		DataReady();
+	static int DataReadyInterruptCallback(int irq, void *context, void *arg);
+	void DataReady();
 
-	void		Run() override;
+	void Run() override;
 
-	uint8_t		RegisterRead(Register reg);
-	void		RegisterWrite(Register reg, uint8_t value);
-	void		RegisterSetBits(Register reg, uint8_t setbits);
-	void		RegisterClearBits(Register reg, uint8_t clearbits);
+	uint8_t RegisterRead(Register reg);
+	void RegisterWrite(Register reg, uint8_t value);
+	void RegisterSetBits(Register reg, uint8_t setbits);
+	void RegisterClearBits(Register reg, uint8_t clearbits);
 
-	void		ResetFIFO();
+	void ResetFIFO();
 
+	uint8_t *_dma_data_buffer{nullptr};
 
-	uint8_t	*_dma_data_buffer{nullptr};
+	PX4Accelerometer _px4_accel;
+	PX4Gyroscope _px4_gyro;
 
-	PX4Accelerometer	_px4_accel;
-	PX4Gyroscope		_px4_gyro;
-
-	static constexpr uint32_t _fifo_interval{1000};						// 1000 us sample interval
+	static constexpr uint32_t _fifo_interval{1000}; // 1000 us sample interval
 
 	perf_counter_t _interval_perf{perf_alloc(PC_INTERVAL, MODULE_NAME": run interval")};
 	perf_counter_t _transfer_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": transfer")};
@@ -100,5 +96,4 @@ private:
 
 	hrt_abstime _time_data_ready{0};
 	hrt_abstime _time_last_temperature_update{0};
-
 };

--- a/src/drivers/imu/st/lsm9ds1/LSM9DS1.cpp
+++ b/src/drivers/imu/st/lsm9ds1/LSM9DS1.cpp
@@ -210,7 +210,7 @@ void LSM9DS1::Run()
 		perf_count(_fifo_empty_perf);
 		return;
 
-	} else if (samples > 32) {
+	} else if (samples > 16) {
 		// not technically an overflow, but more samples than we expected
 		perf_count(_fifo_overflow_perf);
 		ResetFIFO();

--- a/src/lib/drivers/accelerometer/PX4Accelerometer.hpp
+++ b/src/lib/drivers/accelerometer/PX4Accelerometer.hpp
@@ -76,9 +76,9 @@ public:
 		uint8_t samples; // number of samples
 		float dt; // in microseconds
 
-		int16_t x[8];
-		int16_t y[8];
-		int16_t z[8];
+		int16_t x[16];
+		int16_t y[16];
+		int16_t z[16];
 	};
 	static_assert(sizeof(FIFOSample::x) == sizeof(sensor_accel_fifo_s::x), "FIFOSample.x invalid size");
 	static_assert(sizeof(FIFOSample::y) == sizeof(sensor_accel_fifo_s::y), "FIFOSample.y invalid size");

--- a/src/lib/drivers/gyroscope/PX4Gyroscope.hpp
+++ b/src/lib/drivers/gyroscope/PX4Gyroscope.hpp
@@ -77,9 +77,9 @@ public:
 		uint8_t samples; // number of samples
 		float dt; // in microseconds
 
-		int16_t x[8];
-		int16_t y[8];
-		int16_t z[8];
+		int16_t x[16];
+		int16_t y[16];
+		int16_t z[16];
 	};
 	static_assert(sizeof(FIFOSample::x) == sizeof(sensor_gyro_fifo_s::x), "FIFOSample.x invalid size");
 	static_assert(sizeof(FIFOSample::y) == sizeof(sensor_gyro_fifo_s::y), "FIFOSample.y invalid size");


### PR DESCRIPTION
This provides some extra space when the FIFO transfers don't align perfectly. I've also made an effort to keep the different drivers (icm20602, icm20608g, ism330ldc) in sync so we can factor out the common portions later once we've confident in the pattern.