### PR TITLE
LPE: make compatible with lockstep simulation

### DIFF
--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
@@ -35,6 +35,7 @@
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/estimator_status.h>
 #include <uORB/topics/estimator_innovations.h>
+#include <uORB/topics/ekf2_timestamps.h>
 
 using namespace matrix;
 using namespace control;
@@ -254,6 +255,7 @@ private:
 	void publishGlobalPos();
 	void publishOdom();
 	void publishEstimatorStatus();
+	void publishEk2fTimestamps();
 
 	// attributes
 	// ----------------------------
@@ -285,6 +287,7 @@ private:
 	uORB::PublicationData<vehicle_global_position_s> _pub_gpos{ORB_ID(vehicle_global_position)};
 	uORB::PublicationData<vehicle_odometry_s> _pub_odom{ORB_ID(vehicle_odometry)};
 	uORB::PublicationData<estimator_status_s> _pub_est_status{ORB_ID(estimator_status)};
+	uORB::PublicationData<ekf2_timestamps_s> _pub_ekf2_timestamps{ORB_ID(ekf2_timestamps)};
 	uORB::PublicationData<estimator_innovations_s> _pub_innov{ORB_ID(estimator_innovations)};
 	uORB::PublicationData<estimator_innovations_s> _pub_innov_var{ORB_ID(estimator_innovation_variances)};
 


### PR DESCRIPTION
This fixes SITL with lockstep when using LPE and q estimator.

The required changes are:
- Publish ekf2_timestamps because simulator_mavlink expects them.
- Run LPE at 250 Hz instead of 80 Hz in order to keep everything in lockstep running at 250 Hz.