### PR TITLE
sensors: move to WQ

### DIFF
--- a/platforms/common/include/px4_platform_common/tasks.h
+++ b/platforms/common/include/px4_platform_common/tasks.h
@@ -124,11 +124,6 @@ typedef struct {
 // wait for the sensor hub if its data is coming from it.
 #define SCHED_PRIORITY_ESTIMATOR		(PX4_WQ_HP_BASE - 5)
 
-// The sensor hub conditions sensor data. It is not the fastest component
-// in the controller chain, but provides easy-to-use data to the more
-// complex downstream consumers
-#define SCHED_PRIORITY_SENSOR_HUB		(PX4_WQ_HP_BASE - 6)
-
 // Position controllers typically are in a blocking wait on estimator data
 // so when new sensor data is available they will run last. Keeping them
 // on a high priority ensures that they are the first process to be run

--- a/src/modules/sensors/voted_sensors_update.h
+++ b/src/modules/sensors/voted_sensors_update.h
@@ -125,11 +125,7 @@ public:
 	 */
 	void checkFailover();
 
-	int numGyros() const { return _gyro.subscription_count; }
-
-	int gyroFd(int idx) const { return _gyro.subscription[idx]; }
-
-	int bestGyroFd() const { return _gyro.subscription[_gyro.last_best_vote]; }
+	int bestGyroID() const { return _gyro_device_id[_gyro.last_best_vote]; }
 
 	/**
 	 * Calculates the magnitude in m/s/s of the largest difference between the primary and any other accel sensor


### PR DESCRIPTION
Running the `sensors` module out of the same WQ thread as the estimator and position controller is a bit safer and prevents potential priority and starvation issues. There will likely be a small increase in latency between `sensors` and `ekf2` execution (on average), but I expect it to be small and I'll verify on hardware before merging. This also saves a little bit of memory (~ 3 kB) and cpu (~1-1.5% total depending on the board).

I still intend to continue to carve up the sensors module into separate pieces per data type, but this is a safer thing to do short term. (eg https://github.com/PX4/Firmware/pull/14096)


