### PR TITLE
CI: Add GitHub actions status token for Nuttx targets and SITL tests

### DIFF
--- a/.github/workflows/bloaty.yml
+++ b/.github/workflows/bloaty.yml
@@ -1,4 +1,4 @@
-name: bloaty
+name: Bloaty Builds
 
 on:
   push:

--- a/.github/workflows/compile_linux.yml
+++ b/.github/workflows/compile_linux.yml
@@ -1,4 +1,4 @@
-name: linux
+name: Linux Targets
 
 on:
   push:

--- a/.github/workflows/compile_nuttx.yml
+++ b/.github/workflows/compile_nuttx.yml
@@ -1,4 +1,4 @@
-name: nuttx
+name: Nuttx Targets
 
 on:
   push:

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -1,4 +1,4 @@
-name: Python CI checks
+name: Python CI Checks
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Releases](https://img.shields.io/github/release/PX4/Firmware.svg)](https://github.com/PX4/Firmware/releases) [![DOI](https://zenodo.org/badge/22634/PX4/Firmware.svg)](https://zenodo.org/badge/latestdoi/22634/PX4/Firmware)
 
-[![Build Status](http://ci.px4.io:8080/buildStatus/icon?job=PX4/Firmware/master)](http://ci.px4.io:8080/blue/organizations/jenkins/PX4%2FFirmware/activity)
+[![Build Status](http://ci.px4.io:8080/buildStatus/icon?job=PX4/Firmware/master)](http://ci.px4.io:8080/blue/organizations/jenkins/PX4%2FFirmware/activity) ![Nuttx Targets](https://github.com/PX4/Firmware/workflows/nuttx/badge.svg) ![SITL Tests](https://github.com/PX4/Firmware/workflows/SITL%20Tests/badge.svg)
 
 [![Slack](https://px4-slack.herokuapp.com/badge.svg)](http://slack.px4.io)
 


### PR DESCRIPTION
I think some status view of our main stages in Github Actions CI makes sense.

![Screenshot from 2020-03-30 11-33-09](https://user-images.githubusercontent.com/5048656/77903225-68ea8d00-727a-11ea-8e14-1131b928f2eb.png)
