### PR TITLE
uavcan: bug fix sensor bridge init failure

### DIFF
--- a/src/drivers/uavcan/sensors/sensor_bridge.cpp
+++ b/src/drivers/uavcan/sensors/sensor_bridge.cpp
@@ -185,8 +185,13 @@ uavcan_bridge::Channel *UavcanCDevSensorBridgeBase::get_channel_for_node(int nod
 		int ret = init_driver(channel);
 
 		if (ret != PX4_OK) {
+			// Driver initialization failed - probably out of channels.  Return nullptr so
+			// the callback exits gracefully, and clear the assigned node_id for the channel
+			// so future callbacks exit immediately.
 			DEVICE_LOG("INIT ERROR node %d errno %d", channel->node_id, ret);
-			return channel;
+			channel->node_id = -1;
+			_out_of_channels = true;
+			return nullptr;
 		}
 
 		DEVICE_LOG("channel %d class instance %d ok", channel->node_id, channel->class_instance);


### PR DESCRIPTION
Fixes case where a UAVCAN SensorBridge has callback channels available, but NuttX / uORB does not have an additional driver / topic instance available.

Previously, the callback would call the function get_channel_for_node() and receive a valid pointer, even though the backend driver initialization failed and no NuttX driver exists (i.e. attempt to register /dev/baro4 fails but the sensor bridge tries to use it anyways).

This bug applies to barometers and magnetometers connected to PX4 via UAVCAN.
