### PR TITLE
clarify the suitable python3 version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,11 +267,11 @@ endif()
 # If using catkin, Python 2 is found since it points
 # to the Python libs installed with the ROS distro
 if (NOT CATKIN_DEVEL_PREFIX)
-	find_package(PythonInterp 3)
+	find_package(PythonInterp 3.7)
 	# We have a custom error message to tell users how to install python3.
 	if (NOT PYTHONINTERP_FOUND)
-		message(FATAL_ERROR "Python 3 not found. Please install Python 3:\n"
-			"    Ubuntu: sudo apt install python3 python3-devel python3-pip\n"
+		message(FATAL_ERROR "Python 3 not found. Please install Python morh than version 3.7 :\n"
+			"    Ubuntu: sudo apt install python3.x python3.x-dev python3-pip\n"
 			"    macOS: brew install python")
 	endif()
 else()


### PR DESCRIPTION
Hi,
I found the new firmware for python 3 was not working in less than python 3.6 with the encoding problem like below

```
File "tools/px_generate_uorb_topic_files.py", line 527, in <module>
    generate_idx, f, args.temporarydir, args.package, args.templatedir, INCL_DEFAULT)
  File "tools/px_generate_uorb_topic_files.py", line 127, in generate_output_from_file
    msg_context, filename, full_type_name)
  File "/home/stmoon/.local/lib/python3.6/site-packages/genmsg/msg_loader.py", line 285, in load_msg_from_file
    text = f.read()
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 3390: ordinal not in range(128)
```
To solve the problem, I think the python version check should be clarified.

