### PR TITLE
capture.result param in mavlink

### DIFF
--- a/src/modules/camera_feedback/CameraFeedback.cpp
+++ b/src/modules/camera_feedback/CameraFeedback.cpp
@@ -109,7 +109,7 @@ CameraFeedback::Run()
 		// Indicate whether capture feedback from camera is available
 		// What is case 0 for capture.result?
 		if (!_param_camera_capture_feedback.get()) {
-			capture.result = -1;
+			capture.result = 0;
 
 		} else {
 			capture.result = 1;


### PR DESCRIPTION
Boolean indicating success (1) or failure (0) while capturing this image.
QGC need this param be 1 for displaying camera indicator.
1- this param must be 1 when camera feed back is not enabled and camera triggers.
2- must be 1 when camera feed back is enabled and camera feedback recieved.
3- must be 0  when camera feed back is enabled and camera feedback is not recieved.

https://github.com/mavlink/qgroundcontrol/issues/8216#issuecomment-575943525

