### PR TITLE
MC_HTE: Stability improvements

### DIFF
--- a/src/modules/mc_hover_thrust_estimator/zero_order_hover_thrust_ekf.hpp
+++ b/src/modules/mc_hover_thrust_estimator/zero_order_hover_thrust_ekf.hpp
@@ -107,7 +107,7 @@ private:
 	float _dt{0.02f};
 
 	float _residual_lpf{}; ///< used to remove the constant bias of the residual
-	float _innov_test_ratio_lpf{}; ///< used as a delay to trigger the recovery logic
+	float _signed_innov_test_ratio_lpf{}; ///< used as a delay to trigger the recovery logic
 
 	float computeH(float thrust) const;
 	float computeInnovVar(float H) const;
@@ -125,12 +125,14 @@ private:
 
 	void updateState(float K, float innov);
 	void updateStateCovariance(float K, float H);
-	void updateMeasurementNoise(float residual, float H);
+	bool isLargeOffsetDetected() const;
 
 	void bumpStateVariance();
-	void updateLpf(float residual, float innov_test_ratio);
+	void updateLpf(float residual, float signed_innov_test_ratio);
+	void updateMeasurementNoise(float residual, float H);
 
 	status packStatus(float innov, float innov_var, float innov_test_ratio) const;
 
-	static constexpr float noise_learning_time_constant = 0.5f; ///< in seconds
+	static constexpr float _noise_learning_time_constant = 2.f; ///< in seconds
+	static constexpr float _lpf_time_constant = 1.f; ///< in seconds
 };

--- a/src/modules/mc_hover_thrust_estimator/zero_order_hover_thrust_ekf_test.cpp
+++ b/src/modules/mc_hover_thrust_estimator/zero_order_hover_thrust_ekf_test.cpp
@@ -61,6 +61,9 @@ private:
 
 	std::normal_distribution<float> _standard_normal_distribution;
 	std::default_random_engine _random_generator; // Pseudo-random generator with constant seed
+
+protected:
+	static constexpr float _accel_noise_var_min = 1.f; // Constrained in the implementation
 };
 
 float ZeroOrderHoverThrustEkfTest::computeAccelFromThrustAndHoverThrust(float thrust, float hover_thrust)
@@ -91,12 +94,13 @@ TEST_F(ZeroOrderHoverThrustEkfTest, testStaticCase)
 	const float hover_thrust_true = 0.5f;
 
 	// WHEN: we input noiseless data and run the filter
-	ZeroOrderHoverThrustEkf::status status = runEkf(hover_thrust_true, thrust, 1.f);
+	ZeroOrderHoverThrustEkf::status status = runEkf(hover_thrust_true, thrust, 2.f);
 
 	// THEN: The estimate should not move and its variance decrease quickly
 	EXPECT_NEAR(status.hover_thrust, hover_thrust_true, 1e-4f);
 	EXPECT_NEAR(status.hover_thrust_var, 0.f, 1e-3f);
-	EXPECT_NEAR(status.accel_noise_var, 0.f, 1.f); // The noise learning is slow and takes more than 1s to go to zero
+	EXPECT_NEAR(status.accel_noise_var, _accel_noise_var_min,
+		    1.f); // The noise learning is slow and takes more time to go to zero
 }
 
 TEST_F(ZeroOrderHoverThrustEkfTest, testStaticConvergence)
@@ -111,7 +115,8 @@ TEST_F(ZeroOrderHoverThrustEkfTest, testStaticConvergence)
 	// THEN: the state should converge to the true value and its variance decrease
 	EXPECT_NEAR(status.hover_thrust, hover_thrust_true, 1e-2f);
 	EXPECT_NEAR(status.hover_thrust_var, 0.f, 1e-3f);
-	EXPECT_NEAR(status.accel_noise_var, 0.f, 1.f); // The noise learning is slow and takes more than 1s to go to zero
+	EXPECT_NEAR(status.accel_noise_var, _accel_noise_var_min,
+		    1.f); // The noise learning is slow and takes more time to go to zero
 }
 
 TEST_F(ZeroOrderHoverThrustEkfTest, testStaticConvergenceWithNoise)

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
@@ -63,6 +63,12 @@ void PositionControl::setThrustLimits(const float min, const float max)
 	_lim_thr_max = max;
 }
 
+void PositionControl::updateHoverThrust(const float hover_thrust_new)
+{
+	_vel_int(2) += hover_thrust_new - _hover_thrust;
+	setHoverThrust(hover_thrust_new);
+}
+
 void PositionControl::setState(const PositionControlStates &states)
 {
 	_pos = states.position;

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
@@ -114,10 +114,17 @@ public:
 	void setTiltLimit(const float tilt) { _lim_tilt = tilt; }
 
 	/**
-	 * Set the maximum tilt angle in radians the output attitude is allowed to have
-	 * @param thrust [0,1] with which the vehicle hovers not aacelerating down or up with level orientation
+	 * Set the normalized hover thrust
+	 * @param thrust [0,1] with which the vehicle hovers not acelerating down or up with level orientation
 	 */
-	void setHoverThrust(const float thrust) { _hover_thrust = thrust; }
+	void setHoverThrust(const float hover_thrust) { _hover_thrust = hover_thrust; }
+
+	/**
+	 * Update the hover thrust without immediately affecting the output
+	 * by adjusting the integrator. This prevents propagating the dynamics
+	 * of the hover thrust signal directly to the output of the controller.
+	 */
+	void updateHoverThrust(const float hover_thrust_new);
 
 	/**
 	 * Pass the current vehicle state to the controller
@@ -155,6 +162,11 @@ public:
 	 * @see _vel_int
 	 */
 	void resetIntegral() { _vel_int.setZero(); }
+
+	/**
+	 * @return the value of the velocity integrator
+	 */
+	matrix::Vector3f getIntegral() const { return _vel_int; }
 
 	/**
 	 * Get the controllers output local position setpoint

--- a/src/modules/mc_pos_control/PositionControl/PositionControlTest.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControlTest.cpp
@@ -326,3 +326,32 @@ TEST_F(PositionControlBasicTest, InvalidState)
 	_position_control.setState(states);
 	EXPECT_FALSE(runController());
 }
+
+
+TEST_F(PositionControlBasicTest, UpdateHoverThrust)
+{
+	// GIVEN: some hover thrust and 0 velocity change
+	const float hover_thrust = 0.6f;
+	_position_control.setHoverThrust(hover_thrust);
+
+	_input_setpoint.vx = 0.f;
+	_input_setpoint.vy = 0.f;
+	_input_setpoint.vz = -0.f;
+
+	// WHEN: we run the controller
+	EXPECT_TRUE(runController());
+
+	// THEN: the output thrust equals the hover thrust
+	EXPECT_EQ(_output_setpoint.thrust[2], -hover_thrust);
+
+	// HOWEVER WHEN: we set a new hover thrust through the update function
+	const float hover_thrust_new = 0.7f;
+	_position_control.updateHoverThrust(hover_thrust_new);
+	EXPECT_TRUE(runController());
+
+	// THEN: the integral is updated to avoid discontinuities and
+	// the output is still the same
+	EXPECT_EQ(_output_setpoint.thrust[2], -hover_thrust);
+	const Vector3f integrator_new(_position_control.getIntegral());
+	EXPECT_EQ(integrator_new(2) - hover_thrust_new, -hover_thrust);
+}

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -373,7 +373,7 @@ MulticopterPositionControl::parameters_update(bool force)
 				mavlink_log_critical(&_mavlink_log_pub, "Hover thrust has been constrained by min/max");
 			}
 
-			_control.setHoverThrust(_param_mpc_thr_hover.get());
+			_control.updateHoverThrust(_param_mpc_thr_hover.get());
 		}
 
 		_flight_tasks.handleParameterUpdate();
@@ -415,7 +415,7 @@ MulticopterPositionControl::poll_subscriptions()
 		hover_thrust_estimate_s hte;
 
 		if (_hover_thrust_estimate_sub.update(&hte)) {
-			_control.setHoverThrust(hte.hover_thrust);
+			_control.updateHoverThrust(hte.hover_thrust);
 		}
 	}
 }


### PR DESCRIPTION
Follows #14182

Summary of the changes:
- Use a low-passed value of the signed innovation test ratio to trigger
the state variance boost. The threshold of 0.2 has been chosen using log
replay and simulation scenarii.
- Do not reset the learned accel noise during a state variance boost.
After a few tests, this does not seem to help at all.
- Continue to learn the accel noise even if the measurement got rejected
to avoid ignoring sudden changes of noise
- Lower the acceleration noise time constant and increase min/max
values to avoid learning quickly a small variance that could temporary
destabilize the filter
- Update filter time constants. Increasing the speed of the residual lpf
improves the quality of the learned accel noise

Replay from log https://review.px4.io/plot_app?log=82ee3e29-5422-450b-8030-df6a93b81a88 (given by the test team: https://github.com/PX4/Firmware/pull/14182#issuecomment-592782692)

Original data:
![2020-03-12_18-04-27_01_plot](https://user-images.githubusercontent.com/14822839/76546511-edbc6500-648b-11ea-80a1-7bedb7fdbe50.png)

Replayed with tunning proposed by this PR:
![replay82ee3e29](https://user-images.githubusercontent.com/14822839/76545549-3f63f000-648a-11ea-84ce-a6cb97487c05.png):
