### PR TITLE
rename drivers/px4fmu -> drivers/pwm_out

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.interface
+++ b/ROMFS/px4fmu_common/init.d/rc.interface
@@ -9,7 +9,7 @@
 #  Otherwise, the variable name goes to the end of the argument.
 #
 
-set FMU_CMD fmu
+set OUTPUT_CMD pwm_out
 set MIXER_AUX_FILE none
 set OUTPUT_AUX_DEV /dev/pwm_output1
 set OUTPUT_DEV none
@@ -45,16 +45,16 @@ then
 			set OUTPUT_MODE io
 			if param greater DSHOT_CONFIG 0
 			then
-				set FMU_CMD dshot
+				set OUTPUT_CMD dshot
 			fi
 		fi
 	else
 		if param greater DSHOT_CONFIG 0
 		then
 			set OUTPUT_MODE dshot
-			set FMU_CMD dshot
+			set OUTPUT_CMD dshot
 		else
-			set OUTPUT_MODE fmu
+			set OUTPUT_MODE pwm_out
 		fi
 	fi
 fi
@@ -91,11 +91,11 @@ then
 		fi
 	fi
 
-	if [ $OUTPUT_MODE = $FMU_CMD ]
+	if [ $OUTPUT_MODE = $OUTPUT_CMD ]
 	then
-		if ! $FMU_CMD mode_$FMU_MODE
+		if ! $OUTPUT_CMD mode_$FMU_MODE
 		then
-			echo "$FMU_CMD start failed" >> $LOG_FILE
+			echo "$OUTPUT_CMD start failed" >> $LOG_FILE
 			# Error tune.
 			tune_control play -t 2
 		fi
@@ -206,7 +206,7 @@ then
 
 	if [ $MIXER_AUX_FILE != none ]
 	then
-		if $FMU_CMD mode_${AUX_MODE}
+		if $OUTPUT_CMD mode_${AUX_MODE}
 		then
 			# Append aux mixer to main device.
 			if param greater SYS_HITL 0
@@ -233,14 +233,14 @@ then
 				set FAILSAFE_AUX none
 			fi
 		else
-			echo "ERROR: Could not start: fmu mode_pwm" >> $LOG_FILE
+			echo "ERROR: Could not start: pwm_out mode_pwm" >> $LOG_FILE
 			tune_control play -t 20
 			set PWM_AUX_OUT none
 			set FAILSAFE_AUX none
 		fi
 
 		# for DShot do not configure pwm values
-		if [ $FMU_CMD != dshot ]
+		if [ $OUTPUT_CMD != dshot ]
 		then
 			# Set min / max for aux out and rates.
 			if [ $PWM_AUX_OUT != none ]
@@ -322,7 +322,7 @@ then
 	fi
 fi
 
-if [ $OUTPUT_MODE = fmu -o $OUTPUT_MODE = io ]
+if [ $OUTPUT_MODE = pwm_out -o $OUTPUT_MODE = io ]
 then
 	if [ $PWM_OUT != none ]
 	then
@@ -401,7 +401,7 @@ then
 	pwm failsafe -c 8 -p p:PWM_MAIN_FAIL8
 fi
 
-unset FMU_CMD
+unset OUTPUT_CMD
 unset MIXER_AUX_FILE
 unset OUTPUT_AUX_DEV
 unset OUTPUT_DEV

--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -11,8 +11,9 @@ then
 	then
 		# Configure all I2C buses to 100 KHz as they
 		# are all external or slow
-		fmu i2c 1 100000
-		fmu i2c 2 100000
+		# TODO: move this
+		pwm_out i2c 1 100000
+		pwm_out i2c 2 100000
 	fi
 fi
 

--- a/ROMFS/px4fmu_test/init.d/rc.sensors
+++ b/ROMFS/px4fmu_test/init.d/rc.sensors
@@ -3,11 +3,6 @@
 # Standard startup script for onboard sensor drivers.
 #
 
-# Configure all I2C buses to 100 KHz as they
-# are all external or slow
-fmu i2c 1 100000
-fmu i2c 2 100000
-
 if ms5611 -s start
 then
 fi

--- a/boards/airmind/mindpx-v2/default.cmake
+++ b/boards/airmind/mindpx-v2/default.cmake
@@ -44,7 +44,7 @@ px4_add_board(
 		#protocol_splitter
 		pwm_input
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		rc_input
 		roboclaw
 		tap_esc

--- a/boards/av/x-v1/default.cmake
+++ b/boards/av/x-v1/default.cmake
@@ -43,7 +43,7 @@ px4_add_board(
 		#protocol_splitter
 		#pwm_input
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		rc_input
 		roboclaw
 		tap_esc

--- a/boards/bitcraze/crazyflie/default.cmake
+++ b/boards/bitcraze/crazyflie/default.cmake
@@ -12,7 +12,7 @@ px4_add_board(
 		gps
 		imu/mpu9250
 		optical_flow/pmw3901
-		px4fmu
+		pwm_out
 	MODULES
 		attitude_estimator_q
 		#camera_feedback

--- a/boards/holybro/durandal-v1/default.cmake
+++ b/boards/holybro/durandal-v1/default.cmake
@@ -48,7 +48,7 @@ px4_add_board(
 #		pwm_input  - Need to create arch/stm32 arch/stm32h7 arch/kinetis and reloacate
 #					   all arch dependant code there
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		px4io
 		roboclaw
 		tap_esc

--- a/boards/holybro/durandal-v1/stackcheck.cmake
+++ b/boards/holybro/durandal-v1/stackcheck.cmake
@@ -49,7 +49,7 @@ px4_add_board(
 #		pwm_input  - Need to create arch/stm32 arch/stm32h7 arch/kinetis and reloacate
 #					   all arch dependant code there
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		px4io
 		#roboclaw
 		#tap_esc

--- a/boards/holybro/kakutef7/default.cmake
+++ b/boards/holybro/kakutef7/default.cmake
@@ -24,7 +24,7 @@ px4_add_board(
 		optical_flow/px4flow
 		osd
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		rc_input
 		telemetry
 		tone_alarm

--- a/boards/intel/aerofc-v1/default.cmake
+++ b/boards/intel/aerofc-v1/default.cmake
@@ -25,7 +25,7 @@ px4_add_board(
 		#optical_flow/px4flow
 		#protocol_splitter
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		rc_input
 		tap_esc
 		#telemetry # all available telemetry drivers

--- a/boards/intel/aerofc-v1/rtps.cmake
+++ b/boards/intel/aerofc-v1/rtps.cmake
@@ -25,7 +25,7 @@ px4_add_board(
 		#optical_flow/px4flow
 		protocol_splitter
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		rc_input
 		tap_esc
 		#telemetry # all available telemetry drivers

--- a/boards/modalai/fc-v1/default.cmake
+++ b/boards/modalai/fc-v1/default.cmake
@@ -42,7 +42,7 @@ px4_add_board(
 		#protocol_splitter
 		#pwm_input
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		rc_input
 		roboclaw
 		safety_button

--- a/boards/mro/ctrl-zero-f7/default.cmake
+++ b/boards/mro/ctrl-zero-f7/default.cmake
@@ -45,7 +45,7 @@ px4_add_board(
 		#protocol_splitter
 		#pwm_input
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		rc_input
 		roboclaw
 		safety_button

--- a/boards/mro/x21-777/default.cmake
+++ b/boards/mro/x21-777/default.cmake
@@ -40,7 +40,7 @@ px4_add_board(
 		#protocol_splitter
 		pwm_input
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		px4io
 		roboclaw
 		tap_esc

--- a/boards/mro/x21/default.cmake
+++ b/boards/mro/x21/default.cmake
@@ -43,7 +43,7 @@ px4_add_board(
 		#protocol_splitter
 		pwm_input
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		px4io
 		roboclaw
 		tap_esc

--- a/boards/nxp/fmuk66-v3/default.cmake
+++ b/boards/nxp/fmuk66-v3/default.cmake
@@ -44,7 +44,7 @@ px4_add_board(
 		power_monitor/ina226
 		#protocol_splitter
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		rc_input
 		roboclaw
 		safety_button

--- a/boards/nxp/fmurt1062-v1/default.cmake
+++ b/boards/nxp/fmurt1062-v1/default.cmake
@@ -40,7 +40,7 @@ px4_add_board(
 		optical_flow # all available optical flow drivers
 #		pwm_input - not ptorable
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		rc_input
 		roboclaw
 		safety_button

--- a/boards/nxp/rddrone-uavcan146/default.cmake
+++ b/boards/nxp/rddrone-uavcan146/default.cmake
@@ -39,7 +39,7 @@ px4_add_board(
 		#lights
 		#magnetometer # all available magnetometer drivers
 		#optical_flow # all available optical flow drivers
-		#px4fmu
+		#pwm_out
 		#safety_button
 		#tone_alarm
 		#uavcannode # TODO: CAN driver needed

--- a/boards/omnibus/f4sd/default.cmake
+++ b/boards/omnibus/f4sd/default.cmake
@@ -36,7 +36,7 @@ px4_add_board(
 		#pca9685
 		#pwm_input
 		#pwm_out_sim
-		px4fmu
+		pwm_out
 		rc_input
 		#tap_esc
 		#telemetry # all available telemetry drivers

--- a/boards/px4/fmu-v2/default.cmake
+++ b/boards/px4/fmu-v2/default.cmake
@@ -55,7 +55,7 @@ px4_add_board(
 		#protocol_splitter
 		#pwm_input
 		#pwm_out_sim
-		px4fmu
+		pwm_out
 		px4io
 		#roboclaw
 		#tap_esc

--- a/boards/px4/fmu-v2/fixedwing.cmake
+++ b/boards/px4/fmu-v2/fixedwing.cmake
@@ -33,7 +33,7 @@ px4_add_board(
 		lights/rgbled
 		#magnetometer # all available magnetometer drivers
 		magnetometer/hmc5883
-		px4fmu
+		pwm_out
 		px4io
 		#telemetry # all available telemetry drivers
 		telemetry/iridiumsbd

--- a/boards/px4/fmu-v2/lpe.cmake
+++ b/boards/px4/fmu-v2/lpe.cmake
@@ -50,7 +50,7 @@ px4_add_board(
 		#protocol_splitter
 		#pwm_input
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		px4io
 		#tap_esc
 		#telemetry # all available telemetry drivers

--- a/boards/px4/fmu-v2/multicopter.cmake
+++ b/boards/px4/fmu-v2/multicopter.cmake
@@ -31,7 +31,7 @@ px4_add_board(
 		lights/rgbled
 		magnetometer/hmc5883
 		#optical_flow/px4flow
-		px4fmu
+		pwm_out
 		px4io
 		tone_alarm
 	MODULES

--- a/boards/px4/fmu-v2/rover.cmake
+++ b/boards/px4/fmu-v2/rover.cmake
@@ -31,7 +31,7 @@ px4_add_board(
 		lights/rgbled
 		magnetometer/hmc5883
 		optical_flow/px4flow
-		px4fmu
+		pwm_out
 		px4io
 		tone_alarm
 

--- a/boards/px4/fmu-v2/test.cmake
+++ b/boards/px4/fmu-v2/test.cmake
@@ -53,7 +53,7 @@ px4_add_board(
 		#protocol_splitter
 		#pwm_input
 		#pwm_out_sim
-		px4fmu
+		pwm_out
 		px4io
 		#roboclaw
 		#tap_esc

--- a/boards/px4/fmu-v3/default.cmake
+++ b/boards/px4/fmu-v3/default.cmake
@@ -52,7 +52,7 @@ px4_add_board(
 		#protocol_splitter
 		pwm_input
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		px4io
 		roboclaw
 		tap_esc

--- a/boards/px4/fmu-v3/rtps.cmake
+++ b/boards/px4/fmu-v3/rtps.cmake
@@ -52,7 +52,7 @@ px4_add_board(
 		protocol_splitter
 		pwm_input
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		px4io
 		roboclaw
 		tap_esc

--- a/boards/px4/fmu-v3/stackcheck.cmake
+++ b/boards/px4/fmu-v3/stackcheck.cmake
@@ -48,7 +48,7 @@ px4_add_board(
 		protocol_splitter
 		pwm_input
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		px4io
 		roboclaw
 		tap_esc

--- a/boards/px4/fmu-v4/cannode.cmake
+++ b/boards/px4/fmu-v4/cannode.cmake
@@ -52,7 +52,7 @@ px4_add_board(
 		#lights/rgbled_ncp5623c
 		#magnetometer # all available magnetometer drivers
 		#optical_flow # all available optical flow drivers
-		#px4fmu
+		#pwm_out
 		#safety_button
 		#tone_alarm
 		uavcannode

--- a/boards/px4/fmu-v4/default.cmake
+++ b/boards/px4/fmu-v4/default.cmake
@@ -46,7 +46,7 @@ px4_add_board(
 		#protocol_splitter
 		pwm_input
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		rc_input
 		roboclaw
 		safety_button

--- a/boards/px4/fmu-v4/optimized.cmake
+++ b/boards/px4/fmu-v4/optimized.cmake
@@ -46,7 +46,7 @@ px4_add_board(
 		optical_flow # all available optical flow drivers
 		#pwm_input
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		rc_input
 		#roboclaw
 		safety_button

--- a/boards/px4/fmu-v4/rtps.cmake
+++ b/boards/px4/fmu-v4/rtps.cmake
@@ -45,7 +45,7 @@ px4_add_board(
 		protocol_splitter
 		pwm_input
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		rc_input
 		roboclaw
 		safety_button

--- a/boards/px4/fmu-v4/stackcheck.cmake
+++ b/boards/px4/fmu-v4/stackcheck.cmake
@@ -45,7 +45,7 @@ px4_add_board(
 		#protocol_splitter
 		pwm_input
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		rc_input
 		#roboclaw
 		safety_button

--- a/boards/px4/fmu-v4pro/default.cmake
+++ b/boards/px4/fmu-v4pro/default.cmake
@@ -48,7 +48,7 @@ px4_add_board(
 		#protocol_splitter
 		pwm_input
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		px4io
 		roboclaw
 		tap_esc

--- a/boards/px4/fmu-v4pro/rtps.cmake
+++ b/boards/px4/fmu-v4pro/rtps.cmake
@@ -48,7 +48,7 @@ px4_add_board(
 		protocol_splitter
 		pwm_input
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		px4io
 		roboclaw
 		tap_esc

--- a/boards/px4/fmu-v5/critmonitor.cmake
+++ b/boards/px4/fmu-v5/critmonitor.cmake
@@ -46,7 +46,7 @@ px4_add_board(
 		#protocol_splitter
 		pwm_input
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		px4io
 		rc_input
 		roboclaw

--- a/boards/px4/fmu-v5/default.cmake
+++ b/boards/px4/fmu-v5/default.cmake
@@ -48,7 +48,7 @@ px4_add_board(
 		#protocol_splitter
 		pwm_input
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		px4io
 		rc_input
 		roboclaw

--- a/boards/px4/fmu-v5/fixedwing.cmake
+++ b/boards/px4/fmu-v5/fixedwing.cmake
@@ -35,7 +35,7 @@ px4_add_board(
 		magnetometer # all available magnetometer drivers
 		pwm_input
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		px4io
 		rc_input
 		safety_button

--- a/boards/px4/fmu-v5/irqmonitor.cmake
+++ b/boards/px4/fmu-v5/irqmonitor.cmake
@@ -46,7 +46,7 @@ px4_add_board(
 		#protocol_splitter
 		pwm_input
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		px4io
 		rc_input
 		roboclaw

--- a/boards/px4/fmu-v5/multicopter.cmake
+++ b/boards/px4/fmu-v5/multicopter.cmake
@@ -39,7 +39,7 @@ px4_add_board(
 		optical_flow # all available optical flow drivers
 		pwm_input
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		px4io
 		rc_input
 		roboclaw

--- a/boards/px4/fmu-v5/optimized.cmake
+++ b/boards/px4/fmu-v5/optimized.cmake
@@ -43,7 +43,7 @@ px4_add_board(
 		optical_flow # all available optical flow drivers
 		#pwm_input
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		px4io
 		rc_input
 		#roboclaw

--- a/boards/px4/fmu-v5/rover.cmake
+++ b/boards/px4/fmu-v5/rover.cmake
@@ -36,7 +36,7 @@ px4_add_board(
 		pca9685
 		pwm_input
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		px4io
 		rc_input
 		roboclaw

--- a/boards/px4/fmu-v5/rtps.cmake
+++ b/boards/px4/fmu-v5/rtps.cmake
@@ -46,7 +46,7 @@ px4_add_board(
 		protocol_splitter
 		pwm_input
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		px4io
 		rc_input
 		roboclaw

--- a/boards/px4/fmu-v5/stackcheck.cmake
+++ b/boards/px4/fmu-v5/stackcheck.cmake
@@ -47,7 +47,7 @@ px4_add_board(
 		#protocol_splitter
 		pwm_input
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		px4io
 		rc_input
 		#roboclaw

--- a/boards/px4/fmu-v5x/default.cmake
+++ b/boards/px4/fmu-v5x/default.cmake
@@ -47,7 +47,7 @@ px4_add_board(
 		#protocol_splitter
 		pwm_input
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		px4io
 		rc_input
 		roboclaw

--- a/boards/px4/fmu-v5x/p2_base_phy_LAN8742Ai.cmake
+++ b/boards/px4/fmu-v5x/p2_base_phy_LAN8742Ai.cmake
@@ -47,7 +47,7 @@ px4_add_board(
 		#protocol_splitter
 		pwm_input
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		px4io
 		rc_input
 		roboclaw

--- a/boards/uvify/core/default.cmake
+++ b/boards/uvify/core/default.cmake
@@ -33,7 +33,7 @@ px4_add_board(
 		pca9685
 		pwm_input
 		pwm_out_sim
-		px4fmu
+		pwm_out
 		rc_input
 		tone_alarm
 		uavcan

--- a/cmake/px4_add_board.cmake
+++ b/cmake/px4_add_board.cmake
@@ -102,7 +102,7 @@
 #				imu/bmi055
 #				imu/mpu6000
 #				magnetometer/ist8310
-#				px4fmu
+#				pwm_out
 #				px4io
 #				rgbled
 #			MODULES

--- a/src/drivers/pwm_out/CMakeLists.txt
+++ b/src/drivers/pwm_out/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2015-2020 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,11 +31,12 @@
 #
 ############################################################################
 px4_add_module(
-	MODULE drivers__px4fmu
-	MAIN fmu
+	MODULE drivers__pwm_out
+	MAIN pwm_out
 	COMPILE_FLAGS
 	SRCS
-		fmu.cpp
+		PWMOut.cpp
+		PWMOut.hpp
 	DEPENDS
 		arch_io_pins
 		mixer

--- a/src/drivers/pwm_out/PWMOut.cpp
+++ b/src/drivers/pwm_out/PWMOut.cpp
@@ -1802,48 +1802,6 @@ err_out_no_test:
 	return rv;
 }
 
-int PWMOut::fake(int argc, char *argv[])
-{
-	if (argc < 5) {
-		print_usage("not enough arguments");
-		return -1;
-	}
-
-	actuator_controls_s ac;
-
-	ac.control[0] = strtol(argv[1], 0, 0) / 100.0f;
-
-	ac.control[1] = strtol(argv[2], 0, 0) / 100.0f;
-
-	ac.control[2] = strtol(argv[3], 0, 0) / 100.0f;
-
-	ac.control[3] = strtol(argv[4], 0, 0) / 100.0f;
-
-	orb_advert_t handle = orb_advertise(ORB_ID_VEHICLE_ATTITUDE_CONTROLS, &ac);
-
-	if (handle == nullptr) {
-		PX4_ERR("advertise failed");
-		return -1;
-	}
-
-	orb_unadvertise(handle);
-
-	actuator_armed_s aa;
-
-	aa.armed = true;
-	aa.lockdown = false;
-
-	handle = orb_advertise(ORB_ID(actuator_armed), &aa);
-
-	if (handle == nullptr) {
-		PX4_ERR("advertise failed 2");
-		return -1;
-	}
-
-	orb_unadvertise(handle);
-	return 0;
-}
-
 int PWMOut::custom_command(int argc, char *argv[])
 {
 	PortMode new_mode = PORT_MODE_UNSET;
@@ -1983,10 +1941,6 @@ int PWMOut::custom_command(int argc, char *argv[])
 		return test();
 	}
 
-	if (!strcmp(verb, "fake")) {
-		return fake(argc - 1, argv + 1);
-	}
-
 	return print_usage("unknown command");
 }
 
@@ -2115,8 +2069,6 @@ mixer files.
 	PRINT_MODULE_USAGE_ARG("<bus_id> <rate>", "Specify the bus id (>=0) and rate in Hz", false);
 
 	PRINT_MODULE_USAGE_COMMAND_DESCR("test", "Test inputs and outputs");
-	PRINT_MODULE_USAGE_COMMAND_DESCR("fake", "Arm and send an actuator controls command");
-	PRINT_MODULE_USAGE_ARG("<roll> <pitch> <yaw> <thrust>", "Control values in range [-100, 100]", false);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 
 	return 0;

--- a/src/drivers/pwm_out/PWMOut.hpp
+++ b/src/drivers/pwm_out/PWMOut.hpp
@@ -135,8 +135,6 @@ public:
 
 	static int test();
 
-	static int fake(int argc, char *argv[]);
-
 	virtual int	ioctl(file *filp, int cmd, unsigned long arg);
 
 	virtual int	init();

--- a/src/drivers/pwm_out/PWMOut.hpp
+++ b/src/drivers/pwm_out/PWMOut.hpp
@@ -1,0 +1,205 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2012-2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <float.h>
+#include <math.h>
+
+#include <board_config.h>
+#include <drivers/device/device.h>
+#include <drivers/device/i2c.h>
+#include <drivers/drv_hrt.h>
+#include <drivers/drv_input_capture.h>
+#include <drivers/drv_mixer.h>
+#include <drivers/drv_pwm_output.h>
+#include <lib/cdev/CDev.hpp>
+#include <lib/mathlib/mathlib.h>
+#include <lib/mixer_module/mixer_module.hpp>
+#include <lib/parameters/param.h>
+#include <lib/perf/perf_counter.h>
+#include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/getopt.h>
+#include <px4_platform_common/log.h>
+#include <px4_platform_common/module.h>
+#include <uORB/Publication.hpp>
+#include <uORB/PublicationMulti.hpp>
+#include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionCallback.hpp>
+#include <uORB/topics/actuator_armed.h>
+#include <uORB/topics/actuator_controls.h>
+#include <uORB/topics/actuator_outputs.h>
+#include <uORB/topics/multirotor_motor_limits.h>
+#include <uORB/topics/parameter_update.h>
+
+using namespace time_literals;
+
+/** Mode given via CLI */
+enum PortMode {
+	PORT_MODE_UNSET = 0,
+	PORT_FULL_GPIO,
+	PORT_FULL_PWM,
+	PORT_PWM8,
+	PORT_PWM6,
+	PORT_PWM5,
+	PORT_PWM4,
+	PORT_PWM3,
+	PORT_PWM2,
+	PORT_PWM1,
+	PORT_PWM3CAP1,
+	PORT_PWM4CAP1,
+	PORT_PWM4CAP2,
+	PORT_PWM5CAP1,
+	PORT_PWM2CAP2,
+	PORT_CAPTURE,
+};
+
+#if !defined(BOARD_HAS_PWM)
+#  error "board_config.h needs to define BOARD_HAS_PWM"
+#endif
+
+// TODO: keep in sync with drivers/camera_capture
+#define PX4FMU_DEVICE_PATH	"/dev/px4fmu"
+
+class PWMOut : public cdev::CDev, public ModuleBase<PWMOut>, public OutputModuleInterface
+{
+public:
+	enum Mode {
+		MODE_NONE,
+		MODE_1PWM,
+		MODE_2PWM,
+		MODE_2PWM2CAP,
+		MODE_3PWM,
+		MODE_3PWM1CAP,
+		MODE_4PWM,
+		MODE_4PWM1CAP,
+		MODE_4PWM2CAP,
+		MODE_5PWM,
+		MODE_5PWM1CAP,
+		MODE_6PWM,
+		MODE_8PWM,
+		MODE_14PWM,
+		MODE_4CAP,
+		MODE_5CAP,
+		MODE_6CAP,
+	};
+	PWMOut();
+	virtual ~PWMOut();
+
+	/** @see ModuleBase */
+	static int task_spawn(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int custom_command(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int print_usage(const char *reason = nullptr);
+
+	void Run() override;
+
+	/** @see ModuleBase::print_status() */
+	int print_status() override;
+
+	/** change the FMU mode of the running module */
+	static int fmu_new_mode(PortMode new_mode);
+
+	static int test();
+
+	static int fake(int argc, char *argv[]);
+
+	virtual int	ioctl(file *filp, int cmd, unsigned long arg);
+
+	virtual int	init();
+
+	int		set_mode(Mode mode);
+	Mode		get_mode() { return _mode; }
+
+	static int	set_i2c_bus_clock(unsigned bus, unsigned clock_hz);
+
+	static void	capture_trampoline(void *context, uint32_t chan_index,
+					   hrt_abstime edge_time, uint32_t edge_state,
+					   uint32_t overflow);
+
+	void update_pwm_trims();
+
+	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+			   unsigned num_outputs, unsigned num_control_groups_updated) override;
+
+private:
+	static constexpr int FMU_MAX_ACTUATORS = DIRECT_PWM_OUTPUT_CHANNELS;
+	static_assert(FMU_MAX_ACTUATORS <= MAX_ACTUATORS, "Increase MAX_ACTUATORS if this fails");
+
+	MixingOutput _mixing_output{FMU_MAX_ACTUATORS, *this, MixingOutput::SchedulingPolicy::Auto, true};
+
+	Mode		_mode{MODE_NONE};
+
+	unsigned	_pwm_default_rate{50};
+	unsigned	_pwm_alt_rate{50};
+	uint32_t	_pwm_alt_rate_channels{0};
+
+	unsigned	_current_update_rate{0};
+
+	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
+
+
+	unsigned	_num_outputs{0};
+	int		_class_instance{-1};
+
+	bool		_pwm_on{false};
+	uint32_t	_pwm_mask{0};
+	bool		_pwm_initialized{false};
+	bool		_test_mode{false};
+
+	unsigned	_num_disarmed_set{0};
+
+	perf_counter_t	_cycle_perf;
+
+	void		capture_callback(uint32_t chan_index,
+					 hrt_abstime edge_time, uint32_t edge_state, uint32_t overflow);
+	void		update_current_rate();
+	int			set_pwm_rate(unsigned rate_map, unsigned default_rate, unsigned alt_rate);
+	int			pwm_ioctl(file *filp, int cmd, unsigned long arg);
+	void		update_pwm_rev_mask();
+	void		update_pwm_out_state(bool on);
+
+	void		update_params();
+
+	static void		sensor_reset(int ms);
+	static void		peripheral_reset(int ms);
+
+	int		capture_ioctl(file *filp, int cmd, unsigned long arg);
+
+	PWMOut(const PWMOut &) = delete;
+	PWMOut operator=(const PWMOut &) = delete;
+
+};


### PR DESCRIPTION
I think it's finally time to rename drivers/px4fmu to something more appropriate. There are a few minor things that still need to be extracted (i2c set speed and input capture config) for this to be nothing more than a pwm output module, but this should be motivation to go the rest of the way.