### PR TITLE
logger: choose logged instances by logger_topics file

### DIFF
--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -227,10 +227,11 @@ int LoggedTopics::add_topics_from_file(const char *fname)
 			continue;
 		}
 
-		// read line with format: <topic_name>[, <interval>]
+		// read line with format: <topic_name>[ <interval>[ <instance>]]
 		char topic_name[80];
 		uint32_t interval_ms = 0;
-		int nfields = sscanf(line, "%s %u", topic_name, &interval_ms);
+		uint32_t instance = 0;
+		int nfields = sscanf(line, "%s %u %u", topic_name, &interval_ms, &instance);
 
 		if (nfields > 0) {
 			int name_len = strlen(topic_name);
@@ -240,7 +241,8 @@ int LoggedTopics::add_topics_from_file(const char *fname)
 			}
 
 			/* add topic with specified interval_ms */
-			if (add_topic(topic_name, interval_ms)) {
+			if ((nfields > 2 && add_topic(topic_name, interval_ms, instance))
+			    || add_topic_multi(topic_name, interval_ms)) {
 				ntopics++;
 
 			} else {


### PR DESCRIPTION
New logger versions do not allow to log multiple instances of a topic when using 'logger_topics.txt'

This commit restores the previous behavior (log all instances of a topic) and add an option to specify an instance to log

Tested with default (all instances) and a specific instance