### PR TITLE
Replay: support dual gps replay

### DIFF
--- a/msg/ekf2_timestamps.msg
+++ b/msg/ekf2_timestamps.msg
@@ -15,7 +15,8 @@ int16 RELATIVE_TIMESTAMP_INVALID = 32767 # (0x7fff) If one of the relative times
 
 int16 airspeed_timestamp_rel
 int16 distance_sensor_timestamp_rel
-int16 gps_timestamp_rel
+int16 gps0_timestamp_rel
+int16 gps1_timestamp_rel
 int16 optical_flow_timestamp_rel
 int16 vehicle_air_data_timestamp_rel
 int16 vehicle_magnetometer_timestamp_rel

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -803,7 +803,8 @@ void Ekf2::Run()
 
 		ekf2_timestamps.airspeed_timestamp_rel = ekf2_timestamps_s::RELATIVE_TIMESTAMP_INVALID;
 		ekf2_timestamps.distance_sensor_timestamp_rel = ekf2_timestamps_s::RELATIVE_TIMESTAMP_INVALID;
-		ekf2_timestamps.gps_timestamp_rel = ekf2_timestamps_s::RELATIVE_TIMESTAMP_INVALID;
+		ekf2_timestamps.gps0_timestamp_rel = ekf2_timestamps_s::RELATIVE_TIMESTAMP_INVALID;
+		ekf2_timestamps.gps1_timestamp_rel = ekf2_timestamps_s::RELATIVE_TIMESTAMP_INVALID;
 		ekf2_timestamps.optical_flow_timestamp_rel = ekf2_timestamps_s::RELATIVE_TIMESTAMP_INVALID;
 		ekf2_timestamps.vehicle_air_data_timestamp_rel = ekf2_timestamps_s::RELATIVE_TIMESTAMP_INVALID;
 		ekf2_timestamps.vehicle_magnetometer_timestamp_rel = ekf2_timestamps_s::RELATIVE_TIMESTAMP_INVALID;
@@ -928,7 +929,7 @@ void Ekf2::Run()
 				fillGpsMsgWithVehicleGpsPosData(_gps_state[0], gps);
 				_gps_alttitude_ellipsoid[0] = gps.alt_ellipsoid;
 
-				ekf2_timestamps.gps_timestamp_rel = (int16_t)((int64_t)gps.timestamp / 100 - (int64_t)ekf2_timestamps.timestamp / 100);
+				ekf2_timestamps.gps0_timestamp_rel = (int16_t)((int64_t)gps.timestamp / 100 - (int64_t)ekf2_timestamps.timestamp / 100);
 			}
 		}
 
@@ -941,6 +942,8 @@ void Ekf2::Run()
 			if (_gps_subs[1].copy(&gps)) {
 				fillGpsMsgWithVehicleGpsPosData(_gps_state[1], gps);
 				_gps_alttitude_ellipsoid[1] = gps.alt_ellipsoid;
+
+				ekf2_timestamps.gps1_timestamp_rel = (int16_t)((int64_t)gps.timestamp / 100 - (int64_t)ekf2_timestamps.timestamp / 100);
 			}
 		}
 

--- a/src/modules/replay/ReplayEkf2.cpp
+++ b/src/modules/replay/ReplayEkf2.cpp
@@ -154,8 +154,8 @@ ReplayEkf2::publishEkf2Topics(const ekf2_timestamps_s &ekf2_timestamps, std::ifs
 
 	handle_sensor_publication(ekf2_timestamps.airspeed_timestamp_rel, _airspeed_msg_id);
 	handle_sensor_publication(ekf2_timestamps.distance_sensor_timestamp_rel, _distance_sensor_msg_id);
-	handle_sensor_publication(ekf2_timestamps.gps0_timestamp_rel, _gps_msg_id);
-	handle_sensor_publication(ekf2_timestamps.gps1_timestamp_rel, _gps_msg_id);
+	handle_sensor_publication(ekf2_timestamps.gps0_timestamp_rel, _gps0_msg_id);
+	handle_sensor_publication(ekf2_timestamps.gps1_timestamp_rel, _gps1_msg_id);
 	handle_sensor_publication(ekf2_timestamps.optical_flow_timestamp_rel, _optical_flow_msg_id);
 	handle_sensor_publication(ekf2_timestamps.vehicle_air_data_timestamp_rel, _vehicle_air_data_msg_id);
 	handle_sensor_publication(ekf2_timestamps.vehicle_magnetometer_timestamp_rel, _vehicle_magnetometer_msg_id);

--- a/src/modules/replay/ReplayEkf2.cpp
+++ b/src/modules/replay/ReplayEkf2.cpp
@@ -95,8 +95,7 @@ ReplayEkf2::handleTopicUpdate(Subscription &sub, void *data, std::ifstream &repl
 
 		return true;
 
-	} else if (sub.orb_meta == ORB_ID(vehicle_status) || sub.orb_meta == ORB_ID(vehicle_land_detected)
-		   || sub.orb_meta == ORB_ID(vehicle_gps_position)) {
+	} else if (sub.orb_meta == ORB_ID(vehicle_status) || sub.orb_meta == ORB_ID(vehicle_land_detected)) {
 		return publishTopic(sub, data);
 	} // else: do not publish
 
@@ -117,7 +116,10 @@ ReplayEkf2::onSubscriptionAdded(Subscription &sub, uint16_t msg_id)
 
 	} else if (sub.orb_meta == ORB_ID(vehicle_gps_position)) {
 		if (sub.multi_id == 0) {
-			_gps_msg_id = msg_id;
+			_gps0_msg_id = msg_id;
+
+		} else {
+			_gps1_msg_id = msg_id;
 		}
 
 	} else if (sub.orb_meta == ORB_ID(optical_flow)) {
@@ -136,8 +138,7 @@ ReplayEkf2::onSubscriptionAdded(Subscription &sub, uint16_t msg_id)
 	// the main loop should only handle publication of the following topics, the sensor topics are
 	// handled separately in publishEkf2Topics()
 	sub.ignored = sub.orb_meta != ORB_ID(ekf2_timestamps) && sub.orb_meta != ORB_ID(vehicle_status)
-		      && sub.orb_meta != ORB_ID(vehicle_land_detected) &&
-		      (sub.orb_meta != ORB_ID(vehicle_gps_position) || sub.multi_id == 0);
+		      && sub.orb_meta != ORB_ID(vehicle_land_detected);
 }
 
 bool
@@ -153,7 +154,8 @@ ReplayEkf2::publishEkf2Topics(const ekf2_timestamps_s &ekf2_timestamps, std::ifs
 
 	handle_sensor_publication(ekf2_timestamps.airspeed_timestamp_rel, _airspeed_msg_id);
 	handle_sensor_publication(ekf2_timestamps.distance_sensor_timestamp_rel, _distance_sensor_msg_id);
-	handle_sensor_publication(ekf2_timestamps.gps_timestamp_rel, _gps_msg_id);
+	handle_sensor_publication(ekf2_timestamps.gps0_timestamp_rel, _gps_msg_id);
+	handle_sensor_publication(ekf2_timestamps.gps1_timestamp_rel, _gps_msg_id);
 	handle_sensor_publication(ekf2_timestamps.optical_flow_timestamp_rel, _optical_flow_msg_id);
 	handle_sensor_publication(ekf2_timestamps.vehicle_air_data_timestamp_rel, _vehicle_air_data_msg_id);
 	handle_sensor_publication(ekf2_timestamps.vehicle_magnetometer_timestamp_rel, _vehicle_magnetometer_msg_id);
@@ -234,7 +236,8 @@ ReplayEkf2::onExitMainLoop()
 
 	print_sensor_statistics(_airspeed_msg_id, "airspeed");
 	print_sensor_statistics(_distance_sensor_msg_id, "distance_sensor");
-	print_sensor_statistics(_gps_msg_id, "vehicle_gps_position");
+	print_sensor_statistics(_gps0_msg_id, "vehicle_gps_position_0");
+	print_sensor_statistics(_gps1_msg_id, "vehicle_gps_position_1");
 	print_sensor_statistics(_optical_flow_msg_id, "optical_flow");
 	print_sensor_statistics(_sensor_combined_msg_id, "sensor_combined");
 	print_sensor_statistics(_vehicle_air_data_msg_id, "vehicle_air_data");

--- a/src/modules/replay/ReplayEkf2.hpp
+++ b/src/modules/replay/ReplayEkf2.hpp
@@ -82,7 +82,8 @@ private:
 
 	uint16_t _airspeed_msg_id = msg_id_invalid;
 	uint16_t _distance_sensor_msg_id = msg_id_invalid;
-	uint16_t _gps_msg_id = msg_id_invalid;
+	uint16_t _gps0_msg_id = msg_id_invalid;
+	uint16_t _gps1_msg_id = msg_id_invalid;
 	uint16_t _optical_flow_msg_id = msg_id_invalid;
 	uint16_t _sensor_combined_msg_id = msg_id_invalid;
 	uint16_t _vehicle_air_data_msg_id = msg_id_invalid;


### PR DESCRIPTION
**Describe problem solved by this pull request**
Support secondary GPS module in ekf2 replay. Solves https://github.com/PX4/Firmware/issues/13953.

**Describe your solution**
Add relative timestamps to secondary GPS and handle it as any other sensor

**Describe possible alternatives**
According to [this PR](https://github.com/PX4/Firmware/pull/9433) support for a second GPS module was already added but I don't understand how it could have been working properly prior to this PR

**Test data / coverage**
Code has been tested on code similar to v1.10.1

**Additional context**
This code treats the secondary GPS module in the same way as the primary one. It does not solve the second issue mentioned in the issue above related to timeouts.
