### PR TITLE
mavlink: forward everything except what is for us

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2020 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -465,22 +465,16 @@ Mavlink::forward_message(const mavlink_message_t *msg, Mavlink *self)
 				}
 			}
 
-			// We forward messages targetted at the same system, or addressed to all systems, or
-			// if not target system is set.
-			const bool target_system_id_ok =
-				(target_system_id == 0 || target_system_id == self->get_system_id());
-
-			// We forward messages that are targetting another component, or are addressed to all
-			// components, or if the target component is not set.
-			const bool target_component_id_ok =
-				(target_component_id == 0 || target_component_id != self->get_component_id());
+			// If it's a message only for us, we keep it, otherwise, we forward it.
+			const bool targeted_only_at_us =
+				(target_system_id == self->get_system_id() &&
+				 target_component_id == self->get_component_id());
 
 			// We don't forward heartbeats unless it's specifically enabled.
 			const bool heartbeat_check_ok =
 				(msg->msgid != MAVLINK_MSG_ID_HEARTBEAT || self->forward_heartbeats_enabled());
 
-			if (target_system_id_ok && target_component_id_ok && heartbeat_check_ok) {
-
+			if (!targeted_only_at_us && heartbeat_check_ok) {
 				inst->pass_message(msg);
 			}
 		}


### PR DESCRIPTION
The previous forwarding rules exclude another onboard MAVLink node to send messages to a specific target.

E.g. a message from a companion computer with sysid 1 (same as autopilot) with target sysid 190 (for the ground station) was not  forwarded.

With the new rules, anything that is not specifically addressed to the autopilot's sysid and compid is forwarded.

This came up in https://github.com/mavlink/MAVSDK/issues/955.