### PR TITLE
v5x target: Fix wrong FD for TELEM3

### DIFF
--- a/boards/px4/fmu-v5x/default.cmake
+++ b/boards/px4/fmu-v5x/default.cmake
@@ -14,7 +14,7 @@ px4_add_board(
 		GPS1:/dev/ttyS0
 		TEL1:/dev/ttyS6
 		TEL2:/dev/ttyS4
-		TEL3:/dev/ttyS2
+		TEL3:/dev/ttyS1
 		GPS2:/dev/ttyS7
 	DRIVERS
 		adc


### PR DESCRIPTION
This PR fixes wrong File Descriptor for v5x target.

After this change I was able to use TELEM 3 as expected.

**Test data / coverage**
Tested on v5x
