### PR TITLE
MavlinkStreamEstimatorStatus: consistently use ESTIMATOR_STATUS as the stream type

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -2674,7 +2674,7 @@ public:
 
 	static constexpr uint16_t get_id_static()
 	{
-		return MAVLINK_MSG_ID_VIBRATION;
+		return MAVLINK_MSG_ID_ESTIMATOR_STATUS;
 	}
 
 	uint16_t get_id() override
@@ -2689,7 +2689,7 @@ public:
 
 	unsigned get_size() override
 	{
-		return _est_sub.advertised() ? MAVLINK_MSG_ID_VIBRATION_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES : 0;
+		return _est_sub.advertised() ? MAVLINK_MSG_ID_ESTIMATOR_STATUS_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES : 0;
 	}
 
 private:


### PR DESCRIPTION
I noticed that the `MavlinkStreamEstimatorStatus` reports its name as `"ESTIMATOR_STATUS"`, but its ID as `MAVLINK_MSG_ID_VIBRATION`. It also used `MAVLINK_MSG_ID_ESTIMATOR_STATUS_LEN` to compute it's length.

This looks wrong to me, although this stream does send both `ESTIMATOR_STATUS` and `VIBRATION` mavlink messages, so maybe this is intentional?