### PR TITLE
Airframe and mixer for rover DF Robot GPX:Asurada

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/50004_dfrobot_gpx_asurada
+++ b/ROMFS/px4fmu_common/init.d/airframes/50004_dfrobot_gpx_asurada
@@ -1,0 +1,84 @@
+#!/bin/sh
+#
+# @name DF Robot GPX:Asurada
+
+#
+# @type Rover
+# @class Rover
+#
+# @board px4_fmu-v2 exclude
+#
+# @output MAIN2 Steering servo
+# @output MAIN3 Speed of left wheels
+# @output MAIN4 Speed of right wheels
+#
+# @maintainer Katrin Moritz
+#
+# @board px4_fmu-v2 exclude
+#
+
+sh /etc/init.d/rc.rover_defaults
+
+if [ $AUTOCNF = yes ]
+then
+	param set BAT_N_CELLS 2
+
+	param set EKF2_GBIAS_INIT 0.01
+	param set EKF2_ANGERR_INIT 0.01
+	param set EKF2_MAG_TYPE 1
+
+	param set FW_AIRSPD_MIN 0
+	param set FW_AIRSPD_TRIM 1
+	param set FW_AIRSPD_MAX 3
+
+	param set GND_THR_IDLE 0
+	param set GND_THR_CRUISE 0
+	param set GND_THR_MAX 0.5
+
+	# Because this is differential drive, it can make a turn with radius 0.
+	# This corresponds to a turn angle of pi radians.
+	# If a special case is made for differential-drive, this will need to change.
+	param set GND_MAX_ANG 3.142
+	param set GND_WHEEL_BASE 0.3
+
+	# TODO: Set to -1.0, to allow reversing. This will require many changes in the codebase
+	# to support negative throttle.
+	param set GND_THR_MIN 0.0
+	param set GND_SPEED_P 0.25
+	param set GND_SPEED_I 0.001
+	param set GND_SPEED_D 3
+	param set GND_SPEED_IMAX 0.125
+	param set GND_SPEED_THR_SC 1
+
+	param set MIS_LTRMIN_ALT 0.01
+	param set MIS_TAKEOFF_ALT 0.01
+
+	param set NAV_ACC_RAD 0.5
+
+	# Provide ESC a constant 1500 us pulse, which corresponds to
+	# idle on the Roboclaw motor controller on the Aion R1
+	param set PWM_DISARMED 1500
+	param set PWM_MAIN_DIS3 1485
+	param set PWM_MAIN_DIS4 1485
+	param set PWM_MAIN_FAIL3 1485
+	param set PWM_MAIN_FAIL4 1485
+	param set PWM_MAX 2000
+	param set PWM_MIN 1000
+	param set PWM_MAIN_MIN3 970
+	param set PWM_MAIN_MIN4 970
+
+	# Enable Airspeed check circuit breaker because Rovers will have no airspeed sensor
+	param set CBRK_AIRSPD_CHK 162128
+
+	# Differential drive acts like ackermann steering with a maximum turn angle of 180 degrees, or pi radians
+	param set GND_MAX_ANG 3.1415
+
+fi
+
+# Configure this as rover
+set MAV_TYPE 10
+
+# Set mixer
+set MIXER rover_diff_and_servo
+
+set PWM_MAIN_REV2 1

--- a/ROMFS/px4fmu_common/init.d/airframes/50004_dfrobot_gpx_asurada
+++ b/ROMFS/px4fmu_common/init.d/airframes/50004_dfrobot_gpx_asurada
@@ -55,8 +55,7 @@ then
 
 	param set NAV_ACC_RAD 0.5
 
-	# Provide ESC a constant 1500 us pulse, which corresponds to
-	# idle on the Roboclaw motor controller on the Aion R1
+	# Provide ESC a constant 1500 us pulse to idle
 	param set PWM_DISARMED 1500
 	param set PWM_MAIN_DIS3 1485
 	param set PWM_MAIN_DIS4 1485

--- a/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
@@ -146,6 +146,7 @@ px4_add_romfs_files(
 	50001_axialracing_ax10
 	50002_traxxas_stampede_2wd
 	50003_aion_robotics_r1_rover
+	50004_dfrobot_gpx_asurada
 
 	# [60000, 61000] (Unmanned) Underwater Robots
 	60000_uuv_generic

--- a/ROMFS/px4fmu_common/mixers/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/mixers/CMakeLists.txt
@@ -77,6 +77,7 @@ px4_add_romfs_files(
 	tri_y_yaw-.main.mix
 	tri_y_yaw+.main.mix
 	rover_generic.main.mix
+	rover_diff_and_servo.main.mix
 	Viper.main.mix
 	vtol_AAERT.aux.mix
 	vtol_AAVVT.aux.mix

--- a/ROMFS/px4fmu_common/mixers/rover_diff_and_servo.main.mix
+++ b/ROMFS/px4fmu_common/mixers/rover_diff_and_servo.main.mix
@@ -1,0 +1,37 @@
+Generic car mixer (eg DF Robot GPX:Asurada RC Car)
+===========================
+
+Designed for DF Robot GPX:Asurada
+
+This file defines mixers suitable for controlling a DF Robot GPX:Asurada rover using
+PX4FMU. The configuration assumes the steering is connected to PX4FMU
+servo outputs 1 and the motor speed controls to output 2 and 3. Output 0 is
+assumed to be unused.
+
+Inputs to the mixer come from channel group 0 (vehicle attitude), channels 0 (roll), and 3 (thrust).
+
+See the README for more information on the scaler format.
+
+
+Output 0
+-----------------------------------------
+Z:
+
+Steering mixer using roll on output 1
+------------------------------------------
+M: 1
+S: 0 0  10000   10000     0 -10000  10000
+
+
+Output 2
+------------------------------------------
+M: 2
+S: 0 0   -500   -500      0      0  10000
+S: 0 3  10000  10000      0 -10000  10000
+
+
+Output 3
+------------------------------------------
+M: 2
+S: 0 0    500    500      0      0  10000
+S: 0 3  10000  10000      0 -10000  10000


### PR DESCRIPTION
**Describe problem solved by this pull request**
Added a new airframe for the DF Robot GPX:Asurada rover. This rover has 2 motors and one servo.

**Describe your solution**
Added the airframe _50004_dfrobot_gpx_asurada_ and the mixer _rover_diff_and_servo.main.mix_. The airframe is based on the Generic Ground Vehicle airframe. The default PWM values for output 3 and 4 are changed because the included ESCs have other default values.
The mixer file was designed as follows: The servo controls the front wheels via PWM Output 2. The 2 motors control each rear wheel. The PWM Output 3 controls the right rear wheel and PWM Output 4 controls the left rear wheel. A light differential is integrated in the motors. So that the outer wheel runs faster than the inner wheel during steering.

**Describe possible alternatives**
The mixer also can be configured as an Multirotor mixer for including the differential. But then the Outputs have to be changed. Then steering should be connected to PWM Channel 5 and the motors should be connected to PWM Channel 2 and 4.

**Test data / coverage**
Rover was tested in manual mode. This worked as expected.
