### PR TITLE
Ability to disable airspeed scaling

### DIFF
--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -263,7 +263,9 @@ float FixedwingAttitudeControl::get_airspeed_and_update_scaling()
 	 * Forcing the scaling to this value allows reasonable handheld tests.
 	 */
 	const float airspeed_constrained = constrain(airspeed, _param_fw_airspd_min.get(), _param_fw_airspd_max.get());
-	_airspeed_scaling = _param_fw_airspd_trim.get() / airspeed_constrained;
+
+	// Disable airspeed scaling with parameter
+	_airspeed_scaling = (_param_fw_arsp_scale.get())? (_param_fw_airspd_trim.get() / airspeed_constrained) : 1.0f;
 
 	return airspeed;
 }

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -265,7 +265,7 @@ float FixedwingAttitudeControl::get_airspeed_and_update_scaling()
 	const float airspeed_constrained = constrain(airspeed, _param_fw_airspd_min.get(), _param_fw_airspd_max.get());
 
 	// Disable airspeed scaling with parameter
-	_airspeed_scaling = (_param_fw_arsp_scale.get()) ? (_param_fw_airspd_trim.get() / airspeed_constrained) : 1.0f;
+	_airspeed_scaling = (_param_fw_arsp_scale_en.get()) ? (_param_fw_airspd_trim.get() / airspeed_constrained) : 1.0f;
 
 	return airspeed;
 }

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -264,7 +264,6 @@ float FixedwingAttitudeControl::get_airspeed_and_update_scaling()
 	 */
 	const float airspeed_constrained = constrain(airspeed, _param_fw_airspd_min.get(), _param_fw_airspd_max.get());
 
-	// Disable airspeed scaling with parameter
 	_airspeed_scaling = (_param_fw_arsp_scale_en.get()) ? (_param_fw_airspd_trim.get() / airspeed_constrained) : 1.0f;
 
 	return airspeed;

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -265,7 +265,7 @@ float FixedwingAttitudeControl::get_airspeed_and_update_scaling()
 	const float airspeed_constrained = constrain(airspeed, _param_fw_airspd_min.get(), _param_fw_airspd_max.get());
 
 	// Disable airspeed scaling with parameter
-	_airspeed_scaling = (_param_fw_arsp_scale.get())? (_param_fw_airspd_trim.get() / airspeed_constrained) : 1.0f;
+	_airspeed_scaling = (_param_fw_arsp_scale.get()) ? (_param_fw_airspd_trim.get() / airspeed_constrained) : 1.0f;
 
 	return airspeed;
 }

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
@@ -149,7 +149,7 @@ private:
 		(ParamFloat<px4::params::FW_AIRSPD_TRIM>) _param_fw_airspd_trim,
 		(ParamInt<px4::params::FW_ARSP_MODE>) _param_fw_arsp_mode,
 
-		(ParamInt<px4::params::FW_ARSP_SCALE>) _param_fw_arsp_scale,
+		(ParamInt<px4::params::FW_ARSP_SCALE_EN>) _param_fw_arsp_scale_en,
 
 		(ParamBool<px4::params::FW_BAT_SCALE_EN>) _param_fw_bat_scale_en,
 

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
@@ -149,6 +149,8 @@ private:
 		(ParamFloat<px4::params::FW_AIRSPD_TRIM>) _param_fw_airspd_trim,
 		(ParamInt<px4::params::FW_ARSP_MODE>) _param_fw_arsp_mode,
 
+		(ParamInt<px4::params::FW_ARSP_SCALE>) _param_fw_arsp_scale,
+
 		(ParamBool<px4::params::FW_BAT_SCALE_EN>) _param_fw_bat_scale_en,
 
 		(ParamFloat<px4::params::FW_DTRIM_P_FLPS>) _param_fw_dtrim_p_flps,

--- a/src/modules/fw_att_control/fw_att_control_params.c
+++ b/src/modules/fw_att_control/fw_att_control_params.c
@@ -543,7 +543,7 @@ PARAM_DEFINE_INT32(FW_ARSP_MODE, 0);
  * This enables a logic that automatically adjusts the output of the rate controller to take
  * into account the real torque produced by an aerodynamic control surface given
  * the current deviation from the trim airspeed (FW_AIRSPD_TRIM).
- 
+ *
  * Enable when using aerodynamic control surfaces (e.g.: plane)
  * Disable when using rotor wings (e.g.: autogyro)
  *

--- a/src/modules/fw_att_control/fw_att_control_params.c
+++ b/src/modules/fw_att_control/fw_att_control_params.c
@@ -538,18 +538,19 @@ PARAM_DEFINE_FLOAT(FW_FLAPERON_SCL, 0.0f);
 PARAM_DEFINE_INT32(FW_ARSP_MODE, 0);
 
 /**
- * Enable of airspeed scaling
+ * Enable airspeed scaling
  *
- * Enable of airspeed scaling of control surfaces. Disabling of airspeed scaling
- * is important for rotor craft and vehicles with rotor wing such as autogyro.
- * Enable when using aerodynamic control surfaces (e.g.: plane), disable when
- * using rotor wings (e.g.: autogyro)
+ * This enables a logic that automatically adjusts the output of the rate controller to take
+ * into account the real torque produced by an aerodynamic control surface given
+ * the current deviation from the trim airspeed (FW_AIRSPD_TRIM).
+ 
+ * Enable when using aerodynamic control surfaces (e.g.: plane)
+ * Disable when using rotor wings (e.g.: autogyro)
  *
- * @value 1 Airspeed scaling enabled
- * @value 0 Airspeed scaling disabled
+ * @boolean
  * @group FW Attitude Control
  */
-PARAM_DEFINE_INT32(FW_ARSP_SCALE, 1);
+PARAM_DEFINE_INT32(FW_ARSP_SCALE_EN, 1);
 
 /**
  * Manual roll scale

--- a/src/modules/fw_att_control/fw_att_control_params.c
+++ b/src/modules/fw_att_control/fw_att_control_params.c
@@ -538,6 +538,18 @@ PARAM_DEFINE_FLOAT(FW_FLAPERON_SCL, 0.0f);
 PARAM_DEFINE_INT32(FW_ARSP_MODE, 0);
 
 /**
+ * Disable of airspeed scaling
+ *
+ * Disable of airspeed scaling of control surfaces. Disabling of airspeed scaling
+ * is important for rotor craft and vehicles with rotor wing such as autogyro.
+ *
+ * @value 1 Airspeed scaling is enabled.
+ * @value 0 Airspeed scaling disabled
+ * @group FW Attitude Control
+ */
+PARAM_DEFINE_INT32(FW_ARSP_SCALE, 1);
+
+/**
  * Manual roll scale
  *
  * Scale factor applied to the desired roll actuator command in full manual mode. This parameter allows

--- a/src/modules/fw_att_control/fw_att_control_params.c
+++ b/src/modules/fw_att_control/fw_att_control_params.c
@@ -538,12 +538,14 @@ PARAM_DEFINE_FLOAT(FW_FLAPERON_SCL, 0.0f);
 PARAM_DEFINE_INT32(FW_ARSP_MODE, 0);
 
 /**
- * Disable of airspeed scaling
+ * Enable of airspeed scaling
  *
- * Disable of airspeed scaling of control surfaces. Disabling of airspeed scaling
+ * Enable of airspeed scaling of control surfaces. Disabling of airspeed scaling
  * is important for rotor craft and vehicles with rotor wing such as autogyro.
+ * Enable when using aerodynamic control surfaces (e.g.: plane), disable when
+ * using rotor wings (e.g.: autogyro)
  *
- * @value 1 Airspeed scaling is enabled.
+ * @value 1 Airspeed scaling enabled
  * @value 0 Airspeed scaling disabled
  * @group FW Attitude Control
  */


### PR DESCRIPTION
Autogyro (and [rotorcrafts](https://en.wikipedia.org/wiki/Rotorcraft) in general) requires the possibility to disable airspeed scaling.. This pull-request adds a parameter ```FW_ARSP_SCALE``` to the possibility to disable airspeed scaling.

This parameter is two-state. Zero (0) disables airspeed scaling, 1 enables airspeed scaling. 

This issue is solved with setting variable ```_airspeed_scaling``` to 1 for disabling airspeed-scaling. 

https://github.com/ThunderFly-aerospace/PX4Firmware/blob/94feac2b5c96a6f5f102b00dbd7952c179dbab90/src/modules/fw_att_control/FixedwingAttitudeControl.cpp#L267-L268

