### PR TITLE
BMM150: Fix priority assignment

### DIFF
--- a/src/drivers/magnetometer/bmm150/bmm150.cpp
+++ b/src/drivers/magnetometer/bmm150/bmm150.cpp
@@ -379,7 +379,7 @@ int BMM150::init()
 
 	/* measurement will have generated a report, publish */
 	_topic = orb_advertise_multi(ORB_ID(sensor_mag), &mrb,
-				     &_orb_class_instance, (external()) ? ORB_PRIO_HIGH : ORB_PRIO_MAX);
+				     &_orb_class_instance, (external()) ? ORB_PRIO_MAX : ORB_PRIO_HIGH);
 
 	if (_topic == nullptr) {
 		PX4_WARN("ADVERT FAIL");


### PR DESCRIPTION
This PR fixes the priority assignment for the bmm150 magnetometer.

In previous implementation the bmm150 was assigned a priority of 255 even tough was internal.

This could have lead to conflicts if an external mag is actually present.
Indeed, depending on the sequence on which sensors are started, the internal mag could have been used as primary one instead of the external one.

**Test data / coverage**
Before this PR:

```
INFO  [sensors] mag status:
INFO  [ecl/validation] validator: best: 0, prev best: 0, failsafe: NO (0 events)
INFO  [ecl/validation] sensor #0, prio: 255, state: OK 
INFO  [ecl/validation] 	val:  -0.1671, lp:  -0.1661 mean dev:   0.0000 RMS:   0.0021 conf:   1.0000
INFO  [ecl/validation] 	val:  -0.2658, lp:  -0.2717 mean dev:   0.0000 RMS:   0.0043 conf:   1.0000
INFO  [ecl/validation] 	val:   0.5187, lp:   0.5155 mean dev:   0.0001 RMS:   0.0028 conf:   1.0000
INFO  [ecl/validation] sensor #1, prio: 255, state: OK
INFO  [ecl/validation] 	val:  -0.2244, lp:  -0.2256 mean dev:   0.0000 RMS:   0.0060 conf:   1.0000
INFO  [ecl/validation] 	val:  -0.1465, lp:  -0.1467 mean dev:   0.0000 RMS:   0.0059 conf:   1.0000
INFO  [ecl/validation] 	val:   0.5555, lp:   0.5542 mean dev:   0.0001 RMS:   0.0099 conf:   1.0000
```

After this PR:

```
INFO  [sensors] mag status:
INFO  [ecl/validation] validator: best: 1, prev best: 0, failsafe: NO (0 events)
INFO  [ecl/validation] sensor #0, prio: 100, state: OK
INFO  [ecl/validation] 	val:  -0.0527, lp:  -0.0529 mean dev:  -0.0002 RMS:   0.0014 conf:   1.0000
INFO  [ecl/validation] 	val:  -0.2135, lp:  -0.2112 mean dev:  -0.0002 RMS:   0.0015 conf:   1.0000
INFO  [ecl/validation] 	val:   0.5476, lp:   0.5467 mean dev:  -0.0001 RMS:   0.0048 conf:   1.0000
INFO  [ecl/validation] sensor #1, prio: 255, state: OK
INFO  [ecl/validation] 	val:  -0.0325, lp:  -0.0316 mean dev:   0.0000 RMS:   0.0005 conf:   1.0000
INFO  [ecl/validation] 	val:  -0.2031, lp:  -0.2045 mean dev:  -0.0001 RMS:   0.0006 conf:   1.0000
INFO  [ecl/validation] 	val:   0.4784, lp:   0.4821 mean dev:   0.0002 RMS:   0.0032 conf:   1.0000

```
Tested on v5x.