### PR TITLE
Remove unused configs from specific board builds

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/12002_steadidrone_mavrik
+++ b/ROMFS/px4fmu_common/init.d/airframes/12002_steadidrone_mavrik
@@ -16,6 +16,8 @@
 #
 # @maintainer Simon Wilks <simon@uaventure.com>
 #
+# @board px4_fmu-v2_fixedwing exclude
+#
 
 sh /etc/init.d/rc.mc_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13000_generic_vtol_standard
+++ b/ROMFS/px4fmu_common/init.d/airframes/13000_generic_vtol_standard
@@ -17,6 +17,8 @@
 # @output AUX4 Rudder
 # @output AUX5 Throttle
 #
+# @board px4_fmu-v2_fixedwing exclude
+#
 
 sh /etc/init.d/rc.vtol_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13001_caipirinha_vtol
+++ b/ROMFS/px4fmu_common/init.d/airframes/13001_caipirinha_vtol
@@ -12,6 +12,8 @@
 #
 # @maintainer Roman Bapst <roman@px4.io>
 #
+# @board px4_fmu-v2_fixedwing exclude
+#
 
 sh /etc/init.d/rc.vtol_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13002_firefly6
+++ b/ROMFS/px4fmu_common/init.d/airframes/13002_firefly6
@@ -17,6 +17,8 @@
 # @output AUX3 Elevon 2
 # @output AUX4 Gear
 #
+# @board px4_fmu-v2_fixedwing exclude
+#
 
 sh /etc/init.d/rc.vtol_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13003_quad_tailsitter
+++ b/ROMFS/px4fmu_common/init.d/airframes/13003_quad_tailsitter
@@ -7,6 +7,8 @@
 #
 # @maintainer Roman Bapst <roman@px4.io>
 #
+# @board px4_fmu-v2_fixedwing exclude
+#
 
 sh /etc/init.d/rc.vtol_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13004_quad+_tailsitter
+++ b/ROMFS/px4fmu_common/init.d/airframes/13004_quad+_tailsitter
@@ -17,6 +17,7 @@
 # @maintainer Roman Bapst <roman@px4.io>
 #
 # @board px4_fmu-v2 exclude
+# @board px4_fmu-v2_fixedwing exclude
 #
 
 sh /etc/init.d/rc.vtol_defaults

--- a/ROMFS/px4fmu_common/init.d/airframes/13005_vtol_AAERT_quad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13005_vtol_AAERT_quad
@@ -17,6 +17,8 @@
 # @output AUX4 Rudder
 # @output AUX5 Throttle
 #
+# @board px4_fmu-v2_fixedwing exclude
+#
 
 sh /etc/init.d/rc.vtol_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13006_vtol_standard_delta
+++ b/ROMFS/px4fmu_common/init.d/airframes/13006_vtol_standard_delta
@@ -15,6 +15,8 @@
 # @output AUX2 Left elevon
 # @output AUX3 Motor
 #
+# @board px4_fmu-v2_fixedwing exclude
+#
 
 sh /etc/init.d/rc.vtol_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13007_vtol_AAVVT_quad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13007_vtol_AAVVT_quad
@@ -7,6 +7,8 @@
 #
 # @maintainer Sander Smeets <sander@droneslab.com>
 #
+# @board px4_fmu-v2_fixedwing exclude
+#
 
 sh /etc/init.d/rc.vtol_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13008_QuadRanger
+++ b/ROMFS/px4fmu_common/init.d/airframes/13008_QuadRanger
@@ -7,6 +7,8 @@
 #
 # @maintainer Sander Smeets <sander@droneslab.com>
 #
+# @board px4_fmu-v2_fixedwing exclude
+#
 
 sh /etc/init.d/rc.vtol_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13009_vtol_spt_ranger
+++ b/ROMFS/px4fmu_common/init.d/airframes/13009_vtol_spt_ranger
@@ -7,6 +7,8 @@
 #
 # @maintainer Andreas Antener <andreas@uaventure.com>
 #
+# @board px4_fmu-v2_fixedwing exclude
+#
 
 sh /etc/init.d/rc.vtol_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13010_claire
+++ b/ROMFS/px4fmu_common/init.d/airframes/13010_claire
@@ -8,6 +8,7 @@
 # @maintainer Samay Siga <samay_s@icloud.com>
 #
 # @board px4_fmu-v2 exclude
+# @board px4_fmu-v2_fixedwing exclude
 #
 
 sh /etc/init.d/rc.vtol_defaults

--- a/ROMFS/px4fmu_common/init.d/airframes/13012_convergence
+++ b/ROMFS/px4fmu_common/init.d/airframes/13012_convergence
@@ -16,6 +16,8 @@
 # @output MAIN7 Elevon right
 # @output MAIN8 Elevon left
 #
+# @board px4_fmu-v2_fixedwing exclude
+#
 
 sh /etc/init.d/rc.vtol_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
@@ -16,6 +16,8 @@
 # @output MAIN7 Pusher motor
 # @output MAIN8 Pusher reverse channel
 #
+# @board px4_fmu-v2_fixedwing exclude
+#
 
 sh /etc/init.d/rc.vtol_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
+++ b/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
@@ -17,6 +17,8 @@
 # @output MAIN8 motor 4
 #
 # @board px4_fmu-v2 exclude
+# @board px4_fmu-v2_fixedwing exclude
+#
 
 sh /etc/init.d/rc.vtol_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13050_generic_vtol_octo
+++ b/ROMFS/px4fmu_common/init.d/airframes/13050_generic_vtol_octo
@@ -21,6 +21,8 @@
 # @output AUX4 Rudder
 # @output AUX5 Throttle
 #
+# @board px4_fmu-v2_fixedwing exclude
+#
 
 sh /etc/init.d/rc.vtol_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13200_generic_vtol_tailsitter
+++ b/ROMFS/px4fmu_common/init.d/airframes/13200_generic_vtol_tailsitter
@@ -12,6 +12,8 @@
 #
 # @maintainer Roman Bapst <roman@px4.io>
 #
+# @board px4_fmu-v2_fixedwing exclude
+#
 
 sh /etc/init.d/rc.vtol_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/14001_tri_y_yaw+
+++ b/ROMFS/px4fmu_common/init.d/airframes/14001_tri_y_yaw+
@@ -12,6 +12,8 @@
 #
 # @maintainer Trent Lukaczyk <aerialhedgehog@gmail.com>
 #
+# @board px4_fmu-v2_fixedwing exclude
+#
 
 sh /etc/init.d/rc.mc_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/14002_tri_y_yaw-
+++ b/ROMFS/px4fmu_common/init.d/airframes/14002_tri_y_yaw-
@@ -12,6 +12,8 @@
 #
 # @maintainer Trent Lukaczyk <aerialhedgehog@gmail.com>
 #
+# @board px4_fmu-v2_fixedwing exclude
+#
 
 sh /etc/init.d/rc.mc_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/15001_coax_heli
+++ b/ROMFS/px4fmu_common/init.d/airframes/15001_coax_heli
@@ -12,6 +12,8 @@
 #
 # @maintainer Emmanuel Roussel
 #
+# @board px4_fmu-v2_fixedwing exclude
+#
 
 sh /etc/init.d/rc.mc_defaults
 set MIXER coax

--- a/ROMFS/px4fmu_common/init.d/airframes/16001_helicopter
+++ b/ROMFS/px4fmu_common/init.d/airframes/16001_helicopter
@@ -5,8 +5,6 @@
 # @type Helicopter
 # @class Copter
 #
-# @board px4_fmu-v2 exclude
-#
 # @maintainer Bart Slinger <bartslinger@gmail.com>
 #
 # @output MAIN1 main motor
@@ -14,6 +12,9 @@
 # @output MAIN3 right swashplate servo
 # @output MAIN4 left swashplate servo
 # @output MAIN5 tail-rotor servo
+#
+# @board px4_fmu-v2 exclude
+# @board px4_fmu-v2_fixedwing exclude
 #
 
 sh /etc/init.d/rc.mc_defaults

--- a/ROMFS/px4fmu_common/init.d/airframes/17002_TF-AutoG2
+++ b/ROMFS/px4fmu_common/init.d/airframes/17002_TF-AutoG2
@@ -19,6 +19,8 @@
 # @url https://github.com/ThunderFly-aerospace/Auto-G2/
 # @maintainer ThunderFly s.r.o., Roman Dvorak <dvorakroman@thunderfly.cz>
 #
+# @board px4_fmu-v2_fixedwing exclude
+#
 
 sh /etc/init.d/rc.fw_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/2105_maja
+++ b/ROMFS/px4fmu_common/init.d/airframes/2105_maja
@@ -19,6 +19,8 @@
 #
 # @maintainer Andreas Antener <andreas@uaventure.com>
 #
+# @board px4_fmu-v2_multicopter exclude
+#
 
 sh /etc/init.d/rc.fw_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/2106_albatross
+++ b/ROMFS/px4fmu_common/init.d/airframes/2106_albatross
@@ -20,6 +20,8 @@
 #
 # @maintainer Andreas Antener <andreas@uaventure.com>
 #
+# @board px4_fmu-v2_multicopter exclude
+#
 
 sh /etc/init.d/rc.fw_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/2200_mini_talon
+++ b/ROMFS/px4fmu_common/init.d/airframes/2200_mini_talon
@@ -20,6 +20,8 @@
 #
 # @maintainer Friedrich Beckmann <friedrich.beckmann@hs-augsburg.de>
 #
+# @board px4_fmu-v2_multicopter exclude
+#
 
 sh /etc/init.d/rc.fw_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/3000_generic_wing
+++ b/ROMFS/px4fmu_common/init.d/airframes/3000_generic_wing
@@ -15,6 +15,8 @@
 #
 # @maintainer
 #
+# @board px4_fmu-v2_multicopter exclude
+#
 
 sh /etc/init.d/rc.fw_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/3030_io_camflyer
+++ b/ROMFS/px4fmu_common/init.d/airframes/3030_io_camflyer
@@ -15,6 +15,8 @@
 #
 # @maintainer Simon Wilks <simon@uaventure.com>
 #
+# @board px4_fmu-v2_multicopter exclude
+#
 
 sh /etc/init.d/rc.fw_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/3031_phantom
+++ b/ROMFS/px4fmu_common/init.d/airframes/3031_phantom
@@ -17,6 +17,8 @@
 #
 # @maintainer Simon Wilks <simon@uaventure.com>
 #
+# @board px4_fmu-v2_multicopter exclude
+#
 
 sh /etc/init.d/rc.fw_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/3032_skywalker_x5
+++ b/ROMFS/px4fmu_common/init.d/airframes/3032_skywalker_x5
@@ -15,6 +15,8 @@
 #
 # @maintainer Julian Oes <julian@px4.io>
 #
+# @board px4_fmu-v2_multicopter exclude
+#
 
 sh /etc/init.d/rc.fw_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/3033_wingwing
+++ b/ROMFS/px4fmu_common/init.d/airframes/3033_wingwing
@@ -17,6 +17,8 @@
 #
 # @maintainer Lorenz Meier <lorenz@px4.io>
 #
+# @board px4_fmu-v2_multicopter exclude
+#
 
 sh /etc/init.d/rc.fw_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/3034_fx79
+++ b/ROMFS/px4fmu_common/init.d/airframes/3034_fx79
@@ -15,6 +15,8 @@
 #
 # @maintainer Simon Wilks <simon@uaventure.com>
 #
+# @board px4_fmu-v2_multicopter exclude
+#
 
 sh /etc/init.d/rc.fw_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/3035_viper
+++ b/ROMFS/px4fmu_common/init.d/airframes/3035_viper
@@ -15,6 +15,8 @@
 #
 # @maintainer Simon Wilks <simon@uaventure.com>
 #
+# @board px4_fmu-v2_multicopter exclude
+#
 
 sh /etc/init.d/rc.fw_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/3036_pigeon
+++ b/ROMFS/px4fmu_common/init.d/airframes/3036_pigeon
@@ -17,6 +17,8 @@
 #
 # @maintainer Simon Wilks <simon@uaventure.com>
 #
+# @board px4_fmu-v2_multicopter exclude
+#
 
 sh /etc/init.d/rc.fw_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/3037_parrot_disco_mod
+++ b/ROMFS/px4fmu_common/init.d/airframes/3037_parrot_disco_mod
@@ -19,6 +19,8 @@
 #
 # @maintainer Jan Liphardt <JTLiphardt@gmail.com>
 #
+# @board px4_fmu-v2_multicopter exclude
+#
 
 sh /etc/init.d/rc.fw_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/3100_tbs_caipirinha
+++ b/ROMFS/px4fmu_common/init.d/airframes/3100_tbs_caipirinha
@@ -17,6 +17,8 @@
 #
 # @maintainer Lorenz Meier <lorenz@px4.io>
 #
+# @board px4_fmu-v2_multicopter exclude
+#
 
 sh /etc/init.d/rc.fw_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/50000_generic_ground_vehicle
+++ b/ROMFS/px4fmu_common/init.d/airframes/50000_generic_ground_vehicle
@@ -5,14 +5,13 @@
 # @type Rover
 # @class Rover
 #
-# @board px4_fmu-v2 exclude
-#
 # @output MAIN2 steering
 # @output MAIN4 throttle
 #
 # @maintainer
 #
 # @board px4_fmu-v2 exclude
+# @board px4_fmu-v2_fixedwing exclude
 #
 
 sh /etc/init.d/rc.rover_defaults

--- a/ROMFS/px4fmu_common/init.d/airframes/50001_axialracing_ax10
+++ b/ROMFS/px4fmu_common/init.d/airframes/50001_axialracing_ax10
@@ -5,8 +5,6 @@
 # @type Rover
 # @class Rover
 #
-# @board px4_fmu-v2 exclude
-#
 # @output MAIN1 pass-through of control group 0, channel 0
 # @output MAIN2 pass-through of control group 0, channel 1
 # @output MAIN3 pass-through of control group 0, channel 2
@@ -17,6 +15,7 @@
 # @output MAIN8 pass-through of control group 0, channel 7
 #
 # @board px4_fmu-v2 exclude
+# @board px4_fmu-v2_fixedwing exclude
 #
 
 sh /etc/init.d/rc.rover_defaults

--- a/ROMFS/px4fmu_common/init.d/airframes/50002_traxxas_stampede_2wd
+++ b/ROMFS/px4fmu_common/init.d/airframes/50002_traxxas_stampede_2wd
@@ -7,14 +7,13 @@
 # @type Rover
 # @class Rover
 #
-# @board px4_fmu-v2 exclude
-#
 # @output MAIN2 steering
 # @output MAIN4 throttle
 #
 # @maintainer Marco Zorzi
 #
 # @board px4_fmu-v2 exclude
+# @board px4_fmu-v2_fixedwing exclude
 #
 
 sh /etc/init.d/rc.rover_defaults

--- a/ROMFS/px4fmu_common/init.d/airframes/50003_aion_robotics_r1_rover
+++ b/ROMFS/px4fmu_common/init.d/airframes/50003_aion_robotics_r1_rover
@@ -7,14 +7,13 @@
 # @type Rover
 # @class Rover
 #
-# @board px4_fmu-v2 exclude
-#
 # @output MAIN0 Speed of left wheels
 # @output MAIN1 Speed of right wheels
 #
 # @maintainer Timothy Scott
 #
 # @board px4_fmu-v2 exclude
+# @board px4_fmu-v2_fixedwing exclude
 #
 
 sh /etc/init.d/rc.rover_defaults


### PR DESCRIPTION
This just correctly excludes unused configs and fixes earlier typos (exclusion two times in file).