### PR TITLE
EKF2: use fixed time constant for GPS blending

### DIFF
--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -2205,7 +2205,6 @@ void Ekf2::update_gps_offsets()
 {
 
 	// Calculate filter coefficients to be applied to the offsets for each GPS position and height offset
-	// Increase the filter time constant proportional to the inverse of the weighting
 	// A weighting of 1 will make the offset adjust the slowest, a weighting of 0 will make it adjust with zero filtering
 	float alpha[GPS_MAX_RECEIVERS] = {};
 	float omega_lpf = 1.0f / fmaxf(_param_ekf2_gps_tau.get(), 1.0f);
@@ -2213,16 +2212,8 @@ void Ekf2::update_gps_offsets()
 	for (uint8_t i = 0; i < GPS_MAX_RECEIVERS; i++) {
 		if (_gps_state[i].time_usec - _time_prev_us[i] > 0) {
 			// calculate the filter coefficient that achieves the time constant specified by the user adjustable parameter
-			float min_alpha = constrain(omega_lpf * 1e-6f * (float)(_gps_state[i].time_usec - _time_prev_us[i]),
-						    0.0f, 1.0f);
-
-			// scale the filter coefficient so that time constant is inversely proprtional to weighting
-			if (_blend_weights[i] > min_alpha) {
-				alpha[i] = min_alpha / _blend_weights[i];
-
-			} else {
-				alpha[i] = 1.0f;
-			}
+			alpha[i] = constrain(omega_lpf * 1e-6f * (float)(_gps_state[i].time_usec - _time_prev_us[i]),
+					     0.0f, 1.0f);
 
 			_time_prev_us[i] = _gps_state[i].time_usec;
 		}


### PR DESCRIPTION
fixes https://github.com/PX4/Firmware/issues/14251
Use a fixed time constant for the calculation of the offset between the gps_blended_state and the corrected GPS measurements. Discussed with @priseborough and we did not see any downside doing this since the relative GPS uncertainty is still accounted for when calculating the position of the blended solution

**Test data / coverage**
Here is a logfile replayed with the GPS measurements overwritten with constant values. At t = 80s a position offset is added to GPS 0, and at t = 140s the relative uncertainty of the GPS modules is changed

PR/Master
![image](https://user-images.githubusercontent.com/7795133/75536661-e326b800-5a15-11ea-8933-786fbdcdc36b.png)
