### PR TITLE
Add plane catapult launch to Jenkins SITL testing

### DIFF
--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -42,6 +42,13 @@ pipeline {
               vehicle: "plane"
             ],
             [
+              name: "FW_catapult",
+              test: "mavros_posix_test_mission.test",
+              mission: "FW_mission_1",
+              vehicle: "plane_catapult"
+            ],
+
+            [
               name: "MC_box",
               test: "mavros_posix_test_mission.test",
               mission: "MC_mission_box",

--- a/.ci/Jenkinsfile-SITL_tests_ASan
+++ b/.ci/Jenkinsfile-SITL_tests_ASan
@@ -42,6 +42,13 @@ pipeline {
               vehicle: "plane"
             ],
             [
+              name: "FW_catapult",
+              test: "mavros_posix_test_mission.test",
+              mission: "FW_mission_1",
+              vehicle: "plane_catapult"
+            ],
+
+            [
               name: "MC_box",
               test: "mavros_posix_test_mission.test",
               mission: "MC_mission_box",

--- a/test/mavros_posix_tests_missions.test
+++ b/test/mavros_posix_tests_missions.test
@@ -18,6 +18,7 @@
     </include>
     <!-- ROStest -->
     <test test-name="FW_mission_1" pkg="px4" type="mission_test.py" time-limit="300.0" args="FW_mission_1.plan" vehicle="plane"/>
+    <test test-name="FW_mission_1" pkg="px4" type="mission_test.py" time-limit="300.0" args="FW_mission_1.plan" vehicle="plane_catapult"/>
     <test test-name="MC_mission_box" pkg="px4" type="mission_test.py" time-limit="300.0" args="MC_mission_box.plan" vehicle="iris"/>
     <test test-name="VTOL_mission_1" pkg="px4" type="mission_test.py" time-limit="300.0" args="VTOL_mission_1.plan" vehicle="standard_vtol"/>
     <test test-name="VTOL_mission_1" pkg="px4" type="mission_test.py" time-limit="300.0" args="VTOL_mission_1.plan" vehicle="tailsitter"/>


### PR DESCRIPTION
**Describe problem solved by this pull request**
Handlaunch / Catapult launching in fixed wing was not being tested in CI. This PR adds the [`plane_catapult`](https://github.com/PX4/sitl_gazebo/pull/393) model as part of the fixed wing to test the handlaunch

**Describe your solution**
Since mavsdk testing doesn't support fixedwing, this needs to be added to the jenkins SITL tests

