### PR TITLE
Support large number of vehicles in multivehicle SITL

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -108,8 +108,13 @@ fi
 param set MAV_SYS_ID $((px4_instance+1))
 simulator_tcp_port=$((4560+px4_instance))
 udp_offboard_port_local=$((14580+px4_instance))
-udp_offboard_port_remote=$((14540+px4_instance))
+if [ $px4_instance > 9]
+	udp_offboard_port_remote=14549
+then
+	udp_offboard_port_remote=$((14540+px4_instance))
+fi
 udp_gcs_port_local=$((18570+px4_instance))
+
 
 if [ $AUTOCNF = yes ]
 then

--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -108,11 +108,8 @@ fi
 param set MAV_SYS_ID $((px4_instance+1))
 simulator_tcp_port=$((4560+px4_instance))
 udp_offboard_port_local=$((14580+px4_instance))
-if [ $px4_instance > 9]
-	udp_offboard_port_remote=14549
-then
-	udp_offboard_port_remote=$((14540+px4_instance))
-fi
+udp_offboard_port_remote=$((14540+px4_instance))
+[ $px4_instance > 9] && udp_offboard_port_remote=14549 # use the same ports for more than 10 instances to avoid port overlaps
 udp_gcs_port_local=$((18570+px4_instance))
 
 

--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -109,7 +109,7 @@ param set MAV_SYS_ID $((px4_instance+1))
 simulator_tcp_port=$((4560+px4_instance))
 udp_offboard_port_local=$((14580+px4_instance))
 udp_offboard_port_remote=$((14540+px4_instance))
-udp_gcs_port_local=$((14570+px4_instance))
+udp_gcs_port_local=$((18570+px4_instance))
 
 if [ $AUTOCNF = yes ]
 then


### PR DESCRIPTION
**Describe problem solved by this pull request**
Previously, the number of vehicles that were able to be simulated was limited to 10 vehicles. This was due to a overlap on port numbering that overlapped in the rcS definition.

**Describe your solution**
Redefine gcs udp port from `14570` to `18570` in rcS.

**Test data / coverage**
Tested up to 100 instances of vehicles on a desktop.
Image below shows 30 vehicles

![Screenshot from 2020-02-09 12-37-21](https://user-images.githubusercontent.com/5248102/74106153-50a49e80-4b64-11ea-9327-3aa28fc26ead.png)

