### PR TITLE
Up stack for frsky_telemetry

### DIFF
--- a/src/drivers/telemetry/frsky_telemetry/frsky_telemetry.cpp
+++ b/src/drivers/telemetry/frsky_telemetry/frsky_telemetry.cpp
@@ -719,7 +719,7 @@ int frsky_telemetry_main(int argc, char *argv[])
 		frsky_task = px4_task_spawn_cmd("frsky_telemetry",
 						SCHED_DEFAULT,
 						SCHED_PRIORITY_DEFAULT + 4,
-						1380,
+						1400,
 						frsky_telemetry_thread_main,
 						(char *const *)argv);
 


### PR DESCRIPTION
Message in log:

> WARNING [load_mon] frsky_telementry low on stack! (276 bytes left)

It is found in:
https://github.com/PX4/Firmware/issues/9389
https://discuss.px4.io/t/warning-with-frsky-telemetry/12951

Describe:
If use telemetry by FrSky and GPS module when he will be work - then this message (warning) will be show in logs. Apparently a bit lacking if the variables get larger.

**Describe your solution**
Increase stack size

**Test data / coverage**
Check on my FMU - Pixhawk 4
