### PR TITLE
GPS Dynamic model default <1g for multicopter

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.mc_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.mc_defaults
@@ -18,6 +18,8 @@ then
 	param set PWM_MAX 1950
 	param set PWM_MIN 1075
 	param set PWM_RATE 400
+
+	param set GPS_UBX_DYNMODEL 6
 fi
 
 #


### PR DESCRIPTION
**Describe problem solved by this pull request**
As discussed in the estimation call with @priseborough and @bresch :
Multicopter position controlled flight is in our experience always <1g. Acrobatic flying definitely exceeds the acceleration but if control doesn't rely on the GPS velocity and position for navigation we don't expect any problems.

**Describe your solution**
I changed the parameter default to 6 - <1g for multicopter defaults only. 

**Test data / coverage**
We are successfully flying this setting on multiple platforms.

**Additional context**
While looking at the configuration for fixed wing I saw the fixed wing defaults configuring 8 - <4g
https://github.com/PX4/Firmware/blob/15332a7e56d189bcb52605ce5181e16bf898d799/ROMFS/px4fmu_common/init.d/rc.fw_defaults#L52
but VTOL not specifying anything. Is that because like the comment for fixed wing suggests it's only needed for fixed wing takeoff?