### PR TITLE
Support large number of vehicles for mutlivehicle SITL

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -109,7 +109,9 @@ param set MAV_SYS_ID $((px4_instance+1))
 simulator_tcp_port=$((4560+px4_instance))
 udp_offboard_port_local=$((14580+px4_instance))
 udp_offboard_port_remote=$((14540+px4_instance))
-udp_gcs_port_local=$((14570+px4_instance))
+[ $px4_instance -gt 9 ] && udp_offboard_port_remote=14549 # use the same ports for more than 10 instances to avoid port overlaps
+udp_gcs_port_local=$((18570+px4_instance))
+
 
 if [ $AUTOCNF = yes ]
 then

--- a/Tools/gazebo_sitl_multiple_run.sh
+++ b/Tools/gazebo_sitl_multiple_run.sh
@@ -35,6 +35,12 @@ then
 	exit 1
 fi
 
+if [ $num_vehicles -gt 255 ]
+then
+	echo "Tried spawning $num_vehicles vehicles. The maximum number of supported vehicles is 255"
+	exit 1
+fi
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 src_path="$SCRIPT_DIR/.."
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
Previously, the number of vehicles that were able to be simulated was limited to 10 vehicles. This was due to a overlap on port numbering that overlapped in the rcS definition.

Resubmitted #14126 

**Describe your solution**
- Redefine gcs udp port from `14570` to `18570` in rcS.
- Increment remote udp port from 14540 to 14549 to limit overlap with port 14550 which is the default listening port of qgc
- Also since mavlink only supports 255 IDs to be assigned the script errors if you try to spawn more than 255 vehicles

**Test data / coverage**
Tested up to 100 instances of vehicles on a desktop.
Image below shows 30 vehicles

![Screenshot from 2020-02-09 12-37-21](https://user-images.githubusercontent.com/5248102/74106153-50a49e80-4b64-11ea-9327-3aa28fc26ead.png)

