### PR TITLE
replay: remove GPS relative timestamps

### DIFF
--- a/msg/ekf2_timestamps.msg
+++ b/msg/ekf2_timestamps.msg
@@ -15,7 +15,6 @@ int16 RELATIVE_TIMESTAMP_INVALID = 32767 # (0x7fff) If one of the relative times
 
 int16 airspeed_timestamp_rel
 int16 distance_sensor_timestamp_rel
-int16 gps_timestamp_rel
 int16 optical_flow_timestamp_rel
 int16 vehicle_air_data_timestamp_rel
 int16 vehicle_magnetometer_timestamp_rel

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -804,7 +804,6 @@ void Ekf2::Run()
 
 		ekf2_timestamps.airspeed_timestamp_rel = ekf2_timestamps_s::RELATIVE_TIMESTAMP_INVALID;
 		ekf2_timestamps.distance_sensor_timestamp_rel = ekf2_timestamps_s::RELATIVE_TIMESTAMP_INVALID;
-		ekf2_timestamps.gps_timestamp_rel = ekf2_timestamps_s::RELATIVE_TIMESTAMP_INVALID;
 		ekf2_timestamps.optical_flow_timestamp_rel = ekf2_timestamps_s::RELATIVE_TIMESTAMP_INVALID;
 		ekf2_timestamps.vehicle_air_data_timestamp_rel = ekf2_timestamps_s::RELATIVE_TIMESTAMP_INVALID;
 		ekf2_timestamps.vehicle_magnetometer_timestamp_rel = ekf2_timestamps_s::RELATIVE_TIMESTAMP_INVALID;
@@ -928,8 +927,6 @@ void Ekf2::Run()
 			if (_gps_subs[0].copy(&gps)) {
 				fillGpsMsgWithVehicleGpsPosData(_gps_state[0], gps);
 				_gps_alttitude_ellipsoid[0] = gps.alt_ellipsoid;
-
-				ekf2_timestamps.gps_timestamp_rel = (int16_t)((int64_t)gps.timestamp / 100 - (int64_t)ekf2_timestamps.timestamp / 100);
 			}
 		}
 

--- a/src/modules/replay/ReplayEkf2.cpp
+++ b/src/modules/replay/ReplayEkf2.cpp
@@ -115,11 +115,6 @@ ReplayEkf2::onSubscriptionAdded(Subscription &sub, uint16_t msg_id)
 	} else if (sub.orb_meta == ORB_ID(distance_sensor)) {
 		_distance_sensor_msg_id = msg_id;
 
-	} else if (sub.orb_meta == ORB_ID(vehicle_gps_position)) {
-		if (sub.multi_id == 0) {
-			_gps_msg_id = msg_id;
-		}
-
 	} else if (sub.orb_meta == ORB_ID(optical_flow)) {
 		_optical_flow_msg_id = msg_id;
 
@@ -135,9 +130,9 @@ ReplayEkf2::onSubscriptionAdded(Subscription &sub, uint16_t msg_id)
 
 	// the main loop should only handle publication of the following topics, the sensor topics are
 	// handled separately in publishEkf2Topics()
+	// Note: the GPS is not treated here since not missing data is more important than the accuracy of the timestamp
 	sub.ignored = sub.orb_meta != ORB_ID(ekf2_timestamps) && sub.orb_meta != ORB_ID(vehicle_status)
-		      && sub.orb_meta != ORB_ID(vehicle_land_detected) &&
-		      (sub.orb_meta != ORB_ID(vehicle_gps_position) || sub.multi_id == 0);
+		      && sub.orb_meta != ORB_ID(vehicle_land_detected) && sub.orb_meta != ORB_ID(vehicle_gps_position);
 }
 
 bool
@@ -153,7 +148,6 @@ ReplayEkf2::publishEkf2Topics(const ekf2_timestamps_s &ekf2_timestamps, std::ifs
 
 	handle_sensor_publication(ekf2_timestamps.airspeed_timestamp_rel, _airspeed_msg_id);
 	handle_sensor_publication(ekf2_timestamps.distance_sensor_timestamp_rel, _distance_sensor_msg_id);
-	handle_sensor_publication(ekf2_timestamps.gps_timestamp_rel, _gps_msg_id);
 	handle_sensor_publication(ekf2_timestamps.optical_flow_timestamp_rel, _optical_flow_msg_id);
 	handle_sensor_publication(ekf2_timestamps.vehicle_air_data_timestamp_rel, _vehicle_air_data_msg_id);
 	handle_sensor_publication(ekf2_timestamps.vehicle_magnetometer_timestamp_rel, _vehicle_magnetometer_msg_id);
@@ -234,7 +228,6 @@ ReplayEkf2::onExitMainLoop()
 
 	print_sensor_statistics(_airspeed_msg_id, "airspeed");
 	print_sensor_statistics(_distance_sensor_msg_id, "distance_sensor");
-	print_sensor_statistics(_gps_msg_id, "vehicle_gps_position");
 	print_sensor_statistics(_optical_flow_msg_id, "optical_flow");
 	print_sensor_statistics(_sensor_combined_msg_id, "sensor_combined");
 	print_sensor_statistics(_vehicle_air_data_msg_id, "vehicle_air_data");

--- a/src/modules/replay/ReplayEkf2.hpp
+++ b/src/modules/replay/ReplayEkf2.hpp
@@ -82,7 +82,6 @@ private:
 
 	uint16_t _airspeed_msg_id = msg_id_invalid;
 	uint16_t _distance_sensor_msg_id = msg_id_invalid;
-	uint16_t _gps_msg_id = msg_id_invalid;
 	uint16_t _optical_flow_msg_id = msg_id_invalid;
 	uint16_t _sensor_combined_msg_id = msg_id_invalid;
 	uint16_t _vehicle_air_data_msg_id = msg_id_invalid;


### PR DESCRIPTION
Replaces https://github.com/PX4/Firmware/pull/14092

**Describe problem solved by this pull request**
Solves original issue reported [here](https://github.com/PX4/Firmware/issues/13953)

**Describe your solution**
Remove relative timestamps of GPS measurements. The benefit of this is that all GPS data that is logged will actually be published during EKF replay even if the ekf2_timestamps topic has dropouts. The downside is that the accuracy of the measurement timestamps is reduced slightly.

**Describe possible alternatives**
Publish the GPS data anyway if no relative timestamp is found during replay. The upside would be more accurate time stamping and the downside more data to log

**Tests**
Here are the relative timestamps of two GPS modules (logged in microseconds / 10)
![image](https://user-images.githubusercontent.com/7795133/73950912-0f5e8580-48fd-11ea-8915-34e1f860579d.png)
As can be seen the difference from the topic original timestamps is on average ~1 ms. This in comparison to the ~100 ms delay of the GPS measurements themselves should have minimal effect on the replay result. 

Here is the dt of the gps topic after replay, PR (top) vs master (bottom). As can be seen the dropouts are significantly reduced
![image](https://user-images.githubusercontent.com/7795133/73951474-d83ca400-48fd-11ea-98ed-84eb07985283.png)

And here is the selected GPS module, as can be seen the GPS timeout is no longer triggered in the replayed logfile
![image](https://user-images.githubusercontent.com/7795133/73951276-94499f00-48fd-11ea-854b-57b3608c01e9.png)

The PR has been tested on code similar to v1.10.1

Thanks @bkueng for the discussion!
