### PR TITLE
Fix mpu9250 driver missing mpu6500 detection issue.

### DIFF
--- a/src/drivers/imu/mpu9250/mpu9250.h
+++ b/src/drivers/imu/mpu9250/mpu9250.h
@@ -261,7 +261,7 @@ private:
 	PX4Accelerometer	_px4_accel;
 	PX4Gyroscope		_px4_gyro;
 
-	MPU9250_mag		_mag;
+	MPU9250_mag		*_mag;
 
 	unsigned		_call_interval{1000};
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
Fix new mpu9250 driver missing mpu6500 detection issue. This issue may cause mag calibration fail on any FCUs that use mpu6500 sensor.

**Describe your solution**
Add/recover detection for mpu6500.

**Test data / coverage**
Tested against MindPX/MindRacer/Pixhawk.

