### PR TITLE
Enhancement: 0.3 for TFMini was too low, as TFmini outputs slightly m…

### DIFF
--- a/src/drivers/distance_sensor/tfmini/TFMINI.cpp
+++ b/src/drivers/distance_sensor/tfmini/TFMINI.cpp
@@ -60,6 +60,11 @@ TFMINI::init()
 
 	switch (hw_model) {
 	case 1: // TFMINI (12m, 100 Hz)
+		// Note:
+		// Sensor specification shows 0.3m as minimum, but in practice
+		// 0.3 is too close to minimum so chattering of invalid sensor decision
+		// is happening sometimes. this cause EKF to believe inconsistent range readings.
+		// So we set 0.4 as valid minimum.
 		_px4_rangefinder.set_min_distance(0.4f);
 		_px4_rangefinder.set_max_distance(12.0f);
 		_px4_rangefinder.set_fov(math::radians(1.15f));

--- a/src/drivers/distance_sensor/tfmini/TFMINI.cpp
+++ b/src/drivers/distance_sensor/tfmini/TFMINI.cpp
@@ -60,7 +60,7 @@ TFMINI::init()
 
 	switch (hw_model) {
 	case 1: // TFMINI (12m, 100 Hz)
-		_px4_rangefinder.set_min_distance(0.3f);
+		_px4_rangefinder.set_min_distance(0.4f);
 		_px4_rangefinder.set_max_distance(12.0f);
 		_px4_rangefinder.set_fov(math::radians(1.15f));
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
TFMini outputs more than 0.3 when it is very near to the ground.
This cause EKF not fallback to barometer in worst case.

**Describe your solution**
Adjust TFmini min_distance from 0.3 to 0.4 to check faulty condition more precisely.

**Describe possible alternatives**
A clear and concise description of alternative solutions or features you've considered.

**Test data / coverage**
We mounted tfmini on the bottom of vehicle, and debugged with EKF2. When TFmini faulty with in-air condition, it fallback to barometer in vertical fusion.
