### PR TITLE
Enable logging of RPM sensor messages

### DIFF
--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -69,9 +69,9 @@ void LoggedTopics::add_default_topics()
 	add_topic("offboard_control_mode", 1000);
 	add_topic("position_controller_status", 500);
 	add_topic("position_setpoint_triplet", 200);
-	add_topic("rpm", 500);
 	add_topic("radio_status");
 	add_topic("rate_ctrl_status", 200);
+	add_topic("rpm", 500);
 	add_topic("safety", 1000);
 	add_topic("sensor_combined", 100);
 	add_topic("sensor_correction", 1000);

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -69,6 +69,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("offboard_control_mode", 1000);
 	add_topic("position_controller_status", 500);
 	add_topic("position_setpoint_triplet", 200);
+	add_topic("rpm");
 	add_topic("radio_status");
 	add_topic("rate_ctrl_status", 200);
 	add_topic("safety", 1000);
@@ -398,4 +399,3 @@ void LoggedTopics::initialize_configured_topics(SDLogProfileMask profile)
 		add_vision_and_avoidance_topics();
 	}
 }
-

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -69,7 +69,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("offboard_control_mode", 1000);
 	add_topic("position_controller_status", 500);
 	add_topic("position_setpoint_triplet", 200);
-	add_topic("rpm");
+	add_topic("rpm", 500);
 	add_topic("radio_status");
 	add_topic("rate_ctrl_status", 200);
 	add_topic("safety", 1000);


### PR DESCRIPTION
In the previous PR https://github.com/PX4/Firmware/pull/14018, we forgot to add logging of uORB messages from RPM sensor. This PR only enables this logging in FW. 
