### PR TITLE
jMAVSim: warn if not Java 8 is used, select Java 8 in setup script

### DIFF
--- a/Tools/jmavsim_run.sh
+++ b/Tools/jmavsim_run.sh
@@ -66,6 +66,12 @@ if [ "$(uname)" == "Darwin" ]; then
         exit 1
     fi
     export JAVA_HOME=`/usr/libexec/java_home -v 1.8`
+elif [ "$(uname)" == "Linux" ]; then
+    if ! java -version 2>&1 | grep --quiet "1.8" ; then
+        echo "${bold}You need to use Java 8, for more info, see:${normal}"
+        echo "${bold}https://dev.px4.io/master/en/simulation/jmavsim.html#ubuntu${normal}"
+        exit 1
+    fi
 fi
 
 ant create_run_jar copy_res

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -172,12 +172,15 @@ if [[ $INSTALL_SIM == "true" ]]; then
 	echo
 	echo "Installing PX4 simulation dependencies"
 
-	# java (jmavsim or fastrtps)
+	# Java 8 (jmavsim or fastrtps)
 	sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
 		ant \
 		openjdk-8-jre \
 		openjdk-8-jdk \
 		;
+
+    # Set Java 8 as default
+    sudo update-alternatives --set java $(update-alternatives --list java | grep "java-8")
 
 	# Gazebo
 	sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'


### PR DESCRIPTION
This adds a check before running jMAVSim if Java 8 is selected.

It also selects Java 8 by default in the Ubuntu setup script.

Fixes https://github.com/PX4/Devguide/issues/926.