### PR TITLE
FlightTaskManualAltitude: Fix sign error in terrain hold setpoint reset

### DIFF
--- a/src/lib/flight_tasks/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
+++ b/src/lib/flight_tasks/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
@@ -136,7 +136,7 @@ void FlightTaskManualAltitude::_updateAltitudeLock()
 
 				// Adjust the setpoint to maintain the same height error to reduce control transients
 				if (PX4_ISFINITE(_dist_to_ground_lock) && PX4_ISFINITE(_dist_to_bottom)) {
-					_position_setpoint(2) = _position(2) + (_dist_to_ground_lock - _dist_to_bottom);
+					_position_setpoint(2) = _position(2) - (_dist_to_ground_lock - _dist_to_bottom);
 
 				} else {
 					_position_setpoint(2) = _position(2);
@@ -153,7 +153,7 @@ void FlightTaskManualAltitude::_updateAltitudeLock()
 
 				// Adjust the setpoint to maintain the same height error to reduce control transients
 				if (PX4_ISFINITE(_position_setpoint(2))) {
-					_dist_to_ground_lock = _dist_to_bottom + (_position_setpoint(2) - _position(2));
+					_dist_to_ground_lock = _dist_to_bottom - (_position_setpoint(2) - _position(2));
 				}
 			}
 		}


### PR DESCRIPTION
**Describe problem solved by this pull request**
In terrain hold mode, the drone holds its height over the terrain when it's stopped, but follows sea level altitude when moving. Every time the drone stops, the height over terrain setpoint is computed to match the current altitude setpoint, given the current height over the terrain. The opposite is also done to give an altitude setpoint matching the current terrain setpoint when the drone starts moving. These setpoint calculations seem to have a sign error, which will give an error in the computed setpoints when the drone starts/stops terrain holding.

Example illustrating the issue:
* z position = - 10 m (this is in NED frame)
* z position setpoint = - 10.5 m (also NED frame, so setpoint is 0.5 m above current z position)
* height over terrain = 5 m
then we'd get
* height over terrain setpoint = height over terrain + (z position setpoint - z position) = 5 + (-10.5 - (-10)) = 5 + (-0.5) = 5 - 0.5 = 4.5 m. This is below the current position, but it should be above (5.5 m), like the altitude setpoint was.

**Describe your solution**
Flip the signs.