### PR TITLE
apply replay module params before starting ekf2 module

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rc.replay
+++ b/ROMFS/px4fmu_common/init.d-posix/rc.replay
@@ -12,6 +12,7 @@ EOF
 uorb start
 param set SDLOG_DIRS_MAX 7
 
+# apply all params before ekf starts, as some params cannot be changed after startup
 replay tryapplyparams
 ekf2 start -r
 logger start -f -t -b 1000 -p vehicle_attitude

--- a/ROMFS/px4fmu_common/init.d-posix/rc.replay
+++ b/ROMFS/px4fmu_common/init.d-posix/rc.replay
@@ -12,6 +12,7 @@ EOF
 uorb start
 param set SDLOG_DIRS_MAX 7
 
+replay tryapplyparams
 ekf2 start -r
 logger start -f -t -b 1000 -p vehicle_attitude
 sleep 0.2


### PR DESCRIPTION
**Describe problem solved by this pull request**
Currently, replay module params are loaded after starting ekf2 module in rc.replay. This causes log file being replayed and the replay session having mismatch in some ekf2 parameters.

**Describe your solution**
Run 'replay tryapplyparams' before starting ekf2 module

Possibly fixes the issue #14260