### PR TITLE
Commander: Add option for transition to position after takeoff

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2013,7 +2013,7 @@ Commander::run()
 			}
 		}
 
-		/* Reset main state to loiter or auto-mission after takeoff is completed.
+		/* Transition to loiter, auto-mission or position control mode when takeoff is completed.
 		 * Sometimes, the mission result topic is outdated and the mission is still signaled
 		 * as finished even though we only just started with the takeoff. Therefore, we also
 		 * check the timestamp of the mission_result topic. */
@@ -2026,6 +2026,9 @@ Commander::run()
 
 			if ((_param_takeoff_finished_action.get() == 1) && mission_available) {
 				main_state_transition(status, commander_state_s::MAIN_STATE_AUTO_MISSION, status_flags, &_internal_state);
+
+			} else if (_param_takeoff_finished_action.get() == 2) {
+				main_state_transition(status, commander_state_s::MAIN_STATE_POSCTL, status_flags, &_internal_state);
 
 			} else {
 				main_state_transition(status, commander_state_s::MAIN_STATE_AUTO_LOITER, status_flags, &_internal_state);

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -790,6 +790,7 @@ PARAM_DEFINE_INT32(COM_FLIGHT_UUID, 0);
  *
  * @value 0 Hold
  * @value 1 Mission (if valid)
+ * @value 2 Position
  * @group Mission
  */
 PARAM_DEFINE_INT32(COM_TAKEOFF_ACT, 0);


### PR DESCRIPTION
**Describe problem solved by this pull request**
I usually fly in position mode. I want to be able to takeoff by using the button in qgroundcontrol, and then go straight to position mode, so I don't have to manually select position mode in the dropdown after takeoff is complete (and the drone has switched to hold mode which is the default).

**Describe your solution**
Add a new third value to the parameter COM_TAKEOFF_ACT (value 2 = "Position"), and add a case in the Commender to check for this value. If the parameter is set to 2, then transition to position mode when takeoff is finished, instead of transition to hold or mission mode, which are already possible.

**Describe possible alternatives**
I could just deal with it and do the manual mode change every time I take off, but it's inconvenient.