### PR TITLE
PX4Vision: tune MPC_LAND_ALT

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4016_holybro_px4vision
+++ b/ROMFS/px4fmu_common/init.d/airframes/4016_holybro_px4vision
@@ -97,6 +97,8 @@ then
 	param set MPC_Z_TRAJ_P 0.3
 	param set MPC_Z_VEL_I 0.15
 	param set MPC_Z_VEL_P 0.25
+	param set MPC_LAND_ALT1 3
+	param set MPC_LAND_ALT2 1
 
 	# Navigator Parameters
 	param set NAV_ACC_RAD 2

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -674,7 +674,7 @@ PARAM_DEFINE_FLOAT(MPC_YAWRAUTO_MAX, 45.0f);
  * @decimal 1
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_LAND_ALT1, 10.0f);
+PARAM_DEFINE_FLOAT(MPC_LAND_ALT1, 5.0f);
 
 /**
  * Altitude for 2. step of slow landing (landing)
@@ -689,7 +689,7 @@ PARAM_DEFINE_FLOAT(MPC_LAND_ALT1, 10.0f);
  * @decimal 1
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_LAND_ALT2, 5.0f);
+PARAM_DEFINE_FLOAT(MPC_LAND_ALT2, 2.0f);
 
 /**
  * Position control smooth takeoff ramp time constant


### PR DESCRIPTION
During flight testing the PX4Vision, we noticed that the default values for `MPC_LAND_ALT1` and `MPC_LAND_ALT2` are rather tuned towards large vehicles and yield unpleasant pilot experience on such a small racer.

This PR adjusts them to values that are more reasonable for a racer.