### PR TITLE
Makefile/cmake remove legacy target naming helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,23 +209,13 @@ $(CONFIG_TARGETS_DEFAULT):
 all_config_targets: $(ALL_CONFIG_TARGETS)
 all_default_targets: $(CONFIG_TARGETS_DEFAULT)
 
-posix: px4_sitl_default
-
 # board reorganization deprecation warnings (2018-11-22)
 define deprecation_warning
 	$(warning $(1) has been deprecated and will be removed, please use $(2)!)
 endef
 
-px4fmu-%_default:
-	$(call deprecation_warning, ${@},$(subst px4fmu,px4_fmu,$@))
-	$(MAKE) $(subst px4fmu,px4_fmu, $@)
-
-posix_sitl_default:
-	$(call deprecation_warning, ${@},px4_sitl_default)
-	$(MAKE) px4_sitl_default
-
 # All targets with just dependencies but no recipe must either be marked as phony (or have the special @: as recipe).
-.PHONY: all posix px4_sitl_default all_config_targets all_default_targets
+.PHONY: all px4_sitl_default all_config_targets all_default_targets
 
 # Multi- config targets.
 eagle_default: atlflight_eagle_default atlflight_eagle_qurt
@@ -287,7 +277,7 @@ sizes:
 # All default targets that don't require a special build environment
 check: check_px4_sitl_default px4fmu_firmware misc_qgc_extra_firmware alt_firmware tests check_format
 
-# quick_check builds a single nuttx and posix target, runs testing, and checks the style
+# quick_check builds a single nuttx and SITL target, runs testing, and checks the style
 quick_check: check_px4_sitl_test check_px4_fmu-v5_default tests check_format
 
 check_%:

--- a/cmake/px4_config.cmake
+++ b/cmake/px4_config.cmake
@@ -73,27 +73,7 @@ if(NOT PX4_CONFIG_FILE)
 				set(PX4_CONFIG_FILE "${PX4_SOURCE_DIR}/boards/${filename}" CACHE FILEPATH "path to PX4 CONFIG file" FORCE)
 				break()
 			endif()
-
-
-			# LEGACY form
-			# <OS>_<BOARD>_<LABEL> (eg nuttx_px4_fmu-v2_default)
-			string(REGEX REPLACE "^nuttx_|^posix_|^qurt_" "" config_no_os ${CONFIG}) # ignore OS prefix
-
-			if ((${config_no_os} MATCHES "${board}_${label}"))
-				set(PX4_CONFIG_FILE "${PX4_SOURCE_DIR}/boards/${filename}" CACHE FILEPATH "path to PX4 CONFIG file" FORCE)
-				break()
-			endif()
-
-
-			# LEGACY form special case to ease board layout transition (2018-11-18)
-			#  match board with model and label only: eg sitl_default -> px4_sitl_default
-			if ((${config_no_os} MATCHES "${model}_${label}"))
-				set(PX4_CONFIG_FILE "${PX4_SOURCE_DIR}/boards/${filename}" CACHE FILEPATH "path to PX4 CONFIG file" FORCE)
-				break()
-			endif()
-
 		endif()
-
 	endforeach()
 endif()
 


### PR DESCRIPTION
When we consolidated board support under the `boards/` directory about 15 months ago the target naming changed slightly. The optional platform prefix was dropped, the single vendor + model string was split (eg px4fmu -> px4_fmu), and shortcuts for sitl like `posix` were dropped. To help the transition I added various little helpers, but I think it's now a safe time to drop those as well and potentially reduce some confusion (a mismatch case).