### PR TITLE
bmp388: fix double free in case the driver probing fails 

### DIFF
--- a/src/drivers/barometer/bmp388/bmp388.h
+++ b/src/drivers/barometer/bmp388/bmp388.h
@@ -297,9 +297,6 @@ public:
 	// write reg value
 	virtual int set_reg(uint8_t value, uint8_t addr) = 0;
 
-	// bulk read of data into buffer, return same pointer
-	virtual data_s *get_data(uint8_t addr) = 0;
-
 	// bulk read of calibration data into buffer, return same pointer
 	virtual calibration_s *get_calibration(uint8_t addr) = 0;
 

--- a/src/drivers/barometer/bmp388/bmp388_i2c.cpp
+++ b/src/drivers/barometer/bmp388/bmp388_i2c.cpp
@@ -54,14 +54,12 @@ public:
 	uint8_t get_reg(uint8_t addr);
 	int get_reg_buf(uint8_t addr, uint8_t *buf, uint8_t len);
 	int set_reg(uint8_t value, uint8_t addr);
-	data_s *get_data(uint8_t addr);
 	calibration_s *get_calibration(uint8_t addr);
 
 	uint32_t get_device_id() const override { return device::I2C::get_device_id(); }
 
 private:
 	struct calibration_s _cal;
-	struct data_s _data;
 };
 
 IBMP388 *bmp388_i2c_interface(uint8_t busnum, uint32_t device)
@@ -97,18 +95,6 @@ int BMP388_I2C::set_reg(uint8_t value, uint8_t addr)
 {
 	uint8_t cmd[2] = { (uint8_t)(addr), value};
 	return transfer(cmd, sizeof(cmd), nullptr, 0);
-}
-
-data_s *BMP388_I2C::get_data(uint8_t addr)
-{
-	const uint8_t cmd = (uint8_t)(addr);
-
-	if (transfer(&cmd, sizeof(cmd), (uint8_t *)&_data, sizeof(struct data_s)) == OK) {
-		return (&_data);
-
-	} else {
-		return nullptr;
-	}
 }
 
 calibration_s *BMP388_I2C::get_calibration(uint8_t addr)

--- a/src/drivers/barometer/bmp388/bmp388_main.cpp
+++ b/src/drivers/barometer/bmp388/bmp388_main.cpp
@@ -103,10 +103,15 @@ static bool start_bus(bmp388_bus_option &bus)
 
 	BMP388 *dev = new BMP388(interface);
 
-	if (dev == nullptr || (dev->init() != PX4_OK)) {
+	if (dev == nullptr) {
+		PX4_ERR("alloc failed");
+		delete interface;
+		return false;
+	}
+
+	if (dev->init() != PX4_OK) {
 		PX4_ERR("driver start failed");
 		delete dev;
-		delete interface;
 		return false;
 	}
 

--- a/src/drivers/barometer/bmp388/bmp388_spi.cpp
+++ b/src/drivers/barometer/bmp388/bmp388_spi.cpp
@@ -71,14 +71,12 @@ public:
 	uint8_t get_reg(uint8_t addr);
 	int get_reg_buf(uint8_t addr, uint8_t *buf, uint8_t len);
 	int set_reg(uint8_t value, uint8_t addr);
-	data_s *get_data(uint8_t addr);
 	calibration_s *get_calibration(uint8_t addr);
 
 	uint32_t get_device_id() const override { return device::SPI::get_device_id(); }
 
 private:
 	spi_calibration_s _cal;
-	spi_data_s _data;
 };
 
 IBMP388 *bmp388_spi_interface(uint8_t busnum, uint32_t device)
@@ -114,18 +112,6 @@ int BMP388_SPI::set_reg(uint8_t value, uint8_t addr)
 {
 	uint8_t cmd[2] = { (uint8_t)(addr & DIR_WRITE), value}; //clear MSB bit
 	return transfer(&cmd[0], nullptr, 2);
-}
-
-data_s *BMP388_SPI::get_data(uint8_t addr)
-{
-	_data.addr = (uint8_t)(addr | DIR_READ); //set MSB bit
-
-	if (transfer((uint8_t *)&_data, (uint8_t *)&_data, sizeof(struct spi_data_s)) == OK) {
-		return &(_data.data);
-
-	} else {
-		return nullptr;
-	}
 }
 
 calibration_s *BMP388_SPI::get_calibration(uint8_t addr)


### PR DESCRIPTION
'interface' is freed in BMP388's destructor.
I had hardfaults on v5x because of this.

@davids5 @dinomani fyi