### PR TITLE
HTE: enable by default

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -77,13 +77,12 @@ PARAM_DEFINE_FLOAT(MPC_THR_HOVER, 0.5f);
  * Hover thrust source selector
  *
  * Set false to use the fixed parameter MPC_THR_HOVER
- * (EXPERIMENTAL) Set true to use the value computed by the hover thrust estimator
+ * Set true to use the value computed by the hover thrust estimator
  *
  * @boolean
- * @category Developer
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_INT32(MPC_USE_HTE, 0);
+PARAM_DEFINE_INT32(MPC_USE_HTE, 1);
 
 /**
  * Thrust curve in Manual Mode


### PR DESCRIPTION
Following the decision taken during today's DevCall, we're going to enable the hover thrust estimator by default for the beta to see if there are any issues. We can still disable just before the release if we see that something is really broken and that we can't fix it immediately.

FYI: @mrpollo 