### PR TITLE
Get PX4 compile on ARM GCC 9

### DIFF
--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -303,7 +303,7 @@ private:
 	/**
 	 * Trampoline to the worker task
 	 */
-	static void		task_main_trampoline(int argc, char *argv[]);
+	static int		task_main_trampoline(int argc, char *argv[]);
 
 	/**
 	 * worker task
@@ -882,7 +882,7 @@ PX4IO::init()
 				   SCHED_DEFAULT,
 				   SCHED_PRIORITY_ACTUATOR_OUTPUTS,
 				   1500,
-				   (main_t)&PX4IO::task_main_trampoline,
+				   (px4_main_t)&PX4IO::task_main_trampoline,
 				   nullptr);
 
 	if (_task < 0) {
@@ -893,10 +893,11 @@ PX4IO::init()
 	return OK;
 }
 
-void
+int
 PX4IO::task_main_trampoline(int argc, char *argv[])
 {
 	g_dev->task_main();
+	return 0;
 }
 
 void

--- a/src/drivers/telemetry/iridiumsbd/IridiumSBD.cpp
+++ b/src/drivers/telemetry/iridiumsbd/IridiumSBD.cpp
@@ -213,7 +213,7 @@ int IridiumSBD::ioctl(struct file *filp, int cmd, unsigned long arg)
 // private functions                                                 //
 ///////////////////////////////////////////////////////////////////////
 
-void IridiumSBD::main_loop_helper(int argc, char *argv[])
+int IridiumSBD::main_loop_helper(int argc, char *argv[])
 {
 	// start the main loop and stay in it
 	IridiumSBD::instance->main_loop(argc, argv);
@@ -225,6 +225,7 @@ void IridiumSBD::main_loop_helper(int argc, char *argv[])
 	IridiumSBD::instance = nullptr;
 
 	PX4_WARN("stopped");
+	return 0;
 }
 
 void IridiumSBD::main_loop(int argc, char *argv[])

--- a/src/drivers/telemetry/iridiumsbd/IridiumSBD.h
+++ b/src/drivers/telemetry/iridiumsbd/IridiumSBD.h
@@ -139,7 +139,7 @@ private:
 	/*
 	 * Entry point of the task, has to be a static function
 	 */
-	static void main_loop_helper(int argc, char *argv[]);
+	static int main_loop_helper(int argc, char *argv[]);
 
 	/*
 	 * Main driver loop

--- a/src/drivers/uavcan/CMakeLists.txt
+++ b/src/drivers/uavcan/CMakeLists.txt
@@ -71,7 +71,11 @@ add_definitions(
 	-DUAVCAN_PLATFORM=${UAVCAN_PLATFORM}
 )
 
-add_compile_options(-Wno-cast-align) # TODO: fix and enable
+add_compile_options(
+	-Wno-cast-align # TODO: fix and enable
+	-Wno-deprecated-copy # TODO: fix
+	-Wno-address-of-packed-member
+)
 add_subdirectory(${LIBUAVCAN_DIR} libuavcan EXCLUDE_FROM_ALL)
 add_dependencies(uavcan prebuild_targets)
 

--- a/src/lib/parameters/flashparams/CMakeLists.txt
+++ b/src/lib/parameters/flashparams/CMakeLists.txt
@@ -42,6 +42,7 @@ target_compile_options(flashparams
 	PRIVATE
 		-Wno-sign-compare # TODO: fix this
 		-Wno-cast-align # TODO: fix and enable
+		-Wno-address-of-packed-member # TODO: fix this
 )
 
 target_link_libraries(flashparams PRIVATE nuttx_arch)

--- a/src/systemcmds/tests/CMakeLists.txt
+++ b/src/systemcmds/tests/CMakeLists.txt
@@ -98,6 +98,7 @@ px4_add_module(
 		-Wno-unused-but-set-variable
 		-Wno-unused-result
 		-Wno-unused-variable
+		-Wno-vla-larger-than
 	SRCS
 		${srcs}
 	DEPENDS

--- a/src/systemcmds/tests/test_time.c
+++ b/src/systemcmds/tests/test_time.c
@@ -76,8 +76,8 @@ cycletime(void)
 int test_time(int argc, char *argv[])
 {
 	hrt_abstime h, c;
-	int64_t lowdelta, maxdelta = 0;
-	int64_t delta, deltadelta;
+	int lowdelta, maxdelta = 0;
+	int delta, deltadelta;
 
 	/* enable the cycle counter */
 	(*(unsigned long *)0xe000edfc) |= (1 << 24);    /* DEMCR |= DEMCR_TRCENA */
@@ -111,7 +111,7 @@ int test_time(int argc, char *argv[])
 
 		px4_leave_critical_section(flags);
 
-		delta = abs(h - c);
+		delta = h - c;
 		deltadelta = abs(delta - lowdelta);
 
 		if (deltadelta > maxdelta) {
@@ -119,7 +119,7 @@ int test_time(int argc, char *argv[])
 		}
 
 		if (deltadelta > 1000) {
-			fprintf(stderr, "h %" PRIu64 " c %" PRIu64 " d %" PRId64 "\n", h, c, delta - lowdelta);
+			fprintf(stderr, "h %" PRIu64 " c %" PRIu64 " d %d\n", h, c, delta - lowdelta);
 		}
 	}
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
Follow up to https://github.com/PX4/Firmware/pull/13375 and https://github.com/PX4/Firmware/pull/13448.

**Describe your solution**
There are less problems e.g. the new NuttX version is compatible. As discussed with @dagar the main remaining blocking issue is the linker script / flash region error like last time. It seems out of my reach to solve this by myself.

- [x] All binary output including io `overflows end of region flash` for every single section. This is probably due to `warning: creating a segment to contain the file and program headers outside of any MEMORY region`. Maybe the additional "default" section has to be disabled or placed in the linker file (thanks for input by @dinomani).
```
/usr/lib/gcc/arm-none-eabi/9.2.0/../../../../arm-none-eabi/bin/ld.gold: warning: creating a segment to contain the file and program headers outside of any MEMORY region
/usr/lib/gcc/arm-none-eabi/9.2.0/../../../../arm-none-eabi/bin/ld.gold: error: section .text overflows end of region flash
/usr/lib/gcc/arm-none-eabi/9.2.0/../../../../arm-none-eabi/bin/ld.gold: error: section .init_section overflows end of region flash
/usr/lib/gcc/arm-none-eabi/9.2.0/../../../../arm-none-eabi/bin/ld.gold: error: address 0x82e9bd4 is not within region flash
/usr/lib/gcc/arm-none-eabi/9.2.0/../../../../arm-none-eabi/bin/ld.gold: error: section __param overflows end of region flash
/usr/lib/gcc/arm-none-eabi/9.2.0/../../../../arm-none-eabi/bin/ld.gold: error: section .ARM.extab overflows end of region flash
/usr/lib/gcc/arm-none-eabi/9.2.0/../../../../arm-none-eabi/bin/ld.gold: error: section .ARM.exidx overflows end of region flash
/usr/lib/gcc/arm-none-eabi/9.2.0/../../../../arm-none-eabi/bin/ld.gold: error: section .data overflows end of region flash
```

@dagar I had to comment the `--print-memory-usage` since it seems the parameter name is now different. We need to add this info back, it's very useful.

**Test data / coverage**
Untested because of linker error.

**Additional context**
Trying CI build on Windows now using the new toolchain version 0.9 with ARM GCC 9 from https://github.com/PX4/windows-toolchain/releases/tag/v0.9