### PR TITLE
microRTPS: fix timesync support and general cleanup

### DIFF
--- a/msg/templates/urtps/Publisher.cpp.em
+++ b/msg/templates/urtps/Publisher.cpp.em
@@ -69,7 +69,7 @@ except AttributeError:
 
 #include <fastrtps/Domain.h>
 
-@[if 1.5 <= fastrtpsgen_version <= 1.7]@
+@[if fastrtps_version <= 1.7]@
 #include <fastrtps/utils/eClock.h>
 @[end if]@
 
@@ -85,7 +85,7 @@ bool @(topic)_Publisher::init()
     // Create RTPSParticipant
     ParticipantAttributes PParam;
     PParam.rtps.builtin.domainId = 0;
-@[if 1.5 <= fastrtpsgen_version <= 1.7 or ros2_distro == "ardent" or ros2_distro == "bouncy" or ros2_distro == "crystal" or ros2_distro == "dashing"]@
+@[if fastrtps_version <= 1.8]@
     PParam.rtps.builtin.leaseDuration = c_TimeInfinite;
 @[else]@
     PParam.rtps.builtin.discovery_config.leaseDuration = c_TimeInfinite;
@@ -149,7 +149,7 @@ void @(topic)_Publisher::PubListener::onPublicationMatched(Publisher* pub, Match
     }
 }
 
-@[if 1.5 <= fastrtpsgen_version <= 1.7]@
+@[if fastrtps_version <= 1.7]@
 @[    if ros2_distro]@
     void @(topic)_Publisher::publish(@(package)::msg::dds_::@(topic)_* st)
 @[    else]@

--- a/msg/templates/urtps/Publisher.cpp.em
+++ b/msg/templates/urtps/Publisher.cpp.em
@@ -76,9 +76,15 @@ except AttributeError:
 #include "@(topic)_Publisher.h"
 
 
-@(topic)_Publisher::@(topic)_Publisher() : mp_participant(nullptr), mp_publisher(nullptr) {}
+@(topic)_Publisher::@(topic)_Publisher()
+    : mp_participant(nullptr),
+      mp_publisher(nullptr)
+{ }
 
-@(topic)_Publisher::~@(topic)_Publisher() { Domain::removeParticipant(mp_participant);}
+@(topic)_Publisher::~@(topic)_Publisher()
+{
+    Domain::removeParticipant(mp_participant);
+}
 
 bool @(topic)_Publisher::init()
 {
@@ -149,19 +155,7 @@ void @(topic)_Publisher::PubListener::onPublicationMatched(Publisher* pub, Match
     }
 }
 
-@[if fastrtps_version <= 1.7]@
-@[    if ros2_distro]@
-    void @(topic)_Publisher::publish(@(package)::msg::dds_::@(topic)_* st)
-@[    else]@
-    void @(topic)_Publisher::publish(@(topic)_* st)
-@[    end if]@
-@[else]@
-@[    if ros2_distro]@
-    void @(topic)_Publisher::publish(@(package)::msg::@(topic)* st)
-@[    else]@
-    void @(topic)_Publisher::publish(@(topic)* st)
-@[    end if]@
-@[end if]@
+void @(topic)_Publisher::publish(@(topic)_msg_t* st)
 {
     mp_publisher->write(st);
 }

--- a/msg/templates/urtps/Publisher.h.em
+++ b/msg/templates/urtps/Publisher.h.em
@@ -68,7 +68,7 @@ except AttributeError:
 #include <fastrtps/fastrtps_fwd.h>
 #include <fastrtps/publisher/PublisherListener.h>
 
-@[if 1.5 <= fastrtpsgen_version <= 1.7]@
+@[if fastrtps_version <= 1.7]@
 #include "@(topic)_PubSubTypes.h"
 @[else]@
 #include "@(topic)PubSubTypes.h"
@@ -84,7 +84,7 @@ public:
     virtual ~@(topic)_Publisher();
     bool init();
     void run();
-@[if 1.5 <= fastrtpsgen_version <= 1.7]@
+@[if fastrtps_version <= 1.7]@
 @[    if ros2_distro]@
     void publish(@(package)::msg::dds_::@(topic)_* st);
 @[    else]@
@@ -109,7 +109,7 @@ private:
         void onPublicationMatched(Publisher* pub, MatchingInfo& info);
         int n_matched;
     } m_listener;
-@[if 1.5 <= fastrtpsgen_version <= 1.7]@
+@[if fastrtps_version <= 1.7]@
 @[    if ros2_distro]@
     @(package)::msg::dds_::@(topic)_PubSubType @(topic)DataType;
 @[    else]@

--- a/msg/templates/urtps/Publisher.h.em
+++ b/msg/templates/urtps/Publisher.h.em
@@ -77,6 +77,24 @@ except AttributeError:
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 
+@[if fastrtps_version <= 1.7]@
+@[    if ros2_distro]@
+using @(topic)_msg_t = @(package)::msg::dds_::@(topic)_;
+using @(topic)_msg_datatype = @(package)::msg::dds_::@(topic)_PubSubType;
+@[    else]@
+using @(topic)_msg_t = @(topic)_;
+using @(topic)_msg_datatype = @(topic)_PubSubType;
+@[    end if]@
+@[else]@
+@[    if ros2_distro]@
+using @(topic)_msg_t = @(package)::msg::@(topic);
+using @(topic)_msg_datatype = @(package)::msg::@(topic)PubSubType;
+@[    else]@
+using @(topic)_msg_t = @(topic);
+using @(topic)_msg_datatype = @(topic)PubSubType;
+@[    end if]@
+@[end if]@
+
 class @(topic)_Publisher
 {
 public:
@@ -84,19 +102,7 @@ public:
     virtual ~@(topic)_Publisher();
     bool init();
     void run();
-@[if fastrtps_version <= 1.7]@
-@[    if ros2_distro]@
-    void publish(@(package)::msg::dds_::@(topic)_* st);
-@[    else]@
-    void publish(@(topic)_* st);
-@[    end if]@
-@[else]@
-@[    if ros2_distro]@
-    void publish(@(package)::msg::@(topic)* st);
-@[    else]@
-    void publish(@(topic)* st);
-@[    end if]@
-@[end if]@
+    void publish(@(topic)_msg_t* st);
 private:
     Participant *mp_participant;
     Publisher *mp_publisher;
@@ -109,19 +115,7 @@ private:
         void onPublicationMatched(Publisher* pub, MatchingInfo& info);
         int n_matched;
     } m_listener;
-@[if fastrtps_version <= 1.7]@
-@[    if ros2_distro]@
-    @(package)::msg::dds_::@(topic)_PubSubType @(topic)DataType;
-@[    else]@
-    @(topic)_PubSubType @(topic)DataType;
-@[    end if]@
-@[else]@
-@[    if ros2_distro]@
-    @(package)::msg::@(topic)PubSubType @(topic)DataType;
-@[    else]@
-    @(topic)PubSubType @(topic)DataType;
-@[    end if]@
-@[end if]@
+    @(topic)_msg_datatype @(topic)DataType;
 };
 
 #endif // _@(topic)__PUBLISHER_H_

--- a/msg/templates/urtps/RtpsTopics.cpp.em
+++ b/msg/templates/urtps/RtpsTopics.cpp.em
@@ -110,6 +110,7 @@ void RtpsTopics::publish(uint8_t topic_ID, char data_buffer[], size_t len)
             // apply timestamp offset
             uint64_t timestamp = getMsgTimestamp(&st);
             _timesync->subtractOffset(timestamp);
+            setMsgTimestamp(&st, timestamp);
             _@(topic)_pub.publish(&st);
 @[    if topic == 'Timesync' or topic == 'timesync']@
             }
@@ -141,6 +142,7 @@ bool RtpsTopics::getMsg(const uint8_t topic_ID, eprosima::fastcdr::Cdr &scdr)
                 // apply timestamp offset
                 uint64_t timestamp = getMsgTimestamp(&msg);
                 _timesync->addOffset(timestamp);
+                setMsgTimestamp(&msg, timestamp);
                 msg.serialize(scdr);
                 ret = true;
 @[    if topic == 'Timesync' or topic == 'timesync']@

--- a/msg/templates/urtps/RtpsTopics.h.em
+++ b/msg/templates/urtps/RtpsTopics.h.em
@@ -73,22 +73,7 @@ except AttributeError:
 @[end for]@
 
 
-@[for topic in recv_topics]@
-@[    if fastrtps_version <= 1.7]@
-@[        if ros2_distro]@
-using @(topic)_msg_t = @(package)::msg::dds_::@(topic)_;
-@[        else]@
-using @(topic)_msg_t = @(topic)_;
-@[        end if]@
-@[    else]@
-@[        if ros2_distro]@
-using @(topic)_msg_t = @(package)::msg::@(topic) ;
-@[        else]@
-using @(topic)_msg_t = @(topic);
-@[        end if]@
-@[    end if]@
-@[end for]@
-@[for topic in send_topics]@
+@[for topic in (recv_topics + send_topics)]@
 @[    if fastrtps_version <= 1.7]@
 @[        if ros2_distro]@
 using @(topic)_msg_t = @(package)::msg::dds_::@(topic)_;
@@ -103,7 +88,6 @@ using @(topic)_msg_t = @(topic);
 @[        end if]@
 @[    end if]@
 @[end for]@
-
 
 class RtpsTopics {
 public:
@@ -152,7 +136,7 @@ private:
     inline uint8_t getMsgSeq(const T* msg) { return msg->seq(); }
 @[end if]@
 
-    /** Msg metadata Getters **/
+    /** Msg metadata Setters **/
 @[if fastrtps_version <= 1.7 or not ros2_distro]@
     template <class T>
     inline uint64_t setMsgTimestamp(T* msg, const uint64_t& timestamp) { msg->timestamp_() = timestamp; }

--- a/msg/templates/urtps/RtpsTopics.h.em
+++ b/msg/templates/urtps/RtpsTopics.h.em
@@ -20,7 +20,7 @@ from px_generate_uorb_topic_files import MsgScope # this is in Tools/
 send_topics = [(alias[idx] if alias[idx] else s.short_name) for idx, s in enumerate(spec) if scope[idx] == MsgScope.SEND]
 recv_topics = [(alias[idx] if alias[idx] else s.short_name) for idx, s in enumerate(spec) if scope[idx] == MsgScope.RECEIVE]
 package = package[0]
-fastrtpsgen_version = fastrtpsgen_version[0]
+fastrtps_version = fastrtps_version[0]
 try:
     ros2_distro = ros2_distro[0].decode("utf-8")
 except AttributeError:
@@ -74,7 +74,7 @@ except AttributeError:
 
 
 @[for topic in recv_topics]@
-@[    if 1.5 <= fastrtpsgen_version <= 1.7]@
+@[    if fastrtps_version <= 1.7]@
 @[        if ros2_distro]@
 using @(topic)_msg_t = @(package)::msg::dds_::@(topic)_;
 @[        else]@
@@ -89,7 +89,7 @@ using @(topic)_msg_t = @(topic);
 @[    end if]@
 @[end for]@
 @[for topic in send_topics]@
-@[    if 1.5 <= fastrtpsgen_version <= 1.7]@
+@[    if fastrtps_version <= 1.7]@
 @[        if ros2_distro]@
 using @(topic)_msg_t = @(package)::msg::dds_::@(topic)_;
 @[        else]@
@@ -131,7 +131,7 @@ private:
 @[end for]@
 @[end if]@
 
-@[if 1.5 <= fastrtpsgen_version <= 1.7 or not ros2_distro]@
+@[if fastrtps_version <= 1.7 or not ros2_distro]@
     template <class T>
     uint8_t getMsgSysID(T* msg) { return msg->sys_id_(); }
 

--- a/msg/templates/urtps/RtpsTopics.h.em
+++ b/msg/templates/urtps/RtpsTopics.h.em
@@ -118,32 +118,65 @@ public:
 
 private:
 @[if send_topics]@
-    // Publishers
+    /** Publishers **/
 @[for topic in send_topics]@
     @(topic)_Publisher _@(topic)_pub;
 @[end for]@
 @[end if]@
 
 @[if recv_topics]@
-    // Subscribers
+    /** Subscribers **/
 @[for topic in recv_topics]@
     @(topic)_Subscriber _@(topic)_sub;
 @[end for]@
 @[end if]@
 
+    /** Msg metada Getters **/
 @[if fastrtps_version <= 1.7 or not ros2_distro]@
     template <class T>
-    uint8_t getMsgSysID(T* msg) { return msg->sys_id_(); }
+    inline uint64_t getMsgTimestamp(const T* msg) { return msg->timestamp_(); }
 
     template <class T>
-    uint64_t getMsgTimestamp(T* msg) { return msg->timestamp_(); }
+    inline uint8_t getMsgSysID(const T* msg) { return msg->sys_id_(); }
+
+    template <class T>
+    inline uint8_t getMsgSeq(const T* msg) { return msg->seq_(); }
 @[elif ros2_distro]@
     template <class T>
-    uint8_t getMsgSysID(T* msg) { return msg->sys_id(); }
+    inline uint64_t getMsgTimestamp(const T* msg) { return msg->timestamp(); }
 
     template <class T>
-    uint64_t getMsgTimestamp(T* msg) { return msg->timestamp(); }
+    inline uint8_t getMsgSysID(const T* msg) { return msg->sys_id(); }
+
+    template <class T>
+    inline uint8_t getMsgSeq(const T* msg) { return msg->seq(); }
 @[end if]@
 
+    /** Msg metadata Getters **/
+@[if fastrtps_version <= 1.7 or not ros2_distro]@
+    template <class T>
+    inline uint64_t setMsgTimestamp(T* msg, const uint64_t& timestamp) { msg->timestamp_() = timestamp; }
+
+    template <class T>
+    inline uint8_t setMsgSysID(T* msg, const uint8_t& sys_id) { msg->sys_id_() = sys_id; }
+
+    template <class T>
+    inline uint8_t setMsgSeq(T* msg, const uint8_t& seq) { msg->seq_() = seq; }
+@[elif ros2_distro]@
+    template <class T>
+    inline uint64_t setMsgTimestamp(T* msg, const uint64_t& timestamp) { msg->timestamp() = timestamp; }
+
+    template <class T>
+    inline uint8_t setMsgSysID(T* msg, const uint8_t& sys_id) { msg->sys_id() = sys_id; }
+
+    template <class T>
+    inline uint8_t setMsgSeq(T* msg, const uint8_t& seq) { msg->seq() = seq; }
+@[end if]@
+
+    /**
+     * @@brief Timesync object ptr.
+     *         This object is used to compuyte and apply the time offsets to the
+     *         messages timestamps.
+     */
     std::shared_ptr<TimeSync> _timesync;
 };

--- a/msg/templates/urtps/Subscriber.cpp.em
+++ b/msg/templates/urtps/Subscriber.cpp.em
@@ -70,9 +70,15 @@ except AttributeError:
 
 #include "@(topic)_Subscriber.h"
 
-@(topic)_Subscriber::@(topic)_Subscriber() : mp_participant(nullptr), mp_subscriber(nullptr) {}
+@(topic)_Subscriber::@(topic)_Subscriber()
+    : mp_participant(nullptr),
+      mp_subscriber(nullptr)
+{ }
 
-@(topic)_Subscriber::~@(topic)_Subscriber() {   Domain::removeParticipant(mp_participant);}
+@(topic)_Subscriber::~@(topic)_Subscriber()
+{
+    Domain::removeParticipant(mp_participant);
+}
 
 bool @(topic)_Subscriber::init(uint8_t topic_ID, std::condition_variable* t_send_queue_cv, std::mutex* t_send_queue_mutex, std::queue<uint8_t>* t_send_queue)
 {
@@ -89,7 +95,7 @@ bool @(topic)_Subscriber::init(uint8_t topic_ID, std::condition_variable* t_send
 @[else]@
     PParam.rtps.builtin.discovery_config.leaseDuration = c_TimeInfinite;
 @[end if]@
-    PParam.rtps.setName("@(topic)_subscriber"); //You can put the name you want
+    PParam.rtps.setName("@(topic)_subscriber");
     mp_participant = Domain::createParticipant(PParam);
     if(mp_participant == nullptr)
             return false;
@@ -199,19 +205,7 @@ bool @(topic)_Subscriber::hasMsg()
     return false;
 }
 
-@[if fastrtps_version <= 1.7]@
-@[    if ros2_distro]@
-@(package)::msg::dds_::@(topic)_ @(topic)_Subscriber::getMsg()
-@[    else]@
-@(topic)_ @(topic)_Subscriber::getMsg()
-@[    end if]@
-@[else]@
-@[    if ros2_distro]@
-@(package)::msg::@(topic) @(topic)_Subscriber::getMsg()
-@[    else]@
-@(topic) @(topic)_Subscriber::getMsg()
-@[    end if]@
-@[end if]@
+@(topic)_msg_t @(topic)_Subscriber::getMsg()
 {
     return m_listener.msg;
 }

--- a/msg/templates/urtps/Subscriber.cpp.em
+++ b/msg/templates/urtps/Subscriber.cpp.em
@@ -84,7 +84,7 @@ bool @(topic)_Subscriber::init(uint8_t topic_ID, std::condition_variable* t_send
     // Create RTPSParticipant
     ParticipantAttributes PParam;
     PParam.rtps.builtin.domainId = 0; // MUST BE THE SAME AS IN THE PUBLISHER
-@[if 1.5 <= fastrtpsgen_version <= 1.7 or ros2_distro == "ardent" or ros2_distro == "bouncy" or ros2_distro == "crystal" or ros2_distro == "dashing"]@
+@[if fastrtps_version <= 1.8]@
     PParam.rtps.builtin.leaseDuration = c_TimeInfinite;
 @[else]@
     PParam.rtps.builtin.discovery_config.leaseDuration = c_TimeInfinite;
@@ -199,7 +199,7 @@ bool @(topic)_Subscriber::hasMsg()
     return false;
 }
 
-@[if 1.5 <= fastrtpsgen_version <= 1.7]@
+@[if fastrtps_version <= 1.7]@
 @[    if ros2_distro]@
 @(package)::msg::dds_::@(topic)_ @(topic)_Subscriber::getMsg()
 @[    else]@

--- a/msg/templates/urtps/Subscriber.h.em
+++ b/msg/templates/urtps/Subscriber.h.em
@@ -68,7 +68,7 @@ except AttributeError:
 #include <fastrtps/fastrtps_fwd.h>
 #include <fastrtps/subscriber/SubscriberListener.h>
 #include <fastrtps/subscriber/SampleInfo.h>
-@[if 1.5 <= fastrtpsgen_version <= 1.7]@
+@[if fastrtps_version <= 1.7]@
 #include "@(topic)_PubSubTypes.h"
 @[else]@
 #include "@(topic)PubSubTypes.h"
@@ -89,7 +89,7 @@ public:
     bool init(uint8_t topic_ID, std::condition_variable* t_send_queue_cv, std::mutex* t_send_queue_mutex, std::queue<uint8_t>* t_send_queue);
     void run();
     bool hasMsg();
-@[if 1.5 <= fastrtpsgen_version <= 1.7]@
+@[if fastrtps_version <= 1.7]@
 @[    if ros2_distro]@
     @(package)::msg::dds_::@(topic)_ getMsg();
 @[    else]@
@@ -118,7 +118,7 @@ private:
         SampleInfo_t m_info;
         int n_matched;
         int n_msg;
-@[if 1.5 <= fastrtpsgen_version <= 1.7]@
+@[if fastrtps_version <= 1.7]@
 @[    if ros2_distro]@
         @(package)::msg::dds_::@(topic)_ msg;
 @[    else]@
@@ -140,7 +140,7 @@ private:
         std::mutex has_msg_mutex;
 
     } m_listener;
-@[if 1.5 <= fastrtpsgen_version <= 1.7]@
+@[if fastrtps_version <= 1.7]@
 @[    if ros2_distro]@
     @(package)::msg::dds_::@(topic)_PubSubType @(topic)DataType;
 @[    else]@

--- a/msg/templates/urtps/Subscriber.h.em
+++ b/msg/templates/urtps/Subscriber.h.em
@@ -81,6 +81,24 @@ except AttributeError:
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 
+@[if fastrtps_version <= 1.7]@
+@[    if ros2_distro]@
+using @(topic)_msg_t = @(package)::msg::dds_::@(topic)_;
+using @(topic)_msg_datatype = @(package)::msg::dds_::@(topic)_PubSubType;
+@[    else]@
+using @(topic)_msg_t = @(topic)_;
+using @(topic)_msg_datatype = @(topic)_PubSubType;
+@[    end if]@
+@[else]@
+@[    if ros2_distro]@
+using @(topic)_msg_t = @(package)::msg::@(topic);
+using @(topic)_msg_datatype = @(package)::msg::@(topic)PubSubType;
+@[    else]@
+using @(topic)_msg_t = @(topic);
+using @(topic)_msg_datatype = @(topic)PubSubType;
+@[    end if]@
+@[end if]@
+
 class @(topic)_Subscriber
 {
 public:
@@ -89,19 +107,7 @@ public:
     bool init(uint8_t topic_ID, std::condition_variable* t_send_queue_cv, std::mutex* t_send_queue_mutex, std::queue<uint8_t>* t_send_queue);
     void run();
     bool hasMsg();
-@[if fastrtps_version <= 1.7]@
-@[    if ros2_distro]@
-    @(package)::msg::dds_::@(topic)_ getMsg();
-@[    else]@
-    @(topic)_ getMsg();
-@[    end if]@
-@[else]@
-@[    if ros2_distro]@
-    @(package)::msg::@(topic) getMsg();
-@[    else]@
-    @(topic) getMsg();
-@[    end if]@
-@[end if]@
+    @(topic)_msg_t getMsg();
     void unlockMsg();
 
 private:
@@ -118,19 +124,7 @@ private:
         SampleInfo_t m_info;
         int n_matched;
         int n_msg;
-@[if fastrtps_version <= 1.7]@
-@[    if ros2_distro]@
-        @(package)::msg::dds_::@(topic)_ msg;
-@[    else]@
-        @(topic)_ msg;
-@[    end if]@
-@[else]@
-@[    if ros2_distro]@
-        @(package)::msg::@(topic) msg;
-@[    else]@
-        @(topic) msg;
-@[    end if]@
-@[end if]@
+        @(topic)_msg_t msg;
         std::atomic_bool has_msg;
         uint8_t topic_ID;
         std::condition_variable* t_send_queue_cv;
@@ -140,19 +134,7 @@ private:
         std::mutex has_msg_mutex;
 
     } m_listener;
-@[if fastrtps_version <= 1.7]@
-@[    if ros2_distro]@
-    @(package)::msg::dds_::@(topic)_PubSubType @(topic)DataType;
-@[    else]@
-    @(topic)_PubSubType @(topic)DataType;
-@[    end if]@
-@[else]@
-@[    if ros2_distro]@
-    @(package)::msg::@(topic)PubSubType @(topic)DataType;
-@[    else]@
-    @(topic)PubSubType @(topic)DataType;
-@[    end if]@
-@[end if]@
+    @(topic)_msg_datatype @(topic)DataType;
 };
 
 #endif // _@(topic)__SUBSCRIBER_H_

--- a/msg/templates/urtps/microRTPS_timesync.cpp.em
+++ b/msg/templates/urtps/microRTPS_timesync.cpp.em
@@ -163,19 +163,19 @@ bool TimeSync::addMeasurement(int64_t local_t1_ns, int64_t remote_t2_ns, int64_t
 }
 
 void TimeSync::processTimesyncMsg(timesync_msg_t * msg) {
-	if (msg->sys_id() == 1 && msg->seq() != _last_remote_msg_seq) {
-                _last_remote_msg_seq = msg->seq();
+	if (getMsgSysID(msg) == 1 && getMsgSeq(msg) != _last_remote_msg_seq) {
+                _last_remote_msg_seq = getMsgSeq(msg);
 
-		if (msg->tc1() > 0) {
-			if (!addMeasurement(msg->ts1(), msg->tc1(), getMonoRawTimeNSec())) {
+		if (getMsgTC1(msg) > 0) {
+			if (!addMeasurement(getMsgTS1(msg), getMsgTC1(msg), getMonoRawTimeNSec())) {
 				std::cerr << "Offset not updated" << std::endl;
 			}
 
-		} else if (msg->tc1() == 0) {
-			msg->timestamp() = getMonoTimeUSec();
-			msg->sys_id() = 0;
-			msg->seq()++;
-			msg->tc1() = getMonoRawTimeNSec();
+		} else if (getMsgTC1(msg) == 0) {
+			setMsgTimestamp(msg, getMonoTimeUSec());
+			setMsgSysID(msg, 0);
+			setMsgSeq(msg, getMsgSeq(msg) + 1);
+			setMsgTC1(msg, getMonoRawTimeNSec());
 
 			_timesync_pub.publish(msg);
 		}
@@ -185,11 +185,11 @@ void TimeSync::processTimesyncMsg(timesync_msg_t * msg) {
 timesync_msg_t TimeSync::newTimesyncMsg() {
 	timesync_msg_t msg{};
 
-	msg.timestamp() = getMonoTimeUSec();
-	msg.sys_id() = 0;
-	msg.seq() = _last_msg_seq;
-	msg.tc1() = 0;
-	msg.ts1() = getMonoRawTimeNSec();
+	setMsgTimestamp(&msg, getMonoTimeUSec());
+	setMsgSysID(&msg, 0);
+	setMsgSeq(&msg, _last_msg_seq);
+	setMsgTC1(&msg, 0);
+	setMsgTS1(&msg, getMonoRawTimeNSec());
 
 	_last_msg_seq++;
 

--- a/msg/templates/urtps/microRTPS_timesync.cpp.em
+++ b/msg/templates/urtps/microRTPS_timesync.cpp.em
@@ -17,7 +17,7 @@ from px_generate_uorb_topic_helper import * # this is in Tools/
 from px_generate_uorb_topic_files import MsgScope # this is in Tools/
 
 package = package[0]
-fastrtpsgen_version = fastrtpsgen_version[0]
+fastrtps_version = fastrtps_version[0]
 try:
     ros2_distro = ros2_distro[0].decode("utf-8")
 except AttributeError:

--- a/msg/templates/urtps/microRTPS_timesync.h.em
+++ b/msg/templates/urtps/microRTPS_timesync.h.em
@@ -211,4 +211,34 @@ private:
 	 * @@param[in] offset The value of the offset to update to
 	 */
 	inline void updateOffset(const uint64_t& offset) { _offset_ns.store(offset, std::memory_order_relaxed); }
+
+        /** Timesync msg Getters **/
+@[if fastrtps_version <= 1.7 or not ros2_distro]@
+	inline uint64_t getMsgTimestamp(const timesync_msg_t* msg) { return msg->timestamp_(); }
+	inline uint8_t getMsgSysID(const timesync_msg_t* msg) { return msg->sys_id_(); }
+	inline uint8_t getMsgSeq(const timesync_msg_t* msg) { return msg->seq_(); }
+	inline int64_t getMsgTC1(const timesync_msg_t* msg) { return msg->tc1_(); }
+	inline int64_t getMsgTS1(const timesync_msg_t* msg) { return msg->ts1_(); }
+@[elif ros2_distro]@
+	inline uint64_t getMsgTimestamp(const timesync_msg_t* msg) { return msg->timestamp(); }
+	inline uint8_t getMsgSysID(const timesync_msg_t* msg) { return msg->sys_id(); }
+	inline uint8_t getMsgSeq(const timesync_msg_t* msg) { return msg->seq(); }
+	inline int64_t getMsgTC1(const timesync_msg_t* msg) { return msg->tc1(); }
+	inline int64_t getMsgTS1(const timesync_msg_t* msg) { return msg->ts1(); }
+@[end if]@
+
+        /** Timesync msg Setters **/
+@[if fastrtps_version <= 1.7 or not ros2_distro]@
+	inline uint64_t setMsgTimestamp(timesync_msg_t* msg, const uint64_t& timestamp) { msg->timestamp_() = timestamp; }
+	inline uint8_t setMsgSysID(timesync_msg_t* msg, const uint8_t& sys_id) { msg->sys_id_() = sys_id; }
+	inline uint8_t setMsgSeq(timesync_msg_t* msg, const uint8_t& seq) { msg->seq_() = seq; }
+	inline int64_t setMsgTC1(timesync_msg_t* msg, const int64_t& tc1) { msg->tc1_() = tc1; }
+	inline int64_t setMsgTS1(timesync_msg_t* msg, const int64_t& ts1) { msg->ts1_() = ts1; }
+@[elif ros2_distro]@
+	inline uint64_t setMsgTimestamp(timesync_msg_t* msg, const uint64_t& timestamp) { msg->timestamp() = timestamp; }
+	inline uint8_t setMsgSysID(timesync_msg_t* msg, const uint8_t& sys_id) { msg->sys_id() = sys_id; }
+	inline uint8_t setMsgSeq(timesync_msg_t* msg, const uint8_t& seq) { msg->seq() = seq; }
+	inline int64_t setMsgTC1(timesync_msg_t* msg, const int64_t& tc1) { msg->tc1() = tc1; }
+	inline int64_t setMsgTS1(timesync_msg_t* msg, const int64_t& ts1) { msg->ts1() = ts1; }
+@[end if]@
 };

--- a/msg/templates/urtps/microRTPS_timesync.h.em
+++ b/msg/templates/urtps/microRTPS_timesync.h.em
@@ -212,7 +212,7 @@ private:
 	 */
 	inline void updateOffset(const uint64_t& offset) { _offset_ns.store(offset, std::memory_order_relaxed); }
 
-        /** Timesync msg Getters **/
+	/** Timesync msg Getters **/
 @[if fastrtps_version <= 1.7 or not ros2_distro]@
 	inline uint64_t getMsgTimestamp(const timesync_msg_t* msg) { return msg->timestamp_(); }
 	inline uint8_t getMsgSysID(const timesync_msg_t* msg) { return msg->sys_id_(); }
@@ -227,7 +227,7 @@ private:
 	inline int64_t getMsgTS1(const timesync_msg_t* msg) { return msg->ts1(); }
 @[end if]@
 
-        /** Timesync msg Setters **/
+	/** Timesync msg Setters **/
 @[if fastrtps_version <= 1.7 or not ros2_distro]@
 	inline uint64_t setMsgTimestamp(timesync_msg_t* msg, const uint64_t& timestamp) { msg->timestamp_() = timestamp; }
 	inline uint8_t setMsgSysID(timesync_msg_t* msg, const uint8_t& sys_id) { msg->sys_id_() = sys_id; }

--- a/msg/templates/urtps/microRTPS_timesync.h.em
+++ b/msg/templates/urtps/microRTPS_timesync.h.em
@@ -17,7 +17,7 @@ from px_generate_uorb_topic_helper import * # this is in Tools/
 from px_generate_uorb_topic_files import MsgScope # this is in Tools/
 
 package = package[0]
-fastrtpsgen_version = fastrtpsgen_version[0]
+fastrtps_version = fastrtps_version[0]
 try:
     ros2_distro = ros2_distro[0].decode("utf-8")
 except AttributeError:
@@ -86,7 +86,7 @@ static constexpr int64_t TRIGGER_RESET_THRESHOLD_NS = 100ll * 1000ll * 1000ll;
 static constexpr int REQUEST_RESET_COUNTER_THRESHOLD = 5;
 
 @# Sets the timesync DDS type according to the FastRTPS and ROS2 version
-@[if 1.5 <= fastrtpsgen_version <= 1.7]@
+@[if fastrtps_version <= 1.7]@
 @[    if ros2_distro]@
 using timesync_msg_t = @(package)::msg::dds_::Timesync_;
 @[    else]@

--- a/msg/templates/urtps/msg.idl.em
+++ b/msg/templates/urtps/msg.idl.em
@@ -57,7 +57,7 @@ def get_include_directives(spec):
         if genmsg.msgs.is_valid_constant_type(genmsg.msgs.bare_msg_type(field.type)):
             continue
         builtin_type = str(field.base_type).replace('px4/', '')
-        if 1.5 <= fastrtpsgen_version <= 1.7:
+        if fastrtps_version <= 1.7:
             include_directive = '#include "%s_.idl"' % builtin_type
         else:
             include_directive = '#include "%s.idl"' % builtin_type
@@ -77,12 +77,12 @@ def get_idl_type_name(field_type):
 def add_msg_field(field):
     if (not field.is_header):
         if field.is_array:
-            if 1.5 <= fastrtpsgen_version <= 1.7:
+            if fastrtps_version <= 1.7:
                 print('    {0}__{1}_array_{2} {3}_;'.format(topic, str(get_idl_type_name(field.base_type)).replace(" ", "_"), str(field.array_len), field.name))
             else:
                 print('    {0}__{1}_array_{2} {3};'.format(topic, str(get_idl_type_name(field.base_type)).replace(" ", "_"), str(field.array_len), field.name))
         else:
-            if 1.5 <= fastrtpsgen_version <= 1.7:
+            if fastrtps_version <= 1.7:
                 base_type = get_idl_type_name(field.base_type) + "_" if get_idl_type_name(field.base_type) in builtin_types else get_idl_type_name(field.base_type)
             else:
                 base_type = get_idl_type_name(field.base_type) if get_idl_type_name(field.base_type) in builtin_types else get_idl_type_name(field.base_type)
@@ -96,7 +96,7 @@ def add_msg_fields():
 def add_array_typedefs():
     for field in spec.parsed_fields():
         if not field.is_header and field.is_array:
-            if 1.5 <= fastrtpsgen_version <= 1.7:
+            if fastrtps_version <= 1.7:
                 base_type = get_idl_type_name(field.base_type) + "_" if get_idl_type_name(field.base_type) in builtin_types else get_idl_type_name(field.base_type)
             else:
                 base_type = get_idl_type_name(field.base_type) if get_idl_type_name(field.base_type) in builtin_types else get_idl_type_name(field.base_type)
@@ -127,14 +127,14 @@ def add_msg_constants():
 @add_msg_constants()
 @# Array types
 @add_array_typedefs()
-@[if 1.5 <= fastrtpsgen_version <= 1.7]@
+@[if fastrtps_version <= 1.7]@
 struct @(topic)_
 @[else]@
 struct @(topic)
 @[end if]@
 {
 @add_msg_fields()
-@[if 1.5 <= fastrtpsgen_version <= 1.7]@
+@[if fastrtps_version <= 1.7]@
 }; // struct @(topic)_
 
 #pragma keylist @(topic)_

--- a/msg/tools/generate_microRTPS_bridge.py
+++ b/msg/tools/generate_microRTPS_bridge.py
@@ -209,16 +209,16 @@ else:
 if args.fastrtpsgen is None or args.fastrtpsgen == '':
     # Assume fastrtpsgen is in PATH
     fastrtpsgen_path = 'fastrtpsgen'
-    for dirname in os.environ['PATH'].split(':') :
+    for dirname in os.environ['PATH'].split(':'):
         candidate = os.path.join(dirname, 'fastrtpsgen')
-        if os.path.isfile(candidate) :
+        if os.path.isfile(candidate):
             fastrtpsgen_path = candidate
 else:
     # Path to fastrtpsgen is explicitly specified
-    if os.path.isdir(args.fastrtpsgen) :
+    if os.path.isdir(args.fastrtpsgen):
         fastrtpsgen_path = os.path.join(
             os.path.abspath(args.fastrtpsgen), 'fastrtpsgen')
-    else :
+    else:
         fastrtpsgen_path = args.fastrtpsgen
 
 fastrtpsgen_include = args.fastrtpsgen_include
@@ -227,27 +227,13 @@ if fastrtpsgen_include is not None and fastrtpsgen_include != '':
         os.path.abspath(
             args.fastrtpsgen_include) + " "
 
-# get FastRTPSGen version
-# Note: since Fast-RTPS 1.8.x release, FastRTPSGen is now a separated
-# repository and not included in the Fast-RTPS project.
-# The starting version since this separation is 1.0.0, which doesn't
-# follow the Fast-RTPS version convention
-fastrtpsgen_version = 0.0
-if(os.path.exists(fastrtpsgen_path)):
-    try:
-        fastrtpsgen_version_out = subprocess.check_output(
-            [fastrtpsgen_path, "-version"]).strip()[-5:-2]
-    except OSError:
-        raise
-
-    try:
-        fastrtpsgen_version = float(fastrtpsgen_version_out)
-    except ValueError:
-        print("'fastrtpsgen -version' returned None. Hardsetting version to 1.0")
-        fastrtpsgen_version = 1.0
-else:
-    raise Exception(
-        "FastRTPSGen not found. Specify the location of fastrtpsgen with the -f flag")
+# get FastRTPS version (major.minor, since patch is not relevant at this stage)
+fastrtps_version = ""
+try:
+    fastrtps_version = float(subprocess.check_output(
+        "ldconfig -v | grep libfastrtps | tail -c 6", shell=True).decode("utf-8").strip()[-5:-2])
+except ValueError:
+    print("No valid version found to FasRTPS. Make sure it is installed.")
 
 # get ROS 2 version, if exists
 ros2_distro = ""
@@ -322,21 +308,21 @@ uRTPS_SUBSCRIBER_H_TEMPL_FILE = 'Subscriber.h.em'
 
 
 def generate_agent(out_dir):
-    global fastrtpsgen_version
+    global fastrtps_version
 
     if classifier.msgs_to_send:
         for msg_file in classifier.msgs_to_send:
             if gen_idl:
                 if out_dir != agent_out_dir:
                     px_generate_uorb_topic_files.generate_idl_file(msg_file, msg_dir, "", os.path.join(out_dir, "/idl"), urtps_templates_dir,
-                                                                   package, px_generate_uorb_topic_files.INCL_DEFAULT, fastrtpsgen_version, ros2_distro, classifier.msg_id_map)
+                                                                   package, px_generate_uorb_topic_files.INCL_DEFAULT, fastrtps_version, ros2_distro, classifier.msg_id_map)
                 else:
                     px_generate_uorb_topic_files.generate_idl_file(msg_file, msg_dir, "", idl_dir, urtps_templates_dir,
-                                                                   package, px_generate_uorb_topic_files.INCL_DEFAULT, fastrtpsgen_version, ros2_distro, classifier.msg_id_map)
+                                                                   package, px_generate_uorb_topic_files.INCL_DEFAULT, fastrtps_version, ros2_distro, classifier.msg_id_map)
             px_generate_uorb_topic_files.generate_topic_file(msg_file, msg_dir, "", out_dir, urtps_templates_dir,
-                                                             package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtpsgen_version, ros2_distro, uRTPS_PUBLISHER_SRC_TEMPL_FILE)
+                                                             package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtps_version, ros2_distro, uRTPS_PUBLISHER_SRC_TEMPL_FILE)
             px_generate_uorb_topic_files.generate_topic_file(msg_file, msg_dir, "", out_dir, urtps_templates_dir,
-                                                             package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtpsgen_version, ros2_distro, uRTPS_PUBLISHER_H_TEMPL_FILE)
+                                                             package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtps_version, ros2_distro, uRTPS_PUBLISHER_H_TEMPL_FILE)
 
     if classifier.alias_msgs_to_send:
         for msg_file in classifier.alias_msgs_to_send:
@@ -345,28 +331,28 @@ def generate_agent(out_dir):
             if gen_idl:
                 if out_dir != agent_out_dir:
                     px_generate_uorb_topic_files.generate_idl_file(msg_name, msg_dir, msg_alias, os.path.join(out_dir, "/idl"), urtps_templates_dir,
-                                                                   package, px_generate_uorb_topic_files.INCL_DEFAULT, fastrtpsgen_version, ros2_distro, classifier.msg_id_map)
+                                                                   package, px_generate_uorb_topic_files.INCL_DEFAULT, fastrtps_version, ros2_distro, classifier.msg_id_map)
                 else:
                     px_generate_uorb_topic_files.generate_idl_file(msg_name, msg_dir, msg_alias, idl_dir, urtps_templates_dir,
-                                                                   package, px_generate_uorb_topic_files.INCL_DEFAULT, fastrtpsgen_version, ros2_distro, classifier.msg_id_map)
+                                                                   package, px_generate_uorb_topic_files.INCL_DEFAULT, fastrtps_version, ros2_distro, classifier.msg_id_map)
             px_generate_uorb_topic_files.generate_topic_file(msg_name, msg_dir, msg_alias, out_dir, urtps_templates_dir,
-                                                             package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtpsgen_version, ros2_distro, uRTPS_PUBLISHER_SRC_TEMPL_FILE)
+                                                             package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtps_version, ros2_distro, uRTPS_PUBLISHER_SRC_TEMPL_FILE)
             px_generate_uorb_topic_files.generate_topic_file(msg_name, msg_dir, msg_alias, out_dir, urtps_templates_dir,
-                                                             package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtpsgen_version, ros2_distro, uRTPS_PUBLISHER_H_TEMPL_FILE)
+                                                             package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtps_version, ros2_distro, uRTPS_PUBLISHER_H_TEMPL_FILE)
 
     if classifier.msgs_to_receive:
         for msg_file in classifier.msgs_to_receive:
             if gen_idl:
                 if out_dir != agent_out_dir:
                     px_generate_uorb_topic_files.generate_idl_file(msg_file, msg_dir, "", os.path.join(out_dir, "/idl"), urtps_templates_dir,
-                                                                   package, px_generate_uorb_topic_files.INCL_DEFAULT, fastrtpsgen_version, ros2_distro, classifier.msg_id_map)
+                                                                   package, px_generate_uorb_topic_files.INCL_DEFAULT, fastrtps_version, ros2_distro, classifier.msg_id_map)
                 else:
                     px_generate_uorb_topic_files.generate_idl_file(msg_file, msg_dir, "", idl_dir, urtps_templates_dir,
-                                                                   package, px_generate_uorb_topic_files.INCL_DEFAULT, fastrtpsgen_version, ros2_distro, classifier.msg_id_map)
+                                                                   package, px_generate_uorb_topic_files.INCL_DEFAULT, fastrtps_version, ros2_distro, classifier.msg_id_map)
             px_generate_uorb_topic_files.generate_topic_file(msg_file, msg_dir, "", out_dir, urtps_templates_dir,
-                                                             package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtpsgen_version, ros2_distro, uRTPS_SUBSCRIBER_SRC_TEMPL_FILE)
+                                                             package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtps_version, ros2_distro, uRTPS_SUBSCRIBER_SRC_TEMPL_FILE)
             px_generate_uorb_topic_files.generate_topic_file(msg_file, msg_dir, "", out_dir, urtps_templates_dir,
-                                                             package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtpsgen_version, ros2_distro, uRTPS_SUBSCRIBER_H_TEMPL_FILE)
+                                                             package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtps_version, ros2_distro, uRTPS_SUBSCRIBER_H_TEMPL_FILE)
 
     if classifier.alias_msgs_to_receive:
         for msg_file in classifier.alias_msgs_to_receive:
@@ -375,28 +361,28 @@ def generate_agent(out_dir):
             if gen_idl:
                 if out_dir != agent_out_dir:
                     px_generate_uorb_topic_files.generate_idl_file(msg_name, msg_dir, msg_alias, os.path.join(out_dir, "/idl"), urtps_templates_dir,
-                                                                   package, px_generate_uorb_topic_files.INCL_DEFAULT, fastrtpsgen_version, ros2_distro, classifier.msg_id_map)
+                                                                   package, px_generate_uorb_topic_files.INCL_DEFAULT, fastrtps_version, ros2_distro, classifier.msg_id_map)
                 else:
                     px_generate_uorb_topic_files.generate_idl_file(msg_name, msg_dir, msg_alias, idl_dir, urtps_templates_dir,
-                                                                   package, px_generate_uorb_topic_files.INCL_DEFAULT, fastrtpsgen_version, ros2_distro, classifier.msg_id_map)
+                                                                   package, px_generate_uorb_topic_files.INCL_DEFAULT, fastrtps_version, ros2_distro, classifier.msg_id_map)
             px_generate_uorb_topic_files.generate_topic_file(msg_name, msg_dir, msg_alias, out_dir, urtps_templates_dir,
-                                                             package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtpsgen_version, ros2_distro, uRTPS_SUBSCRIBER_SRC_TEMPL_FILE)
+                                                             package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtps_version, ros2_distro, uRTPS_SUBSCRIBER_SRC_TEMPL_FILE)
             px_generate_uorb_topic_files.generate_topic_file(msg_name, msg_dir, msg_alias, out_dir, urtps_templates_dir,
-                                                             package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtpsgen_version, ros2_distro, uRTPS_SUBSCRIBER_H_TEMPL_FILE)
+                                                             package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtps_version, ros2_distro, uRTPS_SUBSCRIBER_H_TEMPL_FILE)
 
     px_generate_uorb_topic_files.generate_uRTPS_general(classifier.msgs_to_send, classifier.alias_msgs_to_send, classifier.msgs_to_receive, classifier.alias_msgs_to_receive, msg_dir, out_dir,
-                                                        urtps_templates_dir, package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtpsgen_version, ros2_distro, uRTPS_AGENT_TEMPL_FILE)
+                                                        urtps_templates_dir, package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtps_version, ros2_distro, uRTPS_AGENT_TEMPL_FILE)
     px_generate_uorb_topic_files.generate_uRTPS_general(classifier.msgs_to_send, classifier.alias_msgs_to_send, classifier.msgs_to_receive, classifier.alias_msgs_to_receive, msg_dir, out_dir,
-                                                        urtps_templates_dir, package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtpsgen_version, ros2_distro, uRTPS_TIMESYNC_CPP_TEMPL_FILE)
+                                                        urtps_templates_dir, package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtps_version, ros2_distro, uRTPS_TIMESYNC_CPP_TEMPL_FILE)
     px_generate_uorb_topic_files.generate_uRTPS_general(classifier.msgs_to_send, classifier.alias_msgs_to_send, classifier.msgs_to_receive, classifier.alias_msgs_to_receive, msg_dir, out_dir,
-                                                        urtps_templates_dir, package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtpsgen_version, ros2_distro, uRTPS_TIMESYNC_H_TEMPL_FILE)
+                                                        urtps_templates_dir, package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtps_version, ros2_distro, uRTPS_TIMESYNC_H_TEMPL_FILE)
     px_generate_uorb_topic_files.generate_uRTPS_general(classifier.msgs_to_send, classifier.alias_msgs_to_send, classifier.msgs_to_receive, classifier.alias_msgs_to_receive, msg_dir, out_dir,
-                                                        urtps_templates_dir, package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtpsgen_version, ros2_distro, uRTPS_AGENT_TOPICS_H_TEMPL_FILE)
+                                                        urtps_templates_dir, package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtps_version, ros2_distro, uRTPS_AGENT_TOPICS_H_TEMPL_FILE)
     px_generate_uorb_topic_files.generate_uRTPS_general(classifier.msgs_to_send, classifier.alias_msgs_to_send, classifier.msgs_to_receive, classifier.alias_msgs_to_receive, msg_dir, out_dir,
-                                                        urtps_templates_dir, package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtpsgen_version, ros2_distro, uRTPS_AGENT_TOPICS_SRC_TEMPL_FILE)
+                                                        urtps_templates_dir, package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtps_version, ros2_distro, uRTPS_AGENT_TOPICS_SRC_TEMPL_FILE)
     if cmakelists:
         px_generate_uorb_topic_files.generate_uRTPS_general(classifier.msgs_to_send, classifier.alias_msgs_to_send, classifier.msgs_to_receive, classifier.alias_msgs_to_receive, msg_dir, out_dir,
-                                                            urtps_templates_dir, package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtpsgen_version, ros2_distro, uRTPS_AGENT_CMAKELISTS_TEMPL_FILE)
+                                                            urtps_templates_dir, package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtps_version, ros2_distro, uRTPS_AGENT_CMAKELISTS_TEMPL_FILE)
 
     # Final steps to install agent
     mkdir_p(os.path.join(out_dir, "fastrtpsgen"))
@@ -407,7 +393,7 @@ def generate_agent(out_dir):
     for idl_file in glob.glob(os.path.join(idl_dir, "*.idl")):
         try:
             ret = subprocess.check_call(fastrtpsgen_path + " -d " + out_dir +
-                                  "/fastrtpsgen -example x64Linux2.6gcc " + fastrtpsgen_include + idl_file, shell=True)
+                                        "/fastrtpsgen -example x64Linux2.6gcc " + fastrtpsgen_include + idl_file, shell=True)
         except OSError:
             raise
 
@@ -452,7 +438,7 @@ def mkdir_p(dirpath):
 
 
 def generate_client(out_dir):
-    global fastrtpsgen_version
+    global fastrtps_version
 
     # Rename work in the default path
     if default_client_out != out_dir:
@@ -467,7 +453,7 @@ def generate_client(out_dir):
             os.rename(def_file, def_file.replace(".h", ".h_"))
 
     px_generate_uorb_topic_files.generate_uRTPS_general(classifier.msgs_to_send, classifier.alias_msgs_to_send, classifier.msgs_to_receive, classifier.alias_msgs_to_receive, msg_dir,
-                                                        out_dir, uorb_templates_dir, package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtpsgen_version, ros2_distro, uRTPS_CLIENT_TEMPL_FILE)
+                                                        out_dir, uorb_templates_dir, package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtps_version, ros2_distro, uRTPS_CLIENT_TEMPL_FILE)
 
     # Final steps to install client
     cp_wildcard(os.path.join(urtps_templates_dir,

--- a/msg/tools/px_generate_uorb_topic_files.py
+++ b/msg/tools/px_generate_uorb_topic_files.py
@@ -167,7 +167,7 @@ def generate_output_from_file(format_idx, filename, outputdir, package, template
     return generate_by_template(output_file, template_file, em_globals)
 
 
-def generate_idl_file(filename_msg, msg_dir, alias, outputdir, templatedir, package, includepath, fastrtpsgen_version, ros2_distro, ids):
+def generate_idl_file(filename_msg, msg_dir, alias, outputdir, templatedir, package, includepath, fastrtps_version, ros2_distro, ids):
     """
     Generates an .idl from .msg file
     """
@@ -175,11 +175,11 @@ def generate_idl_file(filename_msg, msg_dir, alias, outputdir, templatedir, pack
 
     if (alias != ""):
         em_globals = get_em_globals(
-            msg, alias, package, includepath, ids, fastrtpsgen_version, ros2_distro, MsgScope.NONE)
+            msg, alias, package, includepath, ids, fastrtps_version, ros2_distro, MsgScope.NONE)
         spec_short_name = alias
     else:
         em_globals = get_em_globals(
-            msg, "", package, includepath, ids, fastrtpsgen_version, ros2_distro, MsgScope.NONE)
+            msg, "", package, includepath, ids, fastrtps_version, ros2_distro, MsgScope.NONE)
         spec_short_name = em_globals["spec"].short_name
 
     # Make sure output directory exists:
@@ -187,7 +187,7 @@ def generate_idl_file(filename_msg, msg_dir, alias, outputdir, templatedir, pack
         os.makedirs(outputdir)
 
     template_file = os.path.join(templatedir, IDL_TEMPLATE_FILE)
-    if 1.5 <= fastrtpsgen_version <= 1.7:
+    if 1.5 <= fastrtps_version <= 1.7:
         output_file = os.path.join(outputdir, IDL_TEMPLATE_FILE.replace(
             "msg.idl.em", str(spec_short_name + "_.idl")))
     else:
@@ -198,7 +198,7 @@ def generate_idl_file(filename_msg, msg_dir, alias, outputdir, templatedir, pack
 
 
 def generate_uRTPS_general(filename_send_msgs, filename_alias_send_msgs, filename_receive_msgs, filename_alias_receive_msgs,
-                           msg_dir, outputdir, templatedir, package, includepath, ids, fastrtpsgen_version, ros2_distro, template_name):
+                           msg_dir, outputdir, templatedir, package, includepath, ids, fastrtps_version, ros2_distro, template_name):
     """
     Generates source file by msg content
     """
@@ -216,19 +216,19 @@ def generate_uRTPS_general(filename_send_msgs, filename_alias_send_msgs, filenam
     em_globals_list = []
     if send_msgs:
         em_globals_list.extend([get_em_globals(
-            f, "", package, includepath, ids, fastrtpsgen_version, ros2_distro, MsgScope.SEND) for f in send_msgs])
+            f, "", package, includepath, ids, fastrtps_version, ros2_distro, MsgScope.SEND) for f in send_msgs])
 
     if alias_send_msgs:
         em_globals_list.extend([get_em_globals(
-            f[0], f[1], package, includepath, ids, fastrtpsgen_version, ros2_distro, MsgScope.SEND) for f in alias_send_msgs])
+            f[0], f[1], package, includepath, ids, fastrtps_version, ros2_distro, MsgScope.SEND) for f in alias_send_msgs])
 
     if receive_msgs:
         em_globals_list.extend([get_em_globals(
-            f, "", package, includepath, ids, fastrtpsgen_version, ros2_distro, MsgScope.RECEIVE) for f in receive_msgs])
+            f, "", package, includepath, ids, fastrtps_version, ros2_distro, MsgScope.RECEIVE) for f in receive_msgs])
 
     if alias_receive_msgs:
         em_globals_list.extend([get_em_globals(
-            f[0], f[1], package, includepath, ids, fastrtpsgen_version, ros2_distro, MsgScope.RECEIVE) for f in alias_receive_msgs])
+            f[0], f[1], package, includepath, ids, fastrtps_version, ros2_distro, MsgScope.RECEIVE) for f in alias_receive_msgs])
 
     merged_em_globals = merge_em_globals_list(em_globals_list)
 
@@ -243,7 +243,7 @@ def generate_uRTPS_general(filename_send_msgs, filename_alias_send_msgs, filenam
     return generate_by_template(output_file, template_file, merged_em_globals)
 
 
-def generate_topic_file(filename_msg, msg_dir, alias, outputdir, templatedir, package, includepath, ids, fastrtpsgen_version, ros2_distro, template_name):
+def generate_topic_file(filename_msg, msg_dir, alias, outputdir, templatedir, package, includepath, ids, fastrtps_version, ros2_distro, template_name):
     """
     Generates a sources and headers from .msg file
     """
@@ -251,11 +251,11 @@ def generate_topic_file(filename_msg, msg_dir, alias, outputdir, templatedir, pa
 
     if (alias):
         em_globals = get_em_globals(
-            msg, alias, package, includepath, ids, fastrtpsgen_version, ros2_distro, MsgScope.NONE)
+            msg, alias, package, includepath, ids, fastrtps_version, ros2_distro, MsgScope.NONE)
         spec_short_name = alias
     else:
         em_globals = get_em_globals(
-            msg, "", package, includepath, ids, fastrtpsgen_version, ros2_distro, MsgScope.NONE)
+            msg, "", package, includepath, ids, fastrtps_version, ros2_distro, MsgScope.NONE)
         spec_short_name = em_globals["spec"].short_name
 
     # Make sure output directory exists:
@@ -269,7 +269,7 @@ def generate_topic_file(filename_msg, msg_dir, alias, outputdir, templatedir, pa
     return generate_by_template(output_file, template_file, em_globals)
 
 
-def get_em_globals(filename_msg, alias, package, includepath, ids, fastrtpsgen_version, ros2_distro, scope):
+def get_em_globals(filename_msg, alias, package, includepath, ids, fastrtps_version, ros2_distro, scope):
     """
     Generates em globals dictionary
     """
@@ -298,7 +298,7 @@ def get_em_globals(filename_msg, alias, package, includepath, ids, fastrtpsgen_v
         "scope": scope,
         "package": package,
         "alias": alias,
-        "fastrtpsgen_version": fastrtpsgen_version,
+        "fastrtps_version": fastrtps_version,
         "ros2_distro": ros2_distro
     }
 


### PR DESCRIPTION
https://github.com/PX4/Firmware/pull/14297 added timesync for the microRTPS bridge, but was only tested using `px4_ros_com`. While testing it with the raw microRTPS bridge (not `px4_msgs` dependent), I have found that the member function naming was different from the ones generated when using the `px4_ros_com` generation, which resulted on compiler errors. This lead to the need of adding some getters and setters to access some required fields on the bridge itself.

So this PR:
1. makes sure that the timesync works in both `px4_ros_com` and the Firmware generated agent by adding getters and setters to class member functions (which access the msg fields);
2. adds a check for the Fast-RTPS lib version and uses it for the template code specialisation, instead of the FastRTPSGen version, which is much more convenient, as it allows to better synchronise the code with the version supported;
3. cleans the Publisher and Subscriber template code specialisation with a more convenient usage of typedefs.

Tested in SITL with Gazebo, using both agents.
