### PR TITLE
Gazebo: Do not run verbose

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -77,7 +77,7 @@ elif [ "$program" == "gazebo" ] && [ ! -n "$no_sim" ]; then
 			# Set the plugin path so Gazebo finds our model and sim
 			source "$src_path/Tools/setup_gazebo.bash" "${src_path}" "${build_path}"
 
-			gzserver --verbose "${src_path}/Tools/sitl_gazebo/worlds/${model}.world" &
+			gzserver "${src_path}/Tools/sitl_gazebo/worlds/${model}.world" &
 			SIM_PID=`echo $!`
 
 			if [[ -n "$HEADLESS" ]]; then


### PR DESCRIPTION
There is no need in day-to-day development to run verbose and it is preventing regular PX4 status output from properly rendering.