### PR TITLE
navigator: mission WORK_ITEM_TYPE_MOVE_TO_LAND altitude isn't relative

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -853,6 +853,7 @@ Mission::set_mission_items()
 
 					set_vtol_transition_item(&_mission_item, vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC);
 					_mission_item.altitude = _navigator->get_global_position()->alt;
+					_mission_item.altitude_is_relative = false;
 
 					new_work_item_type = WORK_ITEM_TYPE_MOVE_TO_LAND_AFTER_TRANSITION;
 				}


### PR DESCRIPTION
Possible fix for the VTOL flyaway that showed up in SITL CI. https://github.com/PX4/Firmware/pull/13967