### PR TITLE
sensor_accel_fifo increase to 32 samples

### DIFF
--- a/msg/sensor_accel_fifo.msg
+++ b/msg/sensor_accel_fifo.msg
@@ -8,6 +8,6 @@ float32 scale
 
 uint8 samples             # number of valid samples
 
-int16[16] x               # acceleration in the NED X board axis in m/s/s
-int16[16] y               # acceleration in the NED Y board axis in m/s/s
-int16[16] z               # acceleration in the NED Z board axis in m/s/s
+int16[32] x               # acceleration in the NED X board axis in m/s/s
+int16[32] y               # acceleration in the NED Y board axis in m/s/s
+int16[32] z               # acceleration in the NED Z board axis in m/s/s

--- a/src/lib/drivers/accelerometer/PX4Accelerometer.hpp
+++ b/src/lib/drivers/accelerometer/PX4Accelerometer.hpp
@@ -74,9 +74,9 @@ public:
 		uint8_t samples; // number of samples
 		float dt; // in microseconds
 
-		int16_t x[16];
-		int16_t y[16];
-		int16_t z[16];
+		int16_t x[32];
+		int16_t y[32];
+		int16_t z[32];
 	};
 	static_assert(sizeof(FIFOSample::x) == sizeof(sensor_accel_fifo_s::x), "FIFOSample.x invalid size");
 	static_assert(sizeof(FIFOSample::y) == sizeof(sensor_accel_fifo_s::y), "FIFOSample.y invalid size");


### PR DESCRIPTION
Possible fix for the modalai test rack hard fault. The FIFO max sample calculations are based on the max gyro FIFO samples we can handle (currently 32), but this breaks down in the newer ICM4xxxx devices where accel is no longer 1/2 or 1/8th of the gyro data rate. Keeping sensor_accel_fifo and sensor_gyro_fifo sized the same is the simplest option.