### PR TITLE
mc_pos_control: handle landed and takeoff setpoint limiting the same way

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -612,6 +612,14 @@ MulticopterPositionControl::Run()
 			const bool flying = _takeoff.getTakeoffState() >= TakeoffState::flight;
 			const bool flying_but_ground_contact = flying && _vehicle_land_detected.ground_contact;
 
+			if (flying) {
+				_control.setThrustLimits(_param_mpc_thr_min.get(), _param_mpc_thr_max.get());
+
+			} else {
+				// allow zero thrust when taking off and landing
+				_control.setThrustLimits(0.f, _param_mpc_thr_max.get());
+			}
+
 			if (not_taken_off || flying_but_ground_contact) {
 				// we are not flying yet and need to avoid any corrections
 				reset_setpoint_to_nan(setpoint);

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -594,7 +594,7 @@ MulticopterPositionControl::Run()
 			}
 
 			// limit tilt during takeoff ramupup
-			if (_takeoff.getTakeoffState() < TakeoffState::flight && !PX4_ISFINITE(setpoint.thrust[2])) {
+			if (_takeoff.getTakeoffState() < TakeoffState::flight) {
 				constraints.tilt = math::radians(_param_mpc_tiltmax_lnd.get());
 			}
 
@@ -608,7 +608,7 @@ MulticopterPositionControl::Run()
 						    constraints.speed_up, !_control_mode.flag_control_climb_rate_enabled, time_stamp_now);
 			constraints.speed_up = _takeoff.updateRamp(_dt, constraints.speed_up);
 
-			if (_takeoff.getTakeoffState() < TakeoffState::rampup && !PX4_ISFINITE(setpoint.thrust[2])) {
+			if (_takeoff.getTakeoffState() < TakeoffState::rampup) {
 				// we are not flying yet and need to avoid any corrections
 				reset_setpoint_to_nan(setpoint);
 				setpoint.thrust[0] = setpoint.thrust[1] = setpoint.thrust[2] = 0.0f;
@@ -664,7 +664,7 @@ MulticopterPositionControl::Run()
 			// Part of landing logic: if ground-contact/maybe landed was detected, turn off
 			// controller. This message does not have to be logged as part of the vehicle_local_position_setpoint topic.
 			// Note: only adust thrust output if there was not thrust-setpoint demand in D-direction.
-			if (_takeoff.getTakeoffState() > TakeoffState::rampup && !PX4_ISFINITE(setpoint.thrust[2])) {
+			if (_takeoff.getTakeoffState() > TakeoffState::rampup) {
 				limit_thrust_during_landing(attitude_setpoint);
 			}
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -593,6 +593,16 @@ MulticopterPositionControl::Run()
 				constraints.speed_up = _param_mpc_z_vel_max_up.get();
 			}
 
+			// limit tilt during takeoff ramupup
+			if (_takeoff.getTakeoffState() < TakeoffState::flight && !PX4_ISFINITE(setpoint.thrust[2])) {
+				constraints.tilt = math::radians(_param_mpc_tiltmax_lnd.get());
+			}
+
+			// limit altitude only if local position is valid
+			if (PX4_ISFINITE(_states.position(2))) {
+				limit_altitude(setpoint);
+			}
+
 			// handle smooth takeoff
 			_takeoff.updateTakeoffState(_control_mode.flag_armed, _vehicle_land_detected.landed, constraints.want_takeoff,
 						    constraints.speed_up, !_control_mode.flag_control_climb_rate_enabled, time_stamp_now);
@@ -610,15 +620,6 @@ MulticopterPositionControl::Run()
 				_control.resetIntegral();
 				// reactivate the task which will reset the setpoint to current state
 				_flight_tasks.reActivate();
-			}
-
-			if (_takeoff.getTakeoffState() < TakeoffState::flight && !PX4_ISFINITE(setpoint.thrust[2])) {
-				constraints.tilt = math::radians(_param_mpc_tiltmax_lnd.get());
-			}
-
-			// limit altitude only if local position is valid
-			if (PX4_ISFINITE(_states.position(2))) {
-				limit_altitude(setpoint);
 			}
 
 			// Run position control


### PR DESCRIPTION
**Describe problem solved by this pull request**
@jkflying reported an effect I've seen before:
During a normal landing procedure the thrust gets first cut by the reaction to ground detected and then cut by the takeoff logic because the vehicle is back ready for another takeoff.
![image](https://user-images.githubusercontent.com/4668506/76170595-a4b29b00-6183-11ea-9898-7876a6628941.png)

The problem is that the thrust and attitude limit while landing is in the loop order after the position controller ran and directly operates on the attitude setpoint skipping the position controllers minimum thrust limit. The takeoff thrust limitation on the other had is before the position controller and amends the input to it.

**Describe your solution**
I'm unifying the thrust and attitude limit logic to be in one place where it already was for the takeoff. Both logics for takeoff and landing do these things in common:
- cut thrust
- set roll pitch level
- set yawspeed to zero and yaw setpoint to current yaw
- reset position control integral

I still have to check if reactivating flight task and reseting the hover thrust is also desired otherwise they can be conditional for just the takeoff.

**Describe possible alternatives**
It's not 100% clear to me if `MPC_THR_MIN` should be the minimum thrust at all times even during landing and takeoff or if the takeoff ramp should always start at zero thrust and thrust should go down to zero after landing.

**Test data / coverage**
Quick SITL test, needs more testing and review.
