### PR TITLE
Use new quaternion.canonical(), reuse matrix::sign()

### DIFF
--- a/src/lib/flight_tasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/flight_tasks/tasks/Auto/FlightTaskAuto.cpp
@@ -493,7 +493,7 @@ bool FlightTaskAuto::_compute_heading_from_2D_vector(float &heading, Vector2f v)
 		// and multiply by the sign given of cross product of x and v.
 		// Dot product: (x(0)*v(0)+(x(1)*v(1)) = v(0)
 		// Cross product: x(0)*v(1) - v(0)*x(1) = v(1)
-		heading =  math::sign(v(1)) * wrap_pi(acosf(v(0)));
+		heading =  sign(v(1)) * wrap_pi(acosf(v(0)));
 		return true;
 	}
 

--- a/src/lib/flight_tasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
+++ b/src/lib/flight_tasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
@@ -175,7 +175,7 @@ float FlightTaskAutoLineSmoothVel::_constrainOneSide(float val, float constraint
 
 float FlightTaskAutoLineSmoothVel::_constrainAbs(float val, float max)
 {
-	return math::sign(val) * math::min(fabsf(val), fabsf(max));
+	return sign(val) * math::min(fabsf(val), fabsf(max));
 }
 
 float FlightTaskAutoLineSmoothVel::_getMaxXYSpeed() const
@@ -301,7 +301,7 @@ void FlightTaskAutoLineSmoothVel::_prepareSetpoints()
 		else if (z_pos_setpoint_valid) {
 			// Use Z position setpoint to generate a Z velocity setpoint
 
-			const float z_dir = math::sign(_position_setpoint(2) - _trajectory[2].getCurrentPosition());
+			const float z_dir = sign(_position_setpoint(2) - _trajectory[2].getCurrentPosition());
 			const float vel_sp_z = z_dir * _getMaxZSpeed();
 
 			// If available, use the existing velocity as a feedforward, otherwise replace it

--- a/src/lib/flight_tasks/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/lib/flight_tasks/tasks/Orbit/FlightTaskOrbit.cpp
@@ -117,7 +117,7 @@ bool FlightTaskOrbit::setRadius(float r)
 
 	// small radius is more important than high velocity for safety
 	if (!checkAcceleration(r, _v, _acceleration_max)) {
-		_v = math::sign(_v) * sqrtf(_acceleration_max * r);
+		_v = sign(_v) * sqrtf(_acceleration_max * r);
 	}
 
 	_r = r;

--- a/src/lib/flight_tasks/tasks/Utility/VelocitySmoothing.cpp
+++ b/src/lib/flight_tasks/tasks/Utility/VelocitySmoothing.cpp
@@ -36,6 +36,9 @@
 #include <cstdio>
 #include <float.h>
 #include <mathlib/mathlib.h>
+#include <matrix/matrix/math.hpp>
+
+using matrix::sign;
 
 VelocitySmoothing::VelocitySmoothing(float initial_accel, float initial_vel, float initial_pos)
 {
@@ -183,12 +186,12 @@ int VelocitySmoothing::computeDirection()
 	float vel_zero_acc = computeVelAtZeroAcc();
 
 	/* Depending of the direction, start accelerating positively or negatively */
-	int direction = math::sign(_vel_sp - vel_zero_acc);
+	int direction = sign(_vel_sp - vel_zero_acc);
 
 	if (direction == 0) {
 		// If by braking immediately the velocity is exactly
 		// the require one with zero acceleration, then brake
-		direction = math::sign(_state.a);
+		direction = sign(_state.a);
 	}
 
 	return direction;
@@ -199,7 +202,7 @@ float VelocitySmoothing::computeVelAtZeroAcc()
 	float vel_zero_acc = _state.v;
 
 	if (fabsf(_state.a) > FLT_EPSILON) {
-		float j_zero_acc = -math::sign(_state.a) * _max_jerk; // Required jerk to reduce the acceleration
+		float j_zero_acc = -sign(_state.a) * _max_jerk; // Required jerk to reduce the acceleration
 		float t_zero_acc = -_state.a / j_zero_acc; // Required time to cancel the current acceleration
 		vel_zero_acc = _state.v + _state.a * t_zero_acc + 0.5f * j_zero_acc * t_zero_acc * t_zero_acc;
 	}

--- a/src/lib/mathlib/math/Functions.hpp
+++ b/src/lib/mathlib/math/Functions.hpp
@@ -41,15 +41,10 @@
 
 #include "Limits.hpp"
 
+#include <matrix/matrix/math.hpp>
+
 namespace math
 {
-
-// Type-safe signum function
-template<typename T>
-int sign(T val)
-{
-	return (T(FLT_EPSILON) < val) - (val < T(FLT_EPSILON));
-}
 
 // Type-safe signum function with zero treated as positive
 template<typename T>
@@ -114,7 +109,7 @@ const T deadzone(const T &value, const T &dz)
 	T x = constrain(value, (T) - 1, (T) 1);
 	T dzc = constrain(dz, (T) 0, (T) 0.99);
 	// Rescale the input such that we get a piecewise linear function that will be continuous with applied deadzone
-	T out = (x - sign(x) * dzc) / (1 - dzc);
+	T out = (x - matrix::sign(x) * dzc) / (1 - dzc);
 	// apply the deadzone (values zero around the middle)
 	return out * (fabsf(x) > dzc);
 }

--- a/src/modules/mc_att_control/AttitudeControl/AttitudeControl.cpp
+++ b/src/modules/mc_att_control/AttitudeControl/AttitudeControl.cpp
@@ -77,7 +77,7 @@ matrix::Vector3f AttitudeControl::update(matrix::Quatf q, matrix::Quatf qd, cons
 
 	// mix full and reduced desired attitude
 	Quatf q_mix = qd_red.inversed() * qd;
-	q_mix *= math::signNoZero(q_mix(0));
+	q_mix.canonicalize();
 	// catch numerical problems with the domain of acosf and asinf
 	q_mix(0) = math::constrain(q_mix(0), -1.f, 1.f);
 	q_mix(3) = math::constrain(q_mix(3), -1.f, 1.f);
@@ -88,7 +88,7 @@ matrix::Vector3f AttitudeControl::update(matrix::Quatf q, matrix::Quatf qd, cons
 
 	// using sin(alpha/2) scaled rotation axis as attitude error (see quaternion definition by axis angle)
 	// also taking care of the antipodal unit quaternion ambiguity
-	const Vector3f eq = 2.f * math::signNoZero(qe(0)) * qe.imag();
+	const Vector3f eq = 2.f * qe.canonical().imag();
 
 	// calculate angular rates setpoint
 	matrix::Vector3f rate_setpoint = eq.emult(_proportional_gain);

--- a/src/modules/mc_att_control/AttitudeControl/AttitudeControlTest.cpp
+++ b/src/modules/mc_att_control/AttitudeControl/AttitudeControlTest.cpp
@@ -63,6 +63,7 @@ public:
 			const Vector3f rate_setpoint_new = _attitude_control.update(_quat_state, _quat_goal, 0.f);
 			// rotate the simulated state quaternion according to the rate setpoint
 			_quat_state = _quat_state * Quatf(AxisAnglef(rate_setpoint_new));
+			_quat_state = -_quat_state; // produce intermittent antipodal quaternion states to test against unwinding problem
 
 			// expect the error and hence also the output to get smaller with each iteration
 			if (rate_setpoint_new.norm() >= rate_setpoint.norm()) {
@@ -72,20 +73,9 @@ public:
 			rate_setpoint = rate_setpoint_new;
 		}
 
-		EXPECT_EQ(adaptAntipodal(_quat_state), adaptAntipodal(_quat_goal));
+		EXPECT_EQ(_quat_state.canonical(), _quat_goal.canonical());
 		// it shouldn't have taken longer than an iteration timeout to converge
 		EXPECT_GT(i, 0);
-	}
-
-	Quatf adaptAntipodal(const Quatf q)
-	{
-		for (int i = 0; i < 4; i++) {
-			if (fabs(q(i)) > FLT_EPSILON) {
-				return q * math::sign(q(i));
-			}
-		}
-
-		return q;
 	}
 
 	AttitudeControl _attitude_control;

--- a/src/modules/mc_hover_thrust_estimator/zero_order_hover_thrust_ekf.cpp
+++ b/src/modules/mc_hover_thrust_estimator/zero_order_hover_thrust_ekf.cpp
@@ -39,6 +39,8 @@
 
 #include "zero_order_hover_thrust_ekf.hpp"
 
+using matrix::sign;
+
 void ZeroOrderHoverThrustEkf::predict(const float dt)
 {
 	// State is constant
@@ -69,7 +71,7 @@ void ZeroOrderHoverThrustEkf::fuseAccZ(const float acc_z, const float thrust, st
 		bumpStateVariance();
 	}
 
-	const float signed_innov_test_ratio = math::sign(innov) * innov_test_ratio;
+	const float signed_innov_test_ratio = sign(innov) * innov_test_ratio;
 	updateLpf(residual, signed_innov_test_ratio);
 	updateMeasurementNoise(residual, H);
 

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
@@ -219,7 +219,7 @@ void PositionControl::_velocityControl(const float dt)
 	_vel_int += vel_error.emult(_gain_vel_i) * dt;
 
 	// limit thrust integral
-	_vel_int(2) = math::min(fabsf(_vel_int(2)), _lim_thr_max) * math::sign(_vel_int(2));
+	_vel_int(2) = math::min(fabsf(_vel_int(2)), _lim_thr_max) * sign(_vel_int(2));
 }
 
 bool PositionControl::_updateSuccessful()

--- a/src/modules/rover_pos_control/RoverPositionControl.cpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.cpp
@@ -47,9 +47,7 @@
 
 #define ACTUATOR_PUBLISH_PERIOD_MS 4
 
-using matrix::Eulerf;
-using matrix::Quatf;
-using matrix::Vector3f;
+using namespace matrix;
 
 /**
  * L1 control app start / stop handling function
@@ -261,7 +259,7 @@ RoverPositionControl::control_position(const matrix::Vector2f &current_position,
 
 			float desired_r = ground_speed_2d.norm_squared() / math::abs_t(_gnd_control.nav_lateral_acceleration_demand());
 			float desired_theta = (0.5f * M_PI_F) - atan2f(desired_r, _param_wheel_base.get());
-			float control_effort = (desired_theta / _param_max_turn_angle.get()) * math::sign(
+			float control_effort = (desired_theta / _param_max_turn_angle.get()) * sign(
 						       _gnd_control.nav_lateral_acceleration_demand());
 			control_effort = math::constrain(control_effort, -1.0f, 1.0f);
 			_act_controls.control[actuator_controls_s::INDEX_YAW] = control_effort;


### PR DESCRIPTION
**Describe problem solved by this pull request**
As a follow up to https://github.com/PX4/Matrix/pull/116/
- I want to take advantage of the very useful `canonical()` method that @kamilritz added for quaternions instead of implementing different variants in multiple places.
- I make sure the `sign()` function that I originally added to the mathlib is not a duplicate because it got copied for use in the matrix library here https://github.com/PX4/Matrix/pull/116/files#diff-54949d0fd557988a948ea903fee99e69R81. We can just use the one version that gets included.

**Test data / coverage**
- I added arbitrary antipodal quaternions in the AttitudeControl unit tests and made sure the tests fail without the "canonicalization" and pass with.
- I made sure the sign function is to the character the exact same.
