### PR TITLE
Honour PYTHON_EXECUTABLE environment variable pass to cmake #14077

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,11 @@ else
 
 endif
 
+# Pick up specific Python path if set
+ifdef PYTHON_EXECUTABLE
+	CMAKE_ARGS += -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}
+endif
+
 # Functions
 # --------------------------------------------------------------------
 # describe how to build a cmake config


### PR DESCRIPTION
Currently there is no way to specify which version of python you want to build px4 with.  It will pick up the first instance of python/python3 found in the path.

If the manual build process used cmake we could pass -DPYTHON_EXECUTABLE but because there is a make wrapper we can't do that.  This PR adds to the Makefile to pass PYTHON_EXECUTABLE if environment variable is set.

