### PR TITLE
Use velocity_setpoint for feedforward instead of constraint

### DIFF
--- a/src/lib/flight_tasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
+++ b/src/lib/flight_tasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
@@ -237,8 +237,9 @@ float FlightTaskAutoLineSmoothVel::_getMaxZSpeed() const
 
 void FlightTaskAutoLineSmoothVel::_prepareSetpoints()
 {
-	// Interface: A valid position setpoint generates a velocity target using a P controller. If a velocity is specified
-	// that one is used as a velocity limit.
+	// Interface: A valid position setpoint generates a velocity target using conservative motion constraints.
+	// If a velocity is specified, that is used as a feedforward to track the position setpoint
+	// (ie. it assumes the position setpoint is moving at the specified velocity)
 	// If the position setpoints are set to NAN, the values in the velocity setpoints are used as velocity targets: nothing to do here.
 
 	_want_takeoff = false;
@@ -266,9 +267,9 @@ void FlightTaskAutoLineSmoothVel::_prepareSetpoints()
 			math::trajectory::clampToZNorm(vel_sp_constrained, z_speed);
 
 			for (int i = 0; i < 3; i++) {
-				// If available, constrain the velocity using _velocity_setpoint(.)
+				// If available, use the existing velocity as a feedforward, otherwise replace it
 				if (PX4_ISFINITE(_velocity_setpoint(i))) {
-					_velocity_setpoint(i) = _constrainOneSide(vel_sp_constrained(i), _velocity_setpoint(i));
+					_velocity_setpoint(i) += vel_sp_constrained(i);
 
 				} else {
 					_velocity_setpoint(i) = vel_sp_constrained(i);
@@ -287,9 +288,9 @@ void FlightTaskAutoLineSmoothVel::_prepareSetpoints()
 			Vector2f vel_sp_constrained_xy = u_pos_traj_to_dest_xy * _getMaxXYSpeed();
 
 			for (int i = 0; i < 2; i++) {
-				// If available, constrain the velocity using _velocity_setpoint(.)
+				// If available, use the existing velocity as a feedforward, otherwise replace it
 				if (PX4_ISFINITE(_velocity_setpoint(i))) {
-					_velocity_setpoint(i) = _constrainOneSide(vel_sp_constrained_xy(i), _velocity_setpoint(i));
+					_velocity_setpoint(i) += vel_sp_constrained_xy(i);
 
 				} else {
 					_velocity_setpoint(i) = vel_sp_constrained_xy(i);
@@ -303,9 +304,9 @@ void FlightTaskAutoLineSmoothVel::_prepareSetpoints()
 			const float z_dir = math::sign(_position_setpoint(2) - _trajectory[2].getCurrentPosition());
 			const float vel_sp_z = z_dir * _getMaxZSpeed();
 
-			// If available, constrain the velocity using _velocity_setpoint(.)
+			// If available, use the existing velocity as a feedforward, otherwise replace it
 			if (PX4_ISFINITE(_velocity_setpoint(2))) {
-				_velocity_setpoint(2) = _constrainOneSide(vel_sp_z, _velocity_setpoint(2));
+				_velocity_setpoint(2) += vel_sp_z;
 
 			} else {
 				_velocity_setpoint(2) = vel_sp_z;
@@ -328,8 +329,20 @@ void FlightTaskAutoLineSmoothVel::_updateTrajConstraints()
 	_trajectory[2].setMaxJerk(_param_mpc_jerk_auto.get());
 
 	if (_velocity_setpoint(2) < 0.f) { // up
-		_trajectory[2].setMaxAccel(_param_mpc_acc_up_max.get());
-		_trajectory[2].setMaxVel(_param_mpc_z_vel_max_up.get());
+		float z_accel_constraint = _param_mpc_acc_up_max.get();
+		float z_vel_constraint = _param_mpc_z_vel_max_up.get();
+
+		// The constraints are broken because they are used as hard limits by the position controller, so put this here
+		// until the constraints don't do things like cause controller integrators to saturate. Once the controller
+		// doesn't use z speed constraints, this can go in AutoMapper::_prepareTakeoffSetpoints(). Accel limit is to
+		// emulate the motor ramp (also done in the controller) so that the controller can actually track the setpoint.
+		if (_type == WaypointType::takeoff &&  _dist_to_ground < _param_mpc_land_alt1.get()) {
+			z_vel_constraint = _param_mpc_tko_speed.get();
+			z_accel_constraint = math::min(z_accel_constraint, _param_mpc_tko_speed.get() / _param_mpc_tko_ramp_t.get());
+		}
+
+		_trajectory[2].setMaxVel(z_vel_constraint);
+		_trajectory[2].setMaxAccel(z_accel_constraint);
 
 	} else { // down
 		_trajectory[2].setMaxAccel(_param_mpc_acc_down_max.get());

--- a/src/lib/flight_tasks/tasks/AutoMapper/FlightTaskAutoMapper.cpp
+++ b/src/lib/flight_tasks/tasks/AutoMapper/FlightTaskAutoMapper.cpp
@@ -142,9 +142,7 @@ void FlightTaskAutoMapper::_prepareTakeoffSetpoints()
 {
 	// Takeoff is completely defined by target position
 	_position_setpoint = _target;
-	const float speed_tko = (_dist_to_ground > _param_mpc_land_alt1.get()) ? _constraints.speed_up :
-				_param_mpc_tko_speed.get();
-	_velocity_setpoint = Vector3f(NAN, NAN, -speed_tko); // Limit the maximum vertical speed
+	_velocity_setpoint = Vector3f(NAN, NAN, NAN);
 
 	_gear.landing_gear = landing_gear_s::GEAR_DOWN;
 }

--- a/src/lib/flight_tasks/tasks/AutoMapper/FlightTaskAutoMapper.hpp
+++ b/src/lib/flight_tasks/tasks/AutoMapper/FlightTaskAutoMapper.hpp
@@ -70,7 +70,9 @@ protected:
 					_param_mpc_land_alt1, // altitude at which speed limit downwards reaches maximum speed
 					(ParamFloat<px4::params::MPC_LAND_ALT2>)
 					_param_mpc_land_alt2, // altitude at which speed limit downwards reached minimum speed
-					(ParamFloat<px4::params::MPC_TKO_SPEED>) _param_mpc_tko_speed
+					(ParamFloat<px4::params::MPC_TKO_SPEED>) _param_mpc_tko_speed,
+					(ParamFloat<px4::params::MPC_TKO_RAMP_T>)
+					_param_mpc_tko_ramp_t // time constant for smooth takeoff ramp
 				       );
 
 private:


### PR DESCRIPTION
**Describe problem solved by this pull request**
We want to be able to track a moving setpoint from the avoidance interface. However, right now velocity setpoints are used as constraints, which prevents their being used for the feedforward term to be able to specify the position setpoint as a moving target

**Describe your solution**
Use the _velocity_setpoint as a feedforward (which the name would imply), instead of using it as a constraint.

~~Use the _constraints to constrain the takeoff velocity, which was the only usage of the velocity setpoint term for contraining velocities from position setpoints before.~~ _constraints is used in mc_pos_control which introduces lots of discontinuities.

Ported the the only previous usage of the velocity constraint (takeoff speed) in the FlightTaskAutoLineSmoothVel. When the _constraints are removed from mc_pos_control this small code block can be moved to FlightTaskAutoMapper instead, and the constraints passed through via a constraints struct instead.

**Test data / coverage**
Test flown a bunch in SITL. Everything seems to behave exactly as it did before.

@PX4/testflights could you do some flights here? Specifically, make sure auto-takeoffs for missions seem the same as they were before.