### PR TITLE
Tools: make Python import error more readable

### DIFF
--- a/Tools/mavlink_shell.py
+++ b/Tools/mavlink_shell.py
@@ -16,7 +16,7 @@ from argparse import ArgumentParser
 try:
     from pymavlink import mavutil
 except ImportError as e:
-    print("Failed to import pymavlink: " + e)
+    print("Failed to import pymavlink: " + str(e))
     print("")
     print("You may need to install it with:")
     print("    pip3 install --user pymavlink")
@@ -26,7 +26,7 @@ except ImportError as e:
 try:
     import serial
 except ImportError as e:
-    print("Failed to import pyserial: " + e)
+    print("Failed to import pyserial: " + str(e))
     print("")
     print("You may need to install it with:")
     print("    pip3 install --user pyserial")

--- a/Tools/mavlink_ulog_streaming.py
+++ b/Tools/mavlink_ulog_streaming.py
@@ -17,7 +17,7 @@ from argparse import ArgumentParser
 try:
     from pymavlink import mavutil
 except ImportError as e:
-    print("Failed to import pymavlink: " + e)
+    print("Failed to import pymavlink: " + str(e))
     print("")
     print("You may need to install it with:")
     print("    pip3 install --user pymavlink")

--- a/Tools/serial/generate_config.py
+++ b/Tools/serial/generate_config.py
@@ -10,7 +10,7 @@ import sys
 try:
     from jinja2 import Environment, FileSystemLoader
 except ImportError as e:
-    print("Failed to import jinja2: " + e)
+    print("Failed to import jinja2: " + str(e))
     print("")
     print("You may need to install it using:")
     print("    pip3 install --user jinja2")
@@ -20,7 +20,7 @@ except ImportError as e:
 try:
     import yaml
 except ImportError as e:
-    print("Failed to import yaml: " + e)
+    print("Failed to import yaml: " + str(e))
     print("")
     print("You may need to install it using:")
     print("    pip3 install --user pyyaml")

--- a/Tools/upload_log.py
+++ b/Tools/upload_log.py
@@ -17,7 +17,7 @@ import sys
 try:
     import requests
 except ImportError as e:
-    print("Failed to import requests: " + e)
+    print("Failed to import requests: " + str(e))
     print("")
     print("You may need to install it using:")
     print("    pip3 install --user requests")

--- a/Tools/validate_yaml.py
+++ b/Tools/validate_yaml.py
@@ -4,13 +4,12 @@
 from __future__ import print_function
 
 import argparse
-import os
 import sys
 
 try:
     import yaml
 except ImportError as e:
-    print("Failed to import yaml: " + e)
+    print("Failed to import yaml: " + str(e))
     print("")
     print("You may need to install it using:")
     print("    pip3 install --user pyyaml")
@@ -20,7 +19,7 @@ except ImportError as e:
 try:
     import cerberus
 except ImportError as e:
-    print("Failed to import cerberus: " + e)
+    print("Failed to import cerberus: " + str(e))
     print("")
     print("You may need to install it using:")
     print("    pip3 install --user cerberus")

--- a/msg/tools/px_generate_uorb_topic_files.py
+++ b/msg/tools/px_generate_uorb_topic_files.py
@@ -43,31 +43,26 @@ import shutil
 import filecmp
 import argparse
 import sys
-import errno
 
 try:
     import em
 except ImportError as e:
-    print("Python import error: ", e)
-    print('''
-Required python package empy not installed.
-
-Please run:
-    pip3 install --user empy
-''')
-    exit(1)
+    print("Failed to import em: " + str(e))
+    print("")
+    print("You may need to install it using:")
+    print("    pip3 install --user empy")
+    print("")
+    sys.exit(1)
 
 try:
     import genmsg.template_tools
 except ImportError as e:
-    print("Python import error: ", e)
-    print('''
-Required python package pyros-genmsg not installed.
-
-Please run:
-    pip3 install --user pyros-genmsg
-''')
-    exit(1)
+    print("Failed to import genmsg: " + str(e))
+    print("")
+    print("You may need to install it using:")
+    print("    pip3 install --user pyros-genmsg")
+    print("")
+    sys.exit(1)
 
 
 __author__ = "Sergey Belash, Thomas Gubler, Beat Kueng"

--- a/src/lib/mixer/MultirotorMixer/geometries/tools/px_generate_mixers.py
+++ b/src/lib/mixer/MultirotorMixer/geometries/tools/px_generate_mixers.py
@@ -37,27 +37,33 @@ px_generate_mixers.py
 Generates c/cpp header/source files for multirotor mixers
 from geometry descriptions files (.toml format)
 """
+import sys
 
 try:
     import toml
+except ImportError as e:
+    print("Failed to import toml: " + str(e))
+    print("")
+    print("You may need to install it using:")
+    print("    pip3 install --user toml")
+    print("")
+    sys.exit(1)
+
+try:
     import numpy as np
 except ImportError as e:
-    print("python import error: ", e)
-    print('''
-Required python3 packages not installed.
-
-On a GNU/Linux or MacOS system please run:
-  sudo pip3 install numpy toml
-
-On Windows please run:
-  easy_install numpy toml
-''')
-    exit(1)
+    print("Failed to import numpy: " + str(e))
+    print("")
+    print("You may need to install it using:")
+    print("    pip3 install --user numpy")
+    print("")
+    sys.exit(1)
 
 __author__ = "Julien Lecoeur"
 __copyright__ = "Copyright (C) 2013-2017 PX4 Development Team."
 __license__ = "BSD"
 __email__ = "julien.lecoeur@gmail.com"
+
 
 def parse_geometry_toml(filename):
     '''

--- a/src/lib/parameters/px_generate_params.py
+++ b/src/lib/parameters/px_generate_params.py
@@ -11,7 +11,7 @@ import sys
 try:
     from jinja2 import Environment, FileSystemLoader
 except ImportError as e:
-    print("Failed to import jinja2: " + e)
+    print("Failed to import jinja2: " + str(e))
     print("")
     print("You may need to install it using:")
     print("    pip3 install --user jinja2")


### PR DESCRIPTION
The problem with printing the exception was that starting with Python 3.6 the ImportError is yet another (sub) exception called `ModuleNotFoundError` which can't be printed as a string and then triggers
another exception:

```
Traceback (most recent call last):
  File "/home/julianoes/src/Firmware/Tools/serial/generate_config.py", line 11, in <module>
    import jinja2
ModuleNotFoundError: No module named 'jinja2'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/julianoes/src/Firmware/Tools/serial/generate_config.py", line 13, in <module>
    print("Failed to import jinja2: " + e)
TypeError: must be str, not ModuleNotFoundError
```
As per @bkueng's suggestion the easiest is to cast the exception to str and that way prevent the second exception.
