### PR TITLE
logger: disable logger_status publiation in replay builds

### DIFF
--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -792,7 +792,12 @@ void Logger::run()
 				}
 			}
 
+
+#ifndef ORB_USE_PUBLISHER_RULES
+
 			// publish logger status
+			//  - this is disabled in replay builds to ensure all data in ekf2 replay logs only contain
+			//    the same time range, otherwise the plots can be unreadable using common tools
 			if (hrt_elapsed_time(&_logger_status_last) >= 1_s) {
 				for (int i = 0; i < (int)LogType::Count; ++i) {
 
@@ -821,6 +826,8 @@ void Logger::run()
 
 				_logger_status_last = hrt_absolute_time();
 			}
+
+#endif // !ORB_USE_PUBLISHER_RULES
 
 			/* release the log buffer */
 			_writer.unlock();

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -338,7 +338,10 @@ private:
 	PrintLoadReason					_print_load_reason {PrintLoadReason::Preflight};
 
 	uORB::PublicationMulti<logger_status_s>		_logger_status_pub[2] { ORB_ID(logger_status), ORB_ID(logger_status) };
+
+#ifndef ORB_USE_PUBLISHER_RULES // don't publish logger_status when building for replay
 	hrt_abstime					_logger_status_last{0};
+#endif
 
 	uORB::Subscription				_manual_control_sp_sub{ORB_ID(manual_control_setpoint)};
 	uORB::Subscription				_vehicle_command_sub{ORB_ID(vehicle_command)};


### PR DESCRIPTION
 - this is disabled in replay builds to ensure all data in ekf2 replay logs only contains the same time range, otherwise the plots can be unreadable using common tools
 - fixes #14230