### PR TITLE
microRTPS: templates: use full version comparison when checking for version 1.7

### DIFF
--- a/msg/templates/urtps/Publisher.cpp.em
+++ b/msg/templates/urtps/Publisher.cpp.em
@@ -70,7 +70,7 @@ except AttributeError:
 
 #include <fastrtps/Domain.h>
 
-@[if version.parse(fastrtps_version) <= version.parse('1.7')]@
+@[if version.parse(fastrtps_version) <= version.parse('1.7.2')]@
 #include <fastrtps/utils/eClock.h>
 @[end if]@
 

--- a/msg/templates/urtps/Publisher.h.em
+++ b/msg/templates/urtps/Publisher.h.em
@@ -69,7 +69,7 @@ except AttributeError:
 #include <fastrtps/fastrtps_fwd.h>
 #include <fastrtps/publisher/PublisherListener.h>
 
-@[if version.parse(fastrtps_version) <= version.parse('1.7')]@
+@[if version.parse(fastrtps_version) <= version.parse('1.7.2')]@
 #include "@(topic)_PubSubTypes.h"
 @[else]@
 #include "@(topic)PubSubTypes.h"
@@ -78,7 +78,7 @@ except AttributeError:
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 
-@[if version.parse(fastrtps_version) <= version.parse('1.7')]@
+@[if version.parse(fastrtps_version) <= version.parse('1.7.2')]@
 @[    if ros2_distro]@
 using @(topic)_msg_t = @(package)::msg::dds_::@(topic)_;
 using @(topic)_msg_datatype = @(package)::msg::dds_::@(topic)_PubSubType;

--- a/msg/templates/urtps/RtpsTopics.h.em
+++ b/msg/templates/urtps/RtpsTopics.h.em
@@ -75,7 +75,7 @@ except AttributeError:
 
 
 @[for topic in (recv_topics + send_topics)]@
-@[    if version.parse(fastrtps_version) <= version.parse('1.7')]@
+@[    if version.parse(fastrtps_version) <= version.parse('1.7.2')]@
 @[        if ros2_distro]@
 using @(topic)_msg_t = @(package)::msg::dds_::@(topic)_;
 @[        else]@
@@ -117,7 +117,7 @@ private:
 @[end if]@
 
     /** Msg metada Getters **/
-@[if version.parse(fastrtps_version) <= version.parse('1.7') or not ros2_distro]@
+@[if version.parse(fastrtps_version) <= version.parse('1.7.2') or not ros2_distro]@
     template <class T>
     inline uint64_t getMsgTimestamp(const T* msg) { return msg->timestamp_(); }
 
@@ -138,7 +138,7 @@ private:
 @[end if]@
 
     /** Msg metadata Setters **/
-@[if version.parse(fastrtps_version) <= version.parse('1.7') or not ros2_distro]@
+@[if version.parse(fastrtps_version) <= version.parse('1.7.2') or not ros2_distro]@
     template <class T>
     inline uint64_t setMsgTimestamp(T* msg, const uint64_t& timestamp) { msg->timestamp_() = timestamp; }
 

--- a/msg/templates/urtps/Subscriber.h.em
+++ b/msg/templates/urtps/Subscriber.h.em
@@ -69,7 +69,7 @@ except AttributeError:
 #include <fastrtps/fastrtps_fwd.h>
 #include <fastrtps/subscriber/SubscriberListener.h>
 #include <fastrtps/subscriber/SampleInfo.h>
-@[if version.parse(fastrtps_version) <= version.parse('1.7')]@
+@[if version.parse(fastrtps_version) <= version.parse('1.7.2')]@
 #include "@(topic)_PubSubTypes.h"
 @[else]@
 #include "@(topic)PubSubTypes.h"
@@ -82,7 +82,7 @@ except AttributeError:
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 
-@[if version.parse(fastrtps_version) <= version.parse('1.7')]@
+@[if version.parse(fastrtps_version) <= version.parse('1.7.2')]@
 @[    if ros2_distro]@
 using @(topic)_msg_t = @(package)::msg::dds_::@(topic)_;
 using @(topic)_msg_datatype = @(package)::msg::dds_::@(topic)_PubSubType;

--- a/msg/templates/urtps/microRTPS_timesync.h.em
+++ b/msg/templates/urtps/microRTPS_timesync.h.em
@@ -87,7 +87,7 @@ static constexpr int64_t TRIGGER_RESET_THRESHOLD_NS = 100ll * 1000ll * 1000ll;
 static constexpr int REQUEST_RESET_COUNTER_THRESHOLD = 5;
 
 @# Sets the timesync DDS type according to the FastRTPS and ROS2 version
-@[if version.parse(fastrtps_version) <= version.parse('1.7')]@
+@[if version.parse(fastrtps_version) <= version.parse('1.7.2')]@
 @[    if ros2_distro]@
 using timesync_msg_t = @(package)::msg::dds_::Timesync_;
 @[    else]@
@@ -214,7 +214,7 @@ private:
 	inline void updateOffset(const uint64_t& offset) { _offset_ns.store(offset, std::memory_order_relaxed); }
 
 	/** Timesync msg Getters **/
-@[if version.parse(fastrtps_version) <= version.parse('1.7') or not ros2_distro]@
+@[if version.parse(fastrtps_version) <= version.parse('1.7.2') or not ros2_distro]@
 	inline uint64_t getMsgTimestamp(const timesync_msg_t* msg) { return msg->timestamp_(); }
 	inline uint8_t getMsgSysID(const timesync_msg_t* msg) { return msg->sys_id_(); }
 	inline uint8_t getMsgSeq(const timesync_msg_t* msg) { return msg->seq_(); }
@@ -229,7 +229,7 @@ private:
 @[end if]@
 
 	/** Timesync msg Setters **/
-@[if version.parse(fastrtps_version) <= version.parse('1.7') or not ros2_distro]@
+@[if version.parse(fastrtps_version) <= version.parse('1.7.2') or not ros2_distro]@
 	inline uint64_t setMsgTimestamp(timesync_msg_t* msg, const uint64_t& timestamp) { msg->timestamp_() = timestamp; }
 	inline uint8_t setMsgSysID(timesync_msg_t* msg, const uint8_t& sys_id) { msg->sys_id_() = sys_id; }
 	inline uint8_t setMsgSeq(timesync_msg_t* msg, const uint8_t& seq) { msg->seq_() = seq; }

--- a/msg/templates/urtps/msg.idl.em
+++ b/msg/templates/urtps/msg.idl.em
@@ -58,7 +58,7 @@ def get_include_directives(spec):
         if genmsg.msgs.is_valid_constant_type(genmsg.msgs.bare_msg_type(field.type)):
             continue
         builtin_type = str(field.base_type).replace('px4/', '')
-        if version.parse(fastrtps_version) <= version.parse('1.7'):
+        if version.parse(fastrtps_version) <= version.parse('1.7.2'):
             include_directive = '#include "%s_.idl"' % builtin_type
         else:
             include_directive = '#include "%s.idl"' % builtin_type
@@ -78,12 +78,12 @@ def get_idl_type_name(field_type):
 def add_msg_field(field):
     if (not field.is_header):
         if field.is_array:
-            if version.parse(fastrtps_version) <= version.parse('1.7'):
+            if version.parse(fastrtps_version) <= version.parse('1.7.2'):
                 print('    {0}__{1}_array_{2} {3}_;'.format(topic, str(get_idl_type_name(field.base_type)).replace(" ", "_"), str(field.array_len), field.name))
             else:
                 print('    {0}__{1}_array_{2} {3};'.format(topic, str(get_idl_type_name(field.base_type)).replace(" ", "_"), str(field.array_len), field.name))
         else:
-            if version.parse(fastrtps_version) <= version.parse('1.7'):
+            if version.parse(fastrtps_version) <= version.parse('1.7.2'):
                 base_type = get_idl_type_name(field.base_type) + "_" if get_idl_type_name(field.base_type) in builtin_types else get_idl_type_name(field.base_type)
             else:
                 base_type = get_idl_type_name(field.base_type) if get_idl_type_name(field.base_type) in builtin_types else get_idl_type_name(field.base_type)
@@ -97,7 +97,7 @@ def add_msg_fields():
 def add_array_typedefs():
     for field in spec.parsed_fields():
         if not field.is_header and field.is_array:
-            if version.parse(fastrtps_version) <= version.parse('1.7'):
+            if version.parse(fastrtps_version) <= version.parse('1.7.2'):
                 base_type = get_idl_type_name(field.base_type) + "_" if get_idl_type_name(field.base_type) in builtin_types else get_idl_type_name(field.base_type)
             else:
                 base_type = get_idl_type_name(field.base_type) if get_idl_type_name(field.base_type) in builtin_types else get_idl_type_name(field.base_type)
@@ -130,14 +130,14 @@ def add_msg_constants():
 @add_msg_constants()
 @# Array types
 @add_array_typedefs()
-@[if version.parse(fastrtps_version) <= version.parse('1.7')]@
+@[if version.parse(fastrtps_version) <= version.parse('1.7.2')]@
 struct @(topic)_
 @[else]@
 struct @(topic)
 @[end if]@
 {
 @add_msg_fields()
-@[if version.parse(fastrtps_version) <= version.parse('1.7')]@
+@[if version.parse(fastrtps_version) <= version.parse('1.7.2')]@
 }; // struct @(topic)_
 
 #pragma keylist @(topic)_

--- a/msg/tools/px_generate_uorb_topic_files.py
+++ b/msg/tools/px_generate_uorb_topic_files.py
@@ -188,7 +188,7 @@ def generate_idl_file(filename_msg, msg_dir, alias, outputdir, templatedir, pack
         os.makedirs(outputdir)
 
     template_file = os.path.join(templatedir, IDL_TEMPLATE_FILE)
-    if version.parse(fastrtps_version) <= version.parse('1.7'):
+    if version.parse(fastrtps_version) <= version.parse('1.7.2'):
         output_file = os.path.join(outputdir, IDL_TEMPLATE_FILE.replace(
             "msg.idl.em", str(spec_short_name + "_.idl")))
     else:


### PR DESCRIPTION
Apparently for 1.7 check is also required to do an adjustment on the comparison. Though since 1.7.2 is the latest release for ROS 2 Crystal (https://github.com/ros2-gbp/fastrtps-release#fastrtps-crystal---172-0), we are safe to use the patch version as well in the comparison.

Reported in `px4_ros_com` CI: https://travis-ci.com/github/PX4/px4_ros_com/jobs/301916502.