### PR TITLE
Pr fix various reposition bugs in navigator module

### DIFF
--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -228,76 +228,78 @@ Navigator::run()
 
 			} else if (cmd.command == vehicle_command_s::VEHICLE_CMD_DO_REPOSITION) {
 
-				position_setpoint_triplet_s *rep = get_reposition_triplet();
-				position_setpoint_triplet_s *curr = get_position_setpoint_triplet();
+				if (true) {
+					position_setpoint_triplet_s *rep = get_reposition_triplet();
+					position_setpoint_triplet_s *curr = get_position_setpoint_triplet();
 
-				// store current position as previous position and goal as next
-				rep->previous.yaw = get_global_position()->yaw;
-				rep->previous.lat = get_global_position()->lat;
-				rep->previous.lon = get_global_position()->lon;
-				rep->previous.alt = get_global_position()->alt;
+					// store current position as previous position and goal as next
+					rep->previous.yaw = get_global_position()->yaw;
+					rep->previous.lat = get_global_position()->lat;
+					rep->previous.lon = get_global_position()->lon;
+					rep->previous.alt = get_global_position()->alt;
 
-				rep->current.loiter_radius = get_loiter_radius();
-				rep->current.loiter_direction = 1;
-				rep->current.type = position_setpoint_s::SETPOINT_TYPE_LOITER;
+					rep->current.loiter_radius = get_loiter_radius();
+					rep->current.loiter_direction = 1;
+					rep->current.type = position_setpoint_s::SETPOINT_TYPE_LOITER;
 
-				// If no argument for ground speed, use default value.
-				if (cmd.param1 <= 0 || !PX4_ISFINITE(cmd.param1)) {
-					rep->current.cruising_speed = get_cruising_speed();
+					// If no argument for ground speed, use default value.
+					if (cmd.param1 <= 0 || !PX4_ISFINITE(cmd.param1)) {
+						rep->current.cruising_speed = get_cruising_speed();
 
-				} else {
-					rep->current.cruising_speed = cmd.param1;
-				}
+					} else {
+						rep->current.cruising_speed = cmd.param1;
+					}
 
-				rep->current.cruising_throttle = get_cruising_throttle();
-				rep->current.acceptance_radius = get_acceptance_radius();
+					rep->current.cruising_throttle = get_cruising_throttle();
+					rep->current.acceptance_radius = get_acceptance_radius();
 
-				// Go on and check which changes had been requested
-				if (PX4_ISFINITE(cmd.param4)) {
-					rep->current.yaw = cmd.param4;
-					rep->current.yaw_valid = true;
+					// Go on and check which changes had been requested
+					if (PX4_ISFINITE(cmd.param4)) {
+						rep->current.yaw = cmd.param4;
+						rep->current.yaw_valid = true;
 
-				} else {
-					rep->current.yaw = NAN;
-					rep->current.yaw_valid = false;
-				}
+					} else {
+						rep->current.yaw = NAN;
+						rep->current.yaw_valid = false;
+					}
 
-				if (PX4_ISFINITE(cmd.param5) && PX4_ISFINITE(cmd.param6)) {
+					if (PX4_ISFINITE(cmd.param5) && PX4_ISFINITE(cmd.param6)) {
 
-					// Position change with optional altitude change
-					rep->current.lat = cmd.param5;
-					rep->current.lon = cmd.param6;
+						// Position change with optional altitude change
+						rep->current.lat = cmd.param5;
+						rep->current.lon = cmd.param6;
 
-					if (PX4_ISFINITE(cmd.param7)) {
+						if (PX4_ISFINITE(cmd.param7)) {
+							rep->current.alt = cmd.param7;
+
+						} else {
+							rep->current.alt = get_global_position()->alt;
+						}
+
+					} else if (PX4_ISFINITE(cmd.param7) && curr->current.valid
+						   && PX4_ISFINITE(curr->current.lat)
+						   && PX4_ISFINITE(curr->current.lon)) {
+
+						// Altitude without position change
+						rep->current.lat = curr->current.lat;
+						rep->current.lon = curr->current.lon;
 						rep->current.alt = cmd.param7;
 
 					} else {
+						// All three set to NaN - hold in current position
+						rep->current.lat = get_global_position()->lat;
+						rep->current.lon = get_global_position()->lon;
 						rep->current.alt = get_global_position()->alt;
 					}
 
-				} else if (PX4_ISFINITE(cmd.param7) && curr->current.valid
-					   && PX4_ISFINITE(curr->current.lat)
-					   && PX4_ISFINITE(curr->current.lon)) {
+					rep->previous.valid = true;
+					rep->previous.timestamp = hrt_absolute_time();
 
-					// Altitude without position change
-					rep->current.lat = curr->current.lat;
-					rep->current.lon = curr->current.lon;
-					rep->current.alt = cmd.param7;
+					rep->current.valid = true;
+					rep->current.timestamp = hrt_absolute_time();
 
-				} else {
-					// All three set to NaN - hold in current position
-					rep->current.lat = get_global_position()->lat;
-					rep->current.lon = get_global_position()->lon;
-					rep->current.alt = get_global_position()->alt;
+					rep->next.valid = false;
 				}
-
-				rep->previous.valid = true;
-				rep->previous.timestamp = hrt_absolute_time();
-
-				rep->current.valid = true;
-				rep->current.timestamp = hrt_absolute_time();
-
-				rep->next.valid = false;
 
 				// CMD_DO_REPOSITION is acknowledged by commander
 

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -300,13 +300,19 @@ Navigator::run()
 							rep->current.alt = get_global_position()->alt;
 						}
 
-					} else if (PX4_ISFINITE(cmd.param7) && curr->current.valid
-						   && PX4_ISFINITE(curr->current.lat)
-						   && PX4_ISFINITE(curr->current.lon)) {
+					} else if (PX4_ISFINITE(cmd.param7)) {
 
 						// Altitude without position change
-						rep->current.lat = curr->current.lat;
-						rep->current.lon = curr->current.lon;
+						// This condition is necessary for altitude changes just after takeoff where lat and lon are still nan
+						if (curr->current.valid && PX4_ISFINITE(curr->current.lat) && PX4_ISFINITE(curr->current.lon)) {
+							rep->current.lat = curr->current.lat;
+							rep->current.lon = curr->current.lon;
+
+						} else {
+							rep->current.lat = get_global_position()->lat;
+							rep->current.lon = get_global_position()->lon;
+						}
+
 						rep->current.alt = cmd.param7;
 
 					} else {


### PR DESCRIPTION
This pr fixes the following three issues when repositioning in navigator:
- if the "go to" location sent by QGC was outside a geofenced area and the geofence failsafe was set to HOLD then the drone would just exit the geofence and reach destination
- if the "go to" location sent by QGC was inside a geofenced area, the geofence failsafe was set to HOLD and the path to get to destination went outside the geofence, the drone would just go out of the geofence and then enter again to reach destination
- after an auto takeoff from QGC then user could not perform an altitude change because the current waypoint was still set to Nan for lat and lon after a takeoff. To make it work the user would have to repeat the change altitude action twice

These three issues where fixed by the following changes:
- reject a "go to" location outside a geofenced area before we even start to execute it
- reposition to the current location if during the "go to" we exit the geofence
- fix the if statement so if lat and lon are Nan we take the current global position and still change the altitude
