### PR TITLE
arch.sh: use community binary repository for gazebo

### DIFF
--- a/Tools/setup/arch.sh
+++ b/Tools/setup/arch.sh
@@ -134,14 +134,18 @@ if [[ $INSTALL_SIM == "true" ]]; then
 			opencv \
 			protobuf \
 			vtk \
-			yay \
 			;
 
-		# enable multicore gazebo compilation
-		sudo sed -i '/MAKEFLAGS=/c\MAKEFLAGS="-j'$(($(nproc)+2))'"' /etc/makepkg.conf
+		# add community binary repository for gazebo and ROS
+		# https://wiki.archlinux.org/index.php/Unofficial_user_repositories#oscloud
+		if ! grep -q oscloud /etc/pacman.conf; then
+			echo "# ROS gazebo repository for PX4
+[oscloud]
+SigLevel = Never
+Server = http://repo.oscloud.info/" | sudo tee -a /etc/pacman.conf > /dev/null
+		fi
 
-		# install gazebo from AUR
-		yay -S gazebo --noconfirm
+		sudo pacman -Sy --noconfirm --needed gazebo
 
 		if sudo dmidecode -t system | grep -q "Manufacturer: VMware, Inc." ; then
 			# fix VMWare 3D graphics acceleration for gazebo


### PR DESCRIPTION
**Describe problem solved by this pull request**
This makes installation a lot faster and less error prone.

**Describe your solution**
Use @`bionade24`'s arch binary repository https://wiki.archlinux.org/index.php/Unofficial_user_repositories#oscloud

**Test data / coverage**
I tested on two Manjaro machines. More feedback welcome @julianoes @bresch @DanielePettenuzzo 
