### PR TITLE
Pr batt smbus stability

### DIFF
--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -143,22 +143,18 @@ void BATT_SMBUS::RunImpl()
 	// Check if max lifetime voltage delta is greater than allowed.
 	if (_lifetime_max_delta_cell_voltage > BATT_CELL_VOLTAGE_THRESHOLD_FAILED) {
 		new_report.warning = battery_status_s::BATTERY_WARNING_CRITICAL;
-	}
 
-	// Propagate warning state.
-	else {
-		if (new_report.remaining > _low_thr) {
-			new_report.warning = battery_status_s::BATTERY_WARNING_NONE;
+	} else if (new_report.remaining > _low_thr) {
+		new_report.warning = battery_status_s::BATTERY_WARNING_NONE;
 
-		} else if (new_report.remaining > _crit_thr) {
-			new_report.warning = battery_status_s::BATTERY_WARNING_LOW;
+	} else if (new_report.remaining > _crit_thr) {
+		new_report.warning = battery_status_s::BATTERY_WARNING_LOW;
 
-		} else if (new_report.remaining > _emergency_thr) {
-			new_report.warning = battery_status_s::BATTERY_WARNING_CRITICAL;
+	} else if (new_report.remaining > _emergency_thr) {
+		new_report.warning = battery_status_s::BATTERY_WARNING_CRITICAL;
 
-		} else {
-			new_report.warning = battery_status_s::BATTERY_WARNING_EMERGENCY;
-		}
+	} else {
+		new_report.warning = battery_status_s::BATTERY_WARNING_EMERGENCY;
 	}
 
 	// Read battery temperature and covert to Celsius.
@@ -168,6 +164,7 @@ void BATT_SMBUS::RunImpl()
 	new_report.capacity = _batt_capacity;
 	new_report.cycle_count = _cycle_count;
 	new_report.serial_number = _serial_number;
+	new_report.max_cell_voltage_delta = _max_cell_voltage_delta;
 	new_report.cell_count = _cell_count;
 	new_report.voltage_cell_v[0] = _cell_voltages[0];
 	new_report.voltage_cell_v[1] = _cell_voltages[1];
@@ -219,7 +216,7 @@ int BATT_SMBUS::get_cell_voltages()
 
 	for (uint8_t i = 1; i < (sizeof(_cell_voltages) / sizeof(_cell_voltages[0])); i++) {
 		_min_cell_voltage = math::min(_min_cell_voltage, _cell_voltages[i]);
-		max_cell_voltage = math::max(_min_cell_voltage, _cell_voltages[i]);
+		max_cell_voltage = math::max(max_cell_voltage, _cell_voltages[i]);
 	}
 
 	// Calculate the max difference between the min and max cells with complementary filter.

--- a/src/lib/drivers/smbus/SMBus.cpp
+++ b/src/lib/drivers/smbus/SMBus.cpp
@@ -98,6 +98,10 @@ int SMBus::block_read(const uint8_t cmd_code, void *data, const uint8_t length, 
 
 	int result = transfer(&cmd_code, 1, (uint8_t *)&rx_data[3], length + 2);
 
+	if (result != PX4_OK) {
+		return result;
+	}
+
 	uint8_t device_address = get_device_address();
 	rx_data[0] = (device_address << 1) | 0x00;
 	rx_data[1] = cmd_code;


### PR DESCRIPTION
as in the commit note this pr do some staff related to the smbuss batt driver:

1. fixed hardfault if failed to create bus or device
2. fixed forgotten deleting failed device
3. fixed wrong calculation of max_cell_voltage
4. adding missed max_cell_voltage_delta
5. some code beautify

This changes has been tested with different device (BQ40Z80) than this driver has been written to (BQ40Z50). but it seems that the changes are still relevant.
