### PR TITLE
Add sonoma raceway world for SITL gazebo

### DIFF
--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -66,7 +66,7 @@ set(models none shell
 	standard_vtol tailsitter tiltrotor
 	rover boat
 	uuv_hippocampus)
-set(worlds none empty warehouse)
+set(worlds none empty warehouse sonoma_raceway)
 set(all_posix_vmd_make_targets)
 foreach(viewer ${viewers})
 	foreach(debugger ${debuggers})


### PR DESCRIPTION
**Describe problem solved by this pull request**
This PR adds a make target to spawn the `sonoma_raceway`

This is needed to enable https://github.com/PX4/sitl_gazebo/pull/441

[![Demo](https://img.youtube.com/vi/caPbIHKRUCs/0.jpg)](https://youtu.be/caPbIHKRUCs)
