### PR TITLE
microRTPS: use packaging.version to compare FastRTPS lib versions

### DIFF
--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -8,7 +8,7 @@ pipeline {
     stage('Build') {
       agent {
         docker {
-          image 'px4io/px4-dev-ros-melodic:2020-01-13'
+          image 'px4io/px4-dev-ros-melodic:2020-03-16'
           args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
         }
       }
@@ -130,7 +130,7 @@ def createTestNode(Map test_def) {
   return {
     node {
       cleanWs()
-      docker.image("px4io/px4-dev-ros-melodic:2020-01-13").inside('-e HOME=${WORKSPACE}') {
+      docker.image("px4io/px4-dev-ros-melodic:2020-03-16").inside('-e HOME=${WORKSPACE}') {
         stage(test_def.name) {
           def run_script = test_def.get('run_script', 'rostest_px4_run.sh')
           def test_ok = true

--- a/.ci/Jenkinsfile-SITL_tests_ASan
+++ b/.ci/Jenkinsfile-SITL_tests_ASan
@@ -8,7 +8,7 @@ pipeline {
     stage('Build') {
       agent {
         docker {
-          image 'px4io/px4-dev-ros-melodic:2020-01-13'
+          image 'px4io/px4-dev-ros-melodic:2020-03-16'
           args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
         }
       }
@@ -131,7 +131,7 @@ def createTestNode(Map test_def) {
   return {
     node {
       cleanWs()
-      docker.image("px4io/px4-dev-ros-melodic:2020-01-13").inside('-e HOME=${WORKSPACE}') {
+      docker.image("px4io/px4-dev-ros-melodic:2020-03-16").inside('-e HOME=${WORKSPACE}') {
         stage(test_def.name) {
           def run_script = test_def.get('run_script', 'rostest_px4_run.sh')
           def test_ok = true

--- a/.ci/Jenkinsfile-SITL_tests_coverage
+++ b/.ci/Jenkinsfile-SITL_tests_coverage
@@ -79,7 +79,7 @@ pipeline {
         stage('code coverage (python)') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2020-01-13'
+              image 'px4io/px4-dev-base-bionic:2020-03-16'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -99,7 +99,7 @@ pipeline {
         stage('unit tests') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2020-01-13'
+              image 'px4io/px4-dev-base-bionic:2020-03-16'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -137,7 +137,7 @@ def createTestNode(Map test_def) {
   return {
     node {
       cleanWs()
-      docker.image("px4io/px4-dev-ros-melodic:2020-01-13").inside('-e HOME=${WORKSPACE}') {
+      docker.image("px4io/px4-dev-ros-melodic:2020-03-16").inside('-e HOME=${WORKSPACE}') {
         stage(test_def.name) {
           def test_ok = true
           sh('export')

--- a/.ci/Jenkinsfile-compile
+++ b/.ci/Jenkinsfile-compile
@@ -9,10 +9,10 @@ pipeline {
         script {
           def build_nodes = [:]
           def docker_images = [
-            armhf: "px4io/px4-dev-armhf:2020-01-13",
-            base: "px4io/px4-dev-base-bionic:2020-01-13",
-            nuttx: "px4io/px4-dev-nuttx:2020-01-13",
-            snapdragon: "lorenzmeier/px4-dev-snapdragon:2020-01-13"
+            armhf: "px4io/px4-dev-armhf:2020-03-16",
+            base: "px4io/px4-dev-base-bionic:2020-03-16",
+            nuttx: "px4io/px4-dev-nuttx:2020-03-16",
+            snapdragon: "lorenzmeier/px4-dev-snapdragon:2020-03-16"
           ]
 
           def armhf_builds = [
@@ -98,7 +98,7 @@ pipeline {
     // TODO: actually upload artifacts to S3
     // stage('S3 Upload') {
     //   agent {
-    //     docker { image 'px4io/px4-dev-base-bionic:2020-01-13' }
+    //     docker { image 'px4io/px4-dev-base-bionic:2020-03-16' }
     //   }
     //   options {
     //         skipDefaultCheckout()
@@ -132,7 +132,7 @@ def createBuildNode(Boolean archive, String docker_image, String target) {
 
     // TODO: fix the snapdragon image
     bypass_entrypoint = ''
-    if (docker_image == 'lorenzmeier/px4-dev-snapdragon:2020-01-13') {
+    if (docker_image == 'lorenzmeier/px4-dev-snapdragon:2020-03-16') {
       bypass_entrypoint = ' --entrypoint=""'
     }
 

--- a/.ci/Jenkinsfile-hardware
+++ b/.ci/Jenkinsfile-hardware
@@ -12,7 +12,7 @@ pipeline {
             stage("build px4_fmu-v2_test") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx:2020-01-13'
+                  image 'px4io/px4-dev-nuttx:2020-03-16'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -76,7 +76,7 @@ pipeline {
             stage("build px4_fmu-v3_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx:2020-01-13'
+                  image 'px4io/px4-dev-nuttx:2020-03-16'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -149,7 +149,7 @@ pipeline {
             stage("build px4_fmu-v4_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx:2020-01-13'
+                  image 'px4io/px4-dev-nuttx:2020-03-16'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -222,7 +222,7 @@ pipeline {
             stage("build px4_fmu-v4_optimized") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx:2020-01-13'
+                  image 'px4io/px4-dev-nuttx:2020-03-16'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -295,7 +295,7 @@ pipeline {
             stage("build px4_fmu-v4pro_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx:2020-01-13'
+                  image 'px4io/px4-dev-nuttx:2020-03-16'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -368,7 +368,7 @@ pipeline {
             stage("build px4_fmu-v5_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx:2020-01-13'
+                  image 'px4io/px4-dev-nuttx:2020-03-16'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -441,7 +441,7 @@ pipeline {
             stage("build px4_fmu-v5_optimized") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx:2020-01-13'
+                  image 'px4io/px4-dev-nuttx:2020-03-16'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -514,7 +514,7 @@ pipeline {
             stage("build modalai_fc-v1_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx:2020-01-13'
+                  image 'px4io/px4-dev-nuttx:2020-03-16'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -587,7 +587,7 @@ pipeline {
             stage("build holybro_durandal-v1_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx:2020-01-13'
+                  image 'px4io/px4-dev-nuttx:2020-03-16'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -661,7 +661,7 @@ pipeline {
             stage("build holybro_durandal-v1_stackcheck") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx:2020-01-13'
+                  image 'px4io/px4-dev-nuttx:2020-03-16'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -748,7 +748,7 @@ pipeline {
             stage("build nxp_fmuk66-v3_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx:2020-01-13'
+                  image 'px4io/px4-dev-nuttx:2020-03-16'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: px4io/px4-dev-nuttx:2020-01-13
+      - image: px4io/px4-dev-nuttx:2020-03-16
     steps:
       - checkout
       - run:

--- a/.github/workflows/bloaty.yml
+++ b/.github/workflows/bloaty.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: px4io/px4-dev-nuttx:2020-01-13
+    container: px4io/px4-dev-nuttx:2020-03-16
     strategy:
       matrix:
         config: [

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: px4io/px4-dev-base-bionic:2020-01-13
+    container: px4io/px4-dev-base-bionic:2020-03-16
     steps:
     - uses: actions/checkout@v1
       with:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: px4io/px4-dev-base-bionic:2020-01-13
+    container: px4io/px4-dev-base-bionic:2020-03-16
     steps:
     - uses: actions/checkout@v1
       with:

--- a/.github/workflows/compile_linux.yml
+++ b/.github/workflows/compile_linux.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: px4io/px4-dev-armhf:2020-01-13
+    container: px4io/px4-dev-armhf:2020-03-16
     strategy:
       matrix:
         config: [

--- a/.github/workflows/compile_nuttx.yml
+++ b/.github/workflows/compile_nuttx.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: px4io/px4-dev-nuttx:2020-01-13
+    container: px4io/px4-dev-nuttx:2020-03-16
     strategy:
       matrix:
         config: [

--- a/.github/workflows/sitl_tests.yml
+++ b/.github/workflows/sitl_tests.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: px4io/px4-dev-simulation-bionic:2020-01-29
+    container: px4io/px4-dev-simulation-bionic:2020-03-16
     steps:
     - uses: actions/checkout@v1
       with:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
         stage('Catkin build on ROS workspace') {
           agent {
             docker {
-              image 'px4io/px4-dev-ros-melodic:2020-01-13'
+              image 'px4io/px4-dev-ros-melodic:2020-03-16'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
             }
           }
@@ -52,7 +52,7 @@ pipeline {
         stage('Colcon build on ROS2 workspace') {
           agent {
             docker {
-              image 'px4io/px4-dev-ros2-dashing:2020-01-13'
+              image 'px4io/px4-dev-ros2-dashing:2020-03-16'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
             }
           }
@@ -83,7 +83,7 @@ pipeline {
 
         stage('Style check') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-01-13' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-03-16' }
           }
           steps {
             sh 'make check_format'
@@ -98,7 +98,7 @@ pipeline {
         stage('px4_fmu-v5 (no ninja)') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2020-01-13'
+              image 'px4io/px4-dev-nuttx:2020-03-16'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -124,7 +124,7 @@ pipeline {
         stage('px4_sitl (no ninja)') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2020-01-13'
+              image 'px4io/px4-dev-nuttx:2020-03-16'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -150,7 +150,7 @@ pipeline {
         stage('SITL unit tests') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2020-01-13'
+              image 'px4io/px4-dev-base-bionic:2020-03-16'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -190,7 +190,7 @@ pipeline {
         stage('Clang analyzer') {
           agent {
             docker {
-              image 'px4io/px4-dev-clang:2020-01-13'
+              image 'px4io/px4-dev-clang:2020-03-16'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -228,7 +228,7 @@ pipeline {
         stage('Clang tidy') {
           agent {
             docker {
-              image 'px4io/px4-dev-clang:2020-01-13'
+              image 'px4io/px4-dev-clang:2020-03-16'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -250,7 +250,7 @@ pipeline {
         stage('Cppcheck') {
           agent {
             docker {
-              image 'px4io/px4-dev-ros-melodic:2020-01-13'
+              image 'px4io/px4-dev-ros-melodic:2020-03-16'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -288,7 +288,7 @@ pipeline {
         stage('Check stack') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2020-01-13'
+              image 'px4io/px4-dev-nuttx:2020-03-16'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -308,7 +308,7 @@ pipeline {
         stage('ShellCheck') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2020-01-13'
+              image 'px4io/px4-dev-nuttx:2020-03-16'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -327,7 +327,7 @@ pipeline {
         stage('Module config validation') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2020-01-13'
+              image 'px4io/px4-dev-base-bionic:2020-03-16'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -352,7 +352,7 @@ pipeline {
 
         stage('Airframe') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-01-13' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-03-16' }
           }
           steps {
             sh 'make distclean'
@@ -371,7 +371,7 @@ pipeline {
 
         stage('Parameter') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-01-13' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-03-16' }
           }
           steps {
             sh 'make distclean'
@@ -390,7 +390,7 @@ pipeline {
 
         stage('Module') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-01-13' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-03-16' }
           }
           steps {
             sh 'make distclean'
@@ -410,7 +410,7 @@ pipeline {
         stage('uORB graphs') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2020-01-13'
+              image 'px4io/px4-dev-nuttx:2020-03-16'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -439,7 +439,7 @@ pipeline {
 
         stage('Devguide') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-01-13' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-03-16' }
           }
           steps {
             sh('export')
@@ -469,7 +469,7 @@ pipeline {
 
         stage('Userguide') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-01-13' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-03-16' }
           }
           steps {
             sh('export')
@@ -497,7 +497,7 @@ pipeline {
 
         stage('QGroundControl') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-01-13' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-03-16' }
           }
           steps {
             sh('export')
@@ -525,7 +525,7 @@ pipeline {
 
         stage('PX4 ROS msgs') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-01-13' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-03-16' }
           }
           steps {
             sh('export')
@@ -554,7 +554,7 @@ pipeline {
 
         stage('PX4 ROS2 bridge') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-01-13' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-03-16' }
           }
           steps {
             sh('export')
@@ -597,7 +597,7 @@ pipeline {
 
         stage('S3') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-01-13' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-03-16' }
           }
           steps {
             sh('export')

--- a/Tools/docker_run.sh
+++ b/Tools/docker_run.sh
@@ -4,22 +4,22 @@ if [ -z ${PX4_DOCKER_REPO+x} ]; then
 	echo "guessing PX4_DOCKER_REPO based on input";
 	if [[ $@ =~ .*px4_fmu.* ]]; then
 		# nuttx-px4fmu-v{1,2,3,4,5}
-		PX4_DOCKER_REPO="px4io/px4-dev-nuttx:2019-11-25"
+		PX4_DOCKER_REPO="px4io/px4-dev-nuttx:2020-03-16"
 	elif [[ $@ =~ .*ocpoc.* ]] || [[ $@ =~ .*navio2.* ]] || [[ $@ =~ .*raspberry.* ]] || [[ $@ =~ .*beaglebone.* ]]; then
 		# aerotenna_ocpoc_default, beaglebone_blue_default, emlid_navio2_default, px4_raspberrypi_default
-		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2019-11-25"
+		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2020-03-16"
 	elif [[ $@ =~ .*eagle.* ]] || [[ $@ =~ .*excelsior.* ]]; then
 		# eagle, excelsior
-		PX4_DOCKER_REPO="lorenzmeier/px4-dev-snapdragon:2020-01-13"
+		PX4_DOCKER_REPO="lorenzmeier/px4-dev-snapdragon:2020-03-16"
 	elif [[ $@ =~ .*ocpoc.* ]] || [[ $@ =~ .*navio2.* ]] || [[ $@ =~ .*raspberry.* ]] || [[ $@ =~ .*bebop.* ]]; then
 		# aerotenna_ocpoc_default, posix_rpi_cross, posix_bebop_default
-		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2019-11-25"
+		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2020-03-16"
 	elif [[ $@ =~ .*clang.* ]] || [[ $@ =~ .*scan-build.* ]]; then
 		# clang tools
-		PX4_DOCKER_REPO="px4io/px4-dev-clang:2019-11-25"
+		PX4_DOCKER_REPO="px4io/px4-dev-clang:2020-03-16"
 	elif [[ $@ =~ .*tests* ]]; then
 		# run all tests with simulation
-		PX4_DOCKER_REPO="px4io/px4-dev-simulation-bionic:2019-11-25"
+		PX4_DOCKER_REPO="px4io/px4-dev-simulation-bionic:2020-03-16"
 	fi
 else
 	echo "PX4_DOCKER_REPO is set to '$PX4_DOCKER_REPO'";
@@ -27,7 +27,7 @@ fi
 
 # otherwise default to nuttx
 if [ -z ${PX4_DOCKER_REPO+x} ]; then
-	PX4_DOCKER_REPO="px4io/px4-dev-nuttx:2019-11-25"
+	PX4_DOCKER_REPO="px4io/px4-dev-nuttx:2020-03-16"
 fi
 
 # docker hygiene

--- a/Tools/setup/requirements.txt
+++ b/Tools/setup/requirements.txt
@@ -3,6 +3,7 @@ cerberus
 empy>=3.3
 jinja2>=2.8
 numpy>=1.13
+packaging
 pandas>=0.21
 psutil
 pygments

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ install:
 # if the toolchain wasn't restored from build cache download and install it
 - ps: >-
     if (-not (Test-Path C:\PX4)) {
-        Invoke-WebRequest https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Windows+Cygwin+Toolchain+0.8.msi -OutFile C:\Toolchain.msi
+        Invoke-WebRequest https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Windows+Cygwin+Toolchain+0.9.msi -OutFile C:\Toolchain.msi
         Start-Process -Wait msiexec -ArgumentList '/I C:\Toolchain.msi /quiet /qn /norestart /log C:\install.log'
     }
 

--- a/msg/templates/urtps/Publisher.cpp.em
+++ b/msg/templates/urtps/Publisher.cpp.em
@@ -11,6 +11,7 @@
 @#  - ids (List) list of all RTPS msg ids
 @###############################################
 @{
+from packaging import version
 import genmsg.msgs
 
 from px_generate_uorb_topic_helper import * # this is in Tools/
@@ -69,12 +70,11 @@ except AttributeError:
 
 #include <fastrtps/Domain.h>
 
-@[if fastrtps_version <= 1.7]@
+@[if version.parse(fastrtps_version) <= version.parse('1.7')]@
 #include <fastrtps/utils/eClock.h>
 @[end if]@
 
 #include "@(topic)_Publisher.h"
-
 
 @(topic)_Publisher::@(topic)_Publisher()
     : mp_participant(nullptr),
@@ -91,7 +91,7 @@ bool @(topic)_Publisher::init()
     // Create RTPSParticipant
     ParticipantAttributes PParam;
     PParam.rtps.builtin.domainId = 0;
-@[if fastrtps_version <= 1.8]@
+@[if version.parse(fastrtps_version) <= version.parse('1.8')]@
     PParam.rtps.builtin.leaseDuration = c_TimeInfinite;
 @[else]@
     PParam.rtps.builtin.discovery_config.leaseDuration = c_TimeInfinite;

--- a/msg/templates/urtps/Publisher.h.em
+++ b/msg/templates/urtps/Publisher.h.em
@@ -11,6 +11,7 @@
 @#  - ids (List) list of all RTPS msg ids
 @###############################################
 @{
+from packaging import version
 import genmsg.msgs
 
 from px_generate_uorb_topic_helper import * # this is in Tools/
@@ -68,7 +69,7 @@ except AttributeError:
 #include <fastrtps/fastrtps_fwd.h>
 #include <fastrtps/publisher/PublisherListener.h>
 
-@[if fastrtps_version <= 1.7]@
+@[if version.parse(fastrtps_version) <= version.parse('1.7')]@
 #include "@(topic)_PubSubTypes.h"
 @[else]@
 #include "@(topic)PubSubTypes.h"
@@ -77,7 +78,7 @@ except AttributeError:
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 
-@[if fastrtps_version <= 1.7]@
+@[if version.parse(fastrtps_version) <= version.parse('1.7')]@
 @[    if ros2_distro]@
 using @(topic)_msg_t = @(package)::msg::dds_::@(topic)_;
 using @(topic)_msg_datatype = @(package)::msg::dds_::@(topic)_PubSubType;

--- a/msg/templates/urtps/RtpsTopics.h.em
+++ b/msg/templates/urtps/RtpsTopics.h.em
@@ -11,6 +11,7 @@
 @###############################################
 @{
 import os
+from packaging import version
 
 import genmsg.msgs
 
@@ -74,7 +75,7 @@ except AttributeError:
 
 
 @[for topic in (recv_topics + send_topics)]@
-@[    if fastrtps_version <= 1.7]@
+@[    if version.parse(fastrtps_version) <= version.parse('1.7')]@
 @[        if ros2_distro]@
 using @(topic)_msg_t = @(package)::msg::dds_::@(topic)_;
 @[        else]@
@@ -116,7 +117,7 @@ private:
 @[end if]@
 
     /** Msg metada Getters **/
-@[if fastrtps_version <= 1.7 or not ros2_distro]@
+@[if version.parse(fastrtps_version) <= version.parse('1.7') or not ros2_distro]@
     template <class T>
     inline uint64_t getMsgTimestamp(const T* msg) { return msg->timestamp_(); }
 
@@ -137,7 +138,7 @@ private:
 @[end if]@
 
     /** Msg metadata Setters **/
-@[if fastrtps_version <= 1.7 or not ros2_distro]@
+@[if version.parse(fastrtps_version) <= version.parse('1.7') or not ros2_distro]@
     template <class T>
     inline uint64_t setMsgTimestamp(T* msg, const uint64_t& timestamp) { msg->timestamp_() = timestamp; }
 

--- a/msg/templates/urtps/Subscriber.cpp.em
+++ b/msg/templates/urtps/Subscriber.cpp.em
@@ -11,6 +11,7 @@
 @#  - ids (List) list of all RTPS msg ids
 @###############################################
 @{
+from packaging import version
 import genmsg.msgs
 
 from px_generate_uorb_topic_helper import * # this is in Tools/
@@ -90,7 +91,7 @@ bool @(topic)_Subscriber::init(uint8_t topic_ID, std::condition_variable* t_send
     // Create RTPSParticipant
     ParticipantAttributes PParam;
     PParam.rtps.builtin.domainId = 0; // MUST BE THE SAME AS IN THE PUBLISHER
-@[if fastrtps_version <= 1.8]@
+@[if version.parse(fastrtps_version) <= version.parse('1.8')]@
     PParam.rtps.builtin.leaseDuration = c_TimeInfinite;
 @[else]@
     PParam.rtps.builtin.discovery_config.leaseDuration = c_TimeInfinite;

--- a/msg/templates/urtps/Subscriber.h.em
+++ b/msg/templates/urtps/Subscriber.h.em
@@ -11,6 +11,7 @@
 @#  - ids (List) list of all RTPS msg ids
 @###############################################
 @{
+from packaging import version
 import genmsg.msgs
 
 from px_generate_uorb_topic_helper import * # this is in Tools/
@@ -68,7 +69,7 @@ except AttributeError:
 #include <fastrtps/fastrtps_fwd.h>
 #include <fastrtps/subscriber/SubscriberListener.h>
 #include <fastrtps/subscriber/SampleInfo.h>
-@[if fastrtps_version <= 1.7]@
+@[if version.parse(fastrtps_version) <= version.parse('1.7')]@
 #include "@(topic)_PubSubTypes.h"
 @[else]@
 #include "@(topic)PubSubTypes.h"
@@ -81,7 +82,7 @@ except AttributeError:
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 
-@[if fastrtps_version <= 1.7]@
+@[if version.parse(fastrtps_version) <= version.parse('1.7')]@
 @[    if ros2_distro]@
 using @(topic)_msg_t = @(package)::msg::dds_::@(topic)_;
 using @(topic)_msg_datatype = @(package)::msg::dds_::@(topic)_PubSubType;

--- a/msg/templates/urtps/microRTPS_timesync.h.em
+++ b/msg/templates/urtps/microRTPS_timesync.h.em
@@ -11,6 +11,7 @@
 @#  - ids (List) list of all RTPS msg ids
 @###############################################
 @{
+from packaging import version
 import genmsg.msgs
 
 from px_generate_uorb_topic_helper import * # this is in Tools/
@@ -86,7 +87,7 @@ static constexpr int64_t TRIGGER_RESET_THRESHOLD_NS = 100ll * 1000ll * 1000ll;
 static constexpr int REQUEST_RESET_COUNTER_THRESHOLD = 5;
 
 @# Sets the timesync DDS type according to the FastRTPS and ROS2 version
-@[if fastrtps_version <= 1.7]@
+@[if version.parse(fastrtps_version) <= version.parse('1.7')]@
 @[    if ros2_distro]@
 using timesync_msg_t = @(package)::msg::dds_::Timesync_;
 @[    else]@
@@ -213,7 +214,7 @@ private:
 	inline void updateOffset(const uint64_t& offset) { _offset_ns.store(offset, std::memory_order_relaxed); }
 
 	/** Timesync msg Getters **/
-@[if fastrtps_version <= 1.7 or not ros2_distro]@
+@[if version.parse(fastrtps_version) <= version.parse('1.7') or not ros2_distro]@
 	inline uint64_t getMsgTimestamp(const timesync_msg_t* msg) { return msg->timestamp_(); }
 	inline uint8_t getMsgSysID(const timesync_msg_t* msg) { return msg->sys_id_(); }
 	inline uint8_t getMsgSeq(const timesync_msg_t* msg) { return msg->seq_(); }
@@ -228,7 +229,7 @@ private:
 @[end if]@
 
 	/** Timesync msg Setters **/
-@[if fastrtps_version <= 1.7 or not ros2_distro]@
+@[if version.parse(fastrtps_version) <= version.parse('1.7') or not ros2_distro]@
 	inline uint64_t setMsgTimestamp(timesync_msg_t* msg, const uint64_t& timestamp) { msg->timestamp_() = timestamp; }
 	inline uint8_t setMsgSysID(timesync_msg_t* msg, const uint8_t& sys_id) { msg->sys_id_() = sys_id; }
 	inline uint8_t setMsgSeq(timesync_msg_t* msg, const uint8_t& seq) { msg->seq_() = seq; }

--- a/msg/templates/urtps/msg.idl.em
+++ b/msg/templates/urtps/msg.idl.em
@@ -37,6 +37,7 @@
 @#
 @################################################################################
 @{
+from packaging import version
 import genmsg.msgs
 
 from px_generate_uorb_topic_helper import *  # this is in Tools/
@@ -57,7 +58,7 @@ def get_include_directives(spec):
         if genmsg.msgs.is_valid_constant_type(genmsg.msgs.bare_msg_type(field.type)):
             continue
         builtin_type = str(field.base_type).replace('px4/', '')
-        if fastrtps_version <= 1.7:
+        if version.parse(fastrtps_version) <= version.parse('1.7'):
             include_directive = '#include "%s_.idl"' % builtin_type
         else:
             include_directive = '#include "%s.idl"' % builtin_type
@@ -77,12 +78,12 @@ def get_idl_type_name(field_type):
 def add_msg_field(field):
     if (not field.is_header):
         if field.is_array:
-            if fastrtps_version <= 1.7:
+            if version.parse(fastrtps_version) <= version.parse('1.7'):
                 print('    {0}__{1}_array_{2} {3}_;'.format(topic, str(get_idl_type_name(field.base_type)).replace(" ", "_"), str(field.array_len), field.name))
             else:
                 print('    {0}__{1}_array_{2} {3};'.format(topic, str(get_idl_type_name(field.base_type)).replace(" ", "_"), str(field.array_len), field.name))
         else:
-            if fastrtps_version <= 1.7:
+            if version.parse(fastrtps_version) <= version.parse('1.7'):
                 base_type = get_idl_type_name(field.base_type) + "_" if get_idl_type_name(field.base_type) in builtin_types else get_idl_type_name(field.base_type)
             else:
                 base_type = get_idl_type_name(field.base_type) if get_idl_type_name(field.base_type) in builtin_types else get_idl_type_name(field.base_type)
@@ -96,7 +97,7 @@ def add_msg_fields():
 def add_array_typedefs():
     for field in spec.parsed_fields():
         if not field.is_header and field.is_array:
-            if fastrtps_version <= 1.7:
+            if version.parse(fastrtps_version) <= version.parse('1.7'):
                 base_type = get_idl_type_name(field.base_type) + "_" if get_idl_type_name(field.base_type) in builtin_types else get_idl_type_name(field.base_type)
             else:
                 base_type = get_idl_type_name(field.base_type) if get_idl_type_name(field.base_type) in builtin_types else get_idl_type_name(field.base_type)
@@ -123,18 +124,20 @@ def add_msg_constants():
 @[for line in get_include_directives(spec)]@
 @(line)@
 @[end for]@
+
+
 @# Constants
 @add_msg_constants()
 @# Array types
 @add_array_typedefs()
-@[if fastrtps_version <= 1.7]@
+@[if version.parse(fastrtps_version) <= version.parse('1.7')]@
 struct @(topic)_
 @[else]@
 struct @(topic)
 @[end if]@
 {
 @add_msg_fields()
-@[if fastrtps_version <= 1.7]@
+@[if version.parse(fastrtps_version) <= version.parse('1.7')]@
 }; // struct @(topic)_
 
 #pragma keylist @(topic)_

--- a/msg/tools/generate_microRTPS_bridge.py
+++ b/msg/tools/generate_microRTPS_bridge.py
@@ -227,13 +227,9 @@ if fastrtpsgen_include is not None and fastrtpsgen_include != '':
         os.path.abspath(
             args.fastrtpsgen_include) + " "
 
-# get FastRTPS version (major.minor, since patch is not relevant at this stage)
-fastrtps_version = ""
-try:
-    fastrtps_version = float(subprocess.check_output(
-        "ldconfig -v | grep libfastrtps | tail -c 6", shell=True).decode("utf-8").strip()[-5:-2])
-except ValueError:
-    print("No valid version found to FasRTPS. Make sure it is installed.")
+# get FastRTPS version
+fastrtps_version = subprocess.check_output(
+    "ldconfig -v | grep libfastrtps", shell=True).decode("utf-8").strip().split('so.')[-1]
 
 # get ROS 2 version, if exists
 ros2_distro = ""

--- a/msg/tools/px_generate_uorb_topic_files.py
+++ b/msg/tools/px_generate_uorb_topic_files.py
@@ -43,6 +43,7 @@ import shutil
 import filecmp
 import argparse
 import sys
+from packaging import version
 
 try:
     import em
@@ -187,7 +188,7 @@ def generate_idl_file(filename_msg, msg_dir, alias, outputdir, templatedir, pack
         os.makedirs(outputdir)
 
     template_file = os.path.join(templatedir, IDL_TEMPLATE_FILE)
-    if 1.5 <= fastrtps_version <= 1.7:
+    if version.parse(fastrtps_version) <= version.parse('1.7'):
         output_file = os.path.join(outputdir, IDL_TEMPLATE_FILE.replace(
             "msg.idl.em", str(spec_short_name + "_.idl")))
     else:


### PR DESCRIPTION
Supersedes and fixes the reported in https://github.com/PX4/Firmware/pull/14393.

@stmoon after some research I found that `packaging.version` is suited to these kind of comparisons, and so there's no need for parsing the major and minor to numerical. I tested this with FastRTPS master built and installed from source, matching the 1.10 version, and this works as it should. Please test on your side and thanks for the contribution!