### PR TITLE
Commander: enable RC override during takeoff

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1749,10 +1749,13 @@ Commander::run()
 
 		const bool override_auto_mode =
 			(_param_rc_override.get() & OVERRIDE_AUTO_MODE_BIT) &&
-			(_internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_LAND    ||
+			(_internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_TAKEOFF ||
+			 _internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_LAND    ||
 			 _internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_RTL 	  ||
 			 _internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_MISSION ||
-			 _internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_LOITER);
+			 _internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_LOITER ||
+			 _internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_FOLLOW_TARGET ||
+			 _internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_PRECLAND);
 
 		const bool override_offboard_mode =
 			(_param_rc_override.get() & OVERRIDE_OFFBOARD_MODE_BIT) &&


### PR DESCRIPTION
**Describe problem solved by this pull request**
I find myself and other users looking for why the pilot is not able to take over control by moving the sticks during the auto takeoff. The use cases can be
- the pilot seeing things going wrong during takeoff e.g. suddenly something is above the drone
- takeoff altitude being to high
- pilot being impatient
- takeoff waypoint doesn't get reached for some reason like with the problem described in
https://github.com/PX4/Firmware/pull/14193#issuecomment-589091770

**Describe your solution**
I'm adding the `AUTO_TAKEOFF` mode to the modes where the pilot can take over control using the sticks. Also I'm adding the remaining other auto flight modes which are used more rarely from the list here: https://github.com/PX4/Firmware/blob/f3fefd7d9372ec98d404e2e99da2e251114a2d7e/msg/commander_state.msg#L7-L17

**Test data / coverage**
We are flying the takeoff being available to override by the pilot for one client for more than a month now. I quickly rechecked in SITL that it all works like expected.
