### PR TITLE
modify how to check fastrtps version

### DIFF
--- a/msg/tools/generate_microRTPS_bridge.py
+++ b/msg/tools/generate_microRTPS_bridge.py
@@ -230,8 +230,15 @@ if fastrtpsgen_include is not None and fastrtpsgen_include != '':
 # get FastRTPS version (major.minor, since patch is not relevant at this stage)
 fastrtps_version = ""
 try:
-    fastrtps_version = float(subprocess.check_output(
-        "ldconfig -v | grep libfastrtps | tail -c 6", shell=True).decode("utf-8").strip()[-5:-2])
+    version = subprocess.check_output(
+        "ldconfig -v | grep libfastrtps", shell=True).decode("utf-8").strip().split('so.')[-1]
+    version = [int(v) for v in version.split('.')]
+
+    # convert version string to float (in case of 1.10, 1.91 temporarily)
+    fastrtps_version  = 0.0
+    fastrtps_version += version[0]
+    fastrtps_version += version[1] * 0.1 if version[1] < 10 else 0.9 + 0.01*(version[1]-9)
+
 except ValueError:
     print("No valid version found to FasRTPS. Make sure it is installed.")
 


### PR DESCRIPTION
Hi, 

When I compile (```make px4_fmu-v3_rtps```), I found there is a problem about fastrtps library version.

```
Exception in thread "main" java.lang.NullPointerException
	at com.eprosima.fastrtps.fastrtpsgen.execute(fastrtpsgen.java:336)
	at com.eprosima.fastrtps.fastrtpsgen.main(fastrtpsgen.java:1200)
Traceback (most recent call last):
  File "/home/px4/firmware.rtps/Firmware.stmoon/msg/tools/generate_microRTPS_bridge.py", line 466, in <module>
    generate_agent(agent_out_dir)
  File "/home/px4/firmware.rtps/Firmware.stmoon/msg/tools/generate_microRTPS_bridge.py", line 396, in generate_agent
    "/fastrtpsgen -example x64Linux2.6gcc " + fastrtpsgen_include + idl_file, shell=True)
  File "/usr/lib/python3.6/subprocess.py", line 311, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '/home/px4/firmware.rtps/Fast-RTPS-Gen/scripts/fastrtpsgen -d /home/px4/firmware.rtps/Firmware.stmoon/build/px4_fmu-v3_rtps/src/modules/micrortps_bridge/micrortps_client/micrortps_agent/fastrtpsgen -example x64Linux2.6gcc /home/px4/firmware.rtps/Firmware.stmoon/build/px4_fmu-v3_rtps/src/modules/micrortps_bridge/micrortps_client/micrortps_agent/idl/position_setpoint_triplet.idl' returned non-zero exit status 1.
ninja: build stopped: subcommand failed.
Makefile:198: recipe for target 'px4_fmu-v3_rtps' failed
```

and I found this problem is related to the below code to check fastrtps library.
In my case, I use 1.10.0 version for libfastrtps.

```
fastrtps_version = ""
try:
    fastrtps_version = float(subprocess.check_output(
        "ldconfig -v | grep libfastrtps | tail -c 6", shell=True).decode("utf-8").strip()[-5:-2])
except ValueError:
    print("No valid version found to FasRTPS. Make sure it is installed.")
```

```
$ ldconfig -v | grep libfastrtps 
/sbin/ldconfig.real: Can't stat /usr/local/lib/x86_64-linux-gnu: No such file or directory
/sbin/ldconfig.real: Path `/lib/x86_64-linux-gnu' given more than once
/sbin/ldconfig.real: Path `/usr/lib/x86_64-linux-gnu' given more than once
/sbin/ldconfig.real: /lib/x86_64-linux-gnu/ld-2.27.so is the dynamic linker, ignoring

	libfastrtps.so.1 -> libfastrtps.so.1.10.0
```

However, it is difficult to compare version, because the current firmware version is checked using float value (for example, 1.9, 1.8, ...). In my case 1.10 is just 1.1 if I use float value.

Unfortunately, I didn't find version check library in python until now. So, I just suggest a simple method while keeping the current float value version check. (In case of 1.10,  1.91.)

If you have another idea, please let me know. I know it is not perfect.  

How about checking major and minor version each other? (not unified float version value) 

Thanks in advance.

