### PR TITLE
return with error from _log_request_list() in case of failed allocation

### DIFF
--- a/src/modules/mavlink/mavlink_log_handler.cpp
+++ b/src/modules/mavlink/mavlink_log_handler.cpp
@@ -171,6 +171,11 @@ MavlinkLogHandler::_log_request_list(const mavlink_message_t *msg)
 		_pLogHandlerHelper = new LogListHelper;
 	}
 
+	if (!_pLogHandlerHelper) {
+		PX4_ERR("LogListHelper alloc failed");
+		return;
+	}
+
 	if (_pLogHandlerHelper->log_count) {
 		//-- Define (and clamp) range
 		_pLogHandlerHelper->next_entry = request.start < _pLogHandlerHelper->log_count ? request.start :


### PR DESCRIPTION
In case of failed allocation of LogListHelper, the next lines can cause hardfault.
This didn't happen to me, but still its good practice to protect from that.

As more widen question, why LogListHelper is a class at all? why its not part of MavlinkLogHandler?
I think that removing as much as possible dynamic allocations is good practice.
My only thought is to save some RAM, and try to allocate it only if and when Log need to be download. LogListHelper is about 150 bytes.