### PR TITLE
WorkItem modules: Run() shouldn't be public

### DIFF
--- a/platforms/common/px4_work_queue/test/wqueue_scheduled_test.h
+++ b/platforms/common/px4_work_queue/test/wqueue_scheduled_test.h
@@ -47,10 +47,11 @@ public:
 
 	int main();
 
-	void Run() override;
-
 	static px4::AppState appState; /* track requests to terminate app */
 
 private:
+
+	void Run() override;
+
 	int _iter{0};
 };

--- a/platforms/common/px4_work_queue/test/wqueue_test.h
+++ b/platforms/common/px4_work_queue/test/wqueue_test.h
@@ -47,10 +47,11 @@ public:
 
 	int main();
 
-	void Run() override;
-
 	static px4::AppState appState; /* track requests to terminate app */
 
 private:
+
+	void Run() override;
+
 	int _iter{0};
 };

--- a/src/drivers/batt_smbus/batt_smbus.h
+++ b/src/drivers/batt_smbus/batt_smbus.h
@@ -242,11 +242,10 @@ public:
 
 	void resume();
 
-protected:
+private:
 
 	void Run() override;
 
-private:
 	SMBus *_interface;
 
 	perf_counter_t _cycle{perf_alloc(PC_ELAPSED, "batt_smbus_cycle")};

--- a/src/drivers/distance_sensor/ll40ls/LidarLitePWM.h
+++ b/src/drivers/distance_sensor/ll40ls/LidarLitePWM.h
@@ -65,14 +65,14 @@ public:
 	void start() override;
 	void stop() override;
 
-	void Run() override;
-
 protected:
 
 	int collect() override;
 	int measure() override;
 
 private:
+
+	void Run() override;
 
 	uORB::Subscription _sub_pwm_input{ORB_ID(pwm_input)};
 

--- a/src/drivers/dshot/dshot.cpp
+++ b/src/drivers/dshot/dshot.cpp
@@ -127,8 +127,6 @@ public:
 	/** @see ModuleBase */
 	static int print_usage(const char *reason = nullptr);
 
-	void Run() override;
-
 	/** @see ModuleBase::print_status() */
 	int print_status() override;
 
@@ -165,6 +163,9 @@ public:
 	bool telemetryEnabled() const { return _telemetry != nullptr; }
 
 private:
+
+	void Run() override;
+
 	static constexpr uint16_t DISARMED_VALUE = 0;
 
 	enum class DShotConfig {

--- a/src/drivers/imu/icm20948/icm20948.h
+++ b/src/drivers/imu/icm20948/icm20948.h
@@ -369,9 +369,9 @@ protected:
 
 	friend class ICM20948_mag;
 
-	void Run() override;
-
 private:
+
+	void Run() override;
 
 	PX4Accelerometer	_px4_accel;
 	PX4Gyroscope		_px4_gyro;

--- a/src/drivers/imu/mpu9250/mpu9250.h
+++ b/src/drivers/imu/mpu9250/mpu9250.h
@@ -254,9 +254,9 @@ protected:
 
 	friend class MPU9250_mag;
 
-	void Run() override;
-
 private:
+
+	void Run() override;
 
 	PX4Accelerometer	_px4_accel;
 	PX4Gyroscope		_px4_gyro;

--- a/src/drivers/pwm_out_sim/PWMSim.hpp
+++ b/src/drivers/pwm_out_sim/PWMSim.hpp
@@ -61,14 +61,15 @@ public:
 	/** @see ModuleBase::print_status() */
 	int print_status() override;
 
-	void Run() override;
-
 	int ioctl(device::file_t *filp, int cmd, unsigned long arg) override;
 
 	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 private:
+
+	void Run() override;
+
 	static constexpr uint16_t PWM_SIM_DISARMED_MAGIC = 900;
 	static constexpr uint16_t PWM_SIM_FAILSAFE_MAGIC = 600;
 	static constexpr uint16_t PWM_SIM_PWM_MIN_MAGIC = 1000;

--- a/src/drivers/rc_input/RCInput.hpp
+++ b/src/drivers/rc_input/RCInput.hpp
@@ -77,15 +77,15 @@ public:
 	/** @see ModuleBase */
 	static int print_usage(const char *reason = nullptr);
 
-	/** @see ModuleBase::run() */
-	void Run() override;
-
 	/** @see ModuleBase::print_status() */
 	int print_status() override;
 
 	int	init();
 
 private:
+
+	void Run() override;
+
 	enum RC_SCAN {
 		RC_SCAN_PPM = 0,
 		RC_SCAN_SBUS,

--- a/src/drivers/safety_button/SafetyButton.hpp
+++ b/src/drivers/safety_button/SafetyButton.hpp
@@ -55,7 +55,7 @@ class SafetyButton : public ModuleBase<SafetyButton>, public px4::ScheduledWorkI
 {
 public:
 	SafetyButton();
-	virtual ~SafetyButton();
+	~SafetyButton() override;
 
 	/** @see ModuleBase */
 	static int task_spawn(int argc, char *argv[]);
@@ -69,11 +69,10 @@ public:
 	/** @see ModuleBase::print_status() */
 	int print_status() override;
 
-	void Run() override;
-
 	int Start();
 
 private:
+	void Run() override;
 
 	void CheckButton();
 	void FlashButton();

--- a/src/modules/airspeed_selector/airspeed_selector_main.cpp
+++ b/src/modules/airspeed_selector/airspeed_selector_main.cpp
@@ -87,10 +87,10 @@ public:
 	/** @see ModuleBase */
 	static int print_usage(const char *reason = nullptr);
 
-	/* run the main loop */
+private:
+
 	void Run() override;
 
-private:
 	static constexpr int MAX_NUM_AIRSPEED_SENSORS = 3; /**< Support max 3 airspeed sensors */
 	enum airspeed_index {
 		DISABLED_INDEX = -1,

--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -85,11 +85,11 @@ public:
 	/** @see ModuleBase */
 	static int print_usage(const char *reason = nullptr);
 
-	void Run() override;
-
 	bool init();
 
 private:
+
+	void Run() override;
 
 	void update_parameters(bool force = false);
 

--- a/src/modules/battery_status/battery_status.cpp
+++ b/src/modules/battery_status/battery_status.cpp
@@ -94,10 +94,11 @@ public:
 	/** @see ModuleBase */
 	static int print_usage(const char *reason = nullptr);
 
-	void Run() override;
 	bool init();
 
 private:
+	void Run() override;
+
 	int  _adc_fd{-1};			/**< ADC file handle */
 
 	uORB::Subscription	_actuator_ctrl_0_sub{ORB_ID(actuator_controls_0)};		/**< attitude controls sub */

--- a/src/modules/camera_feedback/CameraFeedback.hpp
+++ b/src/modules/camera_feedback/CameraFeedback.hpp
@@ -71,11 +71,11 @@ public:
 	/** @see ModuleBase */
 	static int print_usage(const char *reason = nullptr);
 
-	void Run() override;
-
 	bool init();
 
 private:
+
+	void Run() override;
 
 	uORB::SubscriptionCallbackWorkItem _trigger_sub{this, ORB_ID(camera_trigger)};
 

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -107,13 +107,13 @@ public:
 	/** @see ModuleBase */
 	static int print_usage(const char *reason = nullptr);
 
-	void Run() override;
-
 	bool init();
 
 	int print_status() override;
 
 private:
+	void Run() override;
+
 	int getRangeSubIndex(); ///< get subscription index of first downward-facing range sensor
 	void fillGpsMsgWithVehicleGpsPosData(gps_message &msg, const vehicle_gps_position_s &data);
 

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
@@ -88,11 +88,10 @@ public:
 	/** @see ModuleBase */
 	static int print_usage(const char *reason = nullptr);
 
-	void Run() override;
-
 	bool init();
 
 private:
+	void Run() override;
 
 	uORB::SubscriptionCallbackWorkItem _att_sub{this, ORB_ID(vehicle_attitude)};	/**< vehicle attitude */
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -141,11 +141,11 @@ public:
 	/** @see ModuleBase */
 	static int print_usage(const char *reason = nullptr);
 
-	void Run() override;
-
 	bool init();
 
 private:
+	void Run() override;
+
 	orb_advert_t	_mavlink_log_pub{nullptr};
 
 	uORB::SubscriptionCallbackWorkItem _global_pos_sub{this, ORB_ID(vehicle_global_position)};

--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -78,11 +78,10 @@ public:
 	/** @see ModuleBase */
 	static int print_usage(const char *reason = nullptr);
 
-	void Run() override;
-
 	bool init();
 
 private:
+	void Run() override;
 
 	/**
 	 * initialize some vectors/matrices from parameters

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -95,14 +95,14 @@ public:
 	/** @see ModuleBase */
 	static int print_usage(const char *reason = nullptr);
 
-	void Run() override;
-
 	bool init();
 
 	/** @see ModuleBase::print_status() */
 	int print_status() override;
 
 private:
+	void Run() override;
+
 	Takeoff _takeoff; /**< state machine and ramp to bring the vehicle off the ground without jumps */
 
 	uORB::Publication<vehicle_attitude_setpoint_s>	_vehicle_attitude_setpoint_pub;

--- a/src/modules/mc_rate_control/MulticopterRateControl.hpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.hpp
@@ -75,11 +75,10 @@ public:
 	/** @see ModuleBase */
 	static int print_usage(const char *reason = nullptr);
 
-	void Run() override;
-
 	bool init();
 
 private:
+	void Run() override;
 
 	/**
 	 * initialize some vectors/matrices from parameters

--- a/src/modules/rc_update/rc_update.h
+++ b/src/modules/rc_update/rc_update.h
@@ -83,10 +83,11 @@ public:
 	/** @see ModuleBase */
 	static int print_usage(const char *reason = nullptr);
 
-	void Run() override;
 	bool init();
 
 private:
+
+	void Run() override;
 
 	/**
 	 * Check for changes in rc_parameter_map

--- a/src/modules/temperature_compensation/TemperatureCompensationModule.h
+++ b/src/modules/temperature_compensation/TemperatureCompensationModule.h
@@ -80,8 +80,6 @@ public:
 	/** @see ModuleBase */
 	static int print_usage(const char *reason = nullptr);
 
-	void Run() override;
-
 	/** @see ModuleBase::print_status() */
 	int print_status() override;
 
@@ -91,6 +89,8 @@ public:
 	bool init();
 
 private:
+
+	void Run() override;
 
 	void accelPoll();
 	void gyroPoll();

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -91,7 +91,7 @@ class VtolAttitudeControl : public ModuleBase<VtolAttitudeControl>, public px4::
 public:
 
 	VtolAttitudeControl();
-	~VtolAttitudeControl();
+	~VtolAttitudeControl() override;
 
 	/** @see ModuleBase */
 	static int task_spawn(int argc, char *argv[]);
@@ -101,8 +101,6 @@ public:
 
 	/** @see ModuleBase */
 	static int print_usage(const char *reason = nullptr);
-
-	void Run() override;
 
 	bool init();
 
@@ -129,6 +127,8 @@ public:
 	struct Params 					*get_params() {return &_params;}
 
 private:
+
+	void Run() override;
 
 	uORB::SubscriptionCallbackWorkItem _actuator_inputs_fw{this, ORB_ID(actuator_controls_virtual_fw)};
 	uORB::SubscriptionCallbackWorkItem _actuator_inputs_mc{this, ORB_ID(actuator_controls_virtual_mc)};


### PR DESCRIPTION
In a WorkItem module the `Run()` method should only be executed within the actual WorkQueue thread.