### PR TITLE
platforms: prevent stackoverflow for ekf2 sideslip

### DIFF
--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
@@ -65,7 +65,6 @@ static constexpr wq_config_t I2C3{"wq:I2C3", 1400, -11};
 static constexpr wq_config_t I2C4{"wq:I2C4", 1400, -12};
 
 // PX4 att/pos controllers, highest priority after sensors.
-// Stack size needed with ekf2 sideslip failure triggered was 6750
 static constexpr wq_config_t att_pos_ctrl{"wq:att_pos_ctrl", 7200, -13};
 
 static constexpr wq_config_t hp_default{"wq:hp_default", 1900, -14};

--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
@@ -64,7 +64,9 @@ static constexpr wq_config_t I2C2{"wq:I2C2", 1400, -10};
 static constexpr wq_config_t I2C3{"wq:I2C3", 1400, -11};
 static constexpr wq_config_t I2C4{"wq:I2C4", 1400, -12};
 
-static constexpr wq_config_t att_pos_ctrl{"wq:att_pos_ctrl", 6600, -13}; // PX4 att/pos controllers, highest priority after sensors
+// PX4 att/pos controllers, highest priority after sensors.
+// Stack size needed with ekf2 sideslip failure triggered was 6750
+static constexpr wq_config_t att_pos_ctrl{"wq:att_pos_ctrl", 7200, -13};
 
 static constexpr wq_config_t hp_default{"wq:hp_default", 1900, -14};
 


### PR DESCRIPTION
It turns out that ekf2 needs more stack when sideslip fusion fails.
Sideslip fusion is currently only enabled for fixedwing by default and not executed in testing.

Should fix the crash seen in #14134.