### PR TITLE
logger: fix initial subscribing to topics

### DIFF
--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -506,6 +506,7 @@ bool Logger::initialize_topics()
 			// if we poll on a topic, we don't use the interval and let the polled topic define the maximum interval
 			uint16_t interval_ms = _polling_topic_meta ? 0 : sub.interval_ms;
 			_subscriptions[i] = LoggerSubscription(sub.id, interval_ms, sub.instance);
+			_subscriptions[i].subscribe();
 		}
 	}
 
@@ -1557,15 +1558,22 @@ void Logger::write_all_add_logged_msg(LogType type)
 		sub_count = _num_mission_subs;
 	}
 
+	bool added_subscriptions = false;
+
 	for (int i = 0; i < sub_count; ++i) {
 		LoggerSubscription &sub = _subscriptions[i];
 
 		if (sub.valid()) {
 			write_add_logged_msg(type, sub);
+			added_subscriptions = true;
 		}
 	}
 
 	_writer.unlock();
+
+	if (!added_subscriptions) {
+		PX4_ERR("No subscriptions added"); // this results in invalid log files
+	}
 }
 
 void Logger::write_add_logged_msg(LogType type, LoggerSubscription &subscription)


### PR DESCRIPTION
write_all_add_logged_msg() requires at least some subscriptions to be added
initially, as this message is used to separate ULog header from data.

Fixes https://github.com/PX4/Firmware/issues/14422