### PR TITLE
Fixed reporting of battery voltages in uORB

### DIFF
--- a/msg/battery_status.msg
+++ b/msg/battery_status.msg
@@ -19,7 +19,7 @@ uint16 average_time_to_empty   # predicted remaining battery capacity based on t
 uint16 serial_number       # serial number of the battery pack
 uint8 id                # ID number of a battery. Should be unique and consistent for the lifetime of a vehicle. 1-indexed.
 
-float32[4] voltage_cell_v   # Battery individual cell voltages
+float32[10] voltage_cell_v   # Battery individual cell voltages
 float32 max_cell_voltage_delta   # Max difference between individual cell voltages
 
 bool is_powering_off		# Power off event imminent indication, false if unknown

--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -150,6 +150,18 @@ Battery::updateBatteryStatus(hrt_abstime timestamp, float voltage_v, float curre
 		_battery_status.connected = connected;
 		_battery_status.system_source = selected_source;
 		_battery_status.priority = priority;
+
+		static constexpr int uorb_max_cells = sizeof(_battery_status.voltage_cell_v) / sizeof(
+				_battery_status.voltage_cell_v[0]);
+		int i;
+
+		for (i = 0; i < _params.n_cells && i < uorb_max_cells; i++) {
+			_battery_status.voltage_cell_v[i] = _voltage_filtered_v / _params.n_cells;
+		}
+
+		for (; i < uorb_max_cells; i++) {
+			_battery_status.voltage_cell_v[i] = 0.0f;
+		}
 	}
 
 	_battery_status.timestamp = timestamp;


### PR DESCRIPTION
**Describe problem solved by this pull request**
The `Battery` library does not populate the field `voltage_cell_v` of `battery_status` uORB message, because the analog power monitor and INA226 power monitor cannot measure individual cells. To get around this, the `mavlink` module populated the `BATTERY_STATUS` MAVLink message by dividing the total voltage by the number of cells. This was fixed in https://github.com/PX4/Firmware/pull/13936, so the `mavlink` module now uses the `voltage_cell_v` field of the `battery_status` uORB message.

The issue now is that the MAVLink `BATTERY_STATUS` message does not have a field for total voltage, only for individual cell voltages. However, `SYS_STATUS` only has one field for battery voltage. So, to report the voltage of multiple batteries to the ground station, multiple instances of `BATTERY_STATUS` are sent. Therefore, to properly report the status of multiple batteries, one of two things must happen:

 - The cell voltages in the `BATTERY_STATUS` message must be populated
 - A MAVLink message must be changed: Possibly adding a `total_voltage` field to `BATTERY_STATUS`

**Describe your solution**
This PR replicates the old behavior, of dividing the total voltage by the number of cells. However, this is now done in the `Battery` library rather than in the `mavlink` module, so it only affects power monitors that were not measuring individual cell voltage anyway.

As discussed in https://github.com/PX4/Firmware/pull/13936, this is not ideal, because it can give the impression that every cell is fine, even if one is dying. There should be a discussion about the best way to solve this issue. This PR just gives one possible solution.

**Describe possible alternatives**
The `BATTERY_STATUS` MAVLink message could be changed to add a `total_voltage` field, so that any power monitor can reliably report only the information that it actually measures.

**Test data / coverage**
This was tested on both a v5x with INA226 power monitors and a Pixhawk 4 with analog power monitors. In both cases, two different batteries with 2 different cell counts were used. The uORB `battery_status` message, and MAVLink `BATTERY_STATUS` message, and the voltage reported in the AGS UI were all verified.
