### PR TITLE
AutoSmoothVel: Fix straight line autocontinue

### DIFF
--- a/src/lib/flight_tasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
+++ b/src/lib/flight_tasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
@@ -263,8 +263,8 @@ void FlightTaskAutoLineSmoothVel::_prepareSetpoints()
 			const float z_speed = _getMaxZSpeed();
 
 			Vector3f vel_sp_constrained = u_pos_traj_to_dest * sqrtf(xy_speed * xy_speed + z_speed * z_speed);
-			math::trajectory::clampToXYNorm(vel_sp_constrained, xy_speed);
-			math::trajectory::clampToZNorm(vel_sp_constrained, z_speed);
+			math::trajectory::clampToXYNorm(vel_sp_constrained, xy_speed, 0.5f);
+			math::trajectory::clampToZNorm(vel_sp_constrained, z_speed, 0.5f);
 
 			for (int i = 0; i < 3; i++) {
 				// If available, use the existing velocity as a feedforward, otherwise replace it


### PR DESCRIPTION
This fixes the issue that makes the drone slow-down even in straight lines due to the Z component being constrained to a really small value.

With master:
https://logs.px4.io/plot_app?log=f7efacca-6262-4a65-b4e2-39c7e4f2f5bb
![2020-03-25_14-34-27_01_plot](https://user-images.githubusercontent.com/14822839/77541925-b2676080-6ea5-11ea-83fa-9aac67a414f3.png)

This PR:
https://logs.px4.io/plot_app?log=1692b126-f195-48c1-8150-2b1b499a900e
![2020-03-25_14-30-07_01_plot](https://user-images.githubusercontent.com/14822839/77541555-19d0e080-6ea5-11ea-9117-020ddfb92836.png)

Thanks @jkflying for the help.
