### PR TITLE
CBRK_AIRSPD_CHK: Doc driver not started

### DIFF
--- a/src/lib/circuit_breaker/circuit_breaker_params.c
+++ b/src/lib/circuit_breaker/circuit_breaker_params.c
@@ -90,6 +90,7 @@ PARAM_DEFINE_INT32(CBRK_IO_SAFETY, 0);
  * Circuit breaker for airspeed sensor
  *
  * Setting this parameter to 162128 will disable the check for an airspeed sensor.
+ * The sensor driver will not be started and it cannot be calibrated.
  * WARNING: ENABLING THIS CIRCUIT BREAKER IS AT OWN RISK
  *
  * @reboot_required true


### PR DESCRIPTION
Fixes https://github.com/PX4/Firmware/issues/14053

Clarifies that driver not started when circuit breaker enabled. A feature, as described in https://github.com/PX4/Firmware/issues/14053#issuecomment-580556456