### PR TITLE
work queue: fix some race conditions

### DIFF
--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkItem.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkItem.hpp
@@ -81,6 +81,10 @@ protected:
 
 	virtual ~WorkItem();
 
+	/**
+	 * Remove work item from the runnable queue, if it's there
+	 */
+	void ScheduleClear();
 protected:
 
 	void RunPreamble() { _run_count++; }

--- a/platforms/common/px4_work_queue/ScheduledWorkItem.cpp
+++ b/platforms/common/px4_work_queue/ScheduledWorkItem.cpp
@@ -66,7 +66,9 @@ ScheduledWorkItem::ScheduleOnInterval(uint32_t interval_us, uint32_t delay_us)
 void
 ScheduledWorkItem::ScheduleClear()
 {
+	// first clear any scheduled hrt call, then remove the item from the runnable queue
 	hrt_cancel(&_call);
+	WorkItem::ScheduleClear();
 }
 
 void

--- a/platforms/common/px4_work_queue/WorkItem.cpp
+++ b/platforms/common/px4_work_queue/WorkItem.cpp
@@ -89,6 +89,14 @@ WorkItem::Deinit()
 	}
 }
 
+void
+WorkItem::ScheduleClear()
+{
+	if (_wq != nullptr) {
+		_wq->Remove(this);
+	}
+}
+
 float
 WorkItem::elapsed_time() const
 {

--- a/platforms/common/px4_work_queue/WorkQueue.cpp
+++ b/platforms/common/px4_work_queue/WorkQueue.cpp
@@ -160,6 +160,7 @@ WorkQueue::Run()
 			work_unlock(); // unlock work queue to run (item may requeue itself)
 			work->RunPreamble();
 			work->Run();
+			// Note: after Run() we cannot access work anymore, as it might have been deleted
 			work_lock(); // re-lock
 		}
 

--- a/src/lib/mixer_module/mixer_module.cpp
+++ b/src/lib/mixer_module/mixer_module.cpp
@@ -126,8 +126,8 @@ bool MixingOutput::updateSubscriptions(bool allow_wq_switch)
 
 	if (_scheduling_policy == SchedulingPolicy::Auto) {
 		// first clear everything
-		_interface.ScheduleClear();
 		unregister();
+		_interface.ScheduleClear();
 
 		// if subscribed to control group 0 or 1 then move to the rate_ctrl WQ
 		const bool sub_group_0 = (_groups_required & (1 << 0));

--- a/src/modules/sensors/vehicle_acceleration/VehicleAcceleration.cpp
+++ b/src/modules/sensors/vehicle_acceleration/VehicleAcceleration.cpp
@@ -71,14 +71,14 @@ bool VehicleAcceleration::Start()
 
 void VehicleAcceleration::Stop()
 {
-	Deinit();
-
 	// clear all registered callbacks
 	for (auto &sub : _sensor_sub) {
 		sub.unregisterCallback();
 	}
 
 	_sensor_selection_sub.unregisterCallback();
+
+	Deinit();
 }
 
 void VehicleAcceleration::CheckFilters()

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
@@ -74,14 +74,14 @@ bool VehicleAngularVelocity::Start()
 
 void VehicleAngularVelocity::Stop()
 {
-	Deinit();
-
 	// clear all registered callbacks
 	for (auto &sub : _sensor_sub) {
 		sub.unregisterCallback();
 	}
 
 	_sensor_selection_sub.unregisterCallback();
+
+	Deinit();
 }
 
 void VehicleAngularVelocity::CheckFilters()

--- a/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
@@ -66,11 +66,11 @@ bool VehicleIMU::Start()
 
 void VehicleIMU::Stop()
 {
-	Deinit();
-
 	// clear all registered callbacks
 	_sensor_accel_integrated_sub.unregisterCallback();
 	_sensor_gyro_integrated_sub.unregisterCallback();
+
+	Deinit();
 }
 
 void VehicleIMU::ParametersUpdate(bool force)


### PR DESCRIPTION
 - ScheduledWorkItem::ScheduleClear: remove item from runnable queue

The existing behavior is unexpected: if the work item is already on the
runnable queue, it will still be triggered after a call to ScheduleClear().
This can lead to race conditions.

- uorb callbacks: fix unregister ordering to avoid race conditions 

Mostly only relevant for driver/module stopping, so not critical for current users.