### PR TITLE
cdev: reduce open count (uint16_t -> uint8_t)

### DIFF
--- a/src/lib/cdev/CDev.hpp
+++ b/src/lib/cdev/CDev.hpp
@@ -289,7 +289,7 @@ private:
 	bool		_registered{false};		/**< true if device name was registered */
 
 	uint8_t		_max_pollwaiters{0};		/**< size of the _pollset array */
-	uint16_t	_open_count{0};			/**< number of successful opens */
+	uint8_t		_open_count{0};			/**< number of successful opens */
 
 	/**
 	 * Store a pollwaiter in a slot where we can find it later.


### PR DESCRIPTION
The vast majority of orb subscriptions (uORB::Subscription) aren't even technically a cdev open, so I would guess the max cdev open count on any current PX4 system would be single digits.