### PR TITLE
support velocity odometry with MAV_FRAME_LOCAL_FRD

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1334,6 +1334,20 @@ MavlinkReceiver::handle_message_odometry(mavlink_message_t *msg)
 		odometry.velocity_covariance[odometry.COVARIANCE_MATRIX_VY_VARIANCE] = lin_vel_cov_local(1, 1);
 		odometry.velocity_covariance[odometry.COVARIANCE_MATRIX_VZ_VARIANCE] = lin_vel_cov_local(2, 2);
 
+	} else if (odom.child_frame_id == MAV_FRAME_LOCAL_FRD) {
+		/* data already in correct frame, just copy over */
+		odometry.vx = odom.vx;
+		odometry.vy = odom.vy;
+		odometry.vz = odom.vz;
+
+		odometry.rollspeed = odom.rollspeed;
+		odometry.pitchspeed = odom.pitchspeed;
+		odometry.yawspeed = odom.yawspeed;
+
+		for (size_t i = 0; i < VEL_URT_SIZE; i++) {
+			odometry.velocity_covariance[i] = odom.velocity_covariance[i];
+		}
+
 	} else {
 		PX4_ERR("Body frame %u not supported. Unable to publish velocity", odom.child_frame_id);
 	}


### PR DESCRIPTION
**Describe problem solved by this pull request**
Velocity odometry data from voxl-vision-px4 (offboard) is already in FRD coordinate frame, so no need to translate.  Accept this frame type and copy over.

**Test data / coverage**
Been testing with this setup for the last month internally with positive results.

