### PR TITLE
Robustify against IGN REQUEST LIST: Busy

### DIFF
--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -691,6 +691,14 @@ MavlinkMissionManager::handle_mission_request_list(const mavlink_message_t *msg)
 	mavlink_msg_mission_request_list_decode(msg, &wprl);
 
 	if (CHECK_SYSID_COMPID_MISSION(wprl)) {
+		const bool maybe_completed = (_transfer_seq == current_item_count());
+
+		// If all mission items have been sent and a new mission request list comes in, we can proceed even if  MISSION_ACK was
+		// never received. This could happen on a quick reconnect that doesn't trigger MAVLINK_MISSION_PROTOCOL_TIMEOUT_DEFAULT
+		if (maybe_completed) {
+			switch_to_idle_state();
+		}
+
 		if (_state == MAVLINK_WPM_STATE_IDLE || (_state == MAVLINK_WPM_STATE_SENDLIST
 				&& (uint8_t)_mission_type == wprl.mission_type)) {
 			_time_last_recv = hrt_absolute_time();

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -737,7 +737,7 @@ MavlinkMissionManager::handle_mission_request_list(const mavlink_message_t *msg)
 		} else {
 			PX4_DEBUG("WPM: MISSION_REQUEST_LIST ERROR: busy");
 
-			_mavlink->send_statustext_critical("IGN REQUEST LIST: Busy");
+			_mavlink->send_statustext_info("Mission download request ignored, already active");
 		}
 	}
 }


### PR DESCRIPTION
This PR handles incoming `MISSION_REQUEST_LIST` messages such that
they are no longer ignored if the previously requested mission has
sent all mission items but the ACK has never been received.

In addition, the wording of the warning message in case a new mission is requested while the old one hasn't finished downloading yet, is changed to be a bit more user friendly than "IGN REQUEST LIST: Busy", and its severity is reduced to INFO

Background: I'm trying to fix this user experience:

![IMG_20200318_083207](https://user-images.githubusercontent.com/14265408/77055521-54cca300-69d1-11ea-9a76-7340ea414a70.jpg)
