### PR TITLE
Add SITL target for starting airsim

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -127,6 +127,19 @@ elif [ "$program" == "flightgear" ] && [ -z "$no_sim" ]; then
 	"${src_path}/Tools/flightgear_bridge/FG_run.py" "models/"${model}".json" 0
 	"${build_path}/build_flightgear_bridge/flightgear_bridge" 0 `./get_FGbridge_params.py "models/"${model}".json"` &
 	FG_BRIDGE_PID=`echo $!`
+elif [ "$program" == "airsim" ] && [ ! -n "$no_sim" ]; then
+	if [ "$model" == "iris" ]; then
+		if [ -f ${AIRSIM_APPLICATION_PATH} ]  && [ ! -z ${AIRSIM_APPLICATION_PATH} ]; then
+			${AIRSIM_APPLICATION_PATH} -windowed -ResX 640 -ResY 480 > /dev/null 2>&1 &
+			SIM_PID=`echo $!`
+		else
+			echo "Could not find Airsim at AIRSIM_APPLICATION_PATH=${AIRSIM_APPLICATION_PATH}"
+			exit 1
+		fi
+	else
+		echo "Airsim is only supported for [iris] model"
+		exit 1
+	fi
 fi
 
 pushd "$rootfs" >/dev/null
@@ -180,4 +193,7 @@ elif [ "$program" == "gazebo" ]; then
 elif [ "$program" == "flightgear" ]; then
 	kill $FG_BRIDGE_PID
 	kill -9 `cat /tmp/px4fgfspid_0`
+elif [ "$program" == "airsim" ]; then
+	pkill -9 -P $SIM_PID
+	kill -9 $SIM_PID
 fi

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -73,7 +73,7 @@ ExternalProject_Add(flightgear_bridge
 )
 
 # create targets for each viewer/model/debugger combination
-set(viewers none jmavsim gazebo)
+set(viewers none jmavsim gazebo airsim)
 set(debuggers none ide gdb lldb ddd valgrind callgrind)
 set(models none shell
 	if750a iris iris_opt_flow iris_opt_flow_mockup iris_vision iris_rplidar iris_irlock iris_obs_avoid iris_rtps px4vision solo typhoon_h480


### PR DESCRIPTION
**Describe problem solved by this pull request**
Previously, to run [Airsim](https://github.com/microsoft/AirSim) with PX4 SITL both simulations need to be run separately. The steps involve [multiple steps](https://microsoft.github.io/AirSim/docs/px4_sitl/) and creates confusion always when starting / closing each processes on multiple terminals.

Also, since SITL is run completely independent of Airsim, it is hard to enforce which models were supported or not. Currently only the `iris` model is supported.

**Describe your solution**
This PR sets a make target that automatically starts Airsim when it is stored somewhere as a package. The procedure is as the following.
- Down the latest Linux distribution and one of the environments of Airsim: [link](https://github.com/microsoft/AirSim/releases) Lets assume, we have downloaded the most simple `Blocks` environment
- Extract the zip file
- Run the following command to specify the runscript
```
export AIRSIM_APPLICATION_PATH=<path_to_blocks>/Blocks/Blocks.sh
```
- Run the following target to start airsim and px4 sitl
```
make px4_sitl airsim_iris
```

**Additional context**
The latest Airsim release does not include the latest lockstep fixes, therefore we need to wait for a new release from the Airsim side. Expected ETA <1 week as of https://github.com/microsoft/AirSim/issues/2477
