### PR TITLE
px4iofirmware: add PX4IO_PERF define to completely disable perf counters

### DIFF
--- a/.vscode/cmake-variants.yaml
+++ b/.vscode/cmake-variants.yaml
@@ -16,6 +16,11 @@ CONFIG:
       buildType: RelWithDebInfo
       settings:
         CONFIG: px4_sitl_test
+    px4_io-v2_default:
+      short: px4_io-v2_default
+      buildType: MinSizeRel
+      settings:
+        CONFIG: px4_io-v2_default
     px4_fmu-v2_default:
       short: px4_fmu-v2_default
       buildType: MinSizeRel

--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -176,8 +176,8 @@ add_custom_target(weak_symbols
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Debug/gdbinit.in ${PX4_BINARY_DIR}/.gdbinit)
 
 # vscode launch.json
-#  FIXME: hack to skip if px4_io-v2 because it's a built within another build (eg px4_fmu-v5)
-if(NOT PX4_BOARD MATCHES "px4_io-v2")
+#  skip if built within another cmake project (eg px4_io-v2 with px4_fmu-v5)
+if(NOT NUTTX_DIR MATCHES "external")
 	if(CONFIG_ARCH_CHIP_MIMXRT1062DVL6A)
 		set(DEBUG_DEVICE "MIMXRT1062XXX6A")
 		set(DEBUG_SVD_FILE "MIMXRT1052.svd")
@@ -232,7 +232,7 @@ if(NOT PX4_BOARD MATCHES "px4_io-v2")
 		LIST_DIRECTORIES false
 		${CMAKE_SOURCE_DIR}/../cmsis-svd/data/*/${DEBUG_SVD_FILE}
 	)
-	if(DEBUG_SVD_FILE)
+	if(NOT DEBUG_SVD_FILE MATCHES "unknown")
 		message(STATUS "Found SVD: ${DEBUG_SVD_FILE_PATH}")
 		configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Debug/launch.json.in ${PX4_SOURCE_DIR}/.vscode/launch.json @ONLY)
 	endif()

--- a/platforms/nuttx/src/px4/nxp/imxrt/hrt/hrt.c
+++ b/platforms/nuttx/src/px4/nxp/imxrt/hrt/hrt.c
@@ -48,7 +48,6 @@
 
 #include <px4_platform_common/px4_config.h>
 #include <systemlib/px4_macros.h>
-#include <lib/perf/perf_counter.h>
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
 
@@ -180,6 +179,11 @@ static uint32_t           latency_baseline;
 
 /* timer count at interrupt (for latency purposes) */
 static uint32_t           latency_actual;
+
+/* latency histogram */
+const uint16_t latency_bucket_count = LATENCY_BUCKET_COUNT;
+const uint16_t latency_buckets[LATENCY_BUCKET_COUNT] = { 1, 2, 5, 10, 20, 50, 100, 1000 };
+__EXPORT uint32_t latency_counters[LATENCY_BUCKET_COUNT + 1];
 
 /* timer-specific functions */
 static void hrt_tim_init(void);

--- a/platforms/nuttx/src/px4/nxp/kinetis/hrt/hrt.c
+++ b/platforms/nuttx/src/px4/nxp/kinetis/hrt/hrt.c
@@ -48,7 +48,6 @@
 
 #include <px4_platform_common/px4_config.h>
 #include <systemlib/px4_macros.h>
-#include <lib/perf/perf_counter.h>
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
 
@@ -178,6 +177,11 @@ static uint16_t           latency_baseline;
 
 /* timer count at interrupt (for latency purposes) */
 static uint16_t           latency_actual;
+
+/* latency histogram */
+const uint16_t latency_bucket_count = LATENCY_BUCKET_COUNT;
+const uint16_t latency_buckets[LATENCY_BUCKET_COUNT] = { 1, 2, 5, 10, 20, 50, 100, 1000 };
+__EXPORT uint32_t latency_counters[LATENCY_BUCKET_COUNT + 1];
 
 /* timer-specific functions */
 static void hrt_tim_init(void);

--- a/platforms/nuttx/src/px4/stm/stm32_common/hrt/hrt.c
+++ b/platforms/nuttx/src/px4/stm/stm32_common/hrt/hrt.c
@@ -61,7 +61,6 @@
 
 #include <board_config.h>
 #include <drivers/drv_hrt.h>
-#include <lib/perf/perf_counter.h>
 
 
 #include "stm32_gpio.h"
@@ -255,6 +254,11 @@ static uint16_t			latency_baseline;
 
 /* timer count at interrupt (for latency purposes) */
 static uint16_t			latency_actual;
+
+/* latency histogram */
+const uint16_t latency_bucket_count = LATENCY_BUCKET_COUNT;
+const uint16_t latency_buckets[LATENCY_BUCKET_COUNT] = { 1, 2, 5, 10, 20, 50, 100, 1000 };
+__EXPORT uint32_t latency_counters[LATENCY_BUCKET_COUNT + 1];
 
 /* timer-specific functions */
 static void		hrt_tim_init(void);

--- a/platforms/posix/src/px4/common/drv_hrt.cpp
+++ b/platforms/posix/src/px4/common/drv_hrt.cpp
@@ -43,7 +43,6 @@
 #include <px4_platform_common/workqueue.h>
 #include <px4_platform_common/tasks.h>
 #include <drivers/drv_hrt.h>
-#include <lib/perf/perf_counter.h>
 
 #include <semaphore.h>
 #include <time.h>
@@ -69,6 +68,11 @@ static uint64_t			latency_baseline;
 
 /* timer count at interrupt (for latency purposes) */
 static uint64_t			latency_actual;
+
+/* latency histogram */
+const uint16_t latency_bucket_count = LATENCY_BUCKET_COUNT;
+const uint16_t latency_buckets[LATENCY_BUCKET_COUNT] = { 1, 2, 5, 10, 20, 50, 100, 1000 };
+__EXPORT uint32_t latency_counters[LATENCY_BUCKET_COUNT + 1];
 
 static px4_sem_t 	_hrt_lock;
 static struct work_s	_hrt_work;

--- a/platforms/qurt/src/px4/common/drv_hrt.cpp
+++ b/platforms/qurt/src/px4/common/drv_hrt.cpp
@@ -43,7 +43,6 @@
 #include <px4_platform_common/workqueue.h>
 #include <px4_platform_common/tasks.h>
 #include <drivers/drv_hrt.h>
-#include <lib/perf/perf_counter.h>
 
 #include <semaphore.h>
 #include <time.h>
@@ -65,6 +64,11 @@ static uint64_t			latency_baseline;
 
 /* timer count at interrupt (for latency purposes) */
 static uint64_t			latency_actual;
+
+/* latency histogram */
+const uint16_t latency_bucket_count = LATENCY_BUCKET_COUNT;
+const uint16_t latency_buckets[LATENCY_BUCKET_COUNT] = { 1, 2, 5, 10, 20, 50, 100, 1000 };
+__EXPORT uint32_t latency_counters[LATENCY_BUCKET_COUNT + 1];
 
 static px4_sem_t 	_hrt_lock;
 static struct work_s	_hrt_work;

--- a/src/drivers/drv_hrt.h
+++ b/src/drivers/drv_hrt.h
@@ -78,6 +78,12 @@ typedef struct hrt_call {
 	void			*arg;
 } *hrt_call_t;
 
+
+#define LATENCY_BUCKET_COUNT 8
+extern const uint16_t latency_bucket_count;
+extern const uint16_t latency_buckets[LATENCY_BUCKET_COUNT];
+extern uint32_t latency_counters[LATENCY_BUCKET_COUNT + 1];
+
 /**
  * Get absolute time in [us] (does not wrap).
  */

--- a/src/lib/perf/perf_counter.cpp
+++ b/src/lib/perf/perf_counter.cpp
@@ -48,12 +48,6 @@
 
 #include "perf_counter.h"
 
-/* latency histogram */
-const uint16_t latency_bucket_count = LATENCY_BUCKET_COUNT;
-const uint16_t	latency_buckets[LATENCY_BUCKET_COUNT] = { 1, 2, 5, 10, 20, 50, 100, 1000 };
-__EXPORT uint32_t	latency_counters[LATENCY_BUCKET_COUNT + 1];
-
-
 #ifdef __PX4_QURT
 // There is presumably no dprintf on QURT. Therefore use the usual output to mini-dm.
 #define dprintf(_fd, _text, ...) ((_fd) == 1 ? PX4_INFO((_text), ##__VA_ARGS__) : (void)(_fd))

--- a/src/lib/perf/perf_counter.h
+++ b/src/lib/perf/perf_counter.h
@@ -42,12 +42,6 @@
 #include <stdint.h>
 #include <px4_platform_common/defines.h>
 
-#define LATENCY_BUCKET_COUNT 8
-
-extern const uint16_t latency_bucket_count;
-extern const uint16_t latency_buckets[LATENCY_BUCKET_COUNT];
-extern uint32_t latency_counters[LATENCY_BUCKET_COUNT + 1];
-
 /**
  * Counter types.
  */

--- a/src/modules/px4iofirmware/CMakeLists.txt
+++ b/src/modules/px4iofirmware/CMakeLists.txt
@@ -31,6 +31,8 @@
 #
 ############################################################################
 
+option(PX4IO_PERF "Enable px4io perf counters" OFF)
+
 add_library(px4iofirmware
 	adc.c
 	controls.c
@@ -39,7 +41,7 @@ add_library(px4iofirmware
 	registers.c
 	safety.c
 	serial.c
-	)
+)
 
 set_property(GLOBAL APPEND PROPERTY PX4_MODULE_LIBRARIES px4iofirmware)
 target_link_libraries(px4iofirmware
@@ -50,6 +52,10 @@ target_link_libraries(px4iofirmware
 		nuttx_c
 		mixer
 		rc
-		perf
 		output_limit
 )
+
+if(PX4IO_PERF)
+	target_compile_definitions(px4iofirmware PRIVATE PX4IO_PERF)
+	target_link_libraries(px4iofirmware PRIVATE perf)
+endif()

--- a/src/modules/px4iofirmware/adc.c
+++ b/src/modules/px4iofirmware/adc.c
@@ -44,7 +44,10 @@
 #include <stm32.h>
 
 #include <drivers/drv_hrt.h>
-#include <perf/perf_counter.h>
+
+#if defined(PX4IO_PERF)
+# include <perf/perf_counter.h>
+#endif
 
 #define DEBUG
 #include "px4io.h"
@@ -76,12 +79,16 @@
 #define rJDR4		REG(STM32_ADC_JDR4_OFFSET)
 #define rDR		REG(STM32_ADC_DR_OFFSET)
 
+#if defined(PX4IO_PERF)
 perf_counter_t		adc_perf;
+#endif
 
 int
 adc_init(void)
 {
+#if defined(PX4IO_PERF)
 	adc_perf = perf_alloc(PC_ELAPSED, "adc");
+#endif
 
 	/* put the ADC into power-down mode */
 	rCR2 &= ~ADC_CR2_ADON;
@@ -136,8 +143,9 @@ adc_init(void)
 uint16_t
 adc_measure(unsigned channel)
 {
-
+#if defined(PX4IO_PERF)
 	perf_begin(adc_perf);
+#endif
 
 	/* clear any previous EOC */
 	rSR = 0;
@@ -154,7 +162,9 @@ adc_measure(unsigned channel)
 
 		/* never spin forever - this will give a bogus result though */
 		if (hrt_elapsed_time(&now) > 100) {
+#if defined(PX4IO_PERF)
 			perf_end(adc_perf);
+#endif
 			return 0xffff;
 		}
 	}
@@ -163,6 +173,8 @@ adc_measure(unsigned channel)
 	uint16_t result = rDR;
 	rSR = 0;
 
+#if defined(PX4IO_PERF)
 	perf_end(adc_perf);
+#endif
 	return result;
 }

--- a/src/modules/px4iofirmware/px4io.h
+++ b/src/modules/px4iofirmware/px4io.h
@@ -53,12 +53,6 @@
 #include <output_limit/output_limit.h>
 
 /*
- hotfix: we are critically short of memory in px4io and this is the
- easiest way to reclaim about 800 bytes.
- */
-#define perf_alloc(a,b) NULL
-
-/*
  * Constants and limits.
  */
 #define PX4IO_BL_VERSION			3


### PR DESCRIPTION
This saves a paltry 64 bytes of ram, but it seems to be enough to get us out of the immediate bind (https://github.com/PX4/Firmware/issues/14116). 

On the upside it does save a good chunk of flash (nearly 1 kB).

``` Console
$ make px4_io-v2_default bloaty_compare_master

     VM SIZE    
 -------------- 
  [NEW]     +12    channels_cache.7449
  [NEW]      +8    base_time.7109
  [NEW]      +8    last_mem_time.7465
  [NEW]      +4    brightness.7477
  [NEW]      +4    brightness_counter.7478
  [NEW]      +4    counter.7476
  [NEW]      +4    last_count.7110
  [NEW]      +4    new_channel_count.7087
  [NEW]      +4    new_channel_holdoff.7088
  [NEW]      +4    on_counter.7479
  [NEW]      +1    abort_on_idle.7147
  [NEW]      +1    failsafe.7178
  [NEW]      +1    heartbeat.7471
  [ = ]       0    [Unmapped]
  [ = ]       0    [section .debug_abbrev]
  [ = ]       0    [section .debug_aranges]
  [ = ]       0    [section .debug_frame]
  [ = ]       0    [section .debug_info]
  [ = ]       0    [section .debug_line]
  [ = ]       0    [section .debug_loc]
  [ = ]       0    [section .debug_ranges]
  [ = ]       0    [section .debug_str]
  [ = ]       0    [section .strtab]
  [ = ]       0    [section .symtab]
  [ = ]       0    output_limit_init
  [ = ]       0    ppm
  [DEL]      -1    abort_on_idle.7391
  [DEL]      -1    failsafe.7175
  [DEL]      -1    heartbeat.7529
  -5.7%      -4    [section .bss]
  [DEL]      -4    adc_perf
  [DEL]      -4    brightness.7535
  [DEL]      -4    brightness_counter.7536
  [DEL]      -4    c_gather_dsm
  [DEL]      -4    c_gather_ppm
  [DEL]      -4    c_gather_sbus
  [DEL]      -4    counter.7534
  [DEL]      -4    last_count.7339
  [DEL]      -4    new_channel_count.7316
  [DEL]      -4    new_channel_holdoff.7317
  [DEL]      -4    on_counter.7537
  [DEL]      -4    pc_badidle
  [DEL]      -4    pc_crcerr
  [DEL]      -4    pc_errors
  [DEL]      -4    pc_fe
  [DEL]      -4    pc_idle
  [DEL]      -4    pc_ne
  [DEL]      -4    pc_ore
  [DEL]      -4    pc_regerr
  [DEL]      -4    pc_txns
  -5.9%      -8    adc_init
  [DEL]      -8    base_time.7338
  [DEL]      -8    last_mem_time.7523
  [DEL]     -12    channels_cache.7446
  [DEL]     -22    perf_begin
 -19.4%     -28    controls_init
 -25.8%     -32    adc_measure
 -14.8%     -48    rx_dma_callback
  [DEL]     -50    perf_count
  -5.8%     -60    user_start
 -35.3%     -72    interface_init
  -5.0%     -80    controls_tick
 -40.4%     -84    serial_interrupt
  [DEL]    -196    perf_end
  [DEL]    -216    perf_count_interval
  -1.4%    -952    TOTAL
```