### PR TITLE
boards: airmind mindpx-v2 fix L3GD20 DRDY pin

### DIFF
--- a/boards/airmind/mindpx-v2/src/spi.cpp
+++ b/boards/airmind/mindpx-v2/src/spi.cpp
@@ -43,7 +43,7 @@ constexpr px4_spi_bus_t px4_spi_buses[SPI_BUS_MAX_BUS_ITEMS] = {
 		initSPIConfigExternal(SPI::CS{GPIO::PortD, GPIO::Pin7}),
 	}),
 	initSPIBus(SPI::Bus::SPI4, {
-		initSPIDevice(DRV_GYR_DEVTYPE_L3GD20, SPI::CS{GPIO::PortB, GPIO::Pin2}, SPI::DRDY{GPIO::PortE, GPIO::Pin14}),
+		initSPIDevice(DRV_GYR_DEVTYPE_L3GD20, SPI::CS{GPIO::PortB, GPIO::Pin2}, SPI::DRDY{GPIO::PortE, GPIO::Pin4}),
 		initSPIDevice(DRV_ACC_DEVTYPE_LSM303D, SPI::CS{GPIO::PortD, GPIO::Pin11}),
 		initSPIDevice(DRV_BARO_DEVTYPE_MS5611, SPI::CS{GPIO::PortC, GPIO::Pin15}),
 		initSPIDevice(DRV_IMU_DEVTYPE_MPU6000, SPI::CS{GPIO::PortE, GPIO::Pin3}, SPI::DRDY{GPIO::PortC, GPIO::Pin0}),


### PR DESCRIPTION
@rolandash 

The current l3gd20 driver doesn't use the data ready interrupt, but at some point I'll refactor it into the same form as the new InvenSense drivers which do use interrupts.

