### PR TITLE
SBUS on Linux: replace termios with termios2

### DIFF
--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
@@ -79,6 +79,7 @@ static constexpr wq_config_t UART5{"wq:UART5", 1400, -21};
 static constexpr wq_config_t UART6{"wq:UART6", 1400, -22};
 static constexpr wq_config_t UART7{"wq:UART7", 1400, -23};
 static constexpr wq_config_t UART8{"wq:UART8", 1400, -24};
+static constexpr wq_config_t UART_CUSTOM{"wq:UART_CUSTOM", 1400, -25};
 
 static constexpr wq_config_t lp_default{"wq:lp_default", 1700, -50};
 

--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
@@ -79,7 +79,7 @@ static constexpr wq_config_t UART5{"wq:UART5", 1400, -21};
 static constexpr wq_config_t UART6{"wq:UART6", 1400, -22};
 static constexpr wq_config_t UART7{"wq:UART7", 1400, -23};
 static constexpr wq_config_t UART8{"wq:UART8", 1400, -24};
-static constexpr wq_config_t UART_CUSTOM{"wq:UART_CUSTOM", 1400, -25};
+static constexpr wq_config_t UART_UNKNOWN{"wq:UART_UNKNOWN", 1400, -25};
 
 static constexpr wq_config_t lp_default{"wq:lp_default", 1700, -50};
 

--- a/platforms/common/px4_work_queue/WorkQueueManager.cpp
+++ b/platforms/common/px4_work_queue/WorkQueueManager.cpp
@@ -196,9 +196,9 @@ serial_port_to_wq(const char *serial)
 		return wq_configurations::UART8;
 	}
 
-	PX4_ERR("unknown serial port: %s", serial);
+	PX4_DEBUG("custom serial port: %s", serial);
 
-	return wq_configurations::hp_default;
+	return wq_configurations::UART_CUSTOM;
 }
 
 static void *

--- a/platforms/common/px4_work_queue/WorkQueueManager.cpp
+++ b/platforms/common/px4_work_queue/WorkQueueManager.cpp
@@ -196,9 +196,9 @@ serial_port_to_wq(const char *serial)
 		return wq_configurations::UART8;
 	}
 
-	PX4_DEBUG("custom serial port: %s", serial);
+	PX4_DEBUG("unknown serial port: %s", serial);
 
-	return wq_configurations::UART_CUSTOM;
+	return wq_configurations::UART_UNKNOWN;
 }
 
 static void *

--- a/src/lib/rc/sbus.cpp
+++ b/src/lib/rc/sbus.cpp
@@ -153,12 +153,14 @@ sbus_init(const char *device, bool singlewire)
 int
 sbus_config(int sbus_fd, bool singlewire)
 {
+	int ret = -1;
+
 #if defined(__PX4_LINUX)
 
 	struct termios2 tio = {};
 
 	if (0 != ioctl(sbus_fd, TCGETS2, &tio)) {
-		return -1;
+		return ret;
 	}
 
 	/**
@@ -180,12 +182,11 @@ sbus_config(int sbus_fd, bool singlewire)
 	tio.c_cc[VTIME] = 0;
 
 	if (0 != ioctl(sbus_fd, TCSETS2, &tio)) {
-		return -1;
+		return ret;
 	}
 
-	return 0;
+	ret = 0;
 #else
-	int ret = -1;
 
 	if (sbus_fd >= 0) {
 		struct termios t;
@@ -205,16 +206,16 @@ sbus_config(int sbus_fd, bool singlewire)
 #endif
 		}
 
-		/* initialise the decoder */
-		partial_frame_count = 0;
-		last_rx_time = hrt_absolute_time();
-		sbus_frame_drops = 0;
-
 		ret = 0;
 	}
 
-	return ret;
 #endif
+	/* initialise the decoder */
+	partial_frame_count = 0;
+	last_rx_time = hrt_absolute_time();
+	sbus_frame_drops = 0;
+
+	return ret;
 }
 
 void

--- a/src/lib/rc/sbus.cpp
+++ b/src/lib/rc/sbus.cpp
@@ -41,7 +41,6 @@
 
 #include <fcntl.h>
 #include <unistd.h>
-#include <termios.h>
 #include <string.h>
 
 #ifdef TIOCSSINGLEWIRE
@@ -58,7 +57,9 @@ using namespace time_literals;
 
 #if defined(__PX4_LINUX)
 #include <sys/ioctl.h>
-#include <linux/serial_core.h>
+#include <asm-generic/termbits.h>
+#else
+#include <termios.h>
 #endif
 
 #define SBUS_START_SYMBOL	0x0f
@@ -153,52 +154,35 @@ int
 sbus_config(int sbus_fd, bool singlewire)
 {
 #if defined(__PX4_LINUX)
-	struct termios options;
 
-	if (tcgetattr(sbus_fd, &options) != 0) {
+	struct termios2 tio = {};
+
+	if (0 != ioctl(sbus_fd, TCGETS2, &tio)) {
 		return -1;
 	}
 
-	tcflush(sbus_fd, TCIFLUSH);
-	bzero(&options, sizeof(options));
+	/**
+	 * Setting serial port,8E2, non-blocking.100Kbps
+	 */
+	tio.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL
+			 | IXON);
+	tio.c_iflag |= (INPCK | IGNPAR);
+	tio.c_oflag &= ~OPOST;
+	tio.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
+	tio.c_cflag &= ~(CSIZE | CRTSCTS | PARODD | CBAUD);
+	/**
+	 * use BOTHER to specify speed directly in c_[io]speed member
+	 */
+	tio.c_cflag |= (CS8 | CSTOPB | CLOCAL | PARENB | BOTHER | CREAD);
+	tio.c_ispeed = 100000;
+	tio.c_ospeed = 100000;
+	tio.c_cc[VMIN] = 25;
+	tio.c_cc[VTIME] = 0;
 
-	options.c_cflag |= (CLOCAL | CREAD);
-	options.c_cflag &= ~CSIZE;
-	options.c_cflag |= CS8;
-	options.c_cflag |= PARENB;
-	options.c_cflag &= ~PARODD;
-	options.c_iflag |= INPCK;
-	options.c_cflag |= CSTOPB;
-
-	options.c_cc[VTIME] = 0;
-	options.c_cc[VMIN] = 0;
-
-	cfsetispeed(&options, B38400);
-	cfsetospeed(&options, B38400);
-
-	tcflush(sbus_fd, TCIFLUSH);
-
-	if ((tcsetattr(sbus_fd, TCSANOW, &options)) != 0) {
+	if (0 != ioctl(sbus_fd, TCSETS2, &tio)) {
 		return -1;
 	}
 
-	int baud = 100000;
-	struct serial_struct serials;
-
-	if ((ioctl(sbus_fd, TIOCGSERIAL, &serials)) < 0) {
-		return -1;
-	}
-
-	serials.flags = ASYNC_SPD_CUST;
-	serials.custom_divisor = serials.baud_base / baud;
-
-	if ((ioctl(sbus_fd, TIOCSSERIAL, &serials)) < 0) {
-		return -1;
-	}
-
-	ioctl(sbus_fd, TIOCGSERIAL, &serials);
-
-	tcflush(sbus_fd, TCIFLUSH);
 	return 0;
 #else
 	int ret = -1;


### PR DESCRIPTION
**Describe problem solved by this pull request**
Previous version of code could not set the serial device properly, which leads to incorrect read of `_rcs_buf`. This PR solves that problem.

**Describe your solution**
Code comes from existing `drivers/linux_sbus`, which works well.
A problem still exists that `rc_input` will report
`ERROR [px4_work_queue] unknown serial port: /dev/ttyAMA0`
for that customised ttyAMA0 is not defined which is necessary for function `px4::serial_port_to_wq()`

**Test data / coverage**
``````
pxh> rc_input status
INFO  [rc_input] Running
INFO  [rc_input] Max update rate: 250 Hz
INFO  [rc_input] Serial device: /dev/ttyAMA0
INFO  [rc_input] RC scan state: SBUS, locked: yes
INFO  [rc_input] CRSF Telemetry: no
INFO  [rc_input] SBUS frame drops: 0
rc_input: cycle time: 6006 events, 81508us elapsed, 13.57us avg, min 8us max 89us 5.316us rms
rc_input: publish interval: 1600 events, 14997.50us avg, min 11937us max 19990us 1733.078us rms
 input_rc_s
	timestamp: 4067569737  (0.008766 seconds ago)
	timestamp_last_signal: 4067569737
	channel_count: 18
	rssi: 255
	rc_lost_frame_count: 0
	rc_total_frame_count: 0
	rc_ppm_frame_length: 0
	values: [1512, 1509, 1934, 1522, 1094, 1094, 1514, 1514, 1094, 1094, 1094, 1094, 944, 944, 1514, 1514, 998, 998]
	rc_failsafe: False
	rc_lost: False
	input_source: 9
``````
