### PR TITLE
camera_trigger: lower the polling rate from 200Hz to 20Hz

### DIFF
--- a/src/drivers/camera_trigger/camera_trigger.cpp
+++ b/src/drivers/camera_trigger/camera_trigger.cpp
@@ -512,7 +512,7 @@ void
 CameraTrigger::Run()
 {
 	// default loop polling interval
-	int poll_interval_usec = 5000;
+	int poll_interval_usec = 50000;
 
 	vehicle_command_s cmd{};
 	unsigned cmd_result = vehicle_command_s::VEHICLE_CMD_RESULT_TEMPORARILY_REJECTED;


### PR DESCRIPTION
Camera trigger has a polling rate of 200Hz. This PR lowers it to 20Hz which saves a tiny amount of CPU (0.25% on a pixracer board).

Was there a good reason for running this module so frequently?