### PR TITLE
rcS: fixes for SYS_USE_IO=0

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.interface
+++ b/ROMFS/px4fmu_common/init.d/rc.interface
@@ -109,7 +109,7 @@ then
 		fi
 	fi
 
-	if [ $OUTPUT_MODE = io -o $OUTPUT_MODE = uavcan_esc ]
+	if [ $OUTPUT_MODE = io ]
 	then
 		sh /etc/init.d/rc.io
 	fi

--- a/ROMFS/px4fmu_common/init.d/rc.io
+++ b/ROMFS/px4fmu_common/init.d/rc.io
@@ -10,7 +10,7 @@ then
     set HIL_ARG $OUTPUT_MODE
 fi
 
-if [ $USE_IO = yes -a $IO_PRESENT = yes ]
+if [ $IO_PRESENT = yes ]
 then
 	if px4io start $HIL_ARG
 	then

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -427,7 +427,7 @@ else
 	#
 	sh /etc/init.d/rc.serial
 
-	if [ $IO_PRESENT = no -o $USE_IO = no ]
+	if [ $IO_PRESENT = no ]
 	then
 		# Must be started after the serial config is read
 		rc_input start $RC_INPUT_ARGS


### PR DESCRIPTION
rc.io is called from 2 places in rc.interface:
- `if [ $OUTPUT_MODE = io -o $OUTPUT_MODE = uavcan_esc ]`:
  - `set OUTPUT_MODE io` is only set within USE_IO=yes, so removing
    the check in rc.io has no effect.
  - in case of UAVCAN, we also want the IO for RC, now covered in the next
    case.
- Further down ('Start IO for RC input if needed.').
  This is intended to start IO for RC only, when fmu is already started.
  However the previous check '$USE_IO = yes' in rc.io prevented that.

In addition we don't start rc_input in case of $USE_IO = no.

Fixes no RC on Pixhawk 2 with SYS_USE_IO=0.

Tested on (with SYS_USE_IO=1/0):
- Pixhawk 4
- Pixhawk 4 mini
- Pixhawk Cube 2