### PR TITLE
commander: don't run preflightCheck during calibration on reconnect

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3564,7 +3564,7 @@ void Commander::data_link_check()
 						status.data_link_lost = false;
 						_status_changed = true;
 
-						if (!armed.armed) {
+						if (!armed.armed && !status_flags.condition_calibration_enabled) {
 							// make sure to report preflight check failures to a connecting GCS
 							PreFlightCheck::preflightCheck(&mavlink_log_pub, status, status_flags,
 										       _arm_requirements.global_position, true, true, hrt_elapsed_time(&_boot_timestamp));


### PR DESCRIPTION
Quick follow up to https://github.com/PX4/Firmware/pull/14022.

If the re-connect triggers preflight during calibration (eg intermittant connection) it disrupts QGC calibration. Preflight is re-run after calibration finishes. 