### PR TITLE
VTOL: run vtol state update not only when mc or fw sp are updated

### DIFF
--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -365,23 +365,21 @@ VtolAttitudeControl::Run()
 		bool fw_att_sp_updated = _fw_virtual_att_sp_sub.update(&_fw_virtual_att_sp);
 
 		// update the vtol state machine which decides which mode we are in
-		if (mc_att_sp_updated || fw_att_sp_updated) {
-			_vtol_type->update_vtol_state();
+		_vtol_type->update_vtol_state();
 
-			// reset transition command if not auto control
-			if (_v_control_mode.flag_control_manual_enabled) {
-				if (_vtol_type->get_mode() == mode::ROTARY_WING) {
-					_transition_command = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC;
+		// reset transition command if not auto control
+		if (_v_control_mode.flag_control_manual_enabled) {
+			if (_vtol_type->get_mode() == mode::ROTARY_WING) {
+				_transition_command = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC;
 
-				} else if (_vtol_type->get_mode() == mode::FIXED_WING) {
-					_transition_command = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW;
+			} else if (_vtol_type->get_mode() == mode::FIXED_WING) {
+				_transition_command = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW;
 
-				} else if (_vtol_type->get_mode() == mode::TRANSITION_TO_MC) {
-					/* We want to make sure that a mode change (manual>auto) during the back transition
-					 * doesn't result in an unsafe state. This prevents the instant fall back to
-					 * fixed-wing on the switch from manual to auto */
-					_transition_command = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC;
-				}
+			} else if (_vtol_type->get_mode() == mode::TRANSITION_TO_MC) {
+				/* We want to make sure that a mode change (manual>auto) during the back transition
+				 * doesn't result in an unsafe state. This prevents the instant fall back to
+				 * fixed-wing on the switch from manual to auto */
+				_transition_command = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC;
 			}
 		}
 


### PR DESCRIPTION
Currently the VTOL transition state update is only run when there is a setpoint change of either a the mc_attitude controller or the fw_attitude controller. This is a big problem if, for some reason, they are not updated for some time, eg because of a malfunction. This happened to me recently: After doing a transition to fixed-wing mode in altitude control mode, with a vehicle without GPS, it froze the attitude sp (see https://github.com/PX4/Firmware/issues/14243). Switching back to multicopter was not possible due to the above noted, and it only switched to MC when I also changed to stabilized. 

**Describe problem solved by this pull request**
Ability to switch VTOL state independently of attitude sp changes.

**Describe your solution**
Check the VTOL transition switch every time the VTOL module runs. This results in slightly increased cpu load, eg the average cycle time of the VTOL module increased by roughly 1% (checked with perf). Changes seem not be significant enough to show on the overall CPU usage. 

**Describe possible alternatives**
Fix https://github.com/PX4/Firmware/issues/14243 and make sure that we have updated att sp even when the FW/MC pos controllers break down.

**Test data / coverage**
Bench and flight tested.
