### PR TITLE
MPC: limit tilt to maximum safe value of 89 degrees

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -199,6 +199,8 @@ private:
 	/** During smooth-takeoff, below ALTITUDE_THRESHOLD the yaw-control is turned off ant tilt is limited */
 	static constexpr float ALTITUDE_THRESHOLD = 0.3f;
 
+	static constexpr float MAX_SAFE_TILT_DEG = 89.f; // Numerical issues above this value due to tanf
+
 	systemlib::Hysteresis _failsafe_land_hysteresis{false}; /**< becomes true if task did not update correctly for LOITER_TIME_BEFORE_DESCEND */
 
 	WeatherVane *_wv_controller{nullptr};
@@ -342,6 +344,18 @@ MulticopterPositionControl::parameters_update(bool force)
 		// update parameters from storage
 		ModuleParams::updateParams();
 		SuperBlock::updateParams();
+
+		if (_param_mpc_tiltmax_air.get() > MAX_SAFE_TILT_DEG) {
+			_param_mpc_tiltmax_air.set(MAX_SAFE_TILT_DEG);
+			_param_mpc_tiltmax_air.commit();
+			mavlink_log_critical(&_mavlink_log_pub, "Tilt constrained to safe value");
+		}
+
+		if (_param_mpc_tiltmax_lnd.get() > _param_mpc_tiltmax_air.get()) {
+			_param_mpc_tiltmax_lnd.set(_param_mpc_tiltmax_air.get());
+			_param_mpc_tiltmax_lnd.commit();
+			mavlink_log_critical(&_mavlink_log_pub, "Land tilt has been constrained by max tilt");
+		}
 
 		_control.setPositionGains(Vector3f(_param_mpc_xy_p.get(), _param_mpc_xy_p.get(), _param_mpc_z_p.get()));
 		_control.setVelocityGains(Vector3f(_param_mpc_xy_vel_p.get(), _param_mpc_xy_vel_p.get(), _param_mpc_z_vel_p.get()),

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -306,7 +306,7 @@ PARAM_DEFINE_FLOAT(MPC_XY_VEL_MAX, 12.0f);
  *
  * @unit deg
  * @min 20.0
- * @max 180.0
+ * @max 89.0
  * @decimal 1
  * @group Multicopter Position Control
  */
@@ -319,7 +319,7 @@ PARAM_DEFINE_FLOAT(MPC_TILTMAX_AIR, 45.0f);
  *
  * @unit deg
  * @min 10.0
- * @max 90.0
+ * @max 89.0
  * @decimal 1
  * @group Multicopter Position Control
  */


### PR DESCRIPTION
fixes https://github.com/PX4/Firmware/issues/14456

The following condition is now enforced and the parameters are automatically corrected if a condition is violated:
`MPC_TILTMAX_LND <= MPC_TILTMAX_AIR <= 89 degrees`

I decided to restrict the parameter instead of adding a constraint in the position controller itself as the used needs to know that something was wrong in his setup. @MaEtUgR In addition to that, do you want to protect the `tanf` ? https://github.com/PX4/Firmware/blob/315135c07ec3c5cc111288562ca652b5dcda186e/src/modules/mc_pos_control/PositionControl/PositionControl.cpp#L199 and https://github.com/PX4/Firmware/blob/315135c07ec3c5cc111288562ca652b5dcda186e/src/modules/mc_pos_control/PositionControl/PositionControl.cpp#L176

Tested in SITL:
```
pxh> param set MPC_TILTMAX_LND 90
+ MPC_TILTMAX_LND: curr: 89.0000 -> new: 90.0000
pxh> WARN  [mc_pos_control] Land tilt has been constrained by max tilt
pxh> param set MPC_TILTMAX_AIR 100
+ MPC_TILTMAX_AIR: curr: 89.0000 -> new: 100.0000
pxh> WARN  [mc_pos_control] Tilt constrained to safe value
pxh> param set MPC_TILTMAX_AIR 60
+ MPC_TILTMAX_AIR: curr: 89.0000 -> new: 60.0000
pxh> WARN  [mc_pos_control] Land tilt has been constrained by max tilt
pxh> param show MPC_TILTMAX_LND
x + MPC_TILTMAX_LND [354,641] : 60.0000
```