### PR TITLE
mission feasibilty check: fix for VTOL transition and land waypoint

### DIFF
--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -568,7 +568,7 @@ MissionFeasibilityChecker::checkVTOLLanding(const mission_s &mission, bool land_
 			}
 		}
 
-		if (missionitem.nav_cmd == NAV_CMD_LAND) {
+		if (missionitem.nav_cmd == NAV_CMD_LAND || missionitem.nav_cmd == NAV_CMD_VTOL_LAND) {
 			mission_item_s missionitem_previous {};
 
 			if (i > 0) {


### PR DESCRIPTION
Prior this fix VTOL missions get rejected if they have a DO_LAND_START marker, but then do
not end with a LAND but a VTOL transition and land.
