### PR TITLE
[WIP] initial InvenSense ICM20649 driver

### DIFF
--- a/src/drivers/imu/invensense/icm20649/CMakeLists.txt
+++ b/src/drivers/imu/invensense/icm20649/CMakeLists.txt
@@ -1,0 +1,45 @@
+############################################################################
+#
+#   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+px4_add_module(
+	MODULE drivers__imu__invensense__icm20649
+	MAIN icm20649
+	SRCS
+		ICM20649.cpp
+		ICM20649.hpp
+		icm20649_main.cpp
+	DEPENDS
+		px4_work_queue
+		drivers_accelerometer
+		drivers_gyroscope
+		drivers_magnetometer
+	)

--- a/src/drivers/imu/invensense/icm20649/ICM20649.cpp
+++ b/src/drivers/imu/invensense/icm20649/ICM20649.cpp
@@ -1,0 +1,741 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "ICM20649.hpp"
+
+#include <px4_platform/board_dma_alloc.h>
+
+using namespace time_literals;
+
+static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
+{
+	return (msb << 8u) | lsb;
+}
+
+ICM20649::ICM20649(int bus, uint32_t device, enum Rotation rotation) :
+	SPI(MODULE_NAME, nullptr, bus, device, SPIDEV_MODE3, SPI_SPEED),
+	ScheduledWorkItem(MODULE_NAME, px4::device_bus_to_wq(get_device_id())),
+	_px4_accel(get_device_id(), ORB_PRIO_VERY_HIGH, rotation),
+	_px4_gyro(get_device_id(), ORB_PRIO_VERY_HIGH, rotation)
+{
+	set_device_type(DRV_DEVTYPE_ICM20649);
+
+	_px4_accel.set_device_type(DRV_DEVTYPE_ICM20649);
+	_px4_gyro.set_device_type(DRV_DEVTYPE_ICM20649);
+
+	ConfigureSampleRate(_px4_gyro.get_max_rate_hz());
+}
+
+ICM20649::~ICM20649()
+{
+	Stop();
+
+	if (_dma_data_buffer != nullptr) {
+		board_dma_free(_dma_data_buffer, FIFO::SIZE);
+	}
+
+	perf_free(_transfer_perf);
+	perf_free(_bad_register_perf);
+	perf_free(_bad_transfer_perf);
+	perf_free(_fifo_empty_perf);
+	perf_free(_fifo_overflow_perf);
+	perf_free(_fifo_reset_perf);
+	perf_free(_drdy_interval_perf);
+}
+
+bool ICM20649::Init()
+{
+	if (SPI::init() != PX4_OK) {
+		PX4_ERR("SPI::init failed");
+		return false;
+	}
+
+	// allocate DMA capable buffer
+	_dma_data_buffer = (uint8_t *)board_dma_alloc(FIFO::SIZE);
+
+	if (_dma_data_buffer == nullptr) {
+		PX4_ERR("DMA alloc failed");
+		return false;
+	}
+
+	return Reset();
+}
+
+void ICM20649::Stop()
+{
+	// wait until stopped
+	while (_state.load() != STATE::STOPPED) {
+		_state.store(STATE::REQUEST_STOP);
+		ScheduleNow();
+		px4_usleep(10);
+	}
+}
+
+bool ICM20649::Reset()
+{
+	_state.store(STATE::RESET);
+	ScheduleClear();
+	ScheduleNow();
+	return true;
+}
+
+void ICM20649::PrintInfo()
+{
+	PX4_INFO("FIFO empty interval: %d us (%.3f Hz)", _fifo_empty_interval_us,
+		 static_cast<double>(1000000 / _fifo_empty_interval_us));
+
+	perf_print_counter(_transfer_perf);
+	perf_print_counter(_bad_register_perf);
+	perf_print_counter(_bad_transfer_perf);
+	perf_print_counter(_fifo_empty_perf);
+	perf_print_counter(_fifo_overflow_perf);
+	perf_print_counter(_fifo_reset_perf);
+	perf_print_counter(_drdy_interval_perf);
+
+	_px4_accel.print_status();
+	_px4_gyro.print_status();
+}
+
+int ICM20649::probe()
+{
+	const uint8_t whoami = RegisterRead(Register::BANK_0::WHO_AM_I);
+
+	if (whoami != WHOAMI) {
+		PX4_WARN("unexpected WHO_AM_I 0x%02x", whoami);
+		return PX4_ERROR;
+	}
+
+	return PX4_OK;
+}
+
+void ICM20649::Run()
+{
+	switch (_state.load()) {
+	case STATE::RESET:
+		// PWR_MGMT_1: Device Reset
+		RegisterWrite(Register::BANK_0::PWR_MGMT_1, PWR_MGMT_1_BIT::DEVICE_RESET);
+		_reset_timestamp = hrt_absolute_time();
+		_state.store(STATE::WAIT_FOR_RESET);
+		ScheduleDelayed(100);
+		break;
+
+	case STATE::WAIT_FOR_RESET:
+
+		// The reset value is 0x00 for all registers other than the registers below
+		//  Document Number: RM-000030 Page 5 of 23
+		if ((RegisterRead(Register::BANK_0::WHO_AM_I) == WHOAMI)
+		    && (RegisterRead(Register::BANK_0::PWR_MGMT_1) == 0x40)) {
+
+			// if reset succeeded then configure
+			_state.store(STATE::CONFIGURE);
+			ScheduleNow();
+
+		} else {
+			// RESET not complete
+			if (hrt_elapsed_time(&_reset_timestamp) > 10_ms) {
+				PX4_ERR("Reset failed, retrying");
+				_state.store(STATE::RESET);
+				ScheduleDelayed(10_ms);
+
+			} else {
+				PX4_DEBUG("Reset not complete, check again in 1 ms");
+				ScheduleDelayed(1_ms);
+			}
+		}
+
+		break;
+
+	case STATE::CONFIGURE:
+		if (Configure()) {
+			// if configure succeeded then start reading from FIFO
+			_state.store(STATE::FIFO_READ);
+
+			if (DataReadyInterruptConfigure()) {
+				_data_ready_interrupt_enabled = true;
+
+				// backup schedule as a watchdog timeout
+				ScheduleDelayed(10_ms);
+
+			} else {
+				_data_ready_interrupt_enabled = false;
+				ScheduleOnInterval(_fifo_empty_interval_us, _fifo_empty_interval_us);
+			}
+
+			FIFOReset();
+
+		} else {
+			PX4_DEBUG("Configure failed, retrying");
+			// try again in 1 ms
+			ScheduleDelayed(1_ms);
+		}
+
+		break;
+
+	case STATE::FIFO_READ: {
+			hrt_abstime timestamp_sample = 0;
+			uint8_t samples = 0;
+
+			if (_data_ready_interrupt_enabled) {
+				// re-schedule as watchdog timeout
+				ScheduleDelayed(10_ms);
+
+				// timestamp set in data ready interrupt
+				samples = _fifo_read_samples.load();
+				timestamp_sample = _fifo_watermark_interrupt_timestamp;
+			}
+
+			bool failure = false;
+
+			// manually check FIFO count if no samples from DRDY or timestamp looks bogus
+			if (!_data_ready_interrupt_enabled || (samples == 0)
+			    || (hrt_elapsed_time(&timestamp_sample) > (_fifo_empty_interval_us / 2))) {
+
+				// use the time now roughly corresponding with the last sample we'll pull from the FIFO
+				timestamp_sample = hrt_absolute_time();
+				const uint16_t fifo_count = FIFOReadCount();
+
+				if (fifo_count == 0) {
+					failure = true;
+					perf_count(_fifo_empty_perf);
+				}
+
+				samples = (fifo_count / sizeof(FIFO::DATA) / 2) * 2; // round down to nearest 2
+			}
+
+			if (samples > FIFO_MAX_SAMPLES) {
+				// not technically an overflow, but more samples than we expected or can publish
+				perf_count(_fifo_overflow_perf);
+				failure = true;
+				FIFOReset();
+
+			} else if (samples >= 2) {
+				// require at least 2 samples (we want at least 1 new accel sample per transfer)
+				if (!FIFORead(timestamp_sample, samples)) {
+					failure = true;
+					_px4_accel.increase_error_count();
+					_px4_gyro.increase_error_count();
+				}
+			}
+
+			if (failure || hrt_elapsed_time(&_last_config_check_timestamp) > 10_ms) {
+				// check BANK_0 & BANK_2 registers incrementally
+				if (RegisterCheck(_register_bank0_cfg[_checked_register_bank0], true)
+				    && RegisterCheck(_register_bank2_cfg[_checked_register_bank2], true)) {
+
+					_last_config_check_timestamp = timestamp_sample;
+					_checked_register_bank0 = (_checked_register_bank0 + 1) % size_register_bank0_cfg;
+					_checked_register_bank2 = (_checked_register_bank2 + 1) % size_register_bank2_cfg;
+
+				} else {
+					// register check failed, force reconfigure
+					PX4_DEBUG("Health check failed, reconfiguring");
+					_state.store(STATE::CONFIGURE);
+					ScheduleNow();
+				}
+
+			} else {
+				// periodically update temperature (1 Hz)
+				if (hrt_elapsed_time(&_temperature_update_timestamp) > 1_s) {
+					UpdateTemperature();
+					_temperature_update_timestamp = timestamp_sample;
+				}
+			}
+		}
+
+		break;
+
+	case STATE::REQUEST_STOP:
+		DataReadyInterruptDisable();
+		ScheduleClear();
+		_state.store(STATE::STOPPED);
+		break;
+
+	case STATE::STOPPED:
+		// DO NOTHING
+		break;
+	}
+}
+
+void ICM20649::ConfigureAccel()
+{
+	const uint8_t ACCEL_FS_SEL = RegisterRead(Register::BANK_2::ACCEL_CONFIG) & (Bit2 | Bit1); // 2:1 ACCEL_FS_SEL[1:0]
+
+	switch (ACCEL_FS_SEL) {
+	case ACCEL_FS_SEL_4G:
+		_px4_accel.set_scale(CONSTANTS_ONE_G / 16384);
+		_px4_accel.set_range(4 * CONSTANTS_ONE_G);
+		break;
+
+	case ACCEL_FS_SEL_8G:
+		_px4_accel.set_scale(CONSTANTS_ONE_G / 8192);
+		_px4_accel.set_range(8 * CONSTANTS_ONE_G);
+		break;
+
+	case ACCEL_FS_SEL_16G:
+		_px4_accel.set_scale(CONSTANTS_ONE_G / 4096);
+		_px4_accel.set_range(16 * CONSTANTS_ONE_G);
+		break;
+
+	case ACCEL_FS_SEL_32G:
+		_px4_accel.set_scale(CONSTANTS_ONE_G / 2048);
+		_px4_accel.set_range(32 * CONSTANTS_ONE_G);
+		break;
+	}
+}
+
+void ICM20649::ConfigureGyro()
+{
+	const uint8_t GYRO_FS_SEL = RegisterRead(Register::BANK_2::GYRO_CONFIG_1) & (Bit2 | Bit1); // 2:1 GYRO_FS_SEL[1:0]
+
+	switch (GYRO_FS_SEL) {
+	case GYRO_FS_SEL_500_DPS:
+		_px4_gyro.set_scale(math::radians(1.0f / 131.f));
+		_px4_gyro.set_range(math::radians(500.f));
+		break;
+
+	case GYRO_FS_SEL_1000_DPS:
+		_px4_gyro.set_scale(math::radians(1.0f / 65.5f));
+		_px4_gyro.set_range(math::radians(1000.f));
+		break;
+
+	case GYRO_FS_SEL_2000_DPS:
+		_px4_gyro.set_scale(math::radians(1.0f / 32.8f));
+		_px4_gyro.set_range(math::radians(2000.0f));
+		break;
+
+	case GYRO_FS_SEL_4000_DPS:
+		_px4_gyro.set_scale(math::radians(1.0f / 16.4f));
+		_px4_gyro.set_range(math::radians(4000.0f));
+		break;
+	}
+}
+
+void ICM20649::ConfigureSampleRate(int sample_rate)
+{
+	if (sample_rate == 0) {
+		sample_rate = 1000; // default to 1 kHz
+	}
+
+	static constexpr float sample_min_interval = (1000.f / 4.5f);
+
+	_fifo_empty_interval_us = math::max(((1000000 / sample_rate) / sample_min_interval) * sample_min_interval,
+					    sample_min_interval); // round down to nearest sample_min_interval
+	_fifo_gyro_samples = math::min(_fifo_empty_interval_us / (1000000 / GYRO_RATE), FIFO_MAX_SAMPLES);
+
+	// recompute FIFO empty interval (us) with actual gyro sample limit
+	_fifo_empty_interval_us = _fifo_gyro_samples * (1000000 / GYRO_RATE);
+
+	_fifo_accel_samples = math::min(_fifo_empty_interval_us / (1000000 / ACCEL_RATE), FIFO_MAX_SAMPLES);
+
+	_px4_accel.set_update_rate(1000000 / _fifo_empty_interval_us);
+	_px4_gyro.set_update_rate(1000000 / _fifo_empty_interval_us);
+}
+
+bool ICM20649::Configure()
+{
+	bool success = true;
+
+	for (const auto &reg : _register_bank0_cfg) {
+		if (!RegisterCheck(reg)) {
+			success = false;
+		}
+	}
+
+	for (const auto &reg : _register_bank2_cfg) {
+		if (!RegisterCheck(reg)) {
+			success = false;
+		}
+	}
+
+	ConfigureAccel();
+	ConfigureGyro();
+
+	return success;
+}
+
+int ICM20649::DataReadyInterruptCallback(int irq, void *context, void *arg)
+{
+	static_cast<ICM20649 *>(arg)->DataReady();
+	return 0;
+}
+
+void ICM20649::DataReady()
+{
+	if (_data_ready_count.fetch_add(1) >= (_fifo_gyro_samples - 1)) {
+		_data_ready_count.store(0);
+		_fifo_watermark_interrupt_timestamp = hrt_absolute_time();
+		_fifo_read_samples.store(_fifo_gyro_samples);
+		ScheduleNow();
+	}
+
+	perf_count(_drdy_interval_perf);
+}
+
+bool ICM20649::DataReadyInterruptConfigure()
+{
+	int ret_setevent = -1;
+
+	// Setup data ready on rising edge
+	// TODO: cleanup horrible DRDY define mess
+
+
+	return (ret_setevent == 0);
+}
+
+bool ICM20649::DataReadyInterruptDisable()
+{
+	int ret_setevent = -1;
+
+	// Disable data ready callback
+	// TODO: cleanup horrible DRDY define mess
+
+
+	return (ret_setevent == 0);
+}
+
+bool ICM20649::RegisterCheck(const register_bank0_config_t &reg_cfg, bool notify)
+{
+	const uint8_t reg_value = RegisterRead(reg_cfg.reg);
+	bool success = true;
+
+	if (reg_cfg.set_bits && !(reg_value & reg_cfg.set_bits)) {
+		PX4_DEBUG("0x%02hhX: 0x%02hhX (0x%02hhX not set)", (uint8_t)reg_cfg.reg, reg_value, reg_cfg.set_bits);
+		success = false;
+	}
+
+	if (reg_cfg.clear_bits && (reg_value & reg_cfg.clear_bits)) {
+		PX4_DEBUG("0x%02hhX: 0x%02hhX (0x%02hhX not cleared)", (uint8_t)reg_cfg.reg, reg_value, reg_cfg.clear_bits);
+		success = false;
+	}
+
+	if (!success) {
+		RegisterSetAndClearBits(reg_cfg.reg, reg_cfg.set_bits, reg_cfg.clear_bits);
+
+		if (notify) {
+			perf_count(_bad_register_perf);
+			_px4_accel.increase_error_count();
+			_px4_gyro.increase_error_count();
+		}
+	}
+
+	return success;
+}
+
+bool ICM20649::RegisterCheck(const register_bank2_config_t &reg_cfg, bool notify)
+{
+	const uint8_t reg_value = RegisterRead(reg_cfg.reg);
+	bool success = true;
+
+	if (reg_cfg.set_bits && !(reg_value & reg_cfg.set_bits)) {
+		PX4_DEBUG("0x%02hhX: 0x%02hhX (0x%02hhX not set)", (uint8_t)reg_cfg.reg, reg_value, reg_cfg.set_bits);
+		success = false;
+	}
+
+	if (reg_cfg.clear_bits && (reg_value & reg_cfg.clear_bits)) {
+		PX4_DEBUG("0x%02hhX: 0x%02hhX (0x%02hhX not cleared)", (uint8_t)reg_cfg.reg, reg_value, reg_cfg.clear_bits);
+		success = false;
+	}
+
+	if (!success) {
+		RegisterSetAndClearBits(reg_cfg.reg, reg_cfg.set_bits, reg_cfg.clear_bits);
+
+		if (reg_cfg.reg == Register::BANK_2::ACCEL_CONFIG) {
+			ConfigureAccel();
+
+		} else if (reg_cfg.reg == Register::BANK_2::GYRO_CONFIG_1) {
+			ConfigureGyro();
+		}
+
+		if (notify) {
+			perf_count(_bad_register_perf);
+			_px4_accel.increase_error_count();
+			_px4_gyro.increase_error_count();
+		}
+	}
+
+	return success;
+}
+
+uint8_t ICM20649::RegisterRead(Register::BANK_0 reg)
+{
+	// select BANK_0
+	uint8_t cmd_bank_select[2] { static_cast<uint8_t>(Register::BANK_0::REG_BANK_SEL) | DIR_READ, REG_BANK_SEL_BIT::USER_BANK_0 };
+	transfer(cmd_bank_select, cmd_bank_select, sizeof(cmd_bank_select));
+
+	uint8_t cmd[2] {};
+	cmd[0] = static_cast<uint8_t>(reg) | DIR_READ;
+	transfer(cmd, cmd, sizeof(cmd));
+	return cmd[1];
+}
+
+uint8_t ICM20649::RegisterRead(Register::BANK_2 reg)
+{
+	// select BANK_2
+	uint8_t cmd[4] {
+		(uint8_t)Register::BANK_2::REG_BANK_SEL,
+		REG_BANK_SEL_BIT::USER_BANK_2,
+		(uint8_t)((uint8_t)reg | DIR_READ),
+		0
+	};
+	transfer(cmd, cmd, sizeof(cmd));
+	return cmd[3];
+}
+
+void ICM20649::RegisterWrite(Register::BANK_0 reg, uint8_t value)
+{
+	// select BANK_0
+	uint8_t cmd[4] {
+		(uint8_t)Register::BANK_0::REG_BANK_SEL,
+		REG_BANK_SEL_BIT::USER_BANK_0,
+		(uint8_t)reg,
+		value
+	};
+	transfer(cmd, cmd, sizeof(cmd));
+}
+
+void ICM20649::RegisterWrite(Register::BANK_2 reg, uint8_t value)
+{
+	// select BANK_2
+	uint8_t cmd[4] {
+		(uint8_t)Register::BANK_2::REG_BANK_SEL,
+		REG_BANK_SEL_BIT::USER_BANK_0,
+		(uint8_t)reg,
+		value
+	};
+	transfer(cmd, cmd, sizeof(cmd));
+}
+
+void ICM20649::RegisterSetAndClearBits(Register::BANK_0 reg, uint8_t setbits, uint8_t clearbits)
+{
+	const uint8_t orig_val = RegisterRead(reg);
+	uint8_t val = orig_val;
+
+	if (setbits) {
+		val |= setbits;
+	}
+
+	if (clearbits) {
+		val &= ~clearbits;
+	}
+
+	RegisterWrite(reg, val);
+}
+
+void ICM20649::RegisterSetAndClearBits(Register::BANK_2 reg, uint8_t setbits, uint8_t clearbits)
+{
+	const uint8_t orig_val = RegisterRead(reg);
+	uint8_t val = orig_val;
+
+	if (setbits) {
+		val |= setbits;
+	}
+
+	if (clearbits) {
+		val &= ~clearbits;
+	}
+
+	RegisterWrite(reg, val);
+}
+
+void ICM20649::RegisterSetBits(Register::BANK_0 reg, uint8_t setbits)
+{
+	RegisterSetAndClearBits(reg, setbits, 0);
+}
+
+void ICM20649::RegisterClearBits(Register::BANK_0 reg, uint8_t clearbits)
+{
+	RegisterSetAndClearBits(reg, 0, clearbits);
+}
+
+uint16_t ICM20649::FIFOReadCount()
+{
+	// read FIFO count
+	uint8_t fifo_count_buf[5] {
+		(uint8_t)Register::BANK_0::REG_BANK_SEL,
+		REG_BANK_SEL_BIT::USER_BANK_0,
+		(uint8_t)((uint8_t)Register::BANK_0::FIFO_COUNTH | DIR_READ),
+		0,
+		0,
+	};
+
+	if (transfer(fifo_count_buf, fifo_count_buf, sizeof(fifo_count_buf)) != PX4_OK) {
+		perf_count(_bad_transfer_perf);
+		return 0;
+	}
+
+	return combine(fifo_count_buf[4], fifo_count_buf[4]);
+}
+
+bool ICM20649::FIFORead(const hrt_abstime &timestamp_sample, uint16_t samples)
+{
+	TransferBuffer *report = (TransferBuffer *)_dma_data_buffer;
+	const size_t transfer_size = math::min(samples * sizeof(FIFO::DATA) + 1, FIFO::SIZE);
+	memset(report, 0, transfer_size);
+	report->cmd_bank = static_cast<uint8_t>(Register::BANK_0::REG_BANK_SEL);
+	report->bank = REG_BANK_SEL_BIT::USER_BANK_0;
+	report->cmd = static_cast<uint8_t>(Register::BANK_0::FIFO_R_W) | DIR_READ;
+
+	perf_begin(_transfer_perf);
+
+	if (transfer(_dma_data_buffer, _dma_data_buffer, transfer_size) != PX4_OK) {
+		perf_end(_transfer_perf);
+		perf_count(_bad_transfer_perf);
+		return false;
+	}
+
+	perf_end(_transfer_perf);
+
+	ProcessGyro(timestamp_sample, report, samples);
+	return ProcessAccel(timestamp_sample, report, samples);
+}
+
+void ICM20649::FIFOReset()
+{
+	perf_count(_fifo_reset_perf);
+
+	// FIFO_RST: reset FIFO
+	RegisterSetBits(Register::BANK_0::FIFO_RST, FIFO_RST_BIT::FIFO_RESET);
+	RegisterClearBits(Register::BANK_0::FIFO_RST, FIFO_RST_BIT::FIFO_RESET);
+
+	// reset while FIFO is disabled
+	_data_ready_count.store(0);
+	_fifo_watermark_interrupt_timestamp = 0;
+	_fifo_read_samples.store(0);
+
+	// FIFO_EN_2: enable both gyro and accel
+	for (const auto &r : _register_bank0_cfg) {
+		if (r.reg == Register::BANK_0::FIFO_EN_2) {
+			RegisterSetAndClearBits(r.reg, r.set_bits, r.clear_bits);
+		}
+	}
+}
+
+static bool fifo_accel_equal(const FIFO::DATA &f0, const FIFO::DATA &f1)
+{
+	return (memcmp(&f0.ACCEL_XOUT_H, &f1.ACCEL_XOUT_H, 6) == 0);
+}
+
+bool ICM20649::ProcessAccel(const hrt_abstime &timestamp_sample, const TransferBuffer *const report, uint8_t samples)
+{
+	PX4Accelerometer::FIFOSample accel;
+	accel.timestamp_sample = timestamp_sample;
+	accel.dt = _fifo_empty_interval_us / _fifo_accel_samples;
+
+	bool bad_data = false;
+
+	// accel data is doubled in FIFO, but might be shifted
+	int accel_first_sample = 1;
+
+	if (samples >= 3) {
+		if (fifo_accel_equal(report->f[0], report->f[1])) {
+			// [A0, A1, A2, A3]
+			//  A0==A1, A2==A3
+			accel_first_sample = 1;
+
+		} else if (fifo_accel_equal(report->f[1], report->f[2])) {
+			// [A0, A1, A2, A3]
+			//  A0, A1==A2, A3
+			accel_first_sample = 0;
+
+		} else {
+			perf_count(_bad_transfer_perf);
+			bad_data = true;
+		}
+	}
+
+	int accel_samples = 0;
+
+	for (int i = accel_first_sample; i < samples; i = i + 2) {
+		const FIFO::DATA &fifo_sample = report->f[i];
+		int16_t accel_x = combine(fifo_sample.ACCEL_XOUT_H, fifo_sample.ACCEL_XOUT_L);
+		int16_t accel_y = combine(fifo_sample.ACCEL_YOUT_H, fifo_sample.ACCEL_YOUT_L);
+		int16_t accel_z = combine(fifo_sample.ACCEL_ZOUT_H, fifo_sample.ACCEL_ZOUT_L);
+
+		// sensor's frame is +x forward, +y left, +z up
+		//  flip y & z to publish right handed with z down (x forward, y right, z down)
+		accel.x[accel_samples] = accel_x;
+		accel.y[accel_samples] = (accel_y == INT16_MIN) ? INT16_MAX : -accel_y;
+		accel.z[accel_samples] = (accel_z == INT16_MIN) ? INT16_MAX : -accel_z;
+		accel_samples++;
+	}
+
+	accel.samples = accel_samples;
+
+	_px4_accel.updateFIFO(accel);
+
+	return !bad_data;
+}
+
+void ICM20649::ProcessGyro(const hrt_abstime &timestamp_sample, const TransferBuffer *const report, uint8_t samples)
+{
+	PX4Gyroscope::FIFOSample gyro;
+	gyro.timestamp_sample = timestamp_sample;
+	gyro.samples = samples;
+	gyro.dt = _fifo_empty_interval_us / _fifo_gyro_samples;
+
+	for (int i = 0; i < samples; i++) {
+		const FIFO::DATA &fifo_sample = report->f[i];
+
+		const int16_t gyro_x = combine(fifo_sample.GYRO_XOUT_H, fifo_sample.GYRO_XOUT_L);
+		const int16_t gyro_y = combine(fifo_sample.GYRO_YOUT_H, fifo_sample.GYRO_YOUT_L);
+		const int16_t gyro_z = combine(fifo_sample.GYRO_ZOUT_H, fifo_sample.GYRO_ZOUT_L);
+
+		// sensor's frame is +x forward, +y left, +z up
+		//  flip y & z to publish right handed with z down (x forward, y right, z down)
+		gyro.x[i] = gyro_x;
+		gyro.y[i] = (gyro_y == INT16_MIN) ? INT16_MAX : -gyro_y;
+		gyro.z[i] = (gyro_z == INT16_MIN) ? INT16_MAX : -gyro_z;
+	}
+
+	_px4_gyro.updateFIFO(gyro);
+}
+
+void ICM20649::UpdateTemperature()
+{
+	// read current temperature
+	uint8_t temperature_buf[3] {};
+	temperature_buf[0] = static_cast<uint8_t>(Register::BANK_0::TEMP_OUT_H) | DIR_READ;
+
+	if (transfer(temperature_buf, temperature_buf, sizeof(temperature_buf)) != PX4_OK) {
+		perf_count(_bad_transfer_perf);
+		return;
+	}
+
+	const int16_t TEMP_OUT = combine(temperature_buf[1], temperature_buf[2]);
+	const float TEMP_degC = ((TEMP_OUT - ROOM_TEMPERATURE_OFFSET) / TEMPERATURE_SENSITIVITY) + ROOM_TEMPERATURE_OFFSET;
+
+	if (PX4_ISFINITE(TEMP_degC)) {
+		_px4_accel.set_temperature(TEMP_degC);
+		_px4_gyro.set_temperature(TEMP_degC);
+	}
+}

--- a/src/drivers/imu/invensense/icm20649/ICM20649.hpp
+++ b/src/drivers/imu/invensense/icm20649/ICM20649.hpp
@@ -1,0 +1,188 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file ICM20649.hpp
+ *
+ * Driver for the Invensense ICM20649 connected via SPI.
+ *
+ */
+
+#pragma once
+
+#include "InvenSense_ICM20649_registers.hpp"
+
+#include <drivers/drv_hrt.h>
+#include <lib/drivers/accelerometer/PX4Accelerometer.hpp>
+#include <lib/drivers/device/spi.h>
+#include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
+#include <lib/ecl/geo/geo.h>
+#include <lib/perf/perf_counter.h>
+#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
+
+using namespace InvenSense_ICM20649;
+
+class ICM20649 : public device::SPI, public px4::ScheduledWorkItem
+{
+public:
+	ICM20649(int bus, uint32_t device, enum Rotation rotation = ROTATION_NONE);
+	~ICM20649() override;
+
+	bool Init();
+	void Start();
+	void Stop();
+	bool Reset();
+	void PrintInfo();
+
+private:
+
+	static constexpr uint32_t GYRO_RATE{9000};  // 9 kHz gyro
+	static constexpr uint32_t ACCEL_RATE{4500}; // 4.5 kHz accel
+	static constexpr uint32_t FIFO_MAX_SAMPLES{ math::min(FIFO::SIZE / sizeof(FIFO::DATA) + 1, sizeof(PX4Gyroscope::FIFOSample::x) / sizeof(PX4Gyroscope::FIFOSample::x[0]))};
+
+	// Transfer data
+	struct TransferBuffer {
+		uint8_t cmd_bank_select;
+		uint8_t bank;
+		uint8_t cmd;
+		FIFO::DATA f[FIFO_MAX_SAMPLES];
+	};
+	// ensure no struct padding
+	static_assert(sizeof(TransferBuffer) == (sizeof(uint8_t) + FIFO_MAX_SAMPLES *sizeof(FIFO::DATA)));
+
+	struct register_bank0_config_t {
+		Register::BANK_0 reg;
+		uint8_t set_bits{0};
+		uint8_t clear_bits{0};
+	};
+
+	struct register_bank2_config_t {
+		Register::BANK_2 reg;
+		uint8_t set_bits{0};
+		uint8_t clear_bits{0};
+	};
+
+	int probe() override;
+
+	void Run() override;
+
+	bool Configure();
+	void ConfigureAccel();
+	void ConfigureGyro();
+	void ConfigureSampleRate(int sample_rate);
+
+	static int DataReadyInterruptCallback(int irq, void *context, void *arg);
+	void DataReady();
+	bool DataReadyInterruptConfigure();
+	bool DataReadyInterruptDisable();
+
+	bool RegisterCheck(const register_bank0_config_t &reg_cfg, bool notify = false);
+	bool RegisterCheck(const register_bank2_config_t &reg_cfg, bool notify = false);
+
+	uint8_t RegisterRead(Register::BANK_0 reg);
+	uint8_t RegisterRead(Register::BANK_2 reg);
+
+	void RegisterWrite(Register::BANK_0 reg, uint8_t value);
+	void RegisterWrite(Register::BANK_2 reg, uint8_t value);
+
+	void RegisterSetAndClearBits(Register::BANK_0 reg, uint8_t setbits, uint8_t clearbits);
+	void RegisterSetAndClearBits(Register::BANK_2 reg, uint8_t setbits, uint8_t clearbits);
+
+	void RegisterSetBits(Register::BANK_0 reg, uint8_t setbits);
+	void RegisterClearBits(Register::BANK_0 reg, uint8_t clearbits);
+
+	uint16_t FIFOReadCount();
+	bool FIFORead(const hrt_abstime &timestamp_sample, uint16_t samples);
+	void FIFOReset();
+
+	bool ProcessAccel(const hrt_abstime &timestamp_sample, const TransferBuffer *const buffer, uint8_t samples);
+	void ProcessGyro(const hrt_abstime &timestamp_sample, const TransferBuffer *const buffer, uint8_t samples);
+	void UpdateTemperature();
+
+	uint8_t *_dma_data_buffer{nullptr};
+
+	PX4Accelerometer _px4_accel;
+	PX4Gyroscope _px4_gyro;
+
+	perf_counter_t _transfer_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": transfer")};
+	perf_counter_t _bad_register_perf{perf_alloc(PC_COUNT, MODULE_NAME": bad register")};
+	perf_counter_t _bad_transfer_perf{perf_alloc(PC_COUNT, MODULE_NAME": bad transfer")};
+	perf_counter_t _fifo_empty_perf{perf_alloc(PC_COUNT, MODULE_NAME": FIFO empty")};
+	perf_counter_t _fifo_overflow_perf{perf_alloc(PC_COUNT, MODULE_NAME": FIFO overflow")};
+	perf_counter_t _fifo_reset_perf{perf_alloc(PC_COUNT, MODULE_NAME": FIFO reset")};
+	perf_counter_t _drdy_interval_perf{perf_alloc(PC_INTERVAL, MODULE_NAME": DRDY interval")};
+
+	hrt_abstime _reset_timestamp{0};
+	hrt_abstime _last_config_check_timestamp{0};
+	hrt_abstime _fifo_watermark_interrupt_timestamp{0};
+	hrt_abstime _temperature_update_timestamp{0};
+
+	px4::atomic<uint8_t> _data_ready_count{0};
+	px4::atomic<uint8_t> _fifo_read_samples{0};
+	bool _data_ready_interrupt_enabled{false};
+
+
+	enum class STATE : uint8_t {
+		RESET,
+		WAIT_FOR_RESET,
+		CONFIGURE,
+		FIFO_READ,
+		REQUEST_STOP,
+		STOPPED,
+	};
+
+	px4::atomic<STATE> _state{STATE::RESET};
+
+	uint16_t _fifo_empty_interval_us{1000}; // 1000 us / 1000 Hz transfer interval
+	uint8_t _fifo_gyro_samples{static_cast<uint8_t>(_fifo_empty_interval_us / (1000000 / GYRO_RATE))};
+	uint8_t _fifo_accel_samples{static_cast<uint8_t>(_fifo_empty_interval_us / (1000000 / ACCEL_RATE))};
+
+	uint8_t _checked_register_bank0{0};
+	static constexpr uint8_t size_register_bank0_cfg{4};
+	register_bank0_config_t _register_bank0_cfg[size_register_bank0_cfg] {
+		// Register                      | Set bits, Clear bits
+		{ Register::BANK_0::USER_CTRL,     USER_CTRL_BIT::FIFO_EN | USER_CTRL_BIT::I2C_IF_DIS, USER_CTRL_BIT::I2C_MST_EN },
+		{ Register::BANK_0::PWR_MGMT_1,    PWR_MGMT_1_BIT::CLKSEL_0, PWR_MGMT_1_BIT::DEVICE_RESET | PWR_MGMT_1_BIT::SLEEP },
+		{ Register::BANK_0::INT_ENABLE_1,  INT_ENABLE_1_BIT::RAW_DATA_0_RDY_EN, 0 },
+		{ Register::BANK_0::FIFO_EN_2,     FIFO_EN_2_BIT::ACCEL_FIFO_EN | FIFO_EN_2_BIT::GYRO_Z_FIFO_EN | FIFO_EN_2_BIT::GYRO_Y_FIFO_EN | FIFO_EN_2_BIT::GYRO_X_FIFO_EN, FIFO_EN_2_BIT::TEMP_FIFO_EN },
+	};
+
+	uint8_t _checked_register_bank2{0};
+	static constexpr uint8_t size_register_bank2_cfg{2};
+	register_bank2_config_t _register_bank2_cfg[size_register_bank2_cfg] {
+		// Register                      | Set bits, Clear bits
+		{ Register::BANK_2::GYRO_CONFIG_1, GYRO_CONFIG_1_BIT::GYRO_FS_SEL_2000_DPS, GYRO_CONFIG_1_BIT::GYRO_FCHOICE },
+		{ Register::BANK_2::ACCEL_CONFIG,  ACCEL_CONFIG_BIT::ACCEL_FS_SEL_16G, ACCEL_CONFIG_BIT::ACCEL_FCHOICE },
+	};
+};

--- a/src/drivers/imu/invensense/icm20649/InvenSense_ICM20649_registers.hpp
+++ b/src/drivers/imu/invensense/icm20649/InvenSense_ICM20649_registers.hpp
@@ -1,0 +1,186 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file InvenSense_ICM20649_registers.hpp
+ *
+ * Invensense ICM-20649 registers.
+ *
+ */
+
+#pragma once
+
+#include <cstdint>
+
+// TODO: move to a central header
+static constexpr uint8_t Bit0 = (1 << 0);
+static constexpr uint8_t Bit1 = (1 << 1);
+static constexpr uint8_t Bit2 = (1 << 2);
+static constexpr uint8_t Bit3 = (1 << 3);
+static constexpr uint8_t Bit4 = (1 << 4);
+static constexpr uint8_t Bit5 = (1 << 5);
+static constexpr uint8_t Bit6 = (1 << 6);
+static constexpr uint8_t Bit7 = (1 << 7);
+
+namespace InvenSense_ICM20649
+{
+static constexpr uint32_t SPI_SPEED = 7 * 1000 * 1000; // 7 MHz SPI
+static constexpr uint8_t DIR_READ = 0x80;
+
+static constexpr uint8_t WHOAMI = 0xE1;
+
+static constexpr float TEMPERATURE_SENSITIVITY = 326.8f; // LSB/C
+static constexpr float ROOM_TEMPERATURE_OFFSET = 25.f; // C
+
+namespace Register
+{
+
+enum class BANK_0 : uint8_t {
+	WHO_AM_I             = 0x00,
+
+	USER_CTRL            = 0x03,
+
+	PWR_MGMT_1           = 0x06,
+
+	INT_ENABLE_1         = 0x11,
+
+	TEMP_OUT_H           = 0x39,
+	TEMP_OUT_L           = 0x3A,
+
+	FIFO_EN_2            = 0x67,
+	FIFO_RST             = 0x68,
+
+	FIFO_COUNTH          = 0x70,
+	FIFO_COUNTL          = 0x71,
+	FIFO_R_W             = 0x72,
+
+	REG_BANK_SEL         = 0x7F,
+};
+
+enum class BANK_2 : uint8_t {
+	GYRO_CONFIG_1        = 0x01,
+
+	ACCEL_CONFIG         = 0x14,
+
+	REG_BANK_SEL         = 0x7F,
+};
+
+};
+
+
+//---------------- BANK0 Register bits
+// USER_CTRL
+enum USER_CTRL_BIT : uint8_t {
+	FIFO_EN     = Bit6,
+	I2C_IF_DIS  = Bit4, // Reset I2C Slave module and put the serial interface in SPI mode only
+};
+
+// PWR_MGMT_1
+enum PWR_MGMT_1_BIT : uint8_t {
+	DEVICE_RESET = Bit7,
+	SLEEP        = Bit6,
+
+	CLKSEL_2     = Bit2,
+	CLKSEL_1     = Bit1,
+	CLKSEL_0     = Bit0,
+};
+
+// INT_ENABLE_1
+enum INT_ENABLE_1_BIT : uint8_t {
+	RAW_DATA_0_RDY_EN = Bit0,
+};
+
+// FIFO_EN_2
+enum FIFO_EN_2_BIT : uint8_t {
+	ACCEL_FIFO_EN  = Bit4,
+	GYRO_Z_FIFO_EN = Bit3,
+	GYRO_Y_FIFO_EN = Bit2,
+	GYRO_X_FIFO_EN = Bit1,
+	TEMP_FIFO_EN   = Bit0,
+};
+
+// FIFO_RST
+enum FIFO_RST_BIT : uint8_t {
+	FIFO_RESET = Bit0,
+};
+
+// REG_BANK_SEL
+enum REG_BANK_SEL_BIT : uint8_t {
+	USER_BANK_0 = 0,           // 0: Select USER BANK 0.
+	USER_BANK_2 = Bit4,        // 2: Select USER BANK 0.
+};
+
+//---------------- BANK2 Register bits
+// GYRO_CONFIG_1
+enum GYRO_CONFIG_1_BIT : uint8_t {
+	// GYRO_FS_SEL[1:0]
+	GYRO_FS_SEL_500_DPS  = 0,           // 0b00 = ±500 dps
+	GYRO_FS_SEL_1000_DPS = Bit1,        // 0b01 = ±1000 dps
+	GYRO_FS_SEL_2000_DPS = Bit2,        // 0b10 = ±2000 dps
+	GYRO_FS_SEL_4000_DPS = Bit2 | Bit1, // 0b11 = ±4000 dps
+
+	GYRO_FCHOICE         = Bit0,        // 0 – Bypass gyro DLPF
+};
+
+// ACCEL_CONFIG
+enum ACCEL_CONFIG_BIT : uint8_t {
+	// ACCEL_FS_SEL[1:0]
+	ACCEL_FS_SEL_4G  = 0,           // 0b00: ±4g
+	ACCEL_FS_SEL_8G  = Bit1,        // 0b01: ±8g
+	ACCEL_FS_SEL_16G = Bit2,        // 0b10: ±16g
+	ACCEL_FS_SEL_32G = Bit2 | Bit1, // 0b11: ±30g
+
+	ACCEL_FCHOICE    = Bit0,        // 0: Bypass accel DLPF
+};
+
+namespace FIFO
+{
+static constexpr size_t SIZE = 512;
+
+// FIFO_DATA layout when FIFO_EN has ACCEL_FIFO_EN and GYRO_{Z, Y, X}_FIFO_EN set
+struct DATA {
+	uint8_t ACCEL_XOUT_H;
+	uint8_t ACCEL_XOUT_L;
+	uint8_t ACCEL_YOUT_H;
+	uint8_t ACCEL_YOUT_L;
+	uint8_t ACCEL_ZOUT_H;
+	uint8_t ACCEL_ZOUT_L;
+	uint8_t GYRO_XOUT_H;
+	uint8_t GYRO_XOUT_L;
+	uint8_t GYRO_YOUT_H;
+	uint8_t GYRO_YOUT_L;
+	uint8_t GYRO_ZOUT_H;
+	uint8_t GYRO_ZOUT_L;
+};
+}
+} // namespace InvenSense_ICM20649

--- a/src/drivers/imu/invensense/icm20649/icm20649_main.cpp
+++ b/src/drivers/imu/invensense/icm20649/icm20649_main.cpp
@@ -1,0 +1,151 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "ICM20649.hpp"
+
+#include <px4_platform_common/getopt.h>
+
+namespace icm20649
+{
+ICM20649 *g_dev{nullptr};
+
+static int start(enum Rotation rotation)
+{
+	if (g_dev != nullptr) {
+		PX4_WARN("already started");
+		return 0;
+	}
+
+	// create the driver
+#if defined(PX4_SPI_BUS_1) && defined(PX4_SPIDEV_ICM_20948)
+	g_dev = new ICM20649(PX4_SPI_BUS_1, PX4_SPIDEV_ICM_20948, rotation);
+#endif
+
+	if (g_dev == nullptr) {
+		PX4_ERR("driver start failed");
+		return -1;
+	}
+
+	if (!g_dev->Init()) {
+		PX4_ERR("driver init failed");
+		delete g_dev;
+		g_dev = nullptr;
+		return -1;
+	}
+
+	return 0;
+}
+
+static int stop()
+{
+	if (g_dev == nullptr) {
+		PX4_WARN("driver not running");
+		return -1;
+	}
+
+	g_dev->Stop();
+	delete g_dev;
+	g_dev = nullptr;
+
+	return 0;
+}
+
+static int reset()
+{
+	if (g_dev == nullptr) {
+		PX4_WARN("driver not running");
+		return 0;
+	}
+
+	return g_dev->Reset();
+}
+
+static int status()
+{
+	if (g_dev == nullptr) {
+		PX4_INFO("driver not running");
+		return 0;
+	}
+
+	g_dev->PrintInfo();
+
+	return 0;
+}
+
+static int usage()
+{
+	PX4_INFO("missing command: try 'start', 'stop', 'reset', 'status'");
+	PX4_INFO("options:");
+	PX4_INFO("    -R rotation");
+
+	return 0;
+}
+
+} // namespace icm20649
+
+extern "C" int icm20649_main(int argc, char *argv[])
+{
+	enum Rotation rotation = ROTATION_NONE;
+	int myoptind = 1;
+	int ch = 0;
+	const char *myoptarg = nullptr;
+
+	// start options
+	while ((ch = px4_getopt(argc, argv, "R:", &myoptind, &myoptarg)) != EOF) {
+		switch (ch) {
+		case 'R':
+			rotation = (enum Rotation)atoi(myoptarg);
+			break;
+
+		default:
+			return icm20649::usage();
+		}
+	}
+
+	const char *verb = argv[myoptind];
+
+	if (!strcmp(verb, "start")) {
+		return icm20649::start(rotation);
+
+	} else if (!strcmp(verb, "stop")) {
+		return icm20649::stop();
+
+	} else if (!strcmp(verb, "status")) {
+		return icm20649::status();
+
+	} else if (!strcmp(verb, "reset")) {
+		return icm20649::reset();
+	}
+
+	return icm20649::usage();
+}


### PR DESCRIPTION
This is a driver for the InvenSense ICM20649 in the style of the "new" InvenSense drivers that use FIFOs and grab all raw data. This device is a bit different than some of the older sensors (icm20602, mpu6000, etc) as it has multiple register banks and a 32G dynamic range.

This will need a little bit more effort with actual hardware before it actually works.