### PR TITLE
mavlink: support mission transfer cancellation

### DIFF
--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -601,10 +601,15 @@ MavlinkMissionManager::handle_mission_ack(const mavlink_message_t *msg)
 	if (CHECK_SYSID_COMPID_MISSION(wpa)) {
 		if ((msg->sysid == _transfer_partner_sysid && msg->compid == _transfer_partner_compid)) {
 			if (_state == MAVLINK_WPM_STATE_SENDLIST && _mission_type == wpa.mission_type) {
+
 				_time_last_recv = hrt_absolute_time();
 
-				if (_transfer_seq == current_item_count()) {
+				if (wpa.type == MAV_MISSION_ACCEPTED && _transfer_seq == current_item_count()) {
 					PX4_DEBUG("WPM: MISSION_ACK OK all items sent, switch to state IDLE");
+
+				} else if (wpa.type == MAV_MISSION_OPERATION_CANCELLED) {
+					PX4_DEBUG("WPM: MISSION_ACK CANCELLED, switch to state IDLE");
+					_transfer_in_progress = false;
 
 				} else {
 					_mavlink->send_statustext_critical("WPM: ERR: not all items sent -> IDLE");
@@ -627,6 +632,11 @@ MavlinkMissionManager::handle_mission_ack(const mavlink_message_t *msg)
 						_int_mode = true;
 						send_mission_request(_transfer_partner_sysid, _transfer_partner_compid, _transfer_seq);
 					}
+
+				} else if (wpa.type == MAV_MISSION_OPERATION_CANCELLED) {
+					PX4_DEBUG("WPM: MISSION_ACK CANCELLED, switch to state IDLE");
+					switch_to_idle_state();
+					_transfer_in_progress = false;
 
 				} else if (wpa.type != MAV_MISSION_ACCEPTED) {
 					PX4_WARN("Mission ack result was %d", wpa.type);

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -634,7 +634,6 @@ MavlinkMissionManager::handle_mission_ack(const mavlink_message_t *msg)
 				} else if (wpa.type == MAV_MISSION_OPERATION_CANCELLED) {
 					PX4_DEBUG("WPM: MISSION_ACK CANCELLED, switch to state IDLE");
 					switch_to_idle_state();
-					_transfer_in_progress = false;
 
 				} else if (wpa.type != MAV_MISSION_ACCEPTED) {
 					PX4_WARN("Mission ack result was %d", wpa.type);

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -609,7 +609,6 @@ MavlinkMissionManager::handle_mission_ack(const mavlink_message_t *msg)
 
 				} else if (wpa.type == MAV_MISSION_OPERATION_CANCELLED) {
 					PX4_DEBUG("WPM: MISSION_ACK CANCELLED, switch to state IDLE");
-					_transfer_in_progress = false;
 
 				} else {
 					PX4_DEBUG("WPM: MISSION_ACK ERROR: not all items sent, switch to state IDLE anyway");
@@ -634,6 +633,7 @@ MavlinkMissionManager::handle_mission_ack(const mavlink_message_t *msg)
 				} else if (wpa.type == MAV_MISSION_OPERATION_CANCELLED) {
 					PX4_DEBUG("WPM: MISSION_ACK CANCELLED, switch to state IDLE");
 					switch_to_idle_state();
+					_transfer_in_progress = false;
 
 				} else if (wpa.type != MAV_MISSION_ACCEPTED) {
 					PX4_WARN("Mission ack result was %d", wpa.type);

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -612,8 +612,6 @@ MavlinkMissionManager::handle_mission_ack(const mavlink_message_t *msg)
 					_transfer_in_progress = false;
 
 				} else {
-					_mavlink->send_statustext_critical("WPM: ERR: not all items sent -> IDLE");
-
 					PX4_DEBUG("WPM: MISSION_ACK ERROR: not all items sent, switch to state IDLE anyway");
 				}
 


### PR DESCRIPTION
This adds support for MAV_MISSION_OPERATION_CANCELLED which can be used
to cancel an ongoing upload or download of mission/geofence/rally items.

Tested in SITL against MAVSDK integration test:
```
cmake --build build -j8 && build/src/integration_tests/integration_tests_runner --gtest_filter="SitlTest.Mission*Cancellation"
```

As added in: https://github.com/mavlink/mavlink/pull/1044