### PR TITLE
 fix IntrusiveQueue::remove: several bugs that led to improper state of the queue

### DIFF
--- a/src/drivers/distance_sensor/tfmini/TFMINI.cpp
+++ b/src/drivers/distance_sensor/tfmini/TFMINI.cpp
@@ -168,7 +168,7 @@ TFMINI::collect()
 
 	if (!bytes_available) {
 		perf_end(_sample_perf);
-		return -EAGAIN;
+		return 0;
 	}
 
 	// parse entire buffer
@@ -223,8 +223,8 @@ TFMINI::collect()
 void
 TFMINI::start()
 {
-	// schedule a cycle to start things
-	ScheduleOnInterval(100_us);
+	// schedule a cycle to start things (the sensor sends at 100Hz, but we run a bit faster to avoid missing data)
+	ScheduleOnInterval(7_ms);
 }
 
 void
@@ -246,7 +246,7 @@ TFMINI::Run()
 	if (collect() == -EAGAIN) {
 		// reschedule to grab the missing bits, time to transmit 9 bytes @ 115200 bps
 		ScheduleClear();
-		ScheduleOnInterval(100_us, 87 * 9);
+		ScheduleOnInterval(7_ms, 87 * 9);
 		return;
 	}
 }

--- a/src/include/containers/IntrusiveQueue.hpp
+++ b/src/include/containers/IntrusiveQueue.hpp
@@ -101,9 +101,11 @@ public:
 		if (removeNode == _head) {
 			if (_head->next_intrusive_queue_node() != nullptr) {
 				_head = _head->next_intrusive_queue_node();
+				removeNode->set_next_intrusive_queue_node(nullptr);
 
 			} else {
 				_head = nullptr;
+				_tail = nullptr;
 			}
 
 			return true;
@@ -112,14 +114,13 @@ public:
 		for (T node = _head; node != nullptr; node = node->next_intrusive_queue_node()) {
 			// is sibling the node to remove?
 			if (node->next_intrusive_queue_node() == removeNode) {
-				// replace sibling
-				if (node->next_intrusive_queue_node() != nullptr) {
-					node->set_next_intrusive_queue_node(node->next_intrusive_queue_node()->next_intrusive_queue_node());
-
-				} else {
-					node->set_next_intrusive_queue_node(nullptr);
+				if (removeNode == _tail) {
+					_tail = node;
 				}
 
+				// replace sibling
+				node->set_next_intrusive_queue_node(removeNode->next_intrusive_queue_node());
+				removeNode->set_next_intrusive_queue_node(nullptr);
 				return true;
 			}
 		}


### PR DESCRIPTION
@limhyon noticed that tfmini was not working anymore on master, and traced it down to https://github.com/PX4/Firmware/blob/004d916095321c01c08719e12ca971d1e45a5453/src/drivers/distance_sensor/tfmini/TFMINI.cpp#L248 
The driver was suddenly not scheduled anymore, and removing the line 'fixed' it.

The underlying problem is however an incorrect implementation of `IntrusiveQueue::remove`, and it got revealed with https://github.com/PX4/Firmware/pull/14331.

Also, tfmini was scheduled at 10kHz which seems excessive given the sensor outputs data at 100Hz. It is now reduced to 500Hz.

@limhyon can you test this?