### PR TITLE
i2c_sp_buses: fix style with astyle

### DIFF
--- a/platforms/common/include/px4_platform_common/i2c_spi_buses.h
+++ b/platforms/common/include/px4_platform_common/i2c_spi_buses.h
@@ -235,11 +235,11 @@ protected:
 
 	virtual ~I2CSPIDriver() = default;
 
-	void Run() final {
+	void Run() final
+	{
 		static_cast<T *>(this)->RunImpl();
 
-		if (should_exit())
-		{
+		if (should_exit()) {
 			exit_and_cleanup();
 		}
 	}


### PR DESCRIPTION
**Describe problem solved by this pull request**
I'm commiting the style fix now since it's popping up over and over
when using make format.

I hope it's not another astyle 2 vs 3 issue.