### PR TITLE
Enable VTOL transition test

### DIFF
--- a/test/mavsdk_tests/mavsdk_test_runner.py
+++ b/test/mavsdk_tests/mavsdk_test_runner.py
@@ -128,9 +128,11 @@ class GzserverRunner(Runner):
                     workspace_dir + "/build/px4_sitl_default/build_gazebo",
                     "GAZEBO_MODEL_PATH":
                     workspace_dir + "/Tools/sitl_gazebo/models",
-                    "PX4_SIM_SPEED_FACTOR": str(speed_factor)}
+                    "PX4_SIM_SPEED_FACTOR": str(speed_factor),
+                    "DISPLAY": os.environ['DISPLAY']}
         self.cmd = "gzserver"
-        self.args = [workspace_dir + "/Tools/sitl_gazebo/worlds/" +
+        self.args = ["--verbose",
+                     workspace_dir + "/Tools/sitl_gazebo/worlds/" +
                      model + ".world"]
         self.log_prefix = "gzserver"
 
@@ -144,8 +146,9 @@ class GzclientRunner(Runner):
                     # workspace_dir + "/build/px4_sitl_default/build_gazebo",
                     "GAZEBO_MODEL_PATH":
                     workspace_dir + "/Tools/sitl_gazebo/models",
-                    "DISPLAY": ":0"}
+                    "DISPLAY": os.environ['DISPLAY']}
         self.cmd = "gzclient"
+        self.args = ["--verbose"]
         self.log_prefix = "gzclient"
 
 

--- a/test/mavsdk_tests/mavsdk_test_runner.py
+++ b/test/mavsdk_tests/mavsdk_test_runner.py
@@ -17,11 +17,11 @@ test_matrix = [
         "test_filter": "[multicopter]",
         "timeout_min": 20,
     },
-    #{
-    #    "model": "standard_vtol",
-    #    "test_filter": "[vtol]",
-    #    "timeout_min": 20,
-    #},
+    {
+        "model": "standard_vtol",
+        "test_filter": "[vtol]",
+        "timeout_min": 20,
+    },
     # {
     #     "model": "standard_plane",
     #     "test_filter": "[plane]",

--- a/test/mavsdk_tests/mavsdk_test_runner.py
+++ b/test/mavsdk_tests/mavsdk_test_runner.py
@@ -23,7 +23,7 @@ test_matrix = [
         "timeout_min": 20,
     },
     # {
-    #     "model": "standard_plane",
+    #     "model": "plane",
     #     "test_filter": "[plane]",
     #     "timeout_min": 25,
     # }

--- a/test/mavsdk_tests/test_mission_vtol.cpp
+++ b/test/mavsdk_tests/test_mission_vtol.cpp
@@ -11,7 +11,7 @@
 #include "autopilot_tester.h"
 
 
-TEST_CASE("Takeoff, transition and RTL", "[vtol]")
+TEST_CASE("Takeoff and transition and RTL", "[vtol]")
 {
     AutopilotTester tester;
     tester.connect(connection_url);


### PR DESCRIPTION
This enables the VTOL transition test. All I changed was the TEST_CASE name which was not picked up by the catch2 filter correctly. It runs on my machine :man_shrugging:.