### PR TITLE
Fix crashing for the mavlink module in the iridium mode

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -609,6 +609,10 @@ Mavlink::mavlink_open_uart(const int baud, const char *uart_name, const bool for
 		}
 	}
 
+	/*
+	 * Return here in the iridium mode since the iridium driver does not
+	 * support the subsequent function calls.
+	*/
 	if (_uart_fd < 0 || _mode == MAVLINK_MODE_IRIDIUM) {
 		return _uart_fd;
 	}

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -609,7 +609,7 @@ Mavlink::mavlink_open_uart(const int baud, const char *uart_name, const bool for
 		}
 	}
 
-	if (_uart_fd < 0) {
+	if (_uart_fd < 0 || _mode == MAVLINK_MODE_IRIDIUM) {
 		return _uart_fd;
 	}
 


### PR DESCRIPTION
This PR solve the [Issue #10788](https://github.com/PX4/Firmware/issues/10788).

This introduces a special handling of the serial device in the mavlink module in the iridium mode. As of now [getting the uart config](https://github.com/PX4/Firmware/blob/master/src/modules/mavlink/mavlink_main.cpp#L621) fails for the iridium driver.
