### PR TITLE
Remove duplicite data from RPM message and enable logging of RPM message

### DIFF
--- a/msg/rpm.msg
+++ b/msg/rpm.msg
@@ -1,7 +1,4 @@
 uint64 timestamp                      # time since system start (microseconds)
 
-float32 indicated_frequency_hz        # indicated rotor Frequency in Hz
-float32 estimated_accurancy_hz        # estimated accurancy in Hz
 float32 indicated_frequency_rpm       # indicated rotor Frequency in Revolution per minute
 float32 estimated_accurancy_rpm       # estimated accurancy in Revolution per minute
-

--- a/src/drivers/rpm/pcf8583/PCF8583.cpp
+++ b/src/drivers/rpm/pcf8583/PCF8583.cpp
@@ -132,8 +132,8 @@ void PCF8583::Run()
 		_count = 0;
 	}
 
-	float indicated_rpm = (float)diffCount / _param_pcf8583_magnet.get() / ((float)diffTime / 1000000)*60.f;
-	float estimated_accurancy = 1 / (float)_param_pcf8583_magnet.get() / ((float)diffTime / 1000000)*60.f;
+	float indicated_rpm = (float)diffCount / _param_pcf8583_magnet.get() / ((float)diffTime / 1000000) * 60.f;
+	float estimated_accurancy = 1 / (float)_param_pcf8583_magnet.get() / ((float)diffTime / 1000000) * 60.f;
 
 	// publish
 	rpm_s msg{};

--- a/src/drivers/rpm/pcf8583/PCF8583.cpp
+++ b/src/drivers/rpm/pcf8583/PCF8583.cpp
@@ -132,15 +132,13 @@ void PCF8583::Run()
 		_count = 0;
 	}
 
-	float indicated_frequency = (float)diffCount / _param_pcf8583_magnet.get() / ((float)diffTime / 1000000);
-	float estimated_accurancy = 1 / (float)_param_pcf8583_magnet.get() / ((float)diffTime / 1000000);
+	float indicated_rpm = (float)diffCount / _param_pcf8583_magnet.get() / ((float)diffTime / 1000000)*60.f;
+	float estimated_accurancy = 1 / (float)_param_pcf8583_magnet.get() / ((float)diffTime / 1000000)*60.f;
 
 	// publish
 	rpm_s msg{};
-	msg.indicated_frequency_hz = indicated_frequency;
-	msg.indicated_frequency_rpm = indicated_frequency * 60.f;
-	msg.estimated_accurancy_hz = estimated_accurancy;
-	msg.estimated_accurancy_rpm = estimated_accurancy * 60.f;
+	msg.indicated_frequency_rpm = indicated_rpm;
+	msg.estimated_accurancy_rpm = estimated_accurancy;
 	msg.timestamp = hrt_absolute_time();
 	_rpm_pub.publish(msg);
 }

--- a/src/drivers/rpm/pcf8583/parameters.c
+++ b/src/drivers/rpm/pcf8583/parameters.c
@@ -33,6 +33,7 @@
 
 /**
  * PCF8583 rotorfreq (i2c) pool interval
+ * How often the sensor is readout.
  *
  * @reboot_required true
  * @group Sensors
@@ -45,30 +46,31 @@ PARAM_DEFINE_INT32(PCF8583_POOL, 1000000);
  *
  * @reboot_required true
  * @group Sensors
- * @value 80 0x50
- * @value 81 0x51
+ * @value 80 Address 0x50 (80)
+ * @value 81 Address 0x51 (81)
  */
 PARAM_DEFINE_INT32(PCF8583_ADDR, 80);
 
 /**
- * PCF8583 rotorfreq (i2c) counter reset value
+ * PCF8583 rotorfreq (i2c) pulse reset value
  *
  * Internal device counter is reset to 0 when overun this value,
  * counter is able to store upto 6 digits
- * reset of counter takes some time - measurement with reset has worse accurancy
+ * reset of counter takes some time - measurement with reset has worse accurancy.
+ * 0 means reset counter after every measurement.
  *
  * @reboot_required true
  * @group Sensors
- * @value 0 - reset avter every measurement
  */
 PARAM_DEFINE_INT32(PCF8583_RESET, 500000);
 
 /**
- * PCF8583 rotorfreq (i2c) magnet count
+ * PCF8583 rotorfreq (i2c) pulse count
  *
- * Nmumber of signals per rotation of rotor
+ * Nmumber of signals per rotation of actuator
  *
  * @reboot_required true
+ * @group Sensors
  * @min 1
  */
 PARAM_DEFINE_INT32(PCF8583_MAGNET, 2);

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -69,9 +69,9 @@ void LoggedTopics::add_default_topics()
 	add_topic("offboard_control_mode", 1000);
 	add_topic("position_controller_status", 500);
 	add_topic("position_setpoint_triplet", 200);
-	add_topic("rpm", 500);
 	add_topic("radio_status");
 	add_topic("rate_ctrl_status", 200);
+	add_topic("rpm", 500);
 	add_topic("safety", 1000);
 	add_topic("sensor_combined", 100);
 	add_topic("sensor_correction", 1000);

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -69,6 +69,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("offboard_control_mode", 1000);
 	add_topic("position_controller_status", 500);
 	add_topic("position_setpoint_triplet", 200);
+	add_topic("rpm");
 	add_topic("radio_status");
 	add_topic("rate_ctrl_status", 200);
 	add_topic("safety", 1000);
@@ -398,4 +399,3 @@ void LoggedTopics::initialize_configured_topics(SDLogProfileMask profile)
 		add_vision_and_avoidance_topics();
 	}
 }
-

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -69,7 +69,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("offboard_control_mode", 1000);
 	add_topic("position_controller_status", 500);
 	add_topic("position_setpoint_triplet", 200);
-	add_topic("rpm");
+	add_topic("rpm", 500);
 	add_topic("radio_status");
 	add_topic("rate_ctrl_status", 200);
 	add_topic("safety", 1000);


### PR DESCRIPTION
 * Duplicate data
Original message for our RPM counter contains duplicate data to uORB message. The original message contained rpm and Hz in one message. It was redundant. In this message, I would like to remove HZ values from the message.
I decided to maintain RPM because it is "bigger" number. Related to this is the question of whether to let unchanged data type or use some integer? Currently is used ```float32```. 

 * Logging
Next modification contained in thes PR is to enable logging of RPM message. Here is screenshot of some log from our review fork (PR will follow)  
![Snímek z 2020-03-30 17-18-27](https://user-images.githubusercontent.com/5196729/77929954-8b949a00-72aa-11ea-9e5f-59f41df3bdf5.png)

 * Parameters
I also modified the parameter labels and the correct assignment to the group.