### PR TITLE
Support python3 only systems like Ubuntu 20.04

### DIFF
--- a/platforms/nuttx/NuttX/tools/kconfig-conf
+++ b/platforms/nuttx/NuttX/tools/kconfig-conf
@@ -6,8 +6,14 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export APPSDIR="`pwd`/../apps"
 export CONFIG_ARCH_BOARD_CUSTOM=y
 
+if [ "command -v python3" ]; then
+	PYTHON_EXECUTABLE=python3
+else
+	PYTHON_EXECUTABLE=python
+fi
+
 if [ "${1}" = "--olddefconfig" ]; then
-	PYTHONPATH=${DIR} python ${DIR}/olddefconfig.py > /dev/null
+	PYTHONPATH=${DIR} ${PYTHON_EXECUTABLE} ${DIR}/olddefconfig.py > /dev/null
 else
 	echo "ERROR: ${@} unsupported"
 	exit 1

--- a/src/drivers/uavcan/CMakeLists.txt
+++ b/src/drivers/uavcan/CMakeLists.txt
@@ -93,7 +93,7 @@ foreach(DSDLC_INPUT ${DSDLC_INPUTS})
 	list(APPEND DSDLC_INPUT_FILES ${DSDLC_NEW_INPUT_FILES})
 endforeach(DSDLC_INPUT)
 add_custom_command(OUTPUT px4_uavcan_dsdlc_run.stamp
-	COMMAND ${PYTHON} ${LIBUAVCAN_DIR}/libuavcan/dsdl_compiler/libuavcan_dsdlc ${DSDLC_INPUTS} -O${DSDLC_OUTPUT}
+	COMMAND ${PYTHON_EXECUTABLE} ${LIBUAVCAN_DIR}/libuavcan/dsdl_compiler/libuavcan_dsdlc ${DSDLC_INPUTS} -O${DSDLC_OUTPUT}
 	COMMAND ${CMAKE_COMMAND} -E touch px4_uavcan_dsdlc_run.stamp
 	DEPENDS ${DSDLC_INPUT_FILES}
 	COMMENT "PX4 UAVCAN dsdl compiler"


### PR DESCRIPTION
**Describe problem solved by this pull request**
Ubuntu 20.04 and latest Cygwin come with no Python 2 and no link
from python to python3. To not mess with the system we detect
python3 for seamless support.

**Describe your solution**
- Use cmake's official FindPythonInterp detection also in libuavcan:
https://github.com/PX4/libuavcan/pull/3
- Detect `python3` in the kconfig script

**Describe possible alternatives**
We could cut python 2 in that script and directly call `python3`

**Test data / coverage**
I built PX4 successfully on Ubuntu 20.04 current daily.
SITL works out of the box with the existing ubuntu setup script:
![image (1)](https://user-images.githubusercontent.com/4668506/77828209-5ce7b980-711a-11ea-9f77-cc444a18eec2.png)

`fmu-v5` needs this pr if the system is not adjusted with a link from `/usr/bin/python` to `python3`.

**Additional context**
It was exactly the same problem that made the Windows toolchain v0.9 build fail first and delayed https://github.com/PX4/Firmware/pull/14401. I then added the symbolic link for the current Cygwin toolchain as a workaround here: https://github.com/PX4/windows-toolchain/commit/f08348b85fd502fea99b3ee6dfd5c7da0e8ecce1
