### PR TITLE
ist8310: remove calibration code

### DIFF
--- a/boards/av/x-v1/init/rc.board_sensors
+++ b/boards/av/x-v1/init/rc.board_sensors
@@ -20,7 +20,7 @@ then
 fi
 
 # Possible external compasses
-ist8310 -C -b 1 start
-ist8310 -C -b 2 start
+ist8310 -b 1 start
+ist8310 -b 2 start
 hmc5883 -C -T -X start
 qmc5883 -X start

--- a/boards/holybro/durandal-v1/init/rc.board_sensors
+++ b/boards/holybro/durandal-v1/init/rc.board_sensors
@@ -14,14 +14,14 @@ bmi088 -A -R 10 start
 bmi088 -G -R 10 start
 
 # Possible external compasses
-ist8310 -C -b 1 start
-ist8310 -C -b 2 start
+ist8310 -b 1 start
+ist8310 -b 2 start
 hmc5883 -C -T -X start
 qmc5883 -X start
 lis3mdl -X start
 
 # Possible internal compass
-ist8310 -C -b 5 start
+ist8310 -b 5 start
 
 # Baro on internal SPI
 ms5611 -s start

--- a/boards/holybro/kakutef7/init/rc.board_sensors
+++ b/boards/holybro/kakutef7/init/rc.board_sensors
@@ -15,7 +15,7 @@ fi
 bmp280 start
 
 # Possible external compasses
-ist8310 -C -b 1 start
-ist8310 -C -b 2 start
+ist8310 -b 1 start
+ist8310 -b 2 start
 hmc5883 -C -T -X start
 qmc5883 -X start

--- a/boards/intel/aerofc-v1/init/rc.board_sensors
+++ b/boards/intel/aerofc-v1/init/rc.board_sensors
@@ -11,7 +11,7 @@ mpu9250 -s -R 14 start
 # Possible external compasses
 hmc5883 -X start
 
-ist8310 -C -b 1 -R 4 start
+ist8310 -b 1 -R 4 start
 
 ll40ls start i2c -a
 

--- a/boards/modalai/fc-v1/init/rc.board_sensors
+++ b/boards/modalai/fc-v1/init/rc.board_sensors
@@ -21,8 +21,8 @@ bmi088 -A -R 4 start
 bmi088 -G -R 4 start
 
 # Possible external compasses
-ist8310 -C -b 1 start
-ist8310 -C -b 2 start
+ist8310 -b 1 start
+ist8310 -b 2 start
 hmc5883 -C -T -X start
 qmc5883 -X start
 

--- a/boards/mro/ctrl-zero-f7/init/rc.board_sensors
+++ b/boards/mro/ctrl-zero-f7/init/rc.board_sensors
@@ -21,8 +21,8 @@ bmi088 -G -R 10 start
 dps310 -s start
 
 # Possible external compasses
-ist8310 -C -b 1 start
-ist8310 -C -b 2 start
+ist8310 -b 1 start
+ist8310 -b 2 start
 hmc5883 -C -T -X start
 qmc5883 -X start
 lis3mdl -X start

--- a/boards/mro/x21-777/init/rc.board_sensors
+++ b/boards/mro/x21-777/init/rc.board_sensors
@@ -8,7 +8,6 @@ adc start
 # External I2C bus
 hmc5883 -C -T -X start
 lis3mdl -X start
-ist8310 -C start
 
 # Internal SPI bus ICM-20608-G is rotated 90 deg yaw
 mpu6000 -R 2 -T 20608 start
@@ -20,8 +19,8 @@ mpu6000 -R 2 -T 20602 start
 mpu9250 -R 2 start
 
 # Possible external compasses
-ist8310 -C -b 1 start
-ist8310 -C -b 2 start
+ist8310 -b 1 start
+ist8310 -b 2 start
 hmc5883 -C -T -X start
 qmc5883 -X start
 lis3mdl -X start

--- a/boards/mro/x21/init/rc.board_sensors
+++ b/boards/mro/x21/init/rc.board_sensors
@@ -8,7 +8,7 @@ adc start
 # External I2C bus
 hmc5883 -C -T -X start
 lis3mdl -X start
-ist8310 -C start
+ist8310 start
 qmc5883 -X start
 
 # Internal SPI bus ICM-20608-G is rotated 90 deg yaw

--- a/boards/nxp/fmuk66-v3/init/rc.board_sensors
+++ b/boards/nxp/fmuk66-v3/init/rc.board_sensors
@@ -8,7 +8,7 @@ adc start
 # Possible external compasses
 hmc5883 -C -X start
 lis3mdl -X start
-ist8310 -C -b 1 start
+ist8310 -b 1 start
 qmc5883 -X start
 
 # Internal Mag I2C bus roll 180, yaw 90

--- a/boards/nxp/fmurt1062-v1/init/rc.board_sensors
+++ b/boards/nxp/fmurt1062-v1/init/rc.board_sensors
@@ -30,8 +30,8 @@ bmi055 -A -R 10 start
 bmi055 -G -R 10 start
 
 # Possible external compasses
-ist8310 -C -b 1 start
-ist8310 -C -b 2 start
+ist8310 -b 1 start
+ist8310 -b 2 start
 hmc5883 -C -T -X start
 qmc5883 -X start
 lis3mdl -X start
@@ -44,7 +44,7 @@ then
 fi
 
 # Possible internal compass
-ist8310 -C -b 5 start
+ist8310 -b 5 start
 
 # Baro on internal SPI
 ms5611 -s start

--- a/boards/px4/fmu-v2/init/rc.board_sensors
+++ b/boards/px4/fmu-v2/init/rc.board_sensors
@@ -8,7 +8,7 @@ adc start
 # External I2C bus
 hmc5883 -C -T -X start
 lis3mdl -X start
-ist8310 -C start
+ist8310 start
 
 # Internal I2C bus
 hmc5883 -C -T -I -R 4 start

--- a/boards/px4/fmu-v3/init/rc.board_sensors
+++ b/boards/px4/fmu-v3/init/rc.board_sensors
@@ -8,7 +8,7 @@ adc start
 # External I2C bus
 hmc5883 -C -T -X start
 lis3mdl -X start
-ist8310 -C start
+ist8310 start
 qmc5883 -X start
 
 # Internal I2C bus

--- a/boards/px4/fmu-v5/init/rc.board_sensors
+++ b/boards/px4/fmu-v5/init/rc.board_sensors
@@ -18,8 +18,8 @@ bmi055 -A -R 10 start
 bmi055 -G -R 10 start
 
 # Possible external compasses
-ist8310 -C -b 1 start
-ist8310 -C -b 2 start
+ist8310 -b 1 start
+ist8310 -b 2 start
 hmc5883 -C -T -X start
 qmc5883 -X start
 lis3mdl -X start
@@ -32,7 +32,7 @@ then
 fi
 
 # Possible internal compass
-ist8310 -C -b 5 start
+ist8310 -b 5 start
 
 # Baro on internal SPI
 ms5611 -s start

--- a/boards/px4/fmu-v5x/init/rc.board_sensors
+++ b/boards/px4/fmu-v5x/init/rc.board_sensors
@@ -22,8 +22,8 @@ bmi088 -A -R 12 start
 bmi088 -G -R 12 start
 
 # Possible external compasses
-ist8310 -C -b 1 start
-ist8310 -C -b 2 start
+ist8310 -b 1 start
+ist8310 -b 2 start
 hmc5883 -C -T -X start
 qmc5883 -X start
 


### PR DESCRIPTION
- it does nothing useful
- increases boot time by 2 seconds on pixhawk 4 due to a poll timeout:
```
IST8310 on I2C bus 3 at 0x0e (bus: 100 KHz, max: 400 KHz)
WARN  [ist8310] ERROR: TIMEOUT 2
```
