### PR TITLE
logger - announce full file name (with the last missed digit)

### DIFF
--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1232,7 +1232,7 @@ void Logger::start_log_file(LogType type)
 
 	if (type == LogType::Full) {
 		/* print logging path, important to find log file later */
-		mavlink_log_info(&_mavlink_log_pub, "[logger] file: %s", file_name);
+		mavlink_log_info(&_mavlink_log_pub, "[logger] file:%s", file_name);
 	}
 
 	_writer.start_log_file(type, file_name);


### PR DESCRIPTION
this is very small change but can fix small annoying issue.

**Describe problem solved by this pull request**
now when new log is opened, the string sent with mavlink log to ground concatenate the last digit of the filename. so its look like _"info: [logger] file: /fs/microsd/log/2020-03-06/17_23_4"_
its a bit annoying, the last digit missed... 

**Describe your solution**
removed one space so the last digit will be shown

**Describe possible alternatives**
alternatives can be not to sent the full path at all, so the announcer will be shorter, and focus on what is important 