### PR TITLE
Flow mockup

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/1017_iris_opt_flow_mockup
+++ b/ROMFS/px4fmu_common/init.d-posix/1017_iris_opt_flow_mockup
@@ -11,8 +11,6 @@ if [ $AUTOCNF = yes ]
 then
 	# EKF2
 	param set EKF2_AID_MASK 2
-	param set EKF2_EVP_NOISE 0.05
-	param set EKF2_EVA_NOISE 0.05
 	param set SENS_FLOW_ROT 0
 
 	# LPE: Flow-only mode

--- a/ROMFS/px4fmu_common/init.d-posix/1017_iris_opt_flow_mockup
+++ b/ROMFS/px4fmu_common/init.d-posix/1017_iris_opt_flow_mockup
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+# @name 3DR Iris Quadrotor SITL (Optical Flow)
+#
+# @type Quadrotor Wide
+#
+
+sh /etc/init.d-posix/10016_iris
+
+if [ $AUTOCNF = yes ]
+then
+	# EKF2
+	param set EKF2_AID_MASK 2
+	param set EKF2_EVP_NOISE 0.05
+	param set EKF2_EVA_NOISE 0.05
+	param set SENS_FLOW_ROT 0
+
+	# LPE: Flow-only mode
+	param set LPE_FUSION 242
+	param set LPE_FAKE_ORIGIN 1
+
+	param set MPC_ALT_MODE 2
+fi

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -61,7 +61,7 @@ ExternalProject_Add(mavsdk_tests
 set(viewers none jmavsim gazebo)
 set(debuggers none ide gdb lldb ddd valgrind callgrind)
 set(models none shell
-	if750a iris iris_opt_flow iris_vision iris_rplidar iris_irlock iris_obs_avoid iris_rtps solo typhoon_h480
+	if750a iris iris_opt_flow iris_opt_flow_mockup iris_vision iris_rplidar iris_irlock iris_obs_avoid iris_rtps solo typhoon_h480
 	plane
 	standard_vtol tailsitter tiltrotor
 	hippocampus rover)


### PR DESCRIPTION
This PR adds a mockup optical flow model, that computes a flow measurement without rendering an image.
This is useful for CI SITL tests, where we want to speed up the simulation. This is not possible with the existing image based optical flow plugin as it relies on the camera plugin.

SITL_gazebo: https://github.com/PX4/sitl_gazebo/pull/400