### PR TITLE
MC rate controller: limit K values of PID controller to [0.3, 5.0] in pitch and roll

### DIFF
--- a/src/modules/mc_rate_control/mc_rate_control_params.c
+++ b/src/modules/mc_rate_control/mc_rate_control_params.c
@@ -112,7 +112,7 @@ PARAM_DEFINE_FLOAT(MC_ROLLRATE_FF, 0.0f);
  * Set MC_ROLLRATE_P=1 to implement a PID in the ideal form.
  * Set MC_ROLLRATE_K=1 to implement a PID in the parallel form.
  *
- * @min 0.0
+ * @min 0.01
  * @max 5.0
  * @decimal 4
  * @increment 0.0005
@@ -192,7 +192,7 @@ PARAM_DEFINE_FLOAT(MC_PITCHRATE_FF, 0.0f);
  * Set MC_PITCHRATE_P=1 to implement a PID in the ideal form.
  * Set MC_PITCHRATE_K=1 to implement a PID in the parallel form.
  *
- * @min 0.0
+ * @min 0.01
  * @max 5.0
  * @decimal 4
  * @increment 0.0005

--- a/src/modules/mc_rate_control/mc_rate_control_params.c
+++ b/src/modules/mc_rate_control/mc_rate_control_params.c
@@ -44,7 +44,7 @@
  *
  * Roll rate proportional gain, i.e. control output for angular speed error 1 rad/s.
  *
- * @min 0.0
+ * @min 0.01
  * @max 0.5
  * @decimal 3
  * @increment 0.01
@@ -125,7 +125,7 @@ PARAM_DEFINE_FLOAT(MC_ROLLRATE_K, 1.0f);
  *
  * Pitch rate proportional gain, i.e. control output for angular speed error 1 rad/s.
  *
- * @min 0.0
+ * @min 0.01
  * @max 0.6
  * @decimal 3
  * @increment 0.01


### PR DESCRIPTION
Currently the minimum value for the K parameter is at 0. I find this a bit dangerous during tuning, as an unintended setting to 0 results in complete loss of control around the corresponding axis. Setting any other PID gain to 0 should not be quite as fatal, as in these cases you at least have some control from the other 2 parts (limiting the P to something >0 could though also make sense, no?).

The minimum limit of 0.3 that I propose here is pretty random, but should at least leave some control authority to bring the system safely to the ground. If a smaller than 0.3 value is necessary there is still the option of using a forced-safe. 

What's your opinion @bresch ? Do you know of any system requiring K values smaller than 0.3?