### PR TITLE
Add world targets for SITL gazebo

### DIFF
--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -66,7 +66,7 @@ set(models none shell
 	standard_vtol tailsitter tiltrotor
 	rover boat
 	uuv_hippocampus)
-set(worlds none empty warehouse sonoma_raceway)
+set(worlds none empty baylands ksql_airport mcmillan_airfield sonoma_raceway warehouse)
 set(all_posix_vmd_make_targets)
 foreach(viewer ${viewers})
 	foreach(debugger ${debuggers})


### PR DESCRIPTION
**Describe problem solved by this pull request**
This PR adds world targets for running SITL gazebo in worlds provided by the gazebo model database. To load the worlds, a internet connection is required.

**Test data / coverage**
- baylands
```
make px4_sitl gazebo_iris__baylands
```
[![Demo](https://img.youtube.com/vi/ir1fwOLcd4E/0.jpg)](https://youtu.be/ir1fwOLcd4E)
- yosemite
```
make px4_sitl gazebo_iris__yosemite
```
[![Demo](https://img.youtube.com/vi/7bAz36IsBko/0.jpg)](https://youtu.be/7bAz36IsBko)

- ksq_airport
```
make px4_sitl gazebo_iris__ksq_airport
```
![Screenshot from 2020-03-26 17-36-40](https://user-images.githubusercontent.com/5248102/77672008-a7d1c780-6f88-11ea-8726-00773b181c1c.png)

**Additional context**
The contribution for the new worlds were made by @ahcorde and @tfoote Thanks!