### PR TITLE
Fixed prearm check for INA226 power monitor

### DIFF
--- a/src/drivers/power_monitor/ina226/ina226.h
+++ b/src/drivers/power_monitor/ina226/ina226.h
@@ -146,6 +146,7 @@ private:
 	perf_counter_t		_comms_errors;
 	perf_counter_t 		_collection_errors;
 	perf_counter_t 		_measure_errors;
+	perf_counter_t 		_mutex_wait_time;
 
 	int16_t           _bus_voltage{0};
 	int16_t           _power{-1};
@@ -197,5 +198,7 @@ private:
 
 	int					     measure();
 	int					     collect();
+
+	bool updateUorbInstance(bool connected);
 
 };

--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -171,6 +171,16 @@ Battery::swapUorbAdvert(Battery &other)
 	orb_advert_t tmp = _orb_advert;
 	_orb_advert = other._orb_advert;
 	other._orb_advert = tmp;
+
+	int inst_tmp = _orb_instance;
+	_orb_instance = other._orb_instance;
+	other._orb_instance = inst_tmp;
+}
+
+int
+Battery::getUorbInstance()
+{
+	return _orb_instance;
 }
 
 void

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -117,6 +117,8 @@ public:
 	 */
 	void swapUorbAdvert(Battery &other);
 
+	int getUorbInstance();
+
 protected:
 	struct {
 		param_t v_empty;


### PR DESCRIPTION
**Describe problem solved by this pull request**
During the prearm check, the commander only checks instance 0 of the `battery_status` uORB topic. This is why, in the analog `battery_status` module, the two different batteries switch uORB advertisements as needed, to ensure that the currently-selected battery is publishing to instance 0. This PR adds that same functionality to the INA226 power monitor driver.

**Describe your solution**
Just like with the analog power monitor, each INA226 driver determines whether it is the selected source by checking if it is the lowest-index battery connected. If it is, it swaps uORB advertisements with the other, so that it can be instance 0.

**Describe possible alternatives**
`Commander::battery_status_check()` should be changed to properly account for multiple batteries. However, this is a big change with safety implications, and unanswered questions about failsafes, etc. As a quick fix, I am making the INA226 driver mimic the behavior of the analog power monitor module.

**Test data / coverage**
I connected the following combinations of batteries to an FMU v5x board:

 - 0 batteries
 - 1 battery in port 1
 - 1 battery in port 2
 - 2 batteries

and ensured that the correct battery data is being published to instance 0 of `battery_status`. I also checked `vehicle_status_flags.condition_battery_healthy` to ensure that the prearm check is passing.

**Additional context**
The INA226 power module is used by FMU v5x. This change is necessary to bring v5x up to the same level of functionality as v5.
