### PR TITLE
Cosmetic changes to navigator_params

### DIFF
--- a/src/modules/navigator/navigator_params.c
+++ b/src/modules/navigator/navigator_params.c
@@ -139,9 +139,9 @@ PARAM_DEFINE_INT32(NAV_TRAFF_AVOID, 1);
 PARAM_DEFINE_FLOAT(NAV_TRAFF_A_RADM, 500);
 
 /**
- * Set avoidance radius/distance for umanned vehicles (UTM_GLOBAL_POSITION).
+ * Set avoidance radius/distance for unmanned vehicles (UTM_GLOBAL_POSITION).
  *
- * Defines the avoidance radius/distance at which the avoidance action is triggered for umanned vehicles (UTM_GLOBAL_POSITION).
+ * Defines the avoidance radius/distance at which the avoidance action is triggered for unmanned vehicles (UTM_GLOBAL_POSITION).
  *
  * @unit m
  * @min 10

--- a/src/modules/navigator/navigator_params.c
+++ b/src/modules/navigator/navigator_params.c
@@ -128,28 +128,24 @@ PARAM_DEFINE_FLOAT(NAV_MC_ALT_RAD, 0.8f);
 PARAM_DEFINE_INT32(NAV_TRAFF_AVOID, 1);
 
 /**
- * Set NAV TRAFFIC AVOID RADIUS MANNED
+ * Set avoidance radius/distance for manned vehicles (ADS-B/FLARM).
  *
- * Defines the Radius where NAV TRAFFIC AVOID is Called
- * For Manned Aviation
+ * Defines the avoidance radius/distance at which the avoidance action is triggered for manned vehicles (ADS-B/FLARM).
  *
  * @unit m
  * @min 500
- *
  * @group Mission
  */
 PARAM_DEFINE_FLOAT(NAV_TRAFF_A_RADM, 500);
 
 /**
- * Set NAV TRAFFIC AVOID RADIUS
+ * Set avoidance radius/distance for umanned vehicles (UTM_GLOBAL_POSITION).
  *
- * Defines the Radius where NAV TRAFFIC AVOID is Called
- * For Unmanned Aviation
+ * Defines the avoidance radius/distance at which the avoidance action is triggered for umanned vehicles (UTM_GLOBAL_POSITION).
  *
  * @unit m
  * @min 10
  * @max 500
- *
  * @group Mission
  */
 PARAM_DEFINE_FLOAT(NAV_TRAFF_A_RADU, 10);


### PR DESCRIPTION
As per @hamishwillee  suggestion from this PR: #13159 .


Maybe we should add, that Unmanned collision avoidance is ONLY and ALWAYS triggered if a UTM_Globalposition message is received.

Eg. the Two Failure Cases:
-Manned aviation that sends UTM_Global_position is detected (as Unmanned)
   If it has both Mavlink and ADSB it will be received twice.
-Unmanned aviation that does not send UTM_Global_position is not.
(UTM_Global_Position also needs to be received by mavlink on the Drone)

#13159 