### PR TITLE
Spawn world separately from model in sitl gazebo

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -79,8 +79,8 @@ if [ "$program" == "jmavsim" ] && [ ! -n "$no_sim" ]; then
 	SIM_PID=`echo $!`
 elif [ "$program" == "gazebo" ] && [ ! -n "$no_sim" ]; then
 	if [ -x "$(command -v gazebo)" ]; then
-    # Set the plugin path so Gazebo finds our model and sim
-    source "$src_path/Tools/setup_gazebo.bash" "${src_path}" "${build_path}"
+		# Set the plugin path so Gazebo finds our model and sim
+		source "$src_path/Tools/setup_gazebo.bash" "${src_path}" "${build_path}"
 		if [ -z $PX4_SITL_WORLD ]; then
 			#Spawn predefined world
 			if [ "$world" == "none" ]; then
@@ -103,19 +103,19 @@ elif [ "$program" == "gazebo" ] && [ ! -n "$no_sim" ]; then
 				# Spawn world from environment variable with absolute path
 				gzserver "$PX4_SITL_WORLD" &
 			fi
-        fi
+		fi
 		gz model --spawn-file="${src_path}/Tools/sitl_gazebo/models/${model}/${model}.sdf" --model-name=${model} -x 1.01 -y 0.98 -z 0.83
 
 		SIM_PID=`echo $!`
 
-	if [[ -n "$HEADLESS" ]]; then
-		echo "not running gazebo gui"
-	else
-		# gzserver needs to be running to avoid a race. Since the launch
-		# is putting it into the background we need to avoid it by backing off
-		sleep 3
-		nice -n 20 gzclient --verbose &
-		GUI_PID=`echo $!`
+		if [[ -n "$HEADLESS" ]]; then
+			echo "not running gazebo gui"
+		else
+			# gzserver needs to be running to avoid a race. Since the launch
+			# is putting it into the background we need to avoid it by backing off
+			sleep 3
+			nice -n 20 gzclient --verbose &
+			GUI_PID=`echo $!`
 		fi
 	else
 		echo "You need to have gazebo simulator installed!"

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -66,30 +66,34 @@ set(models none shell
 	standard_vtol tailsitter tiltrotor
 	rover boat
 	uuv_hippocampus)
+set(worlds none empty warehouse)
 set(all_posix_vmd_make_targets)
 foreach(viewer ${viewers})
 	foreach(debugger ${debuggers})
 		foreach(model ${models})
-			if (debugger STREQUAL "none")
-				if (model STREQUAL "none")
-					set(_targ_name "${viewer}")
-				else()
-					set(_targ_name "${viewer}_${model}")
-				endif()
-			else()
-				if (model STREQUAL "none")
-					set(_targ_name "${viewer}___${debugger}")
-				else()
-					set(_targ_name "${viewer}_${model}_${debugger}")
-				endif()
-			endif()
+			foreach(world ${worlds})
+				if (world STREQUAL "none")
+					if (debugger STREQUAL "none")
+						if (model STREQUAL "none")
+							set(_targ_name "${viewer}")
+						else()
+							set(_targ_name "${viewer}_${model}")
+						endif()
+					else()
+						if (model STREQUAL "none")
+							set(_targ_name "${viewer}___${debugger}")
+						else()
+							set(_targ_name "${viewer}_${model}_${debugger}")
+						endif()
+					endif()
 
-			add_custom_target(${_targ_name}
+					add_custom_target(${_targ_name}
 					COMMAND ${PX4_SOURCE_DIR}/Tools/sitl_run.sh
 						$<TARGET_FILE:px4>
 						${debugger}
 						${viewer}
 						${model}
+						${world}
 						${PX4_SOURCE_DIR}
 						${PX4_BINARY_DIR}
 					WORKING_DIRECTORY ${SITL_WORKING_DIR}
@@ -97,12 +101,47 @@ foreach(viewer ${viewers})
 					DEPENDS
 						logs_symlink
 					)
-			list(APPEND all_posix_vmd_make_targets ${_targ_name})
-			if (viewer STREQUAL "gazebo")
-				add_dependencies(${_targ_name} px4 sitl_gazebo)
-			elseif(viewer STREQUAL "jmavsim")
-				add_dependencies(${_targ_name} px4 git_jmavsim)
-			endif()
+					list(APPEND all_posix_vmd_make_targets ${_targ_name})
+					if (viewer STREQUAL "gazebo")
+						add_dependencies(${_targ_name} px4 sitl_gazebo)
+					elseif(viewer STREQUAL "jmavsim")
+						add_dependencies(${_targ_name} px4 git_jmavsim)
+					endif()
+				else()
+					if (viewer STREQUAL "gazebo")
+						if (debugger STREQUAL "none")
+							if (model STREQUAL "none")
+								set(_targ_name "${viewer}___${world}")
+							else()
+								set(_targ_name "${viewer}_${model}__${world}")
+							endif()
+						else()
+							if (model STREQUAL "none")
+								set(_targ_name "${viewer}__${debugger}_${world}")
+							else()
+								set(_targ_name "${viewer}_${model}_${debugger}_${world}")
+							endif()
+						endif()
+
+						add_custom_target(${_targ_name}
+						COMMAND ${PX4_SOURCE_DIR}/Tools/sitl_run.sh
+							$<TARGET_FILE:px4>
+							${debugger}
+							${viewer}
+							${model}
+							${world}
+							${PX4_SOURCE_DIR}
+							${PX4_BINARY_DIR}
+						WORKING_DIRECTORY ${SITL_WORKING_DIR}
+						USES_TERMINAL
+						DEPENDS
+							logs_symlink
+						)
+						list(APPEND all_posix_vmd_make_targets ${_targ_name})
+						add_dependencies(${_targ_name} px4 sitl_gazebo)
+					endif()
+				endif()
+			endforeach()
 		endforeach()
 	endforeach()
 endforeach()

--- a/platforms/posix/cmake/sitl_tests.cmake
+++ b/platforms/posix/cmake/sitl_tests.cmake
@@ -61,6 +61,7 @@ foreach(test_name ${tests})
 			none
 			none
 			test_${test_name}_generated
+			none
 			${PX4_SOURCE_DIR}
 			${PX4_BINARY_DIR}
 		WORKING_DIRECTORY ${SITL_WORKING_DIR})
@@ -79,6 +80,7 @@ add_test(NAME mavlink
 		none
 		none
 		test_mavlink
+		none
 		${PX4_SOURCE_DIR}
 		${PX4_BINARY_DIR}
 	WORKING_DIRECTORY ${SITL_WORKING_DIR})
@@ -96,6 +98,7 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "CYGWIN")
 			none
 			none
 			test_shutdown
+			none
 			${PX4_SOURCE_DIR}
 			${PX4_BINARY_DIR}
 		WORKING_DIRECTORY ${SITL_WORKING_DIR})
@@ -112,6 +115,7 @@ add_test(NAME dyn
 		none
 		none
 		test_dyn_hello
+		none
 		${PX4_SOURCE_DIR}
 		${PX4_BINARY_DIR}
 		$<TARGET_FILE:examples__dyn_hello>
@@ -135,6 +139,7 @@ foreach(cmd_name ${test_cmds})
 			none
 			none
 			cmd_${cmd_name}_generated
+			none
 			${PX4_SOURCE_DIR}
 			${PX4_BINARY_DIR}
 		WORKING_DIRECTORY ${SITL_WORKING_DIR})

--- a/test/mavsdk_tests/mavsdk_test_runner.py
+++ b/test/mavsdk_tests/mavsdk_test_runner.py
@@ -381,12 +381,19 @@ class Tester:
                     self.verbose)
                 self.active_runners.append(gzserver_runner)
 
+                waitforgz_runner = ph.WaitforgzRunner(
+                    os.getcwd(),
+                    log_dir,
+                    test['model'],
+                    case,
+                    self.verbose)
+                self.active_runners.append(waitforgz_runner)
+
                 gzmodelspawn_runner = ph.GzmodelspawnRunner(
                     os.getcwd(),
                     log_dir,
                     test['model'],
                     case,
-                    self.get_max_speed_factor(test),
                     self.verbose)
                 self.active_runners.append(gzmodelspawn_runner)
 

--- a/test/mavsdk_tests/mavsdk_test_runner.py
+++ b/test/mavsdk_tests/mavsdk_test_runner.py
@@ -381,6 +381,15 @@ class Tester:
                     self.verbose)
                 self.active_runners.append(gzserver_runner)
 
+                gzmodelspawn_runner = ph.GzmodelspawnRunner(
+                    os.getcwd(),
+                    log_dir,
+                    test['model'],
+                    case,
+                    self.get_max_speed_factor(test),
+                    self.verbose)
+                self.active_runners.append(gzmodelspawn_runner)
+
                 if self.gui:
                     gzclient_runner = ph.GzclientRunner(
                         os.getcwd(),

--- a/test/mavsdk_tests/process_helper.py
+++ b/test/mavsdk_tests/process_helper.py
@@ -190,7 +190,41 @@ class GzserverRunner(Runner):
         self.cmd = "gzserver"
         self.args = ["--verbose",
                      workspace_dir + "/Tools/sitl_gazebo/worlds/" +
-                     self.model + ".world"]
+                     "empty.world"]
+
+    def add_to_env_if_set(self, var: str) -> None:
+        if var in os.environ:
+            self.env[var] = os.environ[var]
+
+
+class GzmodelspawnRunner(Runner):
+    def __init__(self,
+                 workspace_dir: str,
+                 log_dir: str,
+                 model: str,
+                 case: str,
+                 speed_factor: float,
+                 verbose: bool):
+        super().__init__(log_dir, model, case, verbose)
+        self.name = "gzmodelspawn"
+        self.cwd = workspace_dir
+        self.env = {"PATH": os.environ['PATH'],
+                    "HOME": os.environ['HOME'],
+                    "GAZEBO_PLUGIN_PATH":
+                    workspace_dir + "/build/px4_sitl_default/build_gazebo",
+                    "GAZEBO_MODEL_PATH":
+                    workspace_dir + "/Tools/sitl_gazebo/models",
+                    "PX4_SIM_SPEED_FACTOR": str(speed_factor),
+                    "DISPLAY": os.environ['DISPLAY']}
+        self.add_to_env_if_set("PX4_HOME_LAT")
+        self.add_to_env_if_set("PX4_HOME_LON")
+        self.add_to_env_if_set("PX4_HOME_ALT")
+        self.cmd = "gz"
+        self.args = ["model", "--spawn-file", workspace_dir +
+                     "/Tools/sitl_gazebo/models/" +
+                     self.model + "/" + self.model + ".sdf",
+                     "--model-name", self.model,
+                     "-x", "1.01", "-y", "0.98", "-z", "0.83"]
 
     def add_to_env_if_set(self, var: str) -> None:
         if var in os.environ:

--- a/test/mavsdk_tests/waitforgz.sh
+++ b/test/mavsdk_tests/waitforgz.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+while gz stats -d 0 2>&1 | grep "An instance of Gazebo is not running."; do
+    echo "Still running"
+done
+
+echo "done"

--- a/test/mavsdk_tests/waitforgz.sh
+++ b/test/mavsdk_tests/waitforgz.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
 while gz stats -d 0 2>&1 | grep "An instance of Gazebo is not running."; do
-    echo "Still running"
+    echo "Gazebo not running yet ..."
 done
-
-echo "done"

--- a/test/mavsdk_tests/waitforgz.sh
+++ b/test/mavsdk_tests/waitforgz.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-while gz stats -d 0 2>&1 | grep "An instance of Gazebo is not running."; do
+while gz stats -d 0 2>&1 | grep -q "An instance of Gazebo is not running."; do
     echo "Gazebo not running yet ..."
 done


### PR DESCRIPTION
**Describe problem solved by this pull request**
Previously, the name of the world in gazebo always needed to match the name of the model. This has created a lot of world files that are identical but required just to spawn the model inside the world.

In gazebo, the world files are designed to be interchangable between models. Therefore, there is no need use the world file as a tool to spawn the models. 

**Describe your solution**
This PR creates a logic in the `sitl_run.sh` script so that the model is spawned into gazebo, and not included as part of the world. The logic is as the following.
- If there is no <model>.world existing in the worlds directory, the model is spawned in `empty.world` 
- If there is a model specific world in the worlds directory, the world '<model>.world` is spawned
- If a world file path is specified on the environment variable `PX4_SIM_WORLD`, this world is spawned.

This creates a breaking change against the sitl_gazebo repository, since all the models will be spawned twice if this is used with the previous approach.

This PR needs to have https://github.com/PX4/sitl_gazebo/pull/414 or it will end up spawning two vehicles

**Describe possible alternatives**
Rather than using environment variables with paths, we can also add worlds as part of a cmake target. However, this has to be predefined, and for a non-predefined world path, I believe a environment variable solution should work. 

**Test data / coverage**
Models are spawned correctly. Try
`make px4_sitl  gazebo_solo`

**Additional Context**
@hamishwillee This enables you to spawn worlds separately as we discussed
