### PR TITLE
Add onboard qmc5883 support for MindPX/MindRacer hardware

### DIFF
--- a/boards/airmind/mindpx-v2/init/rc.board_sensors
+++ b/boards/airmind/mindpx-v2/init/rc.board_sensors
@@ -11,6 +11,7 @@ qmc5883 -X start
 
 # Internal I2C bus
 hmc5883 -T -I -R 12 start
+qmc5883 -I -R 12 start
 
 mpu6000 -s -R 8 start
 mpu9250 -s -R 8 start


### PR DESCRIPTION
**Describe problem solved by this pull request**
hmc5883 is discontinued and draining out on inventory. qmc5883 is a drop-in replacement. This PR enable qmc5883 driver on all MindPX /MindRacer hardware.

**Describe your solution**
enable qmc5883 driver on init scripts.

**Test data / coverage**
Tested against MindPX/MindRacer on v1.10.x and v1.11.x

**Additional context**
This is a one line change on MindPX specific code. Should be pretty safe to merge.
@LorenzMeier @dagar @jinger26 Could you please help to make this into v1.10 & v1.11 release?
thanks.