### PR TITLE
Support for multi-part STATUSMESSAGE

### DIFF
--- a/msg/mavlink_log.msg
+++ b/msg/mavlink_log.msg
@@ -1,6 +1,6 @@
 uint64 timestamp		# time since system start (microseconds)
 
-char[50] text
+char[127] text
 uint8 severity # log level (same as in the linux kernel, starting with 0)
 
 uint8 ORB_QUEUE_LENGTH = 5

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -399,9 +399,9 @@ private:
 	MavlinkStreamStatustext &operator = (const MavlinkStreamStatustext &) = delete;
 
 protected:
-	int id;
+	int _id{0};
 
-	explicit MavlinkStreamStatustext(Mavlink *mavlink) : MavlinkStream(mavlink), id(0)
+	explicit MavlinkStreamStatustext(Mavlink *mavlink) : MavlinkStream(mavlink)
 	{}
 
 	bool send(const hrt_abstime t) override
@@ -417,16 +417,16 @@ protected:
 				constexpr unsigned max_chunk_size = sizeof(msg.text);
 				msg.severity = mavlink_log.severity;
 				msg.chunk_seq = 0;
-				msg.id = id++;
+				msg.id = _id++;
 				unsigned text_size;
 
 				while ((text_size = strlen(text)) > 0) {
 					unsigned chunk_size = math::min(text_size, max_chunk_size);
 
 					if (chunk_size < max_chunk_size) {
-						memcpy(&msg.text[0], &text[0], chunk_size + 1);
+						memcpy(&msg.text[0], &text[0], chunk_size);
 						// pad with zeros
-						memset(&msg.text + chunk_size, 0, max_chunk_size - chunk_size);
+						memset(&msg.text[0] + chunk_size, 0, max_chunk_size - chunk_size);
 
 					} else {
 						memcpy(&msg.text[0], &text[0], chunk_size);

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -422,11 +422,14 @@ protected:
 
 				while ((text_size = strlen(text)) > 0) {
 					unsigned chunk_size = math::min(text_size, max_chunk_size);
-					strncpy(msg.text, text, chunk_size);
 
-					// pad with zeros
 					if (chunk_size < max_chunk_size) {
+						memcpy(&msg.text[0], &text[0], chunk_size + 1);
+						// pad with zeros
 						memset(&msg.text + chunk_size, 0, max_chunk_size - chunk_size);
+
+					} else {
+						memcpy(&msg.text[0], &text[0], chunk_size);
 					}
 
 					mavlink_msg_statustext_send_struct(_mavlink->get_channel(), &msg);


### PR DESCRIPTION
**Describe problem solved by this pull request**
This PR implements https://github.com/PX4/Firmware/issues/14169. A status message (msg/mavlink_log.msg) longer than 50 bytes is being chunked and multiple STATUSMESSAGE are sent. Now the only limitation is the buffer size in msg/mavlink_log.msg which got resized to 127 bytes in this PR, which is the same size as in log_message.

**Test data / coverage**
With sitl_gazebo and a modification of the line `mavlink_and_console_log_info(&mavlink_log_pub, "Takeoff detected");`. After takeoff I got the following status messages:
```
STATUSTEXT {severity : 6, text : [logger] file: ./log/2020-03-04/06_02_49.ulg, id : 0, chunk_seq : 0}
STATUSTEXT {severity : 6, text : Using minimum takeoff altitude: 2.50 m, id : 1, chunk_seq : 0}
STATUSTEXT {severity : 6, text : Takeoff detected. Test a very long string. ABCDEFG, id : 2, chunk_seq : 0}
STATUSTEXT {severity : 6, text : HIJKLMNOPQRSTUVWXYZ, id : 2, chunk_seq : 1}
```
