### PR TITLE
VTOL tiltrotor: introduce spin up time with spin up tilt angle

### DIFF
--- a/src/modules/vtol_att_control/tiltrotor.h
+++ b/src/modules/vtol_att_control/tiltrotor.h
@@ -63,9 +63,10 @@ public:
 private:
 
 	struct {
-		float tilt_mc;					/**< actuator value corresponding to mc tilt */
+		float tilt_mc;				/**< actuator value corresponding to mc tilt */
 		float tilt_transition;			/**< actuator value corresponding to transition tilt (e.g 45 degrees) */
-		float tilt_fw;					/**< actuator value corresponding to fw tilt */
+		float tilt_fw;				/**< actuator value corresponding to fw tilt */
+		float tilt_spinup;			/**< actuator value corresponding to spinup tilt */
 		float front_trans_dur_p2;
 	} _params_tiltrotor;
 
@@ -73,6 +74,7 @@ private:
 		param_t tilt_mc;
 		param_t tilt_transition;
 		param_t tilt_fw;
+		param_t tilt_spinup;
 		param_t front_trans_dur_p2;
 	} _params_handles_tiltrotor;
 
@@ -99,6 +101,8 @@ private:
 	float _tilt_control{0.0f};		/**< actuator value for the tilt servo */
 
 	void parameters_update() override;
+	hrt_abstime _last_timestamp_disarmed{0}; /**< used for calculating time since arming */
+	bool _tilt_motors_for_startup{false};
 
 };
 #endif

--- a/src/modules/vtol_att_control/tiltrotor_params.c
+++ b/src/modules/vtol_att_control/tiltrotor_params.c
@@ -72,6 +72,20 @@ PARAM_DEFINE_FLOAT(VT_TILT_TRANS, 0.3f);
 PARAM_DEFINE_FLOAT(VT_TILT_FW, 1.0f);
 
 /**
+ * Tilt actuator control value commanded when disarmed and during the first second after arming.
+ *
+ * This specific tilt during spin-up is necessary for some systems whose motors otherwise don't
+ * spin-up freely.
+ *
+ * @min 0.0
+ * @max 1.0
+ * @increment 0.01
+ * @decimal 3
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_TILT_SPINUP, 0.0f);
+
+/**
  * Duration of front transition phase 2
  *
  * Time in seconds it should take for the rotors to rotate forward completely from the point


### PR DESCRIPTION
As some tiltrotor systems need a certain tilt angle of their motors in order to spin up freely,
this PR introduces an additional parameter VT_TILT_SPINUP and sets the motor tilt to
this value if disarmed or within 1s since arming.

**Test data / coverage**
Bench and flight tested.
