### PR TITLE
make clang-tidy fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -416,7 +416,7 @@ px4_sitl_default-clang:
 	@$(PX4_MAKE) -C "$(SRC_DIR)"/build/px4_sitl_default-clang
 
 clang-tidy: px4_sitl_default-clang
-	@cd "$(SRC_DIR)"/build/px4_sitl_default-clang && run-clang-tidy.py -header-filter=".*\.hpp" -j$(j) -p .
+	@cd "$(SRC_DIR)"/build/px4_sitl_default-clang && "$(SRC_DIR)"/Tools/run-clang-tidy.py -header-filter=".*\.hpp" -j$(j) -p .
 
 # to automatically fix a single check at a time, eg modernize-redundant-void-arg
 #  % run-clang-tidy-4.0.py -fix -j4 -checks=-\*,modernize-redundant-void-arg -p .

--- a/Tools/run-clang-tidy.py
+++ b/Tools/run-clang-tidy.py
@@ -39,7 +39,10 @@ import argparse
 import json
 import multiprocessing
 import os
-import Queue
+try:
+    import queue as Queue
+except ImportError:
+    import Queue
 import re
 import shutil
 import subprocess


### PR DESCRIPTION
Fixes the path, and works with python2/python3