### PR TITLE
Add battery status from ESCs, refactor battery source param

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -348,6 +348,11 @@ else
 
 		sh /etc/init.d/rc.sensors
 
+		if param compare -s BAT1_SOURCE 2
+		then
+			esc_battery start
+		fi
+
 		battery_status start
 		commander start
 	fi

--- a/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
+++ b/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
@@ -411,7 +411,8 @@ Syslink::handle_message(syslink_message_t *msg)
 		memcpy(&vbat, &msg->data[1], sizeof(float));
 		//memcpy(&iset, &msg->data[5], sizeof(float));
 
-		_battery.updateBatteryStatus(t, vbat, -1, true, true, 0, 0, true);
+		_battery.updateBatteryStatus(t, vbat, -1, true,
+					     battery_status_s::BATTERY_SOURCE_POWER_MODULE, 0, 0);
 
 
 		// Update battery charge state

--- a/boards/px4/fmu-v2/default.cmake
+++ b/boards/px4/fmu-v2/default.cmake
@@ -71,6 +71,7 @@ px4_add_board(
 		commander
 		dataman
 		ekf2
+		#esc_battery
 		#events
 		fw_att_control
 		fw_pos_control_l1

--- a/boards/px4/fmu-v3/default.cmake
+++ b/boards/px4/fmu-v3/default.cmake
@@ -68,6 +68,7 @@ px4_add_board(
 		commander
 		dataman
 		ekf2
+		esc_battery
 		events
 		fw_att_control
 		fw_pos_control_l1

--- a/boards/px4/fmu-v4/default.cmake
+++ b/boards/px4/fmu-v4/default.cmake
@@ -63,6 +63,7 @@ px4_add_board(
 		commander
 		dataman
 		ekf2
+		esc_battery
 		events
 		fw_att_control
 		fw_pos_control_l1

--- a/boards/px4/fmu-v4pro/default.cmake
+++ b/boards/px4/fmu-v4pro/default.cmake
@@ -64,6 +64,7 @@ px4_add_board(
 		commander
 		dataman
 		ekf2
+		esc_battery
 		events
 		fw_att_control
 		fw_pos_control_l1

--- a/boards/px4/fmu-v5/default.cmake
+++ b/boards/px4/fmu-v5/default.cmake
@@ -67,6 +67,7 @@ px4_add_board(
 		commander
 		dataman
 		ekf2
+		esc_battery
 		events
 		fw_att_control
 		fw_pos_control_l1

--- a/boards/px4/fmu-v5x/default.cmake
+++ b/boards/px4/fmu-v5x/default.cmake
@@ -65,6 +65,7 @@ px4_add_board(
 		commander
 		dataman
 		ekf2
+		esc_battery
 		events
 		fw_att_control
 		fw_pos_control_l1

--- a/msg/battery_status.msg
+++ b/msg/battery_status.msg
@@ -10,7 +10,11 @@ float32 scale		# Power scaling factor, >= 1, or -1 if unknown
 float32 temperature         # temperature of the battery. NaN if unknown
 int32 cell_count		# Number of cells
 bool connected			# Whether or not a battery is connected, based on a voltage threshold
-bool system_source		# Whether or not a this battery is the active power source for VDD_5V_IN
+
+uint8 BATTERY_SOURCE_POWER_MODULE = 0
+uint8 BATTERY_SOURCE_EXTERNAL = 0
+uint8 BATTERY_SOURCE_ESCS = 0
+uint8 source		# Battery source
 uint8 priority        	# Zero based priority is the connection on the Power Controller V1..Vn AKA BrickN-1
 uint16 capacity         # actual capacity of the battery
 uint16 cycle_count         # number of discharge cycles the battery has experienced

--- a/msg/battery_status.msg
+++ b/msg/battery_status.msg
@@ -11,7 +11,7 @@ float32 temperature         # temperature of the battery. NaN if unknown
 int32 cell_count		# Number of cells
 bool connected			# Whether or not a battery is connected, based on a voltage threshold
 bool system_source		# Whether or not a this battery is the active power source for VDD_5V_IN
-uint8 priority        	# Zerro based priority is the connection on the Power Controller V1..Vn AKA BrickN-1
+uint8 priority        	# Zero based priority is the connection on the Power Controller V1..Vn AKA BrickN-1
 uint16 capacity         # actual capacity of the battery
 uint16 cycle_count         # number of discharge cycles the battery has experienced
 uint16 run_time_to_empty   # predicted remaining battery capacity based on the present rate of discharge in min

--- a/msg/battery_status.msg
+++ b/msg/battery_status.msg
@@ -12,8 +12,8 @@ int32 cell_count		# Number of cells
 bool connected			# Whether or not a battery is connected, based on a voltage threshold
 
 uint8 BATTERY_SOURCE_POWER_MODULE = 0
-uint8 BATTERY_SOURCE_EXTERNAL = 0
-uint8 BATTERY_SOURCE_ESCS = 0
+uint8 BATTERY_SOURCE_EXTERNAL = 1
+uint8 BATTERY_SOURCE_ESCS = 2
 uint8 source		# Battery source
 uint8 priority        	# Zero based priority is the connection on the Power Controller V1..Vn AKA BrickN-1
 uint16 capacity         # actual capacity of the battery

--- a/src/drivers/power_monitor/ina226/ina226.cpp
+++ b/src/drivers/power_monitor/ina226/ina226.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019-2020 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -88,10 +88,9 @@ INA226::INA226(I2CSPIBusOption bus_option, const int bus, int bus_frequency, int
 		0.0,
 		0.0,
 		false,
-		false, // TODO: selected source?
+		battery_status_s::BATTERY_SOURCE_POWER_MODULE,
 		0,
-		0.0,
-		true
+		0.0
 	);
 }
 
@@ -262,10 +261,9 @@ INA226::collect()
 			(float) _bus_voltage * INA226_VSCALE,
 			(float) _current * _current_lsb,
 			true,
-			true, // TODO: Determine if this is the selected source
+			battery_status_s::BATTERY_SOURCE_POWER_MODULE,
 			0,
-			_actuator_controls.control[actuator_controls_s::INDEX_THROTTLE],
-			true
+			_actuator_controls.control[actuator_controls_s::INDEX_THROTTLE]
 		);
 
 		ret = OK;
@@ -276,10 +274,9 @@ INA226::collect()
 			0.0,
 			0.0,
 			false,
-			false, // TODO: selected source?
+			battery_status_s::BATTERY_SOURCE_POWER_MODULE,
 			0,
-			0.0,
-			true
+			0.0
 		);
 		ret = -1;
 		perf_count(_comms_errors);
@@ -352,10 +349,9 @@ INA226::RunImpl()
 			0.0f,
 			0.0f,
 			false,
-			false,
+			battery_status_s::BATTERY_SOURCE_POWER_MODULE,
 			0,
-			0.0f,
-			true
+			0.0f
 		);
 
 		if (init() != OK) {

--- a/src/drivers/power_monitor/voxlpm/voxlpm.cpp
+++ b/src/drivers/power_monitor/voxlpm/voxlpm.cpp
@@ -149,7 +149,8 @@ VOXLPM::measure()
 
 		switch (_ch_type) {
 		case VOXLPM_CH_TYPE_VBATT: {
-				_battery.updateBatteryStatus(tnow, _voltage, _amperage, true, true, 0, 0, true);
+				_battery.updateBatteryStatus(tnow, _voltage, _amperage, true,
+							     battery_status_s::BATTERY_SOURCE_POWER_MODULE, 0, 0);
 			}
 
 		// fallthrough
@@ -170,7 +171,8 @@ VOXLPM::measure()
 	} else {
 		switch (_ch_type) {
 		case VOXLPM_CH_TYPE_VBATT: {
-				_battery.updateBatteryStatus(tnow, 0.0, 0.0, true, true, 0, 0, true);
+				_battery.updateBatteryStatus(tnow, 0.0, 0.0, true,
+							     battery_status_s::BATTERY_SOURCE_POWER_MODULE, 0, 0);
 			}
 			break;
 

--- a/src/drivers/uavcan/sensors/battery.cpp
+++ b/src/drivers/uavcan/sensors/battery.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019-2020 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -95,7 +95,7 @@ UavcanBatteryBridge::battery_sub_cb(const uavcan::ReceivedDataStructure<uavcan::
 	// battery.average_time_to_empty = msg.;
 	battery.serial_number = msg.model_instance_id;
 	battery.connected = true;
-	battery.system_source = msg.status_flags & uavcan::equipment::power::BatteryInfo::STATUS_FLAG_IN_USE;
+	battery.source = battery_status_s::BATTERY_SOURCE_POWER_MODULE;
 	// battery.priority = msg.;
 	// battery.is_powering_off = msg.;
 	// battery.warning = msg.;

--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019-2020 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -121,8 +121,8 @@ Battery::reset()
 
 void
 Battery::updateBatteryStatus(hrt_abstime timestamp, float voltage_v, float current_a,
-			     bool connected, bool selected_source, int priority,
-			     float throttle_normalized, bool should_publish)
+			     bool connected, int source, int priority,
+			     float throttle_normalized)
 {
 	reset();
 	_battery_status.timestamp = timestamp;
@@ -148,7 +148,7 @@ Battery::updateBatteryStatus(hrt_abstime timestamp, float voltage_v, float curre
 		_battery_status.warning = _warning;
 		_battery_status.remaining = _remaining;
 		_battery_status.connected = connected;
-		_battery_status.system_source = selected_source;
+		_battery_status.source = source;
 		_battery_status.priority = priority;
 
 		static constexpr int uorb_max_cells = sizeof(_battery_status.voltage_cell_v) / sizeof(
@@ -161,6 +161,8 @@ Battery::updateBatteryStatus(hrt_abstime timestamp, float voltage_v, float curre
 	}
 
 	_battery_status.timestamp = timestamp;
+
+	const bool should_publish = (source == _params.source);
 
 	if (should_publish) {
 		publish();

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019-2020 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -87,21 +87,18 @@ public:
 	 */
 	float full_cell_voltage() { return _params.v_charged; }
 
-	int source() { return _params.source; }
-
 	/**
 	 * Update current battery status message.
 	 *
 	 * @param voltage_raw: Battery voltage, in Volts
 	 * @param current_raw: Battery current, in Amps
 	 * @param timestamp: Time at which the ADC was read (use hrt_absolute_time())
-	 * @param selected_source: This battery is on the brick that the selected source for selected_source
+	 * @param source: Source type in relation to BAT%d_SOURCE param.
 	 * @param priority: The brick number -1. The term priority refers to the Vn connection on the LTC4417
 	 * @param throttle_normalized: Throttle of the vehicle, between 0 and 1
-	 * @param should_publish If True, this function published a battery_status uORB message.
 	 */
 	void updateBatteryStatus(hrt_abstime timestamp, float voltage_v, float current_a, bool connected,
-				 bool selected_source, int priority, float throttle_normalized, bool should_publish);
+				 int source, int priority, float throttle_normalized);
 
 	/**
 	 * Publishes the uORB battery_status message with the most recently-updated data.

--- a/src/lib/battery/module.yaml
+++ b/src/lib/battery/module.yaml
@@ -130,6 +130,7 @@ parameters:
                     means that measurements are expected to come from a power module. If the value is set to
                     'External' then the system expects to receive mavlink battery status messages.
                     If the value is set to 'ESCs', the battery information are taken from the esc_status message.
+                    This requires the ESC to provide both voltage as well as current.
             type: enum
             values:
                 0: Power Module

--- a/src/lib/battery/module.yaml
+++ b/src/lib/battery/module.yaml
@@ -129,11 +129,12 @@ parameters:
                     This parameter controls the source of battery data. The value 'Power Module'
                     means that measurements are expected to come from a power module. If the value is set to
                     'External' then the system expects to receive mavlink battery status messages.
+                    If the value is set to 'ESCs', the battery information are taken from the esc_status message.
             type: enum
-            unit: mAh
             values:
                 0: Power Module
                 1: External
+                2: ESCs
             reboot_required: true
             num_instances: *max_num_config_instances
             instance_start: 1

--- a/src/modules/battery_status/analog_battery.cpp
+++ b/src/modules/battery_status/analog_battery.cpp
@@ -41,7 +41,7 @@ AnalogBattery::AnalogBattery(int index, ModuleParams *parent) :
 
 void
 AnalogBattery::updateBatteryStatusADC(hrt_abstime timestamp, float voltage_raw, float current_raw,
-				      bool selected_source, int priority, float throttle_normalized)
+				      int source, int priority, float throttle_normalized)
 {
 	float voltage_v = voltage_raw * _analog_params.v_div;
 	float current_a = (current_raw - _analog_params.v_offs_cur) * _analog_params.a_per_v;
@@ -51,7 +51,7 @@ AnalogBattery::updateBatteryStatusADC(hrt_abstime timestamp, float voltage_raw, 
 
 
 	Battery::updateBatteryStatus(timestamp, voltage_v, current_a, connected,
-				     selected_source, priority, throttle_normalized, _params.source == 0);
+				     source, priority, throttle_normalized);
 }
 
 bool AnalogBattery::is_valid()

--- a/src/modules/battery_status/analog_battery.h
+++ b/src/modules/battery_status/analog_battery.h
@@ -47,12 +47,12 @@ public:
 	 * @param voltage_raw Battery voltage read from ADC, volts
 	 * @param current_raw Voltage of current sense resistor, volts
 	 * @param timestamp Time at which the ADC was read (use hrt_absolute_time())
-	 * @param selected_source This battery is on the brick that the selected source for selected_source
+	 * @param source The source as defined by param BAT%d_SOURCE
 	 * @param priority: The brick number -1. The term priority refers to the Vn connection on the LTC4417
 	 * @param throttle_normalized Throttle of the vehicle, between 0 and 1
 	 */
 	void updateBatteryStatusADC(hrt_abstime timestamp, float voltage_raw, float current_raw,
-				    bool selected_source, int priority, float throttle_normalized);
+				    int source, int priority, float throttle_normalized);
 
 	/**
 	 * Whether the ADC channel for the voltage of this battery is valid.

--- a/src/modules/battery_status/battery_status.cpp
+++ b/src/modules/battery_status/battery_status.cpp
@@ -176,11 +176,6 @@ BatteryStatus::adc_poll()
 	float bat_current_adc_readings[BOARD_NUMBER_BRICKS] {};
 	float bat_voltage_adc_readings[BOARD_NUMBER_BRICKS] {};
 
-	/* Based on the valid_chan, used to indicate the selected the lowest index
-	 * (highest priority) supply that is the source for the VDD_5V_IN
-	 * When < 0 none selected
-	 */
-
 	int selected_source = -1;
 
 	adc_report_s adc_report;
@@ -200,7 +195,6 @@ BatteryStatus::adc_poll()
 					 * VDD_5V_IN
 					 */
 					selected_source = b;
-
 				}
 
 				/* look for specific channels and process the raw voltage to measurement data */
@@ -221,19 +215,18 @@ BatteryStatus::adc_poll()
 		}
 
 		for (int b = 0; b < BOARD_NUMBER_BRICKS; b++) {
-			if (_analogBatteries[b]->source() == 0) {
-				actuator_controls_s ctrl{};
-				_actuator_ctrl_0_sub.copy(&ctrl);
 
-				_analogBatteries[b]->updateBatteryStatusADC(
-					hrt_absolute_time(),
-					bat_voltage_adc_readings[b],
-					bat_current_adc_readings[b],
-					selected_source == b,
-					b,
-					ctrl.control[actuator_controls_s::INDEX_THROTTLE]
-				);
-			}
+			actuator_controls_s ctrl{};
+			_actuator_ctrl_0_sub.copy(&ctrl);
+
+			_analogBatteries[b]->updateBatteryStatusADC(
+				hrt_absolute_time(),
+				bat_voltage_adc_readings[b],
+				bat_current_adc_readings[b],
+				battery_status_s::BATTERY_SOURCE_POWER_MODULE,
+				b,
+				ctrl.control[actuator_controls_s::INDEX_THROTTLE]
+			);
 		}
 	}
 }

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3822,6 +3822,8 @@ void Commander::battery_status_check()
 	// oldest timestamp.
 	hrt_abstime oldest_update = hrt_absolute_time();
 
+	_battery_current = 0.0f;
+
 	// Only iterate over connected batteries. We don't care if a disconnected battery is not regularly publishing.
 	for (size_t i = 0; i < num_connected_batteries; i++) {
 		if (batteries[i].warning > worst_warning) {
@@ -3832,9 +3834,8 @@ void Commander::battery_status_check()
 			oldest_update = batteries[i].timestamp;
 		}
 
-		if (batteries[i].system_source) {
-			_battery_current = batteries[i].current_filtered_a;
-		}
+		// Sum up current from all batteries.
+		_battery_current += batteries[i].current_filtered_a;
 	}
 
 	bool battery_warning_level_increased_while_armed = false;

--- a/src/modules/esc_battery/CMakeLists.txt
+++ b/src/modules/esc_battery/CMakeLists.txt
@@ -1,0 +1,43 @@
+############################################################################
+#
+#   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+px4_add_module(
+	MODULE modules__esc_battery
+	MAIN esc_battery
+	COMPILE_FLAGS
+	SRCS
+		EscBattery.cpp
+		EscBattery.hpp
+	DEPENDS
+		px4_work_queue
+	)

--- a/src/modules/esc_battery/EscBattery.cpp
+++ b/src/modules/esc_battery/EscBattery.cpp
@@ -39,7 +39,7 @@ using namespace time_literals;
 EscBattery::EscBattery() :
 	ModuleParams(nullptr),
 	WorkItem(MODULE_NAME, px4::wq_configurations::lp_default),
-	_battery(3, this)
+	_battery(1, this)
 {
 	parameters_updated();
 }

--- a/src/modules/esc_battery/EscBattery.cpp
+++ b/src/modules/esc_battery/EscBattery.cpp
@@ -86,7 +86,7 @@ EscBattery::Run()
 
 	if (_esc_status_sub.update(&esc_status)) {
 
-		if (hrt_elapsed_time(&esc_status.timestamp) < 500_ms ||
+		if (hrt_elapsed_time(&esc_status.timestamp) > 500_ms ||
 		    esc_status.esc_count == 0 ||
 		    esc_status.esc_count > 8) {
 			return;

--- a/src/modules/esc_battery/EscBattery.cpp
+++ b/src/modules/esc_battery/EscBattery.cpp
@@ -80,7 +80,9 @@ EscBattery::Run()
 
 	if (_esc_status_sub.copy(&esc_status)) {
 
-		if (esc_status.esc_count == 0 ||
+		int online_bitmask = (1 << esc_status.esc_count) - 1;
+
+		if (online_bitmask != esc_status.esc_online_flags || esc_status.esc_count == 0 ||
 		    esc_status.esc_count > esc_status_s::CONNECTED_ESC_MAX) {
 			return;
 		}

--- a/src/modules/esc_battery/EscBattery.cpp
+++ b/src/modules/esc_battery/EscBattery.cpp
@@ -32,7 +32,6 @@
  ****************************************************************************/
 
 #include "EscBattery.hpp"
-#include <drivers/drv_hrt.h>
 
 using namespace time_literals;
 
@@ -40,11 +39,6 @@ EscBattery::EscBattery() :
 	ModuleParams(nullptr),
 	WorkItem(MODULE_NAME, px4::wq_configurations::lp_default),
 	_battery(1, this)
-{
-	parameters_updated();
-}
-
-EscBattery::~EscBattery()
 {
 }
 
@@ -84,11 +78,10 @@ EscBattery::Run()
 
 	esc_status_s esc_status;
 
-	if (_esc_status_sub.update(&esc_status)) {
+	if (_esc_status_sub.copy(&esc_status)) {
 
-		if (hrt_elapsed_time(&esc_status.timestamp) > 500_ms ||
-		    esc_status.esc_count == 0 ||
-		    esc_status.esc_count > 8) {
+		if (esc_status.esc_count == 0 ||
+		    esc_status.esc_count > esc_status_s::CONNECTED_ESC_MAX) {
 			return;
 		}
 

--- a/src/modules/esc_battery/EscBattery.cpp
+++ b/src/modules/esc_battery/EscBattery.cpp
@@ -103,9 +103,7 @@ EscBattery::Run()
 		average_voltage_v /= esc_status.esc_count;
 
 		const bool connected = true;
-		const bool selected_source = true;
 		const int priority = 0;
-		const bool should_publish = true;
 
 		actuator_controls_s ctrl;
 		_actuator_ctrl_0_sub.copy(&ctrl);
@@ -115,10 +113,9 @@ EscBattery::Run()
 			average_voltage_v,
 			total_current_a,
 			connected,
-			selected_source,
+			battery_status_s::BATTERY_SOURCE_ESCS,
 			priority,
-			ctrl.control[actuator_controls_s::INDEX_THROTTLE],
-			should_publish);
+			ctrl.control[actuator_controls_s::INDEX_THROTTLE]);
 		_battery.publish();
 	}
 }

--- a/src/modules/esc_battery/EscBattery.cpp
+++ b/src/modules/esc_battery/EscBattery.cpp
@@ -1,0 +1,177 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "EscBattery.hpp"
+#include <drivers/drv_hrt.h>
+
+using namespace time_literals;
+
+EscBattery::EscBattery() :
+	ModuleParams(nullptr),
+	WorkItem(MODULE_NAME, px4::wq_configurations::lp_default),
+	_battery(3, this)
+{
+	parameters_updated();
+}
+
+EscBattery::~EscBattery()
+{
+}
+
+bool
+EscBattery::init()
+{
+	if (!_esc_status_sub.registerCallback()) {
+		PX4_ERR("esc_status callback registration failed!");
+		return false;
+	}
+
+	return true;
+}
+
+void
+EscBattery::parameters_updated()
+{
+	ModuleParams::updateParams();
+}
+
+void
+EscBattery::Run()
+{
+	if (should_exit()) {
+		_esc_status_sub.unregisterCallback();
+		exit_and_cleanup();
+		return;
+	}
+
+	if (_parameter_update_sub.updated()) {
+		// Clear update
+		parameter_update_s param_update;
+		_parameter_update_sub.copy(&param_update);
+
+		parameters_updated();
+	}
+
+	esc_status_s esc_status;
+
+	if (_esc_status_sub.update(&esc_status)) {
+
+		if (hrt_elapsed_time(&esc_status.timestamp) < 500_ms ||
+		    esc_status.esc_count == 0 ||
+		    esc_status.esc_count > 8) {
+			return;
+		}
+
+		float average_voltage_v = 0.0f;
+		float total_current_a = 0.0f;
+
+		for (unsigned i = 0; i < esc_status.esc_count; ++i) {
+			average_voltage_v += esc_status.esc[i].esc_voltage;
+			total_current_a += esc_status.esc[i].esc_current;
+		}
+
+		average_voltage_v /= esc_status.esc_count;
+
+		const bool connected = true;
+		const bool selected_source = true;
+		const int priority = 0;
+		const bool should_publish = true;
+
+		actuator_controls_s ctrl;
+		_actuator_ctrl_0_sub.copy(&ctrl);
+
+		_battery.updateBatteryStatus(
+			esc_status.timestamp,
+			average_voltage_v,
+			total_current_a,
+			connected,
+			selected_source,
+			priority,
+			ctrl.control[actuator_controls_s::INDEX_THROTTLE],
+			should_publish);
+		_battery.publish();
+	}
+}
+
+int EscBattery::task_spawn(int argc, char *argv[])
+{
+	EscBattery *instance = new EscBattery();
+
+	if (instance) {
+		_object.store(instance);
+		_task_id = task_id_is_work_queue;
+
+		if (instance->init()) {
+			return PX4_OK;
+		}
+
+	} else {
+		PX4_ERR("alloc failed");
+	}
+
+	delete instance;
+	_object.store(nullptr);
+	_task_id = -1;
+
+	return PX4_ERROR;
+}
+
+int EscBattery::custom_command(int argc, char *argv[])
+{
+	return print_usage("unknown command");
+}
+
+int EscBattery::print_usage(const char *reason)
+{
+	if (reason) {
+		PX4_WARN("%s\n", reason);
+	}
+
+	PRINT_MODULE_DESCRIPTION(
+		R"DESCR_STR(
+### Description
+This implements using information from the ESC status and publish it as battery status.
+
+)DESCR_STR");
+
+	PRINT_MODULE_USAGE_NAME("esc_battery", "system");
+	PRINT_MODULE_USAGE_COMMAND("start");
+	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
+
+	return 0;
+}
+
+extern "C" __EXPORT int esc_battery_main(int argc, char *argv[])
+{
+	return EscBattery::main(argc, argv);
+}

--- a/src/modules/esc_battery/EscBattery.hpp
+++ b/src/modules/esc_battery/EscBattery.hpp
@@ -1,0 +1,77 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <px4_platform_common/defines.h>
+#include <px4_platform_common/module.h>
+#include <px4_platform_common/module_params.h>
+#include <px4_platform_common/posix.h>
+#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
+#include <uORB/Publication.hpp>
+#include <uORB/PublicationMulti.hpp>
+#include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionCallback.hpp>
+#include <uORB/topics/esc_status.h>
+#include <uORB/topics/parameter_update.h>
+#include <uORB/topics/actuator_controls.h>
+#include <battery/battery.h>
+
+class EscBattery : public ModuleBase<EscBattery>, public ModuleParams, public px4::WorkItem
+{
+public:
+	EscBattery();
+	~EscBattery() override;
+
+	/** @see ModuleBase */
+	static int task_spawn(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int custom_command(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int print_usage(const char *reason = nullptr);
+
+	bool init();
+
+private:
+	void Run() override;
+
+	void parameters_updated();
+
+	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
+	uORB::Subscription _actuator_ctrl_0_sub{ORB_ID(actuator_controls_0)};
+	uORB::SubscriptionCallbackWorkItem _esc_status_sub{this, ORB_ID(esc_status)};
+
+	Battery _battery;
+};

--- a/src/modules/esc_battery/EscBattery.hpp
+++ b/src/modules/esc_battery/EscBattery.hpp
@@ -51,7 +51,7 @@ class EscBattery : public ModuleBase<EscBattery>, public ModuleParams, public px
 {
 public:
 	EscBattery();
-	~EscBattery() override;
+	~EscBattery() = default;
 
 	/** @see ModuleBase */
 	static int task_spawn(int argc, char *argv[]);

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -2,7 +2,7 @@
  *
  *   Copyright (c) 2015 Mark Charlebois. All rights reserved.
  *   Copyright (c) 2016 Anton Matosov. All rights reserved.
- *   Copyright (c) 2017-2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2017-2020 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -366,7 +366,8 @@ void Simulator::handle_message_hil_sensor(const mavlink_message_t *msg)
 		vbatt *= _battery.cell_count();
 
 		const float throttle = 0.0f; // simulate no throttle compensation to make the estimate predictable
-		_battery.updateBatteryStatus(now_us, vbatt, ibatt, true, true, 0, throttle, true);
+		_battery.updateBatteryStatus(now_us, vbatt, ibatt, true, battery_status_s::BATTERY_SOURCE_POWER_MODULE,
+					     0, throttle);
 
 		_last_battery_timestamp = now_us;
 	}


### PR DESCRIPTION
This PR includes two things:

1. Addition of `esc_battery` module to publish the `battery_status` from `esc_status`.
2. Refactoring of how `BAT%d_SOURCE` param is used. The param is now checked inside of the battery library. If the source set matches the data fed to the library, then it is published, otherwise it isn't.