### PR TITLE
px4io - Fix array regs[] size

### DIFF
--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1306,7 +1306,7 @@ PX4IO::io_set_control_state(unsigned group)
 		controls.control[3] = 1.0f;
 	}
 
-	uint16_t regs[_max_actuators];
+	uint16_t regs[_max_controls];
 
 	for (unsigned i = 0; i < _max_controls; i++) {
 		/* ensure FLOAT_TO_REG does not produce an integer overflow */
@@ -1318,7 +1318,6 @@ PX4IO::io_set_control_state(unsigned group)
 		} else {
 			regs[i] = FLOAT_TO_REG(ctrl);
 		}
-
 
 	}
 

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1306,9 +1306,9 @@ PX4IO::io_set_control_state(unsigned group)
 		controls.control[3] = 1.0f;
 	}
 
-	uint16_t regs[_max_controls];
+	uint16_t regs[sizeof(controls.control) / sizeof(controls.control[0])];
 
-	for (unsigned i = 0; i < _max_controls; i++) {
+	for (unsigned i = 0; (i < _max_controls) && (i < sizeof(controls.control) / sizeof(controls.control[0])); i++) {
 		/* ensure FLOAT_TO_REG does not produce an integer overflow */
 		const float ctrl = math::constrain(controls.control[i], -1.0f, 1.0f);
 

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1306,7 +1306,7 @@ PX4IO::io_set_control_state(unsigned group)
 		controls.control[3] = 1.0f;
 	}
 
-	uint16_t regs[sizeof(controls.control) / sizeof(controls.control[0])];
+	uint16_t regs[sizeof(controls.control) / sizeof(controls.control[0])] = {};
 
 	for (unsigned i = 0; (i < _max_controls) && (i < sizeof(controls.control) / sizeof(controls.control[0])); i++) {
 		/* ensure FLOAT_TO_REG does not produce an integer overflow */
@@ -1323,7 +1323,8 @@ PX4IO::io_set_control_state(unsigned group)
 
 	if (!_test_fmu_fail && !_motor_test.in_test_mode) {
 		/* copy values to registers in IO */
-		return io_reg_set(PX4IO_PAGE_CONTROLS, group * PX4IO_PROTOCOL_MAX_CONTROL_COUNT, regs, _max_controls);
+		return io_reg_set(PX4IO_PAGE_CONTROLS, group * PX4IO_PROTOCOL_MAX_CONTROL_COUNT, regs, math::min(_max_controls,
+				  sizeof(controls.control) / sizeof(controls.control[0])));
 
 	} else {
 		return OK;


### PR DESCRIPTION
may cause memory override if _max_controls larger then _max_actuators

**Describe problem solved by this pull request**
probably _max_controls is not larger then _max_actuators. or there is no use of the memory after, in the code scenario. so we never seen an issue

**Describe your solution**
fix array size
