### PR TITLE
Omnibus F4SD: switch over mpu6000 to new driver

### DIFF
--- a/boards/omnibus/f4sd/default.cmake
+++ b/boards/omnibus/f4sd/default.cmake
@@ -22,7 +22,8 @@ px4_add_board(
 		gps
 		#heater
 		#imu # all available imu drivers
-		imu/mpu6000
+		#imu/mpu6000
+		imu/invensense/mpu6000
 		imu/invensense/icm20602
 		#irlock
 		#lights/blinkm
@@ -93,7 +94,7 @@ px4_add_board(
 		shutdown
 		#tests # tests and test runner
 		top
-		topic_listener
+		#topic_listener
 		tune_control
 		usb_connected
 		ver

--- a/boards/omnibus/f4sd/init/rc.board_sensors
+++ b/boards/omnibus/f4sd/init/rc.board_sensors
@@ -5,7 +5,7 @@
 
 adc start
 
-if ! mpu6000 -R 12 -s start
+if ! mpu6000 -R 6 -s start
 then
 	# some boards such as the Hobbywing XRotor F4 G2 use the ICM-20602
 	icm20602 -s -R 6 start

--- a/boards/omnibus/f4sd/init/rc.board_sensors
+++ b/boards/omnibus/f4sd/init/rc.board_sensors
@@ -15,5 +15,5 @@ fi
 # Possible external compasses
 hmc5883 -X start
 
-bmp280 start
+bmp280 -s start
 


### PR DESCRIPTION
I'm seeing 'mpu6000: FIFO empty: 49 events' increasing, but that is expected as there's no DRDY.

What's unfortunate is that it only goes to 1kHz rate loop due to the accel.

Tested on the BetaFPV Whoop.