### PR TITLE
Commander: fix preflight check condition to fail if not in HIL mode

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -697,7 +697,7 @@ Commander::handle_command(vehicle_status_s *status_local, const vehicle_command_
 
 					} else {
 						// Refuse to arm if preflight checks have failed
-						if ((!status_local->hil_state) != vehicle_status_s::HIL_STATE_ON
+						if (status_local->hil_state != vehicle_status_s::HIL_STATE_ON
 						    && !status_flags.condition_system_sensors_initialized) {
 							mavlink_log_critical(&mavlink_log_pub, "Arming denied! Preflight checks have failed");
 							cmd_result = vehicle_command_s::VEHICLE_CMD_RESULT_DENIED;


### PR DESCRIPTION
As I understand the existing code, the `if` statement is only entered if `status_local->hil_state` is `vehicle_status_s::HIL_STATE_ON`. I.e. for all real vehicles, this check is skipped.