### PR TITLE
switch remaining boards to new InvenSense IMU drivers

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4250_teal
+++ b/ROMFS/px4fmu_common/init.d/airframes/4250_teal
@@ -47,7 +47,6 @@ then
 	param set BAT_V_OFFS_CURR -0.0045
 
 	# sensor calibration
-	param set CAL_MAG0_ROT 0
 	param set CAL_MAG_SIDES 63
 	param set SENS_BOARD_ROT 0
 	param set COM_ARM_MAG_ANG -1
@@ -197,10 +196,7 @@ then
 	#mpu6500
 	param set CAL_GYRO_PRIME 2360330
 
-	param set CAL_MAG0_EN 1
-	param set CAL_MAG1_EN 0
 	param set CAL_MAG_PRIME 265738
-
 fi
 
 # Logger mode. Default(1) + estimator replay(2) + thermal calibration(4)

--- a/ROMFS/px4fmu_common/init.d/airframes/6002_draco_r
+++ b/ROMFS/px4fmu_common/init.d/airframes/6002_draco_r
@@ -140,10 +140,5 @@ then
 	param set MAV_1_FORWARD 1
 	param set MAV_1_RATE 800000
 	param set SER_TEL2_BAUD 921600
-
-	# Disable internal magnetometer sensor
-	param set CAL_MAG0_EN 0
-	# Enable external magnetometer sensor
-	param set CAL_MAG1_EN 1
 fi
 

--- a/boards/aerotenna/ocpoc/default.cmake
+++ b/boards/aerotenna/ocpoc/default.cmake
@@ -27,8 +27,7 @@ px4_add_board(
 		differential_pressure # all available differential pressure drivers
 		distance_sensor # all available distance sensor drivers
 		gps
-		#imu # all available imu drivers
-		imu/mpu9250
+		imu/invensense/mpu9250
 		lights/rgbled
 		linux_pwm_out
 		#magnetometer # all available magnetometer drivers

--- a/boards/atlflight/eagle/qurt.cmake
+++ b/boards/atlflight/eagle/qurt.cmake
@@ -46,7 +46,7 @@ px4_add_board(
 	DRIVERS
 		barometer/bmp280
 		gps
-		imu/mpu9250
+		imu/invensense/mpu9250
 		#magnetometer/hmc5883
 		qshell/qurt
 		snapdragon_pwm_out

--- a/boards/atlflight/excelsior/qurt.cmake
+++ b/boards/atlflight/excelsior/qurt.cmake
@@ -46,7 +46,7 @@ px4_add_board(
 	DRIVERS
 		barometer/bmp280
 		gps
-		imu/mpu9250
+		imu/invensense/mpu9250
 		magnetometer/hmc5883
 		qshell/qurt
 		snapdragon_pwm_out

--- a/boards/emlid/navio2/default.cmake
+++ b/boards/emlid/navio2/default.cmake
@@ -21,7 +21,7 @@ px4_add_board(
 		distance_sensor # all available distance sensor drivers
 		gps
 		#imu # all available imu drivers
-		imu/mpu9250
+		imu/invensense/mpu9250
 		imu/st/lsm9ds1
 		linux_pwm_out
 		#magnetometer # all available magnetometer drivers

--- a/boards/holybro/durandal-v1/default.cmake
+++ b/boards/holybro/durandal-v1/default.cmake
@@ -33,7 +33,6 @@ px4_add_board(
 		imu/adis16497
 		imu/bmi088
 		imu/invensense/icm20689
-		imu/mpu6000
 		irlock
 		lights/blinkm
 		lights/rgbled

--- a/boards/holybro/durandal-v1/init/rc.board_sensors
+++ b/boards/holybro/durandal-v1/init/rc.board_sensors
@@ -5,8 +5,7 @@
 adc start
 
 # Internal SPI bus ICM-20689
-mpu6000 -R 8 -s -T 20689 start
-#icm20689 -R 2 -s start
+icm20689 -R 2 -s start
 
 # Internal SPI bus BMI088 accel
 bmi088 -A -R 10 -s start

--- a/boards/holybro/durandal-v1/stackcheck.cmake
+++ b/boards/holybro/durandal-v1/stackcheck.cmake
@@ -32,9 +32,8 @@ px4_add_board(
 		#imu/adis16448
 		#imu/adis16477
 		#imu/adis16497
-		imu/bmi088
-		#imu/invensense/icm20689
-		#imu/mpu6000
+		#imu/bmi088
+		imu/invensense/icm20689
 		#irlock
 		#lights/blinkm
 		#lights/rgbled

--- a/boards/holybro/kakutef7/default.cmake
+++ b/boards/holybro/kakutef7/default.cmake
@@ -19,7 +19,8 @@ px4_add_board(
 		barometer/bmp280
 		dshot
 		gps
-		imu/mpu6000
+		imu/invensense/icm20689
+		imu/invensense/mpu6000
 		magnetometer
 		optical_flow/px4flow
 		osd

--- a/boards/holybro/kakutef7/init/rc.board_sensors
+++ b/boards/holybro/kakutef7/init/rc.board_sensors
@@ -6,9 +6,9 @@
 adc start
 
 # The default IMU is an ICM20689, but there might also be an MPU6000
-if ! mpu6000 -R 12 -s start
+if ! mpu6000 -R 6 -s start
 then
-	mpu6000 -R 12 -s -T 20689 start
+	icm20689 -R 6 -s start
 fi
 
 # Onboard Baro

--- a/boards/intel/aerofc-v1/default.cmake
+++ b/boards/intel/aerofc-v1/default.cmake
@@ -17,7 +17,7 @@ px4_add_board(
 		#differential_pressure # all available differential pressure drivers
 		distance_sensor
 		gps
-		imu/mpu9250
+		imu/invensense/mpu9250
 		#irlock
 		#magnetometer # all available magnetometer drivers
 		magnetometer/hmc5883

--- a/boards/intel/aerofc-v1/init/rc.board_sensors
+++ b/boards/intel/aerofc-v1/init/rc.board_sensors
@@ -9,7 +9,8 @@ if ! ms5611 -T 5607 start
 then
 	ms5611 start
 fi
-mpu9250 -s -R 14 start
+
+mpu9250 -s -R 0 start
 
 # Possible external compasses
 hmc5883 -X start

--- a/boards/intel/aerofc-v1/rtps.cmake
+++ b/boards/intel/aerofc-v1/rtps.cmake
@@ -17,7 +17,7 @@ px4_add_board(
 		#differential_pressure # all available differential pressure drivers
 		distance_sensor
 		gps
-		imu/mpu9250
+		imu/invensense/mpu9250
 		#irlock
 		#magnetometer # all available magnetometer drivers
 		magnetometer/hmc5883

--- a/boards/modalai/fc-v1/default.cmake
+++ b/boards/modalai/fc-v1/default.cmake
@@ -27,7 +27,6 @@ px4_add_board(
 		imu/bmi088
 		imu/invensense/icm20602
 		imu/invensense/icm42688p
-		imu/mpu6000
 		irlock
 		lights/blinkm
 		lights/rgbled

--- a/boards/modalai/fc-v1/init/rc.board_sensors
+++ b/boards/modalai/fc-v1/init/rc.board_sensors
@@ -10,7 +10,7 @@ voxlpm -X -b 3 -T VBATT start
 voxlpm -X -b 3 -T P5VDC start
 
 # Internal SPI bus ICM-20602
-mpu6000 -R 6 -s -T 20602 start
+icm20602 -R 12 -s start
 
 # Internal SPI bus ICM-42688
 icm42688p -R 12 -s start

--- a/boards/mro/ctrl-zero-f7/default.cmake
+++ b/boards/mro/ctrl-zero-f7/default.cmake
@@ -30,7 +30,7 @@ px4_add_board(
 		#heater
 		#imu # all available imu drivers
 		imu/bmi088
-		imu/mpu6000
+		imu/invensense/icm20602
 		imu/icm20948
 		irlock
 		lights/blinkm

--- a/boards/mro/ctrl-zero-f7/init/rc.board_sensors
+++ b/boards/mro/ctrl-zero-f7/init/rc.board_sensors
@@ -6,16 +6,14 @@
 adc start
 
 # Internal ICM-20602
-mpu6000 -R 10 -s -T 20602 start
+icm20602 -s -R 4 start
 
-# Internal ICM-20689
-#icm20689 -s -R 10 start
-
-# Internal SPI bus BMI088 accel
+# Internal SPI bus BMI088 accel & gyro
 bmi088 -A -R 10 -s start
-
-# Internal SPI bus BMI088 gyro
 bmi088 -G -R 10 -s start
+
+# Internal ICM-20948
+icm20948 -s -R 10 start
 
 # Interal DPS310 (barometer)
 dps310 -s start
@@ -25,3 +23,4 @@ ist8310 -X start
 hmc5883 -T -X start
 qmc5883 -X start
 lis3mdl -X start
+rm3100 -X start

--- a/boards/mro/ctrl-zero-f7/src/spi.cpp
+++ b/boards/mro/ctrl-zero-f7/src/spi.cpp
@@ -38,8 +38,7 @@
 constexpr px4_spi_bus_t px4_spi_buses[SPI_BUS_MAX_BUS_ITEMS] = {
 	initSPIBus(SPI::Bus::SPI1, {
 		initSPIDevice(DRV_IMU_DEVTYPE_ICM20602, SPI::CS{GPIO::PortC, GPIO::Pin2}, SPI::DRDY{GPIO::PortD, GPIO::Pin15}),
-		// ICM-20948
-		initSPIDevice(DRV_DEVTYPE_UNUSED, SPI::CS{GPIO::PortE, GPIO::Pin15}, SPI::DRDY{GPIO::PortE, GPIO::Pin12}),
+		initSPIDevice(DRV_IMU_DEVTYPE_ICM20948, SPI::CS{GPIO::PortE, GPIO::Pin15}, SPI::DRDY{GPIO::PortE, GPIO::Pin12}),
 	}, {GPIO::PortE, GPIO::Pin3}),
 	initSPIBus(SPI::Bus::SPI2, {
 		initSPIDevice(SPIDEV_FLASH(0), SPI::CS{GPIO::PortD, GPIO::Pin10}),

--- a/boards/mro/x21-777/default.cmake
+++ b/boards/mro/x21-777/default.cmake
@@ -25,8 +25,9 @@ px4_add_board(
 		#dshot
 		gps
 		#imu # all available imu drivers
-		imu/mpu6000
-		imu/mpu9250
+		imu/invensense/icm20602
+		imu/invensense/icm20608g
+		imu/invensense/mpu9250
 		irlock
 		lights/blinkm
 		lights/rgbled

--- a/boards/mro/x21-777/init/rc.board_sensors
+++ b/boards/mro/x21-777/init/rc.board_sensors
@@ -5,18 +5,14 @@
 
 adc start
 
-# External I2C bus
-hmc5883 -T -X start
-lis3mdl -X start
+# Internal SPI bus ICM-20608-G
+icm20608g -s -R 8 start
 
-# Internal SPI bus ICM-20608-G is rotated 90 deg yaw
-mpu6000 -s -R 2 -T 20608 start
+# Internal SPI bus ICM-20602
+icm20602 -s -R 8 start
 
-# Internal SPI bus ICM-20602-G is rotated 90 deg yaw
-mpu6000 -s -R 2 -T 20602 start
-
-# Internal SPI bus mpu9250 is rotated 90 deg yaw
-mpu9250 -s -R 2 start
+# Internal SPI bus mpu9250
+mpu9250 -s -R 8 start
 
 # Possible external compasses
 ist8310 -X start

--- a/boards/mro/x21/default.cmake
+++ b/boards/mro/x21/default.cmake
@@ -26,8 +26,9 @@ px4_add_board(
 		gps
 		#heater
 		#imu # all available imu drivers
-		imu/mpu6000
-		imu/mpu9250
+		imu/invensense/icm20602
+		imu/invensense/icm20608g
+		imu/invensense/mpu9250
 		irlock
 		lights/blinkm
 		lights/rgbled

--- a/boards/mro/x21/init/rc.board_sensors
+++ b/boards/mro/x21/init/rc.board_sensors
@@ -11,14 +11,14 @@ lis3mdl -X start
 ist8310 -X start
 qmc5883 -X start
 
-# Internal SPI bus ICM-20608-G is rotated 90 deg yaw
-mpu6000 -s -R 2 -T 20608 start
+# Internal SPI bus ICM-20608-G
+icm20608g -s -R 8 start
 
-# Internal SPI bus ICM-20602-G is rotated 90 deg yaw
-mpu6000 -s -R 2 -T 20602 start
+# Internal SPI bus ICM-20602
+icm20602 -s -R 8 start
 
-# Internal SPI bus mpu9250 is rotated 90 deg yaw
-mpu9250 -s -R 2 start
+# Internal SPI bus mpu9250
+mpu9250 -s -R 8 start
 
 # Internal SPI
 ms5611 -s start

--- a/boards/nxp/fmuk66-v3/default.cmake
+++ b/boards/nxp/fmuk66-v3/default.cmake
@@ -27,9 +27,6 @@ px4_add_board(
 		#imu # all available imu drivers
 		imu/fxas21002c
 		imu/fxos8701cq
-		imu/l3gd20
-		imu/mpu6000
-		imu/mpu9250
 		irlock
 		lights/blinkm
 		lights/rgbled

--- a/boards/nxp/fmurt1062-v1/init/rc.board_sensors
+++ b/boards/nxp/fmurt1062-v1/init/rc.board_sensors
@@ -18,10 +18,10 @@
 adc start
 
 # Internal SPI bus ICM-20602
-mpu6000 -R 8 -s -T 20602 start
+icm20602 -R 2 -s start
 
 # Internal SPI bus ICM-20689
-mpu6000 -R 8 -s -T 20689 start
+icm20689 -R 2 -s start
 
 # Internal SPI bus BMI055 accel
 bmi055 -A -R 10 -s start
@@ -47,11 +47,3 @@ ist8310 -I start
 
 # Baro on internal SPI
 ms5611 -s start
-
-# External RM3100
-rm3100 -X start
-
-# Possible pmw3901 optical flow sensor
-pmw3901 -S start
-
-px4flow start -X

--- a/boards/px4/fmu-v2/default.cmake
+++ b/boards/px4/fmu-v2/default.cmake
@@ -36,11 +36,13 @@ px4_add_board(
 		#imu/adis16448
 		#imu/adis16477
 		#imu/adis16497
-		#imu/invensense/mpu6000 # WIP
 		imu/l3gd20
 		imu/lsm303d
-		imu/mpu6000
-		#imu/mpu9250
+		#imu/invensense/icm20608g
+		imu/invensense/mpu6000
+		#imu/invensense/mpu9250
+		#imu/icm20948
+		#imu/mpu6000 # legacy mpu6000
 		#iridiumsbd
 		#irlock
 		#lights/blinkm
@@ -52,6 +54,7 @@ px4_add_board(
 		#optical_flow/px4flow
 		#osd
 		#pca9685
+		#power_monitor/ina226
 		#protocol_splitter
 		#pwm_input
 		#pwm_out_sim
@@ -85,6 +88,7 @@ px4_add_board(
 		mc_hover_thrust_estimator
 		mc_pos_control
 		mc_rate_control
+		#micrortps_bridge
 		navigator
 		rc_update
 		#rover_pos_control

--- a/boards/px4/fmu-v2/fixedwing.cmake
+++ b/boards/px4/fmu-v2/fixedwing.cmake
@@ -24,12 +24,14 @@ px4_add_board(
 		camera_capture
 		camera_trigger
 		differential_pressure # all available differential pressure drivers
-		distance_sensor # all available distance sensor drivers
+		#distance_sensor # all available distance sensor drivers
+		distance_sensor/ll40ls
+		distance_sensor/sf0x
 		gps
 		imu/l3gd20
 		imu/lsm303d
-		imu/mpu6000
-		#imu/mpu9250
+		imu/invensense/mpu6000
+		#imu/invensense/mpu9250
 		lights/rgbled
 		#magnetometer # all available magnetometer drivers
 		magnetometer/hmc5883

--- a/boards/px4/fmu-v2/init/rc.board_sensors
+++ b/boards/px4/fmu-v2/init/rc.board_sensors
@@ -17,14 +17,10 @@ rm3100 -X start
 # Internal I2C bus
 hmc5883 -T -I -R 4 start
 
-# Internal SPI bus ICM-20608-G
-mpu6000 -s -T 20608 start
-
-
 # Internal SPI (auto detect ms5611 or ms5607)
-if ! ms5611 -T 5607 -s start
+if ! ms5611 -T 5607 -s -b 1 start
 then
-	ms5611 -s start
+	ms5611 -s -b 1 start
 fi
 
 set BOARD_FMUV3 0
@@ -32,15 +28,15 @@ set BOARD_FMUV3 0
 # V3 build hwtypecmp supports V2|V2M|V30
 if ver hwtypecmp V30
 then
-	# Check for Pixhawk 2.0 cube
-	# MPU6K is rotated 180 degrees yaw
-	if mpu6000 -s -R 4 start
+	# Check for Pixhawk 2.0 cube (isolated IMU on SPI4)
+	#  mpu6000 on v2.0, mpu9250 on v2.1
+	if mpu6000 -s -b 4 -R 10 start
 	then
 		set BOARD_FMUV3 20
 	else
 		# Check for Pixhawk 2.1 cube
-		# (external) MPU9250 is rotated 180 degrees yaw
-		if mpu9250 -s -R 4 start
+		# isolated/external mpu9250 (SPI4)
+		if mpu9250 -s -b 4 -R 10 start
 		then
 			set BOARD_FMUV3 21
 		fi
@@ -50,17 +46,20 @@ fi
 # Check if a Pixhack (which reports as V2M) is present
 if ver hwtypecmp V2M
 then
+	# Internal SPI bus ICM-20608-G
+	icm20608g -s -b 1 -R 14 start
+
 	# Pixhawk Mini doesn't have these sensors,
 	# so if they are found we know its a Pixhack
 
-	# MPU6K is rotated 180 degrees yaw
-	if mpu6000 -s -R 4 start
+	# mppu6000 internal (SPI1)
+	if mpu6000 -s -b 1 -R 10 start
 	then
 		set BOARD_FMUV3 20
 	else
 		# Check for Pixhack 3.1
-		# (external) MPU9250 is rotated 180 degrees yaw
-		if mpu9250 -s -R 4 start
+		#  mpu9250 external (SPI4)
+		if mpu9250 -s -b 1 -R 10 start
 		then
 			set BOARD_FMUV3 21
 		fi
@@ -72,43 +71,53 @@ then
 	# sensor heating is available, but we disable it for now
 	param set SENS_EN_THERMAL 0
 
-	# (external) L3GD20H is rotated 180 degrees yaw
-	l3gd20 -s -R 4 start
+	# ICM20948 as external magnetometer on I2C (e.g. Here GPS)
+	if ! icm20948 -X -R 6 start
+	then
+		# external emulated AK09916 (Here2) is rotated 270 degrees yaw
+		ak09916 -X -R 6 start
+	fi
 
-	# (external) LSM303D is rotated 270 degrees yaw
-	lsm303d -s -R 6 start
+	# l3gd20 (external/isolated SPI4)
+	l3gd20 -s -b 4 -R 4 start
+
+	# lsm303d (external/isolated SPI4)
+	lsm303d -s -b 4 -R 6 start
+
+	# ms5611 (external/isolated SPI4)
+	ms5611 -s -b 4 start
 
 	if [ $BOARD_FMUV3 = 20 ]
 	then
-		# v2.0 internal MPU6000 is rotated 180 deg roll, 270 deg yaw
-		mpu6000 -s -R 14 start
+		# v2.0 internal mpu6000
+		mpu6000 -s -b 1 start
 
 		# v2.0 Has internal hmc5883 on SPI1
-		hmc5883 -T -S -R 8 start
+		hmc5883 -T -s -b 1 -R 8 start
 	fi
 
 	if [ $BOARD_FMUV3 = 21 ]
 	then
-		# v2.1 internal MPU9250 is rotated 180 deg roll, 270 deg yaw
-		mpu9250 -s -R 14 start
+		# v2.1 mpu9250 on SPI1
+		mpu9250 -s -b 1 start
 	fi
 
 else
 	# $BOARD_FMUV3 = 0 -> FMUv2
 
-	mpu6000 -s start
+	mpu6000 -s -b 1 -R 14 start
 
 	# As we will use the external mag and the ICM-20608-G
 	# V2 build hwtypecmp is always false
 	# V3 build hwtypecmp supports V2|V2M|V30
 	if ! ver hwtypecmp V2M
 	then
-		mpu9250 -s start
+		mpu9250 -s -b 1 -R 14 start
 	# else: On the PixhawkMini the mpu9250 has been disabled due to HW errata
 	fi
 
-	l3gd20 -s start
-	lsm303d -s start
+	l3gd20 -s -b 1 start
+	lsm303d -s -b 1 start
 fi
 
 unset BOARD_FMUV3

--- a/boards/px4/fmu-v2/lpe.cmake
+++ b/boards/px4/fmu-v2/lpe.cmake
@@ -35,8 +35,7 @@ px4_add_board(
 		#imu # all available imu drivers
 		imu/l3gd20
 		imu/lsm303d
-		imu/mpu6000
-		#imu/mpu9250
+		imu/invensense/mpu6000
 		#iridiumsbd
 		irlock
 		#lights/blinkm

--- a/boards/px4/fmu-v2/multicopter.cmake
+++ b/boards/px4/fmu-v2/multicopter.cmake
@@ -26,7 +26,7 @@ px4_add_board(
 		imu/l3gd20
 		imu/lsm303d
 		imu/mpu6000
-		#imu/mpu9250
+		#imu/invensense/mpu9250
 		irlock
 		lights/rgbled
 		magnetometer/hmc5883

--- a/boards/px4/fmu-v2/rover.cmake
+++ b/boards/px4/fmu-v2/rover.cmake
@@ -26,8 +26,8 @@ px4_add_board(
 		gps
 		imu/l3gd20
 		imu/lsm303d
-		imu/mpu6000
-		#imu/mpu9250
+		imu/invensense/mpu6000
+		#imu/invensense/mpu9250
 		lights/rgbled
 		magnetometer/hmc5883
 		optical_flow/px4flow

--- a/boards/px4/fmu-v2/test.cmake
+++ b/boards/px4/fmu-v2/test.cmake
@@ -37,8 +37,8 @@ px4_add_board(
 		#imu/adis16497
 		imu/l3gd20
 		imu/lsm303d
-		imu/mpu6000
-		#imu/mpu9250
+		imu/invensense/mpu6000
+		#imu/invensense/mpu9250
 		#iridiumsbd
 		#irlock
 		#lights/blinkm

--- a/boards/px4/fmu-v3/default.cmake
+++ b/boards/px4/fmu-v3/default.cmake
@@ -34,8 +34,9 @@ px4_add_board(
 		imu/adis16497
 		imu/l3gd20
 		imu/lsm303d
-		imu/mpu6000
-		imu/mpu9250
+		imu/invensense/icm20608g
+		imu/invensense/mpu6000
+		imu/invensense/mpu9250
 		imu/icm20948
 		irlock
 		lights/blinkm

--- a/boards/px4/fmu-v3/init/rc.board_sensors
+++ b/boards/px4/fmu-v3/init/rc.board_sensors
@@ -17,14 +17,10 @@ rm3100 -X start
 # Internal I2C bus
 hmc5883 -T -I -R 4 start
 
-# Internal SPI bus ICM-20608-G
-mpu6000 -s -T 20608 start
-
-
 # Internal SPI (auto detect ms5611 or ms5607)
-if ! ms5611 -T 5607 -s start
+if ! ms5611 -T 5607 -s -b 1 start
 then
-	ms5611 -s start
+	ms5611 -s -b 1 start
 fi
 
 set BOARD_FMUV3 0
@@ -32,15 +28,15 @@ set BOARD_FMUV3 0
 # V3 build hwtypecmp supports V2|V2M|V30
 if ver hwtypecmp V30
 then
-	# Check for Pixhawk 2.0 cube
-	# MPU6K is rotated 180 degrees yaw
-	if mpu6000 -s -R 4 start
+	# Check for Pixhawk 2.0 cube (isolated IMU on SPI4)
+	#  mpu6000 on v2.0, mpu9250 on v2.1
+	if mpu6000 -s -b 4 -R 10 start
 	then
 		set BOARD_FMUV3 20
 	else
 		# Check for Pixhawk 2.1 cube
-		# (external) MPU9250 is rotated 180 degrees yaw
-		if mpu9250 -s -R 4 start
+		# isolated/external mpu9250 (SPI4)
+		if mpu9250 -s -b 4 -R 10 start
 		then
 			set BOARD_FMUV3 21
 		fi
@@ -50,17 +46,20 @@ fi
 # Check if a Pixhack (which reports as V2M) is present
 if ver hwtypecmp V2M
 then
+	# Internal SPI bus ICM-20608-G
+	icm20608g -s -b 1 -R 14 start
+
 	# Pixhawk Mini doesn't have these sensors,
 	# so if they are found we know its a Pixhack
 
-	# MPU6K is rotated 180 degrees yaw
-	if mpu6000 -s -R 4 start
+	# mppu6000 internal (SPI1)
+	if mpu6000 -s -b 1 -R 10 start
 	then
 		set BOARD_FMUV3 20
 	else
 		# Check for Pixhack 3.1
-		# (external) MPU9250 is rotated 180 degrees yaw
-		if mpu9250 -s -R 4 start
+		#  mpu9250 external (SPI4)
+		if mpu9250 -s -b 1 -R 10 start
 		then
 			set BOARD_FMUV3 21
 		fi
@@ -79,43 +78,46 @@ then
 		ak09916 -X -R 6 start
 	fi
 
-	# (external) L3GD20H is rotated 180 degrees yaw
-	l3gd20 -s -R 4 start
+	# l3gd20 (external/isolated SPI4)
+	l3gd20 -s -b 4 -R 4 start
 
-	# (external) LSM303D is rotated 270 degrees yaw
-	lsm303d -s -R 6 start
+	# lsm303d (external/isolated SPI4)
+	lsm303d -s -b 4 -R 6 start
+
+	# ms5611 (external/isolated SPI4)
+	ms5611 -s -b 4 start
 
 	if [ $BOARD_FMUV3 = 20 ]
 	then
-		# v2.0 internal MPU6000 is rotated 180 deg roll, 270 deg yaw
-		mpu6000 -s -R 14 start
+		# v2.0 internal mpu6000
+		mpu6000 -s -b 1 start
 
 		# v2.0 Has internal hmc5883 on SPI1
-		hmc5883 -T -S -R 8 start
+		hmc5883 -T -s -b 1 -R 8 start
 	fi
 
 	if [ $BOARD_FMUV3 = 21 ]
 	then
-		# v2.1 internal MPU9250 is rotated 180 deg roll, 270 deg yaw
-		mpu9250 -s -R 14 start
+		# v2.1 mpu9250 on SPI1
+		mpu9250 -s -b 1 start
 	fi
 
 else
 	# $BOARD_FMUV3 = 0 -> FMUv2
 
-	mpu6000 -s start
+	mpu6000 -s -b 1 -R 14 start
 
 	# As we will use the external mag and the ICM-20608-G
 	# V2 build hwtypecmp is always false
 	# V3 build hwtypecmp supports V2|V2M|V30
 	if ! ver hwtypecmp V2M
 	then
-		mpu9250 -s start
+		mpu9250 -s -b 1 -R 14 start
 	# else: On the PixhawkMini the mpu9250 has been disabled due to HW errata
 	fi
 
-	l3gd20 -s start
-	lsm303d -s start
+	l3gd20 -s -b 1 start
+	lsm303d -s -b 1 start
 fi
 
 unset BOARD_FMUV3

--- a/boards/px4/fmu-v3/rtps.cmake
+++ b/boards/px4/fmu-v3/rtps.cmake
@@ -34,8 +34,9 @@ px4_add_board(
 		imu/adis16497
 		imu/l3gd20
 		imu/lsm303d
-		imu/mpu6000
-		imu/mpu9250
+		imu/invensense/icm20608g
+		imu/invensense/mpu6000
+		imu/invensense/mpu9250
 		imu/icm20948
 		irlock
 		lights/blinkm

--- a/boards/px4/fmu-v3/stackcheck.cmake
+++ b/boards/px4/fmu-v3/stackcheck.cmake
@@ -33,8 +33,9 @@ px4_add_board(
 		#imu # all available imu drivers
 		imu/l3gd20
 		imu/lsm303d
-		imu/mpu6000
-		imu/mpu9250
+		imu/invensense/icm20608g
+		imu/invensense/mpu6000
+		imu/invensense/mpu9250
 		irlock
 		lights/blinkm
 		lights/rgbled

--- a/boards/px4/fmu-v4/cannode.cmake
+++ b/boards/px4/fmu-v4/cannode.cmake
@@ -44,10 +44,9 @@ px4_add_board(
 		#imu/adis16448
 		#imu/adis16477
 		#imu/adis16497
-		#imu/invensense/icm20602
-		#imu/invensense/icm20608-g
-		imu/mpu6000
-		imu/mpu9250
+		imu/invensense/icm20602
+		imu/invensense/icm20608g
+		imu/invensense/mpu9250
 		#lights/rgbled
 		#lights/rgbled_ncp5623c
 		#magnetometer # all available magnetometer drivers

--- a/boards/px4/fmu-v4/default.cmake
+++ b/boards/px4/fmu-v4/default.cmake
@@ -31,9 +31,8 @@ px4_add_board(
 		imu/invensense/icm20602
 		imu/invensense/icm20608g
 		imu/invensense/icm40609d
-		#imu/invensense/mpu9250
-		#imu/mpu6000 # legacy icm20602/icm20608g driver
-		imu/mpu9250
+		imu/invensense/mpu6500
+		imu/invensense/mpu9250
 		irlock
 		lights/blinkm
 		lights/rgbled

--- a/boards/px4/fmu-v4/init/rc.board_sensors
+++ b/boards/px4/fmu-v4/init/rc.board_sensors
@@ -35,18 +35,18 @@ fi
 # chip select pin. There are different boards with either one of them and the WHO_AM_I register
 # will prevent the incorrect driver from a successful initialization.
 
-# ICM20602 internal SPI bus ICM-20608-G is rotated 90 deg yaw
+# ICM20602 internal SPI bus ICM-20608-G
 if ! icm20602 -s -R 8 start
 then
-	# ICM20608 internal SPI bus ICM-20602-G is rotated 90 deg yaw
+	# ICM20608 internal SPI bus ICM-20602-G
 	icm20608g -s -R 8 start
 fi
 
 # For Teal One airframe
 if param compare SYS_AUTOSTART 4250
 then
-	mpu9250 -s -R 14 start
+	mpu6500 -s -R 0 start
 else
-	# mpu9250 internal SPI bus mpu9250 is rotated 90 deg yaw
-	mpu9250 -s -R 2 start
+	# mpu9250 internal SPI bus mpu9250
+	mpu9250 -s -R 8 start
 fi

--- a/boards/px4/fmu-v4/optimized.cmake
+++ b/boards/px4/fmu-v4/optimized.cmake
@@ -35,9 +35,8 @@ px4_add_board(
 		imu/invensense/icm20602
 		imu/invensense/icm20608g
 		#imu/invensense/icm40609d
-		#imu/invensense/mpu9250
-		#imu/mpu6000 # legacy icm20602/icm20608g driver
-		imu/mpu9250
+		#imu/invensense/mpu6500
+		imu/invensense/mpu9250
 		irlock
 		lights/blinkm
 		lights/rgbled

--- a/boards/px4/fmu-v4/rtps.cmake
+++ b/boards/px4/fmu-v4/rtps.cmake
@@ -30,9 +30,9 @@ px4_add_board(
 		imu/adis16497
 		imu/invensense/icm20602
 		imu/invensense/icm20608g
-		#imu/invensense/mpu9250
-		#imu/mpu6000 # legacy icm20602/icm20608g driver
-		imu/mpu9250
+		imu/invensense/icm40609d
+		imu/invensense/mpu6500
+		imu/invensense/mpu9250
 		irlock
 		lights/blinkm
 		lights/rgbled

--- a/boards/px4/fmu-v4/stackcheck.cmake
+++ b/boards/px4/fmu-v4/stackcheck.cmake
@@ -30,9 +30,9 @@ px4_add_board(
 		#imu/adis16497
 		imu/invensense/icm20602
 		imu/invensense/icm20608g
+		#imu/invensense/icm40609d
+		#imu/invensense/mpu6500
 		#imu/invensense/mpu9250
-		#imu/mpu6000 # legacy icm20602/icm20608g driver
-		imu/mpu9250
 		irlock
 		lights/blinkm
 		lights/rgbled

--- a/boards/px4/fmu-v4pro/default.cmake
+++ b/boards/px4/fmu-v4pro/default.cmake
@@ -30,9 +30,7 @@ px4_add_board(
 		#imu # all available imu drivers
 		imu/invensense/icm20602
 		imu/invensense/icm20608g
-		#imu/invensense/mpu9250
-		#imu/mpu6000 # legacy icm20602/icm20608g driver
-		imu/mpu9250
+		imu/invensense/mpu9250
 		irlock
 		lights/blinkm
 		lights/rgbled

--- a/boards/px4/fmu-v4pro/init/rc.board_sensors
+++ b/boards/px4/fmu-v4pro/init/rc.board_sensors
@@ -14,7 +14,7 @@ icm20608g -s -R 8 start
 icm20602 -s -R 8 start
 
 # Internal SPI bus mpu9250
-mpu9250 -s -R 2 start
+mpu9250 -s -R 8 start
 
 # Internal SPI bus
 lis3mdl -s -R 0 start

--- a/boards/px4/fmu-v4pro/rtps.cmake
+++ b/boards/px4/fmu-v4pro/rtps.cmake
@@ -30,9 +30,7 @@ px4_add_board(
 		#imu # all available imu drivers
 		imu/invensense/icm20602
 		imu/invensense/icm20608g
-		#imu/invensense/mpu9250
-		#imu/mpu6000 # legacy icm20602/icm20608g driver
-		imu/mpu9250
+		imu/invensense/mpu9250
 		irlock
 		lights/blinkm
 		lights/rgbled

--- a/boards/px4/fmu-v5/critmonitor.cmake
+++ b/boards/px4/fmu-v5/critmonitor.cmake
@@ -31,7 +31,9 @@ px4_add_board(
 		imu/adis16477
 		imu/adis16497
 		imu/bmi055
-		imu/mpu6000
+		imu/invensense/icm20602
+		imu/invensense/icm20689
+		#imu/mpu6000 # legacy icm20602/icm20689 driver
 		irlock
 		lights/blinkm
 		lights/rgbled

--- a/boards/px4/fmu-v5/default.cmake
+++ b/boards/px4/fmu-v5/default.cmake
@@ -33,7 +33,7 @@ px4_add_board(
 		imu/bmi055
 		imu/invensense/icm20602
 		imu/invensense/icm20689
-		imu/mpu6000
+		#imu/mpu6000 # legacy icm20602/icm20689 driver
 		irlock
 		lights/blinkm
 		lights/rgbled

--- a/boards/px4/fmu-v5/fixedwing.cmake
+++ b/boards/px4/fmu-v5/fixedwing.cmake
@@ -28,7 +28,9 @@ px4_add_board(
 		imu/adis16497
 		#imu # all available imu drivers
 		imu/bmi055
-		imu/mpu6000
+		imu/invensense/icm20602
+		imu/invensense/icm20689
+		#imu/mpu6000 # legacy icm20602/icm20689 driver
 		lights/rgbled
 		lights/rgbled_ncp5623c
 		lights/rgbled_pwm

--- a/boards/px4/fmu-v5/init/rc.board_sensors
+++ b/boards/px4/fmu-v5/init/rc.board_sensors
@@ -6,16 +6,10 @@
 adc start
 
 # Internal SPI bus ICM-20602
-mpu6000 -R 8 -s -T 20602 start
-#icm20602 -s -R 6 start
+icm20602 -s -R 2 start
 
 # Internal SPI bus ICM-20689
-mpu6000 -R 8 -s -T 20689 start
-#icm20689 -s -R 6 start
-
-# new sensor drivers (in testing)
-#icm20602 -s start
-#icm20689 -s start
+icm20689 -s -R 2 start
 
 # Internal SPI bus BMI055 accel
 bmi055 -A -R 10 -s start

--- a/boards/px4/fmu-v5/irqmonitor.cmake
+++ b/boards/px4/fmu-v5/irqmonitor.cmake
@@ -31,7 +31,9 @@ px4_add_board(
 		imu/adis16477
 		imu/adis16497
 		imu/bmi055
-		imu/mpu6000
+		imu/invensense/icm20602
+		imu/invensense/icm20689
+		#imu/mpu6000 # legacy icm20602/icm20689 driver
 		irlock
 		lights/blinkm
 		lights/rgbled
@@ -50,6 +52,7 @@ px4_add_board(
 		px4io
 		rc_input
 		roboclaw
+		rpm
 		safety_button
 		tap_esc
 		telemetry # all available telemetry drivers

--- a/boards/px4/fmu-v5/multicopter.cmake
+++ b/boards/px4/fmu-v5/multicopter.cmake
@@ -29,7 +29,9 @@ px4_add_board(
 		imu/adis16497
 		#imu # all available imu drivers
 		imu/bmi055
-		imu/mpu6000
+		imu/invensense/icm20602
+		imu/invensense/icm20689
+		#imu/mpu6000 # legacy icm20602/icm20689 driver
 		irlock
 		lights/blinkm
 		lights/rgbled

--- a/boards/px4/fmu-v5/optimized.cmake
+++ b/boards/px4/fmu-v5/optimized.cmake
@@ -33,7 +33,7 @@ px4_add_board(
 		imu/bmi055
 		imu/invensense/icm20602
 		imu/invensense/icm20689
-		imu/mpu6000
+		#imu/mpu6000 # legacy icm20602/icm20689 driver
 		irlock
 		#lights/blinkm
 		lights/rgbled

--- a/boards/px4/fmu-v5/rover.cmake
+++ b/boards/px4/fmu-v5/rover.cmake
@@ -26,7 +26,9 @@ px4_add_board(
 		imu/adis16477
 		imu/adis16497
 		imu/bmi055
-		imu/mpu6000
+		imu/invensense/icm20602
+		imu/invensense/icm20689
+		#imu/mpu6000 # legacy icm20602/icm20689 driver
 		lights/rgbled
 		lights/rgbled_ncp5623c
 		lights/rgbled_pwm

--- a/boards/px4/fmu-v5/rtps.cmake
+++ b/boards/px4/fmu-v5/rtps.cmake
@@ -31,7 +31,9 @@ px4_add_board(
 		imu/adis16477
 		imu/adis16497
 		imu/bmi055
-		imu/mpu6000
+		imu/invensense/icm20602
+		imu/invensense/icm20689
+		#imu/mpu6000 # legacy icm20602/icm20689 driver
 		irlock
 		lights/blinkm
 		lights/rgbled
@@ -50,6 +52,7 @@ px4_add_board(
 		px4io
 		rc_input
 		roboclaw
+		rpm
 		safety_button
 		tap_esc
 		telemetry # all available telemetry drivers

--- a/boards/px4/fmu-v5/stackcheck.cmake
+++ b/boards/px4/fmu-v5/stackcheck.cmake
@@ -32,7 +32,9 @@ px4_add_board(
 		#imu/adis16477
 		#imu/adis16497
 		#imu/bmi055
-		imu/mpu6000
+		#imu/invensense/icm20602
+		imu/invensense/icm20689
+		#imu/mpu6000 # legacy icm20602/icm20689 driver
 		#irlock
 		#lights/blinkm
 		lights/rgbled

--- a/boards/px4/fmu-v5x/default.cmake
+++ b/boards/px4/fmu-v5x/default.cmake
@@ -32,7 +32,7 @@ px4_add_board(
 		imu/adis16477
 		imu/adis16497
 		imu/bmi088
-		imu/mpu6000
+		imu/invensense/icm20602
 		imu/st/ism330dlc
 		irlock
 		lights/blinkm

--- a/boards/px4/fmu-v5x/init/rc.board_sensors
+++ b/boards/px4/fmu-v5x/init/rc.board_sensors
@@ -10,7 +10,7 @@ ina226 -X -b 1 -t 1 -k start
 ina226 -X -b 2 -t 2 -k start
 
 # Internal SPI bus ICM-20602
-mpu6000 -R 8 -s -T 20602 start
+icm20602 -R 2 -s start
 
 # Internal SPI bus ISM300DLC
 ism330dlc -s start

--- a/boards/px4/fmu-v5x/p2_base_phy_LAN8742Ai.cmake
+++ b/boards/px4/fmu-v5x/p2_base_phy_LAN8742Ai.cmake
@@ -32,7 +32,7 @@ px4_add_board(
 		imu/adis16477
 		imu/adis16497
 		imu/bmi088
-		imu/mpu6000
+		imu/invensense/icm20602
 		imu/st/ism330dlc
 		irlock
 		lights/blinkm

--- a/boards/px4/raspberrypi/default.cmake
+++ b/boards/px4/raspberrypi/default.cmake
@@ -20,7 +20,7 @@ px4_add_board(
 		distance_sensor # all available distance sensor drivers
 		gps
 		#imu # all available imu drivers
-		imu/mpu9250
+		imu/invensense/mpu9250
 		linux_pwm_out
 		#magnetometer # all available magnetometer drivers
 		magnetometer/hmc5883

--- a/boards/uvify/core/default.cmake
+++ b/boards/uvify/core/default.cmake
@@ -22,8 +22,9 @@ px4_add_board(
 		distance_sensor # all available distance sensor drivers
 		dshot
 		gps
-		imu/mpu6000
-		imu/mpu9250
+		imu/invensense/icm20602
+		imu/invensense/icm20608g
+		imu/invensense/mpu9250
 		irlock
 		lights/rgbled_ncp5623c
 		magnetometer/bmm150

--- a/boards/uvify/core/init/rc.board_sensors
+++ b/boards/uvify/core/init/rc.board_sensors
@@ -17,8 +17,8 @@ then
 	# GPS LED
 	rgbled_ncp5623c start -X -a 0x38
 
-	#mpu6000 -s -R 4 -T 20608 start
-	mpu9250 start -s -R 4
+	#icm20608g -s -R 10 start
+	mpu9250 start -s -R 10
 
 	# Default GNSS with LIS3MDL magnetometer with external i2c.
 	lis3mdl start -R 2 -X
@@ -27,7 +27,7 @@ fi
 # Draco
 if param compare SYS_AUTOSTART 4072
 then
-	mpu9250 start -s -R 2
+	mpu9250 start -s -R 8
 fi
 
 # IFO
@@ -39,7 +39,7 @@ then
 	# IFO rgb LED
 	pca9685 -X start
 
-	mpu9250 start -s -R 2
+	mpu9250 start -s -R 8
 	lis3mdl start -R 2 -X
 fi
 
@@ -50,9 +50,9 @@ then
 	rgbled_ncp5623c start -X -a 0x38
 
 	# IMU
-	mpu9250 start -s -R 2
+	mpu9250 start -s -R 8
 	lis3mdl start -R 2 -X
 
 	# FLOW on SPI2
-	pmw3901 start -s 2
+	pmw3901 start -s -b 2
 fi

--- a/boards/uvify/core/nuttx-config/include/board.h
+++ b/boards/uvify/core/nuttx-config/include/board.h
@@ -225,6 +225,7 @@
 
 /* UART8 has no alternate pin config */
 
+
 /*
  * CAN
  *

--- a/posix-configs/ocpoc/px4.config
+++ b/posix-configs/ocpoc/px4.config
@@ -15,7 +15,7 @@ param set MAV_BROADCAST 1
 param set MAV_TYPE 2
 param set MAV_SYS_ID 1
 
-mpu9250 -s -R 10 start
+mpu9250 -s -R 4 start
 hmc5883 -I start
 ms5611 -s start
 

--- a/posix-configs/rpi/px4.config
+++ b/posix-configs/rpi/px4.config
@@ -14,10 +14,11 @@ fi
 param set SYS_AUTOSTART 4001
 param set MAV_BROADCAST 1
 param set MAV_TYPE 2
+param set IMU_GYRO_RATEMAX 400
 
 dataman start
 
-mpu9250 -s -R 8 start
+mpu9250 -s -R 2 start
 lsm9ds1 -s -R 4 start
 lsm9ds1_mag -s -R 4 start
 ms5611 -X start

--- a/posix-configs/rpi/px4_fw.config
+++ b/posix-configs/rpi/px4_fw.config
@@ -14,10 +14,11 @@ fi
 param set MAV_BROADCAST 1
 param set SYS_AUTOSTART 2100
 param set MAV_TYPE 1
+param set IMU_GYRO_RATEMAX 400
 
 dataman start
 
-mpu9250 -s -R 8 start
+mpu9250 -s -R 2 start
 lsm9ds1 -s -R 4 start
 lsm9ds1_mag -s -R 4 start
 ms5611 -X start

--- a/posix-configs/rpi/px4_test.config
+++ b/posix-configs/rpi/px4_test.config
@@ -14,10 +14,11 @@ fi
 param set SYS_AUTOSTART 4001
 param set MAV_BROADCAST 1
 param set MAV_TYPE 2
+param set IMU_GYRO_RATEMAX 400
 
 dataman start
 
-mpu9250 -s -R 8 start
+mpu9250 -s -R 2 start
 lsm9ds1 -s -R 4 start
 lsm9ds1_mag -s -R 4 start
 ms5611 -X start

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1770,6 +1770,10 @@ void Logger::write_version(LogType type)
 		write_info(type, "sys_mcu", mcu_ver);
 	}
 
+	// data versioning: increase this on every larger data change (format/semantic)
+	// 1: switch to FIFO drivers (disabled on-chip DLPF)
+	write_info(type, "ver_data_format", 1);
+
 #ifndef BOARD_HAS_NO_UUID
 
 	/* write the UUID if enabled */


### PR DESCRIPTION
A lot of this has already received testing in one form or another. This PR finally makes the switch to the new InvenSense drivers (almost) everywhere.

 - 8 kHz gyro, 4 kHz accel using FIFOs and SPI DMA (mpu6000 accel is 1 kHz)
 - significantly reduces jitter in the system (regular driver scheduling synchronized with sensor, no more timer correction fudge factor)
 - clip counters
 - sensor side DLPF completely disabled (other than mpu6000)
 - with IMU_GYRO_RATEMAX drivers can run both faster (up to 4 kHz on new boards) or slower (down to 250 Hz) while still fetching and processing all raw data (8 kHz)
     - this let's you configure the system for high performance racing setups or optionally significantly lowering cpu usage when a high rate inner loop isn't necessary
 - it's much easier to see at a glance if the sensor and driver are working correctly together
      - sensor setup and driver are internally consistent (configured ODR, data ready interrupt, etc), so if something isn't configured or operating correctly it becomes extremely obvious
 - drivers have simple data consistentcy check (duplicated accel data) that can be used to set the max SPI speed safely (eg mpu6000, mpu6500, mpu9250 capable of 20 MHz SPI, but have been limited to 10 MHz to reduce transfer errors)
 - mpu9250 mag disabled by default (it weirdly impacts the data output rate)
 - Note: in many cases the secondary IMUs are still unchanged
      - fmu-v2/v3 (lsm303d + l3gd20)
      - fmu-v5 bmi055
      - fmu-v5x bmi088
      - modalal_fc-v1 bmi088
      - holybro_durandal-v1 bmi088

TODO: board rotations + testing
 - [x] airmind/mindpx-v2
 - [x] emlid/navio2
 - [x] holybro/durandal-v1
 - [x] modalai/fc-v1
 - [x] mro/ctrl-zero-f7
 - [x] px4/fmu-v2
 - [x] px4/fmu-v3
 - [x] px4/fmu-v4
 - [x] px4/fmu-v4pro
 - [x] px4/fmu-v5
    - https://review.px4.io/plot_app?log=6a74189a-82d2-4241-91ac-03a5b0dc2ca8
    - https://review.px4.io/plot_app?log=f3f445fb-bbf4-433e-bf44-2c5314dce720
    - https://review.px4.io/plot_app?log=39718629-fc97-4b0b-a62b-707e0a8dc0df
 - [x] px4/fmu-v5x
 - [x] uvify/core
