### PR TITLE
[BACKPORT] modalai_fc-v1 - 5a1c46deebbe38de35c7ab656ed78248e91eb850

### DIFF
--- a/boards/modalai/fc-v1/src/board_config.h
+++ b/boards/modalai/fc-v1/src/board_config.h
@@ -252,6 +252,10 @@
 
 /* HW has to large of R termination on ADC todo:change when HW value is chosen */
 
+#define HW_REV_VER_ADC_BASE STM32_ADC3_BASE
+
+#define SYSTEM_ADC_BASE STM32_ADC1_BASE
+
 #define BOARD_ADC_OPEN_CIRCUIT_V     (5.6f)
 
 /* HW Version and Revision drive signals Default to 1 to detect */


### PR DESCRIPTION
**Describe problem solved by this pull request**
Fixes issue with hardware detection by backporting commit: 5a1c46deebbe38de35c7ab656ed78248e91eb850

also picks up change from b30171ba8d9c02b42a9bf58ca6802e96b31d69cc

**Test data / coverage**
Tested on our Flight Core and VOXL-Flight hardware (didn't affect Flight Core initially as there were no resistors stuffed.... but VOXL-Flight does have sense resistors and the detection was hit and miss)

I didn't touch the ADC_CHANNELS array (like the FMUv5x commit), as we use this in our bench testing via adc_test.