### PR TITLE
msg/esc_status: added fields to handle ESCs failures

### DIFF
--- a/msg/esc_report.msg
+++ b/msg/esc_report.msg
@@ -5,4 +5,16 @@ float32 esc_voltage					# Voltage measured from current ESC [V] - if supported
 float32 esc_current					# Current measured from current ESC [A] - if supported
 uint8 esc_temperature					# Temperature measured from current ESC [degC] - if supported
 uint8 esc_address					# Address of current ESC (in most cases 1-8 / must be set by driver)
+
 uint8 esc_state					# State of ESC - depend on Vendor
+
+uint8 failures					# Bitmask to indicate the internal ESC faults
+
+uint8 FAILURE_NONE = 0
+uint8 FAILURE_OVER_CURRENT_MASK = 1 		# (1 << 0)
+uint8 FAILURE_OVER_VOLTAGE_MASK = 2 		# (1 << 1)
+uint8 FAILURE_OVER_TEMPERATURE_MASK = 4 	# (1 << 2)
+uint8 FAILURE_OVER_RPM_MASK = 8			# (1 << 3)
+uint8 FAILURE_INCONSISTENT_CMD_MASK = 16 	# (1 << 4)  Set if ESC received an inconsistent command (i.e out of boundaries)
+uint8 FAILURE_MOTOR_STUCK_MASK = 32		# (1 << 5)
+uint8 FAILURE_GENERIC_MASK = 64			# (1 << 6)

--- a/msg/esc_status.msg
+++ b/msg/esc_status.msg
@@ -23,4 +23,6 @@ uint8 esc_online_flags					# Bitmask indicating which ESC is online/offline
 # esc_online_flags bit 6 : Set to 1 if ESC6 is online
 # esc_online_flags bit 7 : Set to 1 if ESC7 is online
 
+uint8 esc_armed_flags					# Bitmask indicating which ESC is armed. For ESC's where the arming state is not known (returned by the ESC), the arming bits should always be set.
+
 esc_report[8] esc

--- a/src/drivers/dshot/dshot.cpp
+++ b/src/drivers/dshot/dshot.cpp
@@ -604,6 +604,7 @@ void DShotOutput::handleNewTelemetryData(int motor_index, const DShotTelemetry::
 		++esc_status.counter;
 		// FIXME: mark all ESC's as online, otherwise commander complains even for a single dropout
 		esc_status.esc_online_flags = (1 << esc_status.esc_count) - 1;
+		esc_status.esc_armed_flags = (1 << esc_status.esc_count) - 1;
 
 		_telemetry->esc_status_pub.update();
 

--- a/src/drivers/mkblctrl/mkblctrl.cpp
+++ b/src/drivers/mkblctrl/mkblctrl.cpp
@@ -611,6 +611,8 @@ MK::task_main()
 			esc.timestamp = hrt_absolute_time();
 			esc.esc_count = (uint8_t) _num_outputs;
 			esc.esc_connectiontype = esc_status_s::ESC_CONNECTION_TYPE_I2C;
+			esc.esc_online_flags = (1 << esc.esc_count) - 1;
+			esc.esc_armed_flags = (1 << esc.esc_count) - 1;
 
 			for (unsigned int i = 0; i < _num_outputs; i++) {
 				esc.esc[i].esc_address = (uint8_t) BLCTRL_BASE_ADDR + i;

--- a/src/drivers/tap_esc/tap_esc.cpp
+++ b/src/drivers/tap_esc/tap_esc.cpp
@@ -573,6 +573,8 @@ void TAP_ESC::cycle()
 					_esc_feedback.esc_connectiontype = esc_status_s::ESC_CONNECTION_TYPE_SERIAL;
 					_esc_feedback.counter++;
 					_esc_feedback.esc_count = num_outputs;
+					_esc_feedback.esc_online_flags = (1 << num_outputs) - 1;
+					_esc_feedback.esc_armed_flags = (1 << num_outputs) - 1;
 
 					_esc_feedback.timestamp = hrt_absolute_time();
 

--- a/src/drivers/uavcan/actuators/esc.cpp
+++ b/src/drivers/uavcan/actuators/esc.cpp
@@ -163,6 +163,7 @@ UavcanEscController::orb_pub_timer_cb(const uavcan::TimerEvent &)
 	_esc_status.counter += 1;
 	_esc_status.esc_connectiontype = esc_status_s::ESC_CONNECTION_TYPE_CAN;
 	_esc_status.esc_online_flags = check_escs_status();
+	_esc_status.esc_armed_flags = (1 << _rotor_count) - 1;
 
 	_esc_status_pub.publish(_esc_status);
 }


### PR DESCRIPTION
**Describe problem solved by this pull request**
This PR is the first piece required for start handling ESC failures.

Currently esc telemetry is not yet used in PX4 architecture to monitor and react to possible ESCs failures.
esc_status field in esc_report.msg is currently defined as _State of ESC - depend on Vendor_  
Which makes the development of a generic logic to handle such states very hard.

**Describe your solution**
By introducing a standard convention of ESCs states that the various drivers can report would allow PX4 architecture to actually use this info for detecting and reacting to ESC failures.

To do so, an additional bitfield, **failures** (uint8), has been introduced with a subset of common ESC failures that a "smart esc" might report.

To indicate which ESCs are ready to operate (=Armed), the field **esc_armed_flags** has been introduced.

In this scenario each driver shall map its custom flags to the PX4 ones. In case a specific failure  does not fall under the defined subset `FAILURE_GENERIC` can be used. Bit 7 is left empty in case we need to expand the failures.

The original `esc_status` is kept mostly for log analysis purposes -> an advanced user (or someone developing ESCs) might be interested in seeing all the internal states of the ESC.

With the addidion of those fields is possible to identify the following states:
- ESC Armed with failures (e.g in flight failure)
- ESC Disarmed with failures (in this case arming can be denied)
- ESC Armed/disarmed without failures





