### PR TITLE
EKF2: Fix GPS blending time jitter

### DIFF
--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -1833,7 +1833,7 @@ bool Ekf2::blend_gps_data()
 	float dt_min = 0.3f;
 
 	for (uint8_t i = 0; i < GPS_MAX_RECEIVERS; i++) {
-		float raw_dt = 0.001f * (float)(_gps_state[i].time_usec - _time_prev_us[i]);
+		float raw_dt = 1e-6f * (float)(_gps_state[i].time_usec - _time_prev_us[i]);
 
 		if (raw_dt > 0.0f && raw_dt < 0.3f) {
 			_gps_dt[i] = 0.1f * raw_dt + 0.9f * _gps_dt[i];


### PR DESCRIPTION
The logic to determine if the two GPS modules were running at the same rate was bugged leading to time jitter clearly visible in the position innovations.

Here is a logfile replayed on v1.10.1 and on this PR
![image](https://user-images.githubusercontent.com/7795133/75253144-43cbb000-57de-11ea-9427-bc8c8e3f5b3d.png)
