### PR TITLE
Add support for VTOL multivehicle simulation in SITL gazebo

### DIFF
--- a/Tools/gazebo_sitl_multiple_run.sh
+++ b/Tools/gazebo_sitl_multiple_run.sh
@@ -29,9 +29,9 @@ done
 num_vehicles=${NUM_VEHICLES:=3}
 export PX4_SIM_MODEL=${VEHICLE_MODEL:=iris}
 
-if [ "$PX4_SIM_MODEL" != "iris" ] & [ "$PX4_SIM_MODEL" != "plane" ]
+if [ "$PX4_SIM_MODEL" != "iris" ] && [ "$PX4_SIM_MODEL" != "plane" ] && [ "$PX4_SIM_MODEL" != "standard_vtol" ]
 then
-	echo "Currently only iris and plane vehicle model is supported!"
+	echo "Currently only the following vehicle models are supported! [iris, plane, standard_vtol]"
 	exit 1
 fi
 
@@ -69,7 +69,7 @@ while [ $n -lt $num_vehicles ]; do
 	gz sdf -p  /tmp/${PX4_SIM_MODEL}_${n}.urdf > /tmp/${PX4_SIM_MODEL}_${n}.sdf
 	echo "Spawning ${PX4_SIM_MODEL}_${n}"
 
-	gz model --spawn-file=/tmp/${PX4_SIM_MODEL}_${n}.sdf --model-name=${PX4_SIM_MODEL}_${n} -x 0.0 -y $((2*${n})) -z 0.0
+	gz model --spawn-file=/tmp/${PX4_SIM_MODEL}_${n}.sdf --model-name=${PX4_SIM_MODEL}_${n} -x 0.0 -y $((3*${n})) -z 0.0
 
 	popd &>/dev/null
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
This adds support to multivehicle simulation with `standard_vtol` by extending #13729 #13806

**Describe your solution**
Generate the sdf file of `standard_vtol` using xacro so that mavlink port / sysid can be configured

**Test data / coverage**
![ezgif com-video-to-gif(2)](https://user-images.githubusercontent.com/5248102/72689212-57189b00-3b0f-11ea-82aa-bdbd13ce5353.gif)
Full video: [video](https://youtu.be/lAjjTFFZebI)

To test this can be run with the following command
```
Tools/gazebo_sitl_multiple_run.sh -m standard_vtol
```
**Additional context**
- This PR depends on the implementation in the submodule https://github.com/PX4/sitl_gazebo/pull/398
- The distance between models have been increased since the vtol model has a bigger wingspan and makes the vehicles collide
- Fixes https://github.com/PX4/Firmware/issues/10835