### PR TITLE
logger: fix style for weird astyle rule

### DIFF
--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -340,6 +340,7 @@ private:
 	uORB::PublicationMulti<logger_status_s>		_logger_status_pub[2] { ORB_ID(logger_status), ORB_ID(logger_status) };
 
 #ifndef ORB_USE_PUBLISHER_RULES // don't publish logger_status when building for replay
+
 	hrt_abstime					_logger_status_last{0};
 #endif
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
Adding the `#ifndef` in https://github.com/PX4/Firmware/pull/14239 for some weird reason broke the style.

**Describe your solution**
Adding a newline in between makes astyle not recognize the pattern that leads to it thinking the style is broken.

**Describe possible alternatives**
different rule? clang-format?
