### PR TITLE
boards: fmu-v2/v3 limit rate loop by default

### DIFF
--- a/boards/px4/fmu-v2/init/rc.board_defaults
+++ b/boards/px4/fmu-v2/init/rc.board_defaults
@@ -25,4 +25,7 @@ unset BL_FILE
 if [ $AUTOCNF = yes ]
 then
 
+	# to minimize cpu usage on older boards limit inner loop to 400 Hz
+	param set IMU_GYRO_RATEMAX 400
+
 fi

--- a/boards/px4/fmu-v2/nuttx-config/scripts/script.ld
+++ b/boards/px4/fmu-v2/nuttx-config/scripts/script.ld
@@ -1,5 +1,5 @@
 /****************************************************************************
- * nuttx-configs/px4_fmu-v2/scripts/ld.script
+ * scripts/ld.script
  *
  *   Copyright (C) 2011 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/boards/px4/fmu-v3/init/rc.board_defaults
+++ b/boards/px4/fmu-v3/init/rc.board_defaults
@@ -4,7 +4,28 @@
 #------------------------------------------------------------------------------
 
 
+#
+# Bootloader upgrade
+#
+set BL_FILE /etc/extras/px4fmuv3_bl.bin
+if [ -f $BL_FILE ]
+then
+	if param compare SYS_BL_UPDATE 1
+	then
+		param set SYS_BL_UPDATE 0
+		param save
+		echo "BL update..." >> $LOG_FILE
+		bl_update $BL_FILE
+		echo "BL update done" >> $LOG_FILE
+		reboot
+	fi
+fi
+unset BL_FILE
+
 if [ $AUTOCNF = yes ]
 then
+
+	# to minimize cpu usage on older boards limit inner loop to 400 Hz
+	param set IMU_GYRO_RATEMAX 400
 
 fi

--- a/boards/px4/fmu-v3/src/board_config.h
+++ b/boards/px4/fmu-v3/src/board_config.h
@@ -496,7 +496,6 @@ __BEGIN_DECLS
 
 extern void stm32_spiinitialize(void);
 
-
 /****************************************************************************************************
  * Name: board_spi_reset board_peripheral_reset
  *


### PR DESCRIPTION
Setting `IMU_GYRO_RATEMAX` per board isn't great architecturally, but we need to keep cpu usage under control on these older boards by default.