### PR TITLE
fix the encoding problem for subprocess.check_output

### DIFF
--- a/msg/tools/generate_microRTPS_bridge.py
+++ b/msg/tools/generate_microRTPS_bridge.py
@@ -253,7 +253,7 @@ else:
 ros2_distro = ""
 try:
     rosversion_out = subprocess.check_output(["rosversion", "-d"])
-    rosversion_out = rosversion_out.rstrip()
+    rosversion_out = rosversion_out.rstrip().decode('utf-8')
     if rosversion_out not in ["<unknown>", "kinetic", "lunar", "melodic"]:
         ros2_distro = rosversion_out
 except OSError as e:


### PR DESCRIPTION
**Describe problem solved by this pull request**
When I compile ```make px4_sitl_rtps```, I found the error like below with just standalone, no ROS.

```
stmoon@stmoon-XPS-13-9370:/home/px4/firmware.rtps/Firmware.stmoon/build/px4_sitl_rtps/src/modules/micrortps_bridge/micrortps_client/micrortps_agent/build$ make 
Scanning dependencies of target micrortps_agent
[  0%] Building CXX object CMakeFiles/micrortps_agent.dir/RtpsTopics.cpp.o
In file included from /home/px4/firmware.rtps/Firmware.stmoon/build/px4_sitl_rtps/src/modules/micrortps_bridge/micrortps_client/micrortps_agent/RtpsTopics.h:38:0,
                 from /home/px4/firmware.rtps/Firmware.stmoon/build/px4_sitl_rtps/src/modules/micrortps_bridge/micrortps_client/micrortps_agent/RtpsTopics.cpp:34:
/home/px4/firmware.rtps/Firmware.stmoon/build/px4_sitl_rtps/src/modules/micrortps_bridge/micrortps_client/micrortps_agent/adc_report_Publisher.h:60:18: error: ‘px4’ has not been declared
     void publish(px4::msg::adc_report* st);
                  ^~~
/home/px4/firmware.rtps/Firmware.stmoon/build/px4_sitl_rtps/src/modules/micrortps_bridge/micrortps_client/micrortps_agent/adc_report_Publisher.h:60:38: error: expected ‘,’ or ‘...’ before ‘*’ token
```


**Describe your solution**

I found the python code output type of ```subprocess.check_output``` is binary in my case.  To clarify it, I clarify the encoding type, utf-8 like below
```python
rosversion_out = rosversion_out.rstrip().decode('utf-8')
```

Actually, I solved the problem in another pull request. However, I think the problem should be separated.
 