### PR TITLE
logger: fix thread deadlock

### DIFF
--- a/src/modules/logger/log_writer_file.cpp
+++ b/src/modules/logger/log_writer_file.cpp
@@ -295,8 +295,12 @@ void LogWriterFile::run()
 			/* Wait for a call to notify(), which indicates new data is available.
 			 * Note that at this point there could already be new data available (because of a longer write),
 			 * and calling pthread_cond_wait() will still wait for the next notify(). But this is generally
-			 * not an issue because notify() is called regularly. */
-			pthread_cond_wait(&_cv, &_mtx);
+			 * not an issue because notify() is called regularly.
+			 * If the logger was switched off in the meantime, do not wait for data, instead run this loop
+			 * once more to write remaining data and close the file. */
+			if (_buffers[0]._should_run) {
+				pthread_cond_wait(&_cv, &_mtx);
+			}
 		}
 
 		// go back to idle


### PR DESCRIPTION
**Describe problem solved by this pull request**
Logger sometimes doesn't create a log file.

If the logger gets stopped at an unfortunate time, the `buffer.close_file()` function can be skipped, in the log_writer_file run loop.

The lock gets unlocked here
https://github.com/PX4/Firmware/blob/master/src/modules/logger/log_writer_file.cpp#L274-L277
which allows for `_buffers[0]._should_run` to change to false. The file didn't close yet since the `_buffers[0]._should_run` was true when that check happened.
The logger now does't have new data so the `notify()` is not called, which results in:
https://github.com/PX4/Firmware/blob/master/src/modules/logger/log_writer_file.cpp#L299
waiting indefinitely.

When the logger is started again, this while loop runs infinitely, waiting for the file to get closed, which is blocked by the `pthread_cond_wait(&_cv, &_mtx)`.
https://github.com/PX4/Firmware/blob/master/src/modules/logger/log_writer_file.cpp#L90-L95
and no new log file is created.

**Describe your solution**
Do not wait for new data if the logger is not running, instead run the loop once more and allow for the remaining data to be written and file closed.

**Test data / coverage**
Due to being a race condition, the problem can be reproduced at random times when stopping the logger. The problem occurs in SITL as well. I debugged the problem and tested a solution with various print statements. In order to test if the solution is valid since it occurs randomly, I caught situations when the loop would be stuck in a wait condition, but was "saved" by the fix instead, and  one more loop iteration was performed, and the file was closed.

**Additional context**
Our system basically never shuts down, which means that once this bug happens, we do not get the logs anymore until we notice we do not get them (usually already too late) and reboot the drone.
