### PR TITLE
vscode small improvements

### DIFF
--- a/.vscode/.gitignore
+++ b/.vscode/.gitignore
@@ -7,3 +7,5 @@ launch.json
 
 # C/C++ extension does some local caching in this folder
 ipch/
+
+browse.vc.db*

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -2,24 +2,76 @@
     "configurations": [
         {
             "name": "Linux",
-            "intelliSenseMode": "gcc-x64",
-            "includePath": [
-                "${workspaceFolder}/**"
-            ],
-            "defines": [],
             "browse": {
-                "path": [
-                    "${workspaceFolder}/src/",
-                    "${workspaceFolder}/src/lib/",
-                    "${workspaceFolder}/src/lib/matrix",
-                    "${workspaceFolder}/src/platforms",
-                    "${workspaceFolder}/platforms/",
-                    "."
-                ],
-                "limitSymbolsToIncludedHeaders": true
+                "limitSymbolsToIncludedHeaders": true,
+                "databaseFilename": "${workspaceFolder}/.vscode/browse.vc.db"
             },
             "compileCommands": "${workspaceFolder}/.vscode/compile_commands.json",
-            "configurationProvider": "ms-vscode.cmake-tools"
+            "compilerPath": "/usr/bin/g++",
+            "configurationProvider": "ms-vscode.cmake-tools",
+            "cppStandard": "c++14",
+            "cStandard": "c11",
+            "defines": [
+                "__PX4_LINUX",
+                "__PX4_POSIX"
+            ],
+            "forcedInclude": [
+                "${workspaceFolder}/src/include/visibility.h"
+            ],
+            "includePath": [
+                "${workspaceFolder}/boards/px4/sitl/src",
+                "${workspaceFolder}/build/px4_sitl_default",
+                "${workspaceFolder}/platforms/common/include",
+                "${workspaceFolder}/platforms/posix/include",
+                "${workspaceFolder}/platforms/posix/src/px4/common/include",
+                "${workspaceFolder}/platforms/posix/src/px4/common/include",
+                "${workspaceFolder}/platforms/posix/src/px4/generic/generic/include",
+                "${workspaceFolder}/src",
+                "${workspaceFolder}/src/include",
+                "${workspaceFolder}/src/lib",
+                "${workspaceFolder}/src/lib",
+                "${workspaceFolder}/src/lib/matrix",
+                "${workspaceFolder}/src/modules"
+            ],
+            "intelliSenseMode": "${default}"
+        },
+        {
+            "name": "Mac",
+            "browse": {
+                "limitSymbolsToIncludedHeaders": true,
+                "databaseFilename": "${workspaceFolder}/.vscode/browse.vc.db"
+            },
+            "compileCommands": "${workspaceFolder}/.vscode/compile_commands.json",
+            "compilerPath": "/usr/bin/clang++",
+            "configurationProvider": "ms-vscode.cmake-tools",
+            "cppStandard": "c++14",
+            "cStandard": "c11",
+            "defines": [
+                "__PX4_DARWIN",
+                "__PX4_POSIX"
+            ],
+            "forcedInclude": [
+                "${workspaceFolder}/src/include/visibility.h"
+            ],
+            "includePath": [
+                "${workspaceFolder}/boards/px4/sitl/src",
+                "${workspaceFolder}/build/px4_sitl_default",
+                "${workspaceFolder}/platforms/common/include",
+                "${workspaceFolder}/platforms/posix/include",
+                "${workspaceFolder}/platforms/posix/src/px4/common/include",
+                "${workspaceFolder}/platforms/posix/src/px4/common/include",
+                "${workspaceFolder}/platforms/posix/src/px4/generic/generic/include",
+                "${workspaceFolder}/src",
+                "${workspaceFolder}/src/include",
+                "${workspaceFolder}/src/lib",
+                "${workspaceFolder}/src/lib",
+                "${workspaceFolder}/src/lib/matrix",
+                "${workspaceFolder}/src/modules"
+            ],
+            "intelliSenseMode": "${default}",
+            "macFrameworkPath": [
+                "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks"
+            ]
         }
     ],
     "version": 4

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -11,6 +11,8 @@
         "ms-python.python",
         "ms-vscode.cmake-tools",
         "ms-vscode.cpptools",
+        "redhat.vscode-yaml",
+        "timonwong.shellcheck",
         "twxs.cmake",
         "uavcan.dsdl",
         "wholroyd.jinja",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,8 +4,8 @@
         "astyle.cpp.enable": true,
         "breadcrumbs.enabled": true,
         "cmake.autoRestartBuild": true,
-        "cmake.buildDirectory": "${workspaceFolder}/build/${variant:CONFIG}",
         "cmake.buildBeforeRun": true,
+        "cmake.buildDirectory": "${workspaceFolder}/build/${variant:CONFIG}",
         "cmake.configureOnOpen": true,
         "cmake.copyCompileCommands": "${workspaceFolder}/.vscode/compile_commands.json",
         "cmake.debugConfig": {
@@ -53,17 +53,20 @@
                         ]
                 }
         },
-        "cortex-debug.enableTelemetry": false,
+        "C_Cpp.autoAddFileAssociations": false,
         "C_Cpp.clang_format_fallbackStyle": "none",
-        "C_Cpp.configurationWarnings": "Disabled",
+        "C_Cpp.default.browse.databaseFilename": "${workspaceRoot}/.vscode/browse.vc.db",
         "C_Cpp.default.cppStandard": "c++14",
         "C_Cpp.default.cStandard": "c11",
         "C_Cpp.default.intelliSenseMode": "gcc-x64",
-        "C_Cpp.errorSquiggles": "Disabled",
         "C_Cpp.formatting": "Disabled",
         "C_Cpp.intelliSenseEngine": "Default",
-        "C_Cpp.intelliSenseEngineFallback": "Disabled",
+        "C_Cpp.intelliSenseEngineFallback": "Enabled",
+        "C_Cpp.vcpkg.enabled": false,
+        "C_Cpp.workspaceParsingPriority": "medium",
+        "cortex-debug.enableTelemetry": false,
         "debug.toolBarLocation": "docked",
+        "editor.acceptSuggestionOnEnter": "off",
         "editor.defaultFormatter": "chiehyu.vscode-astyle",
         "editor.dragAndDrop": false,
         "editor.insertSpaces": false,
@@ -77,7 +80,7 @@
         "files.insertFinalNewline": true,
         "files.trimTrailingWhitespace": true,
         "files.watcherExclude": {
-                "**/build/*": true
+                "${workspaceFolder}/build": true
         },
         "git.detectSubmodulesLimit": 20,
         "git.ignoreLimitWarning": true,
@@ -157,13 +160,21 @@
                 "vector": "cpp"
         },
         "search.exclude": {
-                "build/**": true
+                "${workspaceFolder}/build": true
         },
         "search.showLineNumbers": true,
+        "search.smartCase": true,
+        "shellcheck.exclude": [2154],
         "telemetry.enableTelemetry": false,
+        "terminal.integrated.copyOnSelection": true,
+        "terminal.integrated.rightClickCopyPaste": true,
+        "terminal.integrated.scrollback": 5000,
         "window.title": "${dirty} ${activeEditorMedium}${separator}${rootName}",
         "workbench.editor.highlightModifiedTabs": true,
         "workbench.enableExperiments": false,
         "workbench.settings.enableNaturalLanguageSearch": false,
-        "workbench.statusBar.feedback.visible": false
+        "workbench.statusBar.feedback.visible": false,
+        "yaml.schemas": {
+                "${workspaceRoot}/validation/module_schema.yaml": "${workspaceRoot}/src/modules/*/module.yaml"
+        },
 }

--- a/platforms/nuttx/cmake/jlink.cmake
+++ b/platforms/nuttx/cmake/jlink.cmake
@@ -32,7 +32,9 @@
 ############################################################################
 
 # jlink_upload (flash binary)
-find_program(JLinkGDBServerCLExe_PATH JLinkGDBServerCLExe)
+find_program(JLinkGDBServerCLExe_PATH JLinkGDBServerCLExe
+	HINTS /Applications/SEGGER/JLink
+)
 if(JLinkGDBServerCLExe_PATH)
 	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Debug/jlink_gdb_start.sh.in ${PX4_BINARY_DIR}/jlink_gdb_start.sh @ONLY)
 	add_custom_target(jlink_upload
@@ -48,7 +50,9 @@ if(JLinkGDBServerCLExe_PATH)
 endif()
 
 # jlink_debug_gdb (flash binary and run with gdb attached)
-find_program(JLinkGDBServerExe_PATH JLinkGDBServerExe)
+find_program(JLinkGDBServerExe_PATH JLinkGDBServerExe
+	HINTS /Applications/SEGGER/JLink
+)
 if(JLinkGDBServerExe_PATH AND CMAKE_GDB)
 	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Debug/jlink_debug_gdb.sh.in ${PX4_BINARY_DIR}/jlink_debug_gdb.sh @ONLY)
 	add_custom_target(jlink_debug_gdb
@@ -63,7 +67,9 @@ if(JLinkGDBServerExe_PATH AND CMAKE_GDB)
 endif()
 
 # jlink_debug_ozone (run Segger Ozone debugger with current target configuration)
-find_program(Ozone_PATH Ozone)
+find_program(Ozone_PATH Ozone
+	HINTS /Applications/Ozone.app/Contents/MacOS/
+)
 if(Ozone_PATH)
 	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Debug/jlink_debug_ozone.sh.in ${PX4_BINARY_DIR}/jlink_debug_ozone.sh @ONLY)
 	add_custom_target(jlink_debug_ozone


### PR DESCRIPTION
Nothing too exciting here.
 - updates to `.vscode/c_cpp_properties.json` that help things resolve a little better if you don't have a proper compile_commands.json from a successful configure (split for Mac and Linux)
 - add yaml extension to recommended
 - add shellcheck extension to recommended
 - decrease workspace parsing priority
 - disable annoying c++ file extension auto add
 - terminal increase scrollback buffer and make it easier to copy and paste
 - cmake jlink helpers add path hints for macos (eg jlink_debug_ozone target)