### PR TITLE
Enable Code Coverage on MAVSDK tests with Codecov

### DIFF
--- a/.github/workflows/sitl_tests_coverage.yml
+++ b/.github/workflows/sitl_tests_coverage.yml
@@ -31,11 +31,13 @@ jobs:
     #   run: mkdir -p MAVSDK/build/default && cd MAVSDK/build/default && cmake ../.. && make -j4 && make install
     - name: Run Coverage Tests
       run: make tests_integration_coverage
-    - name: Upload coverage information to Coveralls
-      uses: coverallsapp/github-action@master
-      with:
-        path-to-lcov: coverage/lcov.info
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+    # We are not actively using coveralls, but we keep the config
+    # in case the service should be re-enabled later
+    # - name: Upload coverage information to Coveralls
+    #   uses: coverallsapp/github-action@master
+    #   with:
+    #     path-to-lcov: coverage/lcov.info
+    #     github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Upload coverage information to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/sitl_tests_coverage.yml
+++ b/.github/workflows/sitl_tests_coverage.yml
@@ -10,13 +10,35 @@ jobs:
     - uses: actions/checkout@v1
       with:
         token: ${{ secrets.ACCESS_TOKEN }}
+    # see https://github.com/actions/checkout/issues/14
+    - name: disable the keychain credential helper
+      run: git config --global credential.helper ""
+    - name: enable the local store credential helper
+      run: git config --global --add credential.helper store
+    - name: add credential
+      run: echo "https://x-access-token:${{ secrets.ACCESS_TOKEN }}@github.com" >> ~/.git-credentials
+    - name: tell git to use https instead of ssh whenever it encounters it
+      run: 'git config --global url."https://github.com/".insteadof git@github.com:'
+    - name: get submodules
+      run: 'git submodule update --init --recursive'
+    - name: Set Python 3 as default
+      run: update-alternatives --install /usr/bin/python python /usr/bin/python3 10
     - name: Install psutil
       run: pip3 install psutil
-# TODO: disabled 2019-01-09 due to failures
-#    - name: Run simulation tests
-#      run: make tests_integration_coverage
-    - name: Upload coverage to Codecov
+    # - name: Download newer mavsdk
+    #   run: git clone https://github.com/mavlink/MAVSDK.git && cd MAVSDK && git submodule init && git submodule update && mkdir -p build/default
+    # - name: Build newer mavsdk
+    #   run: mkdir -p MAVSDK/build/default && cd MAVSDK/build/default && cmake ../.. && make -j4 && make install
+    - name: Run Coverage Tests
+      run: make tests_integration_coverage
+    - name: Upload coverage information to Coveralls
+      uses: coverallsapp/github-action@master
+      with:
+        path-to-lcov: coverage/lcov.info
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Upload coverage information to Codecov
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: mavsdk
+        file: coverage/lcov.info

--- a/Makefile
+++ b/Makefile
@@ -480,7 +480,7 @@ distclean: gazeboclean
 # All other targets are handled by PX4_MAKE. Add a rule here to avoid printing an error.
 %:
 	$(if $(filter $(FIRST_ARG),$@), \
-		$(error "$@ cannot be the first argument. Use '$(MAKE) help|list_config_targets' to get a list of all possible [configuration] targets."),@#)
+		$(error "Make target $@ not found. It either does not exist or $@ cannot be the first argument. Use '$(MAKE) help|list_config_targets' to get a list of all possible [configuration] targets."),@#)
 
 # Print a list of non-config targets (based on http://stackoverflow.com/a/26339924/1487069)
 help:

--- a/Makefile
+++ b/Makefile
@@ -368,6 +368,8 @@ tests_integration_coverage:
 	@$(MAKE) --no-print-directory px4_sitl_default sitl_gazebo
 	@$(MAKE) --no-print-directory px4_sitl_default mavsdk_tests
 	@"$(SRC_DIR)"/test/mavsdk_tests/mavsdk_test_runner.py --speed-factor 100
+	@mkdir -p coverage
+	@lcov --directory build/px4_sitl_default --base-directory build/px4_sitl_default --gcov-tool gcov --capture -o coverage/lcov.info
 
 tests_mission: rostest
 	@"$(SRC_DIR)"/test/rostest_px4_run.sh mavros_posix_tests_missions.test

--- a/Makefile
+++ b/Makefile
@@ -367,7 +367,7 @@ tests_integration_coverage:
 	@$(MAKE) --no-print-directory px4_sitl_default PX4_CMAKE_BUILD_TYPE=Coverage
 	@$(MAKE) --no-print-directory px4_sitl_default sitl_gazebo
 	@$(MAKE) --no-print-directory px4_sitl_default mavsdk_tests
-	@"$(SRC_DIR)"/test/mavsdk_tests/mavsdk_test_runner.py --speed-factor 15
+	@"$(SRC_DIR)"/test/mavsdk_tests/mavsdk_test_runner.py --speed-factor 100
 
 tests_mission: rostest
 	@"$(SRC_DIR)"/test/rostest_px4_run.sh mavros_posix_tests_missions.test

--- a/cmake/coverage.cmake
+++ b/cmake/coverage.cmake
@@ -34,16 +34,31 @@
 find_program(LCOV_PATH lcov)
 find_program(GENHTML_PATH genhtml)
 
+message(STATUS "Building for code coverage")
+
 # add code coverage build type
+if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang") OR ("${CMAKE_CXX_COMPILER_ID}" MATCHES "AppleClang"))
+	set(CMAKE_C_FLAGS_COVERAGE "--coverage -ftest-coverage -fdiagnostics-absolute-paths -O0 -fprofile-arcs -fno-inline-functions"
+		CACHE STRING "Flags used by the C compiler during coverage builds" FORCE)
 
-set(CMAKE_C_FLAGS_COVERAGE "--coverage -ftest-coverage -fprofile-arcs -O0 -fno-default-inline -fno-inline"
-        CACHE STRING "Flags used by the C compiler during coverage builds" FORCE)
+	set(CMAKE_CXX_FLAGS_COVERAGE "--coverage -ftest-coverage -fdiagnostics-absolute-paths -O0-fprofile-arcs -fno-inline-functions -fno-elide-constructors"
+		CACHE STRING "Flags used by the C++ compiler during coverage builds" FORCE)
 
-set(CMAKE_CXX_FLAGS_COVERAGE "--coverage -ftest-coverage -fprofile-arcs -O0 -fno-default-inline -fno-inline -fno-elide-constructors"
-        CACHE STRING "Flags used by the C++ compiler during coverage builds" FORCE)
-
-set(CMAKE_EXE_LINKER_FLAGS_COVERAGE "--coverage -ftest-coverage -lgcov"
+	set(CMAKE_EXE_LINKER_FLAGS_COVERAGE "-ftest-coverage -fdiagnostics-absolute-paths"
         CACHE STRING "Flags used for linking binaries during coverage builds" FORCE)
+
+else()
+	# Add  -fprofile-abs-path for GCC v8/9 later on
+	set(CMAKE_C_FLAGS_COVERAGE "--coverage -ftest-coverage -fprofile-arcs -O0 -fno-default-inline -fno-inline"
+		CACHE STRING "Flags used by the C compiler during coverage builds" FORCE)
+
+	# Add  -fprofile-abs-path for GCC v8/9 later on
+	set(CMAKE_CXX_FLAGS_COVERAGE "--coverage -ftest-coverage -fprofile-arcs -O0 -fno-default-inline -fno-inline -fno-elide-constructors"
+		CACHE STRING "Flags used by the C++ compiler during coverage builds" FORCE)
+
+	set(CMAKE_EXE_LINKER_FLAGS_COVERAGE "--coverage -ftest-coverage -lgcov"
+        CACHE STRING "Flags used for linking binaries during coverage builds" FORCE)
+endif()
 
 mark_as_advanced(CMAKE_CXX_FLAGS_COVERAGE CMAKE_C_FLAGS_COVERAGE CMAKE_EXE_LINKER_FLAGS_COVERAGE)
 

--- a/cmake/px4_add_common_flags.cmake
+++ b/cmake/px4_add_common_flags.cmake
@@ -92,10 +92,12 @@ function(px4_add_common_flags)
 		)
 
 	# compiler specific flags
-	if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+	if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang") OR ("${CMAKE_CXX_COMPILER_ID}" MATCHES "AppleClang"))
 
 		# force color for clang (needed for clang + ccache)
 		add_compile_options(-fcolor-diagnostics)
+		# force absolute paths
+		add_compile_options(-fdiagnostics-absolute-paths)
 
 		# QuRT 6.4.X compiler identifies as Clang but does not support this option
 		if (NOT "${PX4_PLATFORM}" STREQUAL "qurt")

--- a/codecov.yml
+++ b/codecov.yml
@@ -24,7 +24,7 @@ comment:
   behavior: default
   require_changes: no
 
-# fixes:
-#     - "platforms/::./platforms/"
-#     - "src/::./src/"
-#     - "mavlink/::./mavlink/"
+ignore:
+  - "src/examples"
+  - "src/modules/attitude_estimator_q"
+  - "src/modules/local_position_estimator"

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,7 +4,7 @@ codecov:
 coverage:
   precision: 2
   round: down
-  range: "70...100"
+  range: "50...100"
 
   status:
     project: yes

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,30 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: no
+
+# fixes:
+#     - "platforms/::./platforms/"
+#     - "src/::./src/"
+#     - "mavlink/::./mavlink/"

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -747,7 +747,7 @@ void Simulator::run()
 
 			} else {
 				::close(_fd);
-				system_sleep(1);
+				system_usleep(100);
 			}
 		}
 

--- a/test/mavsdk_tests/CMakeLists.txt
+++ b/test/mavsdk_tests/CMakeLists.txt
@@ -14,6 +14,7 @@ if(MAVSDK_FOUND)
         autopilot_tester.cpp
         test_mission_multicopter.cpp
         test_mission_plane.cpp
+        test_mission_vtol.cpp
     )
 
     target_link_libraries(mavsdk_tests

--- a/test/mavsdk_tests/autopilot_tester.cpp
+++ b/test/mavsdk_tests/autopilot_tester.cpp
@@ -14,7 +14,7 @@ void AutopilotTester::connect(const std::string uri)
 
     std::cout << "Waiting for system connect" << std::endl;
     REQUIRE(poll_condition_with_timeout(
-        [this]() { return _mavsdk.is_connected(); }, std::chrono::seconds(10)));
+        [this]() { return _mavsdk.is_connected(); }, std::chrono::seconds(25)));
 
     auto& system = _mavsdk.system();
 
@@ -53,6 +53,18 @@ void AutopilotTester::takeoff()
 void AutopilotTester::land()
 {
     const auto result = _action->land();
+    REQUIRE(result == Action::Result::SUCCESS);
+}
+
+void AutopilotTester::transition_to_fixedwing()
+{
+    const auto result = _action->transition_to_fixedwing();
+    REQUIRE(result == Action::Result::SUCCESS);
+}
+
+void AutopilotTester::transition_to_multicopter()
+{
+    const auto result = _action->transition_to_multicopter();
     REQUIRE(result == Action::Result::SUCCESS);
 }
 

--- a/test/mavsdk_tests/autopilot_tester.h
+++ b/test/mavsdk_tests/autopilot_tester.h
@@ -26,6 +26,8 @@ public:
     void arm();
     void takeoff();
     void land();
+    void transition_to_fixedwing();
+    void transition_to_multicopter();
     void wait_until_disarmed();
     void wait_until_hovering();
     void prepare_square_mission(MissionOptions mission_options);

--- a/test/mavsdk_tests/mavsdk_test_runner.py
+++ b/test/mavsdk_tests/mavsdk_test_runner.py
@@ -8,6 +8,7 @@ import os
 import psutil
 import subprocess
 import sys
+import signal
 
 
 test_matrix = [
@@ -78,6 +79,13 @@ class Runner:
         returncode = self.process.poll()
         if returncode is not None:
             return returncode
+
+        print("Sending SIGINT to {}".format(self.process.pid))
+        self.process.send_signal(signal.SIGINT)
+        try:
+            return self.process.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            pass
 
         print("Terminating {}".format(self.process.pid))
         self.process.terminate()

--- a/test/mavsdk_tests/test_mission_plane.cpp
+++ b/test/mavsdk_tests/test_mission_plane.cpp
@@ -1,7 +1,7 @@
 //
-// Multicopter mission test.
+// Plane mission test.
 //
-// Author: Julian Oes <julian@oes.ch>
+// Author: Lorenz Meier <lorenz@px4.io>, Julian Oes <julian@oes.ch>
 
 #include <mavsdk/mavsdk.h>
 #include <mavsdk/plugins/action/action.h>
@@ -11,7 +11,7 @@
 #include "autopilot_tester.h"
 
 
-TEST_CASE("Takeoff and land (Plane)", "[plane]")
+TEST_CASE("Takeoff and land (plane)", "[plane]")
 {
     AutopilotTester tester;
     tester.connect(connection_url);
@@ -22,3 +22,36 @@ TEST_CASE("Takeoff and land (Plane)", "[plane]")
     tester.land();
     tester.wait_until_disarmed();
 }
+
+// TODO: Add land pattern
+
+// TEST_CASE("Fly square missions (plane)", "[plane]")
+// {
+//     AutopilotTester tester;
+//     tester.connect(connection_url);
+//     tester.wait_until_ready();
+
+//     SECTION("Mission including RTL (plane)") {
+//         AutopilotTester::MissionOptions mission_options;
+//         mission_options.leg_length_m = 250.0;
+//         mission_options.relative_altitude_m = 40.0;
+//         mission_options.rtl_at_end = true;
+//         tester.prepare_square_mission(mission_options);
+//         tester.arm();
+//         tester.execute_mission();
+//         tester.wait_until_disarmed();
+//     }
+
+//     SECTION("Mission with manual RTL (plane)") {
+//         AutopilotTester::MissionOptions mission_options;
+//         mission_options.leg_length_m = 250.0;
+//         mission_options.relative_altitude_m = 40.0;
+//         mission_options.rtl_at_end = false;
+//         tester.prepare_square_mission(mission_options);
+//         tester.arm();
+//         tester.execute_mission();
+//         tester.wait_until_hovering();
+//         tester.execute_rtl();
+//         tester.wait_until_disarmed();
+//     }
+// }

--- a/test/mavsdk_tests/test_mission_vtol.cpp
+++ b/test/mavsdk_tests/test_mission_vtol.cpp
@@ -1,0 +1,25 @@
+//
+// VTOL mission test.
+//
+// Author: Lorenz Meier <lorenz@px4.io>
+
+#include <mavsdk/mavsdk.h>
+#include <mavsdk/plugins/action/action.h>
+#include <mavsdk/plugins/telemetry/telemetry.h>
+#include <iostream>
+#include <string>
+#include "autopilot_tester.h"
+
+
+TEST_CASE("Takeoff, transition and RTL", "[vtol]")
+{
+    AutopilotTester tester;
+    tester.connect(connection_url);
+    tester.wait_until_ready();
+    tester.arm();
+    tester.takeoff();
+    tester.wait_until_hovering();
+    tester.transition_to_fixedwing();
+    tester.execute_rtl();
+    tester.wait_until_disarmed();
+}


### PR DESCRIPTION
This enables code coverage on the MAVSDK tests. We still need much tighter acceptance criteria there, but we're starting to form up a pipeline for integration testing that gives us real insights what is going on.