### PR TITLE
mc_pos_control: hotfix for takeoff ramp stuck with NAN

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -587,6 +587,12 @@ MulticopterPositionControl::Run()
 			// check if all local states are valid and map accordingly
 			set_vehicle_states(setpoint.vz);
 
+			// fix to prevent the takeoff ramp to ramp to a too high value or get stuck because of NAN
+			// TODO: this should get obsolete once the takeoff limiting moves into the flight tasks
+			if (!PX4_ISFINITE(constraints.speed_up) || (constraints.speed_up > _param_mpc_z_vel_max_up.get())) {
+				constraints.speed_up = _param_mpc_z_vel_max_up.get();
+			}
+
 			// handle smooth takeoff
 			_takeoff.updateTakeoffState(_control_mode.flag_armed, _vehicle_land_detected.landed, constraints.want_takeoff,
 						    constraints.speed_up, !_control_mode.flag_control_climb_rate_enabled, time_stamp_now);


### PR DESCRIPTION
**Describe problem solved by this pull request**
Follow up to #13973 reported and proposed by @dusan19.
Summary: The takeoff ramp can get stuck with an upwards velocity limit of NAN which is a valid value in the interface and means do not limit.

**Describe your solution**
I propose to make sure just before the takeoff ramp calculation that the value is already the maximum and not NAN anymore. This leaves the interface for flight tasks and solves the problem described in #13973.

I admit it's not the nicest of all solutions but with the context that
- we want to move towards not constraining the velocity setpoint more than necessary in the middle of the position controller (which is what that variable was originally created for)
- having the takeoff ramp class used in in flight tasks
I think it's an acceptable fix.

All the logic that changes the setpoints after the developer generated them in the flight task is prone to lead to problems.

**Describe possible alternatives**
#13973

**Test data / coverage**
Untested, just quickly pushed for @dusan19 to test. I can test it later as well.