### PR TITLE
uORB::SubscriptionCallback relax interval check to accommodate realistic sensor publication rates and occasional jitter

### DIFF
--- a/src/drivers/pwm_out/PWMOut.cpp
+++ b/src/drivers/pwm_out/PWMOut.cpp
@@ -36,7 +36,8 @@
 PWMOut::PWMOut() :
 	CDev(PX4FMU_DEVICE_PATH),
 	OutputModuleInterface(MODULE_NAME, px4::wq_configurations::hp_default),
-	_cycle_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": cycle"))
+	_cycle_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")),
+	_interval_perf(perf_alloc(PC_INTERVAL, MODULE_NAME": interval"))
 {
 	_mixing_output.setAllMinValues(PWM_DEFAULT_MIN);
 	_mixing_output.setAllMaxValues(PWM_DEFAULT_MAX);
@@ -52,6 +53,7 @@ PWMOut::~PWMOut()
 	unregister_class_devname(PWM_OUTPUT_BASE_DEVICE_PATH, _class_instance);
 
 	perf_free(_cycle_perf);
+	perf_free(_interval_perf);
 }
 
 int PWMOut::init()
@@ -397,6 +399,11 @@ void PWMOut::update_current_rate()
 	// oneshot
 	if ((_pwm_default_rate == 0) || (_pwm_alt_rate == 0)) {
 		max_rate = 2000;
+
+	} else {
+		// run up to twice PWM rate to reduce end-to-end latency
+		//  actual pulse width only updated for next period regardless of output module
+		max_rate *= 2;
 	}
 
 	// max interval 0.5 - 100 ms (10 - 2000Hz)
@@ -564,6 +571,7 @@ void PWMOut::Run()
 	}
 
 	perf_begin(_cycle_perf);
+	perf_count(_interval_perf);
 
 	_mixing_output.update();
 
@@ -1992,6 +2000,7 @@ int PWMOut::print_status()
 	}
 
 	perf_print_counter(_cycle_perf);
+	perf_print_counter(_interval_perf);
 	_mixing_output.printStatus();
 
 	return 0;

--- a/src/drivers/pwm_out/PWMOut.hpp
+++ b/src/drivers/pwm_out/PWMOut.hpp
@@ -181,6 +181,7 @@ private:
 	unsigned	_num_disarmed_set{0};
 
 	perf_counter_t	_cycle_perf;
+	perf_counter_t	_interval_perf;
 
 	void		capture_callback(uint32_t chan_index,
 					 hrt_abstime edge_time, uint32_t edge_state, uint32_t overflow);

--- a/src/modules/uORB/SubscriptionInterval.hpp
+++ b/src/modules/uORB/SubscriptionInterval.hpp
@@ -47,6 +47,8 @@
 
 #include "Subscription.hpp"
 
+#include <mathlib/mathlib.h>
+
 namespace uORB
 {
 
@@ -121,7 +123,9 @@ public:
 	bool copy(void *dst)
 	{
 		if (_subscription.copy(dst)) {
-			_last_update = hrt_absolute_time();
+			const hrt_abstime now = hrt_absolute_time();
+			// shift last update time forward, but don't let it get further behind than the interval
+			_last_update = math::constrain(_last_update + _interval_us, now - _interval_us, now);
 			return true;
 		}
 


### PR DESCRIPTION
Let me start by saying I admit this seems hacky, so I'm certainly open to alternatives.

Currently in master in output modules like `drivers/px4fmu` we use a `uORB::SubscriptionCallbackWorkItem` to schedule the module to run on any updates to the relevant (mixed) actuator_controls, but with a max interval set to limit the update appropriately for the actuator.

For example when using typical 400 Hz PWM ESCs we set the interval of the `uORB::SubscriptionCallbackWorkItem` to 2500 us with the intended goal of mixing and updating the actuators at their maximum rate. Unfortunately in reality our actual data rates don't align perfectly due to minor clock differences between sensors and the flight controller, occasional jitter, and minor implementation details with the interval check (timestamp after successful copy, etc).

As a result our "400 Hz synchronized inner loop" actually looks like this...

### IMU_GYRO_RATEMAX 400 (https://github.com/PX4/Firmware/pull/14174)
```
update: 1s, num topics: 67
TOPIC NAME                     INST #SUB #MSG #LOST #QSIZE
sensor_gyro                       0    1  398     0 4
sensor_accel                      0    1  398     0 4
actuator_controls_0               0    5  399  1158 1
rate_ctrl_status                  0    0  399     0 1
actuator_outputs                  0    3  237   525 1
multirotor_motor_limits           0    1  237     0 1
```

The 400 Hz pwm output module running synchronized with the 400 Hz IMU and rate controller is actually only running at roughly 237 Hz due to the uORB::SubscriptionCallbackWorkItem interval check (using hrt_elapsed_time()).


If we relax the interval check we can achieve the desired result (synchronized `IMU -> rate controller -> mixing -> actuator output`).

### IMU_GYRO_RATEMAX 400 (relaxed interval check)

```
update: 1s, num topics: 67
TOPIC NAME                     INST #SUB #MSG #LOST #QSIZE
sensor_gyro                       0    1  399     0 4
sensor_accel                      0    1  399     0 4
actuator_controls_0               0    5  399   915 1
rate_ctrl_status                  0    0  399     0 1
actuator_outputs                  0    3  399  1333 1
multirotor_motor_limits           0    1  399     0 1
```

I think this makes sense if you consider the uORB::SubscriptionCallback interval as a crude throttling mechanism (mixing is expensive) and not a precise rate control protection. Writing pwm outputs slightly faster than 400 Hz is still safe (verifying with @davids5), and much better than the alternative of narrowly misaligning and running much slower than intended.

I also considered resurrecting the mechanism we used to have in old orb subscriptions where if you had an orb subscription interval set and you checked for an update it would schedule an hrt callback to notify the subscription when the interval had finally elapsed. Although this mechanism would result in nice clean round update interval numbers it also inserts and hides latency and ruins the back-to-back-to-back work queue pipeline execution.

Thoughts?