### PR TITLE
fix mavlink_log_handler: close file descriptor if still open in destructor

### DIFF
--- a/src/modules/mavlink/mavlink_log_handler.cpp
+++ b/src/modules/mavlink/mavlink_log_handler.cpp
@@ -349,6 +349,10 @@ LogListHelper::LogListHelper()
 //-------------------------------------------------------------------
 LogListHelper::~LogListHelper()
 {
+	if (current_log_filep) {
+		::fclose(current_log_filep);
+	}
+
 	// Remove log data files (if any)
 	unlink(kLogData);
 	unlink(kTmpData);


### PR DESCRIPTION
Fixes https://github.com/PX4/Firmware/issues/14157