### PR TITLE
VTOL land detector: disable freefall detection if FW and move to airspeed_validated

### DIFF
--- a/src/modules/land_detector/VtolLandDetector.cpp
+++ b/src/modules/land_detector/VtolLandDetector.cpp
@@ -40,6 +40,7 @@
  */
 
 #include <drivers/drv_hrt.h>
+#include <matrix/math.hpp>
 
 #include "VtolLandDetector.h"
 
@@ -92,6 +93,15 @@ bool VtolLandDetector::_get_landed_state()
 	_was_in_air = !landed;
 
 	return landed;
+}
+
+bool VtolLandDetector::_get_freefall_state()
+{
+	bool free_fall_detected =
+		MulticopterLandDetector::_get_freefall_state(); // true if falling or in a parabolic flight (low gravity)
+
+	// only return a positive free fall detected if not in fixed-wing mode
+	return _vehicle_status.vehicle_type != vehicle_status_s::VEHICLE_TYPE_FIXED_WING && free_fall_detected;
 }
 
 } // namespace land_detector

--- a/src/modules/land_detector/VtolLandDetector.cpp
+++ b/src/modules/land_detector/VtolLandDetector.cpp
@@ -49,7 +49,7 @@ namespace land_detector
 void VtolLandDetector::_update_topics()
 {
 	MulticopterLandDetector::_update_topics();
-	_airspeed_sub.update(&_airspeed);
+	_airspeed_validated_sub.update(&_airspeed_validated);
 	_vehicle_status_sub.update(&_vehicle_status);
 }
 
@@ -74,10 +74,9 @@ bool VtolLandDetector::_get_landed_state()
 	bool landed = MulticopterLandDetector::_get_landed_state();
 
 	// for vtol we additionally consider airspeed
-	if (hrt_elapsed_time(&_airspeed.timestamp) < 1_s && _airspeed.confidence > 0.99f
-	    && PX4_ISFINITE(_airspeed.indicated_airspeed_m_s)) {
+	if (hrt_elapsed_time(&_airspeed_validated.timestamp) < 1_s && PX4_ISFINITE(_airspeed_validated.true_airspeed_m_s)) {
 
-		_airspeed_filtered = 0.95f * _airspeed_filtered + 0.05f * _airspeed.indicated_airspeed_m_s;
+		_airspeed_filtered = 0.95f * _airspeed_filtered + 0.05f * _airspeed_validated.true_airspeed_m_s;
 
 	} else {
 		// if airspeed does not update, set it to zero and rely on multicopter land detector

--- a/src/modules/land_detector/VtolLandDetector.h
+++ b/src/modules/land_detector/VtolLandDetector.h
@@ -41,7 +41,7 @@
 
 #pragma once
 
-#include <uORB/topics/airspeed.h>
+#include <uORB/topics/airspeed_validated.h>
 #include <uORB/topics/vehicle_status.h>
 
 #include "MulticopterLandDetector.h"
@@ -62,10 +62,10 @@ protected:
 
 private:
 
-	uORB::Subscription _airspeed_sub{ORB_ID(airspeed)};
+	uORB::Subscription _airspeed_validated_sub{ORB_ID(airspeed_validated)};
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
 
-	airspeed_s _airspeed{};
+	airspeed_validated_s _airspeed_validated{};
 	vehicle_status_s _vehicle_status{};
 
 	bool _was_in_air{false}; /**< indicates whether the vehicle was in the air in the previous iteration */

--- a/src/modules/land_detector/VtolLandDetector.h
+++ b/src/modules/land_detector/VtolLandDetector.h
@@ -59,6 +59,7 @@ protected:
 	void _update_topics() override;
 	bool _get_landed_state() override;
 	bool _get_maybe_landed_state() override;
+	bool _get_freefall_state() override;
 
 private:
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/26798987/73182831-0d850d00-411a-11ea-9d23-84ddb35c9084.png)
It seems that the multicopter free fall function is running in fixed-wing mode, which triggers freefall when making parabolic flight maneuvers (eg pitching strongly down), as then the vertical acceleration is low.

![image](https://user-images.githubusercontent.com/26798987/73182849-14138480-411a-11ea-88f6-c291fa24102a.png)

It is though not relevant for land detection, as this is currently switched off (landing = false) for the fixed-wing portion of the flight. The error message though still pops up, so this PR is mainly there to fix that.
To enable a proper land detection in the future for VTOL, I didn't just kill off the free fall detection for VTOL in FW flight, but added a VTOL-specific one that also takes into account airspeed, and thus disabling free fall detection if the airspeed is above the stall speed of the vehicle.

