### PR TITLE
roboclaw: Link to user manual updated

### DIFF
--- a/src/drivers/roboclaw/roboclaw_main.cpp
+++ b/src/drivers/roboclaw/roboclaw_main.cpp
@@ -82,7 +82,7 @@ static void usage()
 	PRINT_MODULE_DESCRIPTION(R"DESCR_STR(
 ### Description
 
-This driver communicates over UART with the [Roboclaw motor driver](http://downloads.ionmc.com/docs/roboclaw_user_manual.pdf).
+This driver communicates over UART with the [Roboclaw motor driver](http://downloads.basicmicro.com/docs/roboclaw_user_manual.pdf).
 It performs two tasks:
 
  - Control the motors based on the `actuator_controls_0` UOrb topic.


### PR DESCRIPTION
The old link was broken. This is a matching link from (what appears to be) the actual vendor. The version matches last version I could find on wayback machine.

Please merge as well as approve, as I can't .