### PR TITLE
Commander: preflight check fixes

### DIFF
--- a/src/modules/commander/Arming/PreFlightCheck/checks/airspeedCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/airspeedCheck.cpp
@@ -79,12 +79,12 @@ bool PreFlightCheck::airspeedCheck(orb_advert_t *mavlink_log_pub, vehicle_status
 		goto out;
 	}
 
-	/**
+	/*
 	 * Check if airspeed is higher than 4m/s (accepted max) while the vehicle is landed / not flying
 	 * Negative and positive offsets are considered. Do not check anymore while arming because pitot cover
 	 * might have been removed.
 	 */
-	if (fabsf(airspeed.indicated_airspeed_m_s) > 4.0f && !prearm) {
+	if (fabsf(airspeed.indicated_airspeed_m_s) > 4.0f && prearm) {
 		if (report_fail) {
 			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: check Airspeed Cal or Pitot");
 		}

--- a/src/modules/commander/Arming/PreFlightCheck/checks/powerCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/powerCheck.cpp
@@ -48,36 +48,35 @@ bool PreFlightCheck::powerCheck(orb_advert_t *mavlink_log_pub, const vehicle_sta
 	if (!prearm) {
 		// Ignore power check after arming.
 		return true;
+	}
 
-	} else {
-		uORB::SubscriptionData<system_power_s> system_power_sub{ORB_ID(system_power)};
-		system_power_sub.update();
-		const system_power_s &system_power = system_power_sub.get();
+	uORB::SubscriptionData<system_power_s> system_power_sub{ORB_ID(system_power)};
+	system_power_sub.update();
+	const system_power_s &system_power = system_power_sub.get();
 
-		if (hrt_elapsed_time(&system_power.timestamp) < 200_ms) {
+	if (hrt_elapsed_time(&system_power.timestamp) < 200_ms) {
 
-			/* copy avionics voltage */
-			float avionics_power_rail_voltage = system_power.voltage5v_v;
+		/* copy avionics voltage */
+		float avionics_power_rail_voltage = system_power.voltage5v_v;
 
-			// avionics rail
-			// Check avionics rail voltages
-			if (avionics_power_rail_voltage < 4.5f) {
-				success = false;
+		// avionics rail
+		// Check avionics rail voltages
+		if (avionics_power_rail_voltage < 4.5f) {
+			success = false;
 
-				if (report_fail) {
-					mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Avionics Power low: %6.2f Volt",
-							     (double)avionics_power_rail_voltage);
-				}
+			if (report_fail) {
+				mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Avionics Power low: %6.2f Volt",
+						     (double)avionics_power_rail_voltage);
+			}
 
-			} else if (avionics_power_rail_voltage < 4.9f) {
-				if (report_fail) {
-					mavlink_log_critical(mavlink_log_pub, "CAUTION: Avionics Power low: %6.2f Volt", (double)avionics_power_rail_voltage);
-				}
+		} else if (avionics_power_rail_voltage < 4.9f) {
+			if (report_fail) {
+				mavlink_log_critical(mavlink_log_pub, "CAUTION: Avionics Power low: %6.2f Volt", (double)avionics_power_rail_voltage);
+			}
 
-			} else if (avionics_power_rail_voltage > 5.4f) {
-				if (report_fail) {
-					mavlink_log_critical(mavlink_log_pub, "CAUTION: Avionics Power high: %6.2f Volt", (double)avionics_power_rail_voltage);
-				}
+		} else if (avionics_power_rail_voltage > 5.4f) {
+			if (report_fail) {
+				mavlink_log_critical(mavlink_log_pub, "CAUTION: Avionics Power high: %6.2f Volt", (double)avionics_power_rail_voltage);
 			}
 		}
 	}

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -286,7 +286,7 @@ extern "C" __EXPORT int commander_main(int argc, char *argv[])
 	}
 
 	if (!strcmp(argv[1], "check")) {
-		bool preflight_check_res = PreFlightCheck::preflightCheck(nullptr, status, status_flags, true, true, false, 30_s);
+		bool preflight_check_res = PreFlightCheck::preflightCheck(nullptr, status, status_flags, true, true, true, 30_s);
 		PX4_INFO("Preflight check: %s", preflight_check_res ? "OK" : "FAILED");
 
 		bool prearm_check_res = PreFlightCheck::preArmCheck(nullptr, status_flags, safety_s{},
@@ -1280,7 +1280,7 @@ Commander::run()
 	arm_auth_init(&mavlink_log_pub, &status.system_id);
 
 	// run preflight immediately to find all relevant parameters, but don't report
-	PreFlightCheck::preflightCheck(&mavlink_log_pub, status, status_flags, _arm_requirements.global_position, false, false,
+	PreFlightCheck::preflightCheck(&mavlink_log_pub, status, status_flags, _arm_requirements.global_position, false, true,
 				       hrt_elapsed_time(&_boot_timestamp));
 
 	while (!should_exit()) {
@@ -3355,7 +3355,7 @@ void *commander_low_prio_loop(void *arg)
 						tune_positive(true);
 
 						// time since boot not relevant here
-						if (PreFlightCheck::preflightCheck(&mavlink_log_pub, status, status_flags, false, false, false, 30_s)) {
+						if (PreFlightCheck::preflightCheck(&mavlink_log_pub, status, status_flags, false, false, true, 30_s)) {
 
 							status_flags.condition_system_sensors_initialized = true;
 						}

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3558,11 +3558,17 @@ void Commander::data_link_check()
 			switch (telemetry.remote_type) {
 			case telemetry_status_s::MAV_TYPE_GCS:
 
-				// Recover from data link lost
+				// Initial connection or recovery from data link lost
 				if (status.data_link_lost) {
 					if (telemetry.heartbeat_time > _datalink_last_heartbeat_gcs) {
 						status.data_link_lost = false;
 						_status_changed = true;
+
+						if (!armed.armed) {
+							// make sure to report preflight check failures to a connecting GCS
+							PreFlightCheck::preflightCheck(&mavlink_log_pub, status, status_flags,
+										       _arm_requirements.global_position, true, true, hrt_elapsed_time(&_boot_timestamp));
+						}
 
 						if (_datalink_last_heartbeat_gcs != 0) {
 							mavlink_log_info(&mavlink_log_pub, "Data link regained");

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -154,7 +154,8 @@ transition_result_t arming_state_transition(vehicle_status_s *status, const safe
 			if ((last_preflight_check == 0) || (hrt_elapsed_time(&last_preflight_check) > 1000 * 1000)) {
 
 				status_flags->condition_system_sensors_initialized = PreFlightCheck::preflightCheck(mavlink_log_pub, *status,
-						*status_flags, arm_requirements.global_position, false, false, time_since_boot);
+						*status_flags, arm_requirements.global_position, false, status->arming_state != vehicle_status_s::ARMING_STATE_ARMED,
+						time_since_boot);
 
 				last_preflight_check = hrt_absolute_time();
 			}


### PR DESCRIPTION
Fixes some serious bugs around preflight checks:
- fix `prearm` flag to preflightCheck
  This was inverted, i.e. set to false in most cases, whereas it should be true.
  As a consequence, both powerCheck and airspeed.confidence checks were not executed.
- fix commander: run preflight checks on GCS connection
  Regression from 6dec451, leading to preflight failures not being reported at all. Only after a failed arming attempt the messages would be sent. And for GPS check failures, in case they are set to optional (default), arming would be possible, but switching to position would be rejected w/o error.
  We need to run the preflight checks periodically, but this at least restores the previous behavior.