### PR TITLE
px4/fmu-v4: restore SPIDEV integers from stable v1.10

### DIFF
--- a/boards/px4/fmu-v4/src/board_config.h
+++ b/boards/px4/fmu-v4/src/board_config.h
@@ -146,12 +146,12 @@
 #define SPI_BUS_INIT_MASK        (PX4_SPI_BUS_RAMTRON | PX4_SPI_BUS_SENSORS)
 
 /* Use these in place of the uint32_t enumeration to select a specific SPI device on SPI1 */
-#define PX4_SPIDEV_MPU               PX4_MK_SPI_SEL(PX4_SPI_BUS_SENSORS, 1)
-#define PX4_SPIDEV_HMC               PX4_MK_SPI_SEL(PX4_SPI_BUS_SENSORS, 2)
-#define PX4_SPIDEV_LIS               PX4_MK_SPI_SEL(PX4_SPI_BUS_SENSORS, 3)
-#define PX4_SPIDEV_ICM_20608         PX4_MK_SPI_SEL(PX4_SPI_BUS_SENSORS, 4)
-#define PX4_SPIDEV_ICM_20602         PX4_MK_SPI_SEL(PX4_SPI_BUS_SENSORS, 5)
-#define PX4_SPIDEV_MPU2              PX4_MK_SPI_SEL(PX4_SPI_BUS_SENSORS, 6)
+#define PX4_SPIDEV_MPU               PX4_MK_SPI_SEL(PX4_SPI_BUS_SENSORS, 4)
+#define PX4_SPIDEV_HMC               PX4_MK_SPI_SEL(PX4_SPI_BUS_SENSORS, 5)
+#define PX4_SPIDEV_LIS               PX4_MK_SPI_SEL(PX4_SPI_BUS_SENSORS, 7)
+#define PX4_SPIDEV_ICM_20608         PX4_MK_SPI_SEL(PX4_SPI_BUS_SENSORS, 10)
+#define PX4_SPIDEV_ICM_20602         PX4_MK_SPI_SEL(PX4_SPI_BUS_SENSORS, 11)
+#define PX4_SPIDEV_MPU2              PX4_MK_SPI_SEL(PX4_SPI_BUS_SENSORS, 14)
 
 /**
  * Onboard MS5611 and FRAM are both on bus SPI2.


### PR DESCRIPTION
After the v1.10 release I deleted several obsolete SPIDEVs from the fmu-v4 board_config.h. This arbitrary integer is a factor in the driver device ids, so this inadvertently changed the device ids of the sensors. This is a minor inconvenience for regular calibrations and slightly more of an inconvenience for thermal calibrations (TC_*).

I'll revert the SPIDEV numbering changes to stay consistent with PX4 stable v1.10 and earlier.