### PR TITLE
perf: latency add more buckets, print percentage, and average

### DIFF
--- a/src/lib/perf/perf_counter.h
+++ b/src/lib/perf/perf_counter.h
@@ -42,7 +42,7 @@
 #include <stdint.h>
 #include <px4_platform_common/defines.h>
 
-#define LATENCY_BUCKET_COUNT 8
+#define LATENCY_BUCKET_COUNT 14
 
 extern const uint16_t latency_bucket_count;
 extern const uint16_t latency_buckets[LATENCY_BUCKET_COUNT];


### PR DESCRIPTION
Add a bit more granularity to perf latency and slightly better output (percentages and average).

``` Console
nsh> perf latency
bucket [us] : events
          1 : 19437 (93.70 %)
          2 : 303 (1.46 %)
          3 : 208 (1.00 %)
          4 : 82 (0.39 %)
          5 : 70 (0.33 %)
         10 : 486 (2.34 %)
         20 : 158 (0.76 %)
         30 : 1 (0.00 %)
         40 : 0 (0.00 %)
         50 : 0 (0.00 %)
        100 : 0 (0.00 %)
        200 : 0 (0.00 %)
        500 : 0 (0.00 %)
       1000 : 0 (0.00 %)
 >1000 : 0
Average : 1.420 us
```