### PR TITLE
change topic name for the multiple agents

### DIFF
--- a/msg/templates/urtps/Publisher.cpp.em
+++ b/msg/templates/urtps/Publisher.cpp.em
@@ -80,7 +80,7 @@ except AttributeError:
 
 @(topic)_Publisher::~@(topic)_Publisher() { Domain::removeParticipant(mp_participant);}
 
-bool @(topic)_Publisher::init()
+bool @(topic)_Publisher::init(int sys_id)
 {
     // Create RTPSParticipant
     ParticipantAttributes PParam;
@@ -109,15 +109,23 @@ bool @(topic)_Publisher::init()
     PublisherAttributes Wparam;
     Wparam.topic.topicKind = NO_KEY;
     Wparam.topic.topicDataType = @(topic)DataType.getName();
+    std::string topicName;
+    if ( sys_id == 0 ) {
+        topicName = std::string("@(topic)_PubSubTopic");
+    }
+    else {
+        topicName = std::string("agent") + std::to_string(sys_id)+ std::string("/@(topic)_PubSubTopic");
+    }
+
 @[if ros2_distro]@
 @[    if ros2_distro == "ardent"]@
     Wparam.qos.m_partition.push_back("rt");
-    Wparam.topic.topicName = "@(topic)_PubSubTopic";
+    Wparam.topic.topicName = topicName;
 @[    else]@
-    Wparam.topic.topicName = "rt/@(topic)_PubSubTopic";
+    Wparam.topic.topicName = std::string("rt/") + topicName;
 @[    end if]@
 @[else]@
-    Wparam.topic.topicName = "@(topic)_PubSubTopic";
+    Wparam.topic.topicName = std::string("rt/") + topicName;
 @[end if]@
     mp_publisher = Domain::createPublisher(mp_participant, Wparam, static_cast<PublisherListener*>(&m_listener));
     if(mp_publisher == nullptr)

--- a/msg/templates/urtps/Publisher.h.em
+++ b/msg/templates/urtps/Publisher.h.em
@@ -82,7 +82,7 @@ class @(topic)_Publisher
 public:
     @(topic)_Publisher();
     virtual ~@(topic)_Publisher();
-    bool init();
+    bool init(int sys_id=0);
     void run();
 @[if 1.5 <= fastrtpsgen_version <= 1.7]@
 @[    if ros2_distro]@

--- a/msg/templates/urtps/RtpsTopics.cpp.em
+++ b/msg/templates/urtps/RtpsTopics.cpp.em
@@ -61,7 +61,7 @@ except AttributeError:
 
 #include "RtpsTopics.h"
 
-bool RtpsTopics::init(std::condition_variable* t_send_queue_cv, std::mutex* t_send_queue_mutex, std::queue<uint8_t>* t_send_queue)
+bool RtpsTopics::init(std::condition_variable* t_send_queue_cv, std::mutex* t_send_queue_mutex, std::queue<uint8_t>* t_send_queue, uint8_t sys_id)
 {
 @[if recv_topics]@
     // Initialise subscribers
@@ -81,7 +81,7 @@ bool RtpsTopics::init(std::condition_variable* t_send_queue_cv, std::mutex* t_se
     // Initialise publishers
     std::cout << "---- Publishers ----" << std::endl;
 @[for topic in send_topics]@
-    if (_@(topic)_pub.init()) {
+    if (_@(topic)_pub.init(sys_id)) {
         std::cout << "- @(topic) publisher started" << std::endl;
     } else {
         std::cerr << "ERROR starting @(topic) publisher" << std::endl;

--- a/msg/templates/urtps/RtpsTopics.h.em
+++ b/msg/templates/urtps/RtpsTopics.h.em
@@ -66,7 +66,7 @@ recv_topics = [(alias[idx] if alias[idx] else s.short_name) for idx, s in enumer
 
 class RtpsTopics {
 public:
-    bool init(std::condition_variable* t_send_queue_cv, std::mutex* t_send_queue_mutex, std::queue<uint8_t>* t_send_queue);
+    bool init(std::condition_variable* t_send_queue_cv, std::mutex* t_send_queue_mutex, std::queue<uint8_t>* t_send_queue, uint8_t sys_id);
 @[if send_topics]@
     void publish(uint8_t topic_ID, char data_buffer[], size_t len);
 @[end if]@

--- a/msg/templates/urtps/microRTPS_agent.cpp.em
+++ b/msg/templates/urtps/microRTPS_agent.cpp.em
@@ -254,7 +254,7 @@ int main(int argc, char** argv)
 @[end if]@
 
 @[if recv_topics]@
-    topics.init(&t_send_queue_cv, &t_send_queue_mutex, &t_send_queue);
+    bool inited = false;
 @[end if]@
 
     running = true;
@@ -270,6 +270,12 @@ int main(int argc, char** argv)
         // Publish messages received from UART
         while (0 < (length = transport_node->read(&topic_ID, data_buffer, BUFFER_SIZE)))
         {
+            @[if recv_topics]@
+            if (!inited) {
+                inited = topics.init(&t_send_queue_cv, &t_send_queue_mutex, &t_send_queue, transport_node->get_sysid());
+            }
+            @[end if]@
+
             topics.publish(topic_ID, data_buffer, sizeof(data_buffer));
             ++received;
             total_read += length;

--- a/msg/templates/urtps/microRTPS_transport.cpp
+++ b/msg/templates/urtps/microRTPS_transport.cpp
@@ -165,6 +165,9 @@ ssize_t Transport_node::read(uint8_t *topic_ID, char out_buffer[], size_t buffer
 	struct Header *header = (struct Header *)&rx_buffer[msg_start_pos];
 	uint32_t payload_len = ((uint32_t)header->payload_len_h << 8) | header->payload_len_l;
 
+	// set sys id
+	this->set_sysid(header->sys_ID);
+
 	// The message won't fit the buffer.
 	if (buffer_len < header_size + payload_len) {
 		return -EMSGSIZE;
@@ -231,6 +234,7 @@ ssize_t Transport_node::write(const uint8_t topic_ID, char buffer[], size_t leng
 	uint16_t crc = crc16((uint8_t *)&buffer[sizeof(header)], length);
 
 	header.topic_ID = topic_ID;
+	header.sys_ID = this->get_sysid();
 	header.seq = seq++;
 	header.payload_len_h = (length >> 8) & 0xff;
 	header.payload_len_l = length & 0xff;

--- a/msg/templates/urtps/microRTPS_transport.h
+++ b/msg/templates/urtps/microRTPS_transport.h
@@ -44,6 +44,8 @@ public:
 	Transport_node();
 	virtual ~Transport_node();
 
+	void set_sysid(uint8_t id) {sys_id = id;}
+	uint8_t get_sysid() {return sys_id;}
 	virtual int init() {return 0;}
 	virtual uint8_t close() {return 0;}
 	ssize_t read(uint8_t *topic_ID, char out_buffer[], size_t buffer_len);
@@ -75,11 +77,13 @@ protected:
 protected:
 	uint32_t rx_buff_pos;
 	char rx_buffer[1024] = {};
+	uint8_t sys_id;
 
 private:
 	struct __attribute__((packed)) Header {
 		char marker[3];
 		uint8_t topic_ID;
+		uint8_t sys_ID;
 		uint8_t seq;
 		uint8_t payload_len_h;
 		uint8_t payload_len_l;

--- a/msg/tools/generate_microRTPS_bridge.py
+++ b/msg/tools/generate_microRTPS_bridge.py
@@ -253,7 +253,7 @@ else:
 ros2_distro = ""
 try:
     rosversion_out = subprocess.check_output(["rosversion", "-d"])
-    rosversion_out = rosversion_out.rstrip()
+    rosversion_out = rosversion_out.rstrip().decode('utf-8')
     if rosversion_out not in ["<unknown>", "kinetic", "lunar", "melodic"]:
         ros2_distro = rosversion_out
 except OSError as e:

--- a/src/modules/micrortps_bridge/micrortps_client/microRTPS_client_main.cpp
+++ b/src/modules/micrortps_bridge/micrortps_client/microRTPS_client_main.cpp
@@ -47,6 +47,7 @@
 #include <px4_platform_common/posix.h>
 #include <px4_platform_common/tasks.h>
 #include <px4_platform_common/time.h>
+#include <px4_platform_common/module_params.h>
 
 extern "C" __EXPORT int micrortps_client_main(int argc, char *argv[]);
 
@@ -149,6 +150,11 @@ static int micrortps_start(int argc, char *argv[])
 		_rtps_task = -1;
 		return -1;
 	}
+
+	int32_t sys_id;
+	param_t sys_id_param = param_find("MAV_SYS_ID");
+	param_get(sys_id_param, &sys_id);
+	transport_node->set_sysid(sys_id);
 
 	struct timespec begin;
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
When I use RTPS for the multiple drones, I found each drone has the same topic name.
 
**Describe your solution**
To distinguish the topic name, I attached the "agent" with the sys ID.
For the backward compatibility, if the sys ID does not set, the topic name is the same as before  

Thanks 
SungTae Moon