### PR TITLE
microRTPS: use fastrtpsgen '-typeros2' option

### DIFF
--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -8,7 +8,7 @@ pipeline {
     stage('Build') {
       agent {
         docker {
-          image 'px4io/px4-dev-ros-melodic:2020-03-29'
+          image 'px4io/px4-dev-ros-melodic:2020-04-01'
           args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
         }
       }
@@ -130,7 +130,7 @@ def createTestNode(Map test_def) {
   return {
     node {
       cleanWs()
-      docker.image("px4io/px4-dev-ros-melodic:2020-03-29").inside('-e HOME=${WORKSPACE}') {
+      docker.image("px4io/px4-dev-ros-melodic:2020-04-01").inside('-e HOME=${WORKSPACE}') {
         stage(test_def.name) {
           def run_script = test_def.get('run_script', 'rostest_px4_run.sh')
           def test_ok = true

--- a/.ci/Jenkinsfile-SITL_tests_ASan
+++ b/.ci/Jenkinsfile-SITL_tests_ASan
@@ -8,7 +8,7 @@ pipeline {
     stage('Build') {
       agent {
         docker {
-          image 'px4io/px4-dev-ros-melodic:2020-03-29'
+          image 'px4io/px4-dev-ros-melodic:2020-04-01'
           args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
         }
       }
@@ -131,7 +131,7 @@ def createTestNode(Map test_def) {
   return {
     node {
       cleanWs()
-      docker.image("px4io/px4-dev-ros-melodic:2020-03-29").inside('-e HOME=${WORKSPACE}') {
+      docker.image("px4io/px4-dev-ros-melodic:2020-04-01").inside('-e HOME=${WORKSPACE}') {
         stage(test_def.name) {
           def run_script = test_def.get('run_script', 'rostest_px4_run.sh')
           def test_ok = true

--- a/.ci/Jenkinsfile-SITL_tests_coverage
+++ b/.ci/Jenkinsfile-SITL_tests_coverage
@@ -79,7 +79,7 @@ pipeline {
         stage('code coverage (python)') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2020-03-29'
+              image 'px4io/px4-dev-base-bionic:2020-04-01'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -99,7 +99,7 @@ pipeline {
         stage('unit tests') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2020-03-29'
+              image 'px4io/px4-dev-base-bionic:2020-04-01'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -137,7 +137,7 @@ def createTestNode(Map test_def) {
   return {
     node {
       cleanWs()
-      docker.image("px4io/px4-dev-ros-melodic:2020-03-29").inside('-e HOME=${WORKSPACE}') {
+      docker.image("px4io/px4-dev-ros-melodic:2020-04-01").inside('-e HOME=${WORKSPACE}') {
         stage(test_def.name) {
           def test_ok = true
           sh('export')

--- a/.ci/Jenkinsfile-compile
+++ b/.ci/Jenkinsfile-compile
@@ -9,10 +9,10 @@ pipeline {
         script {
           def build_nodes = [:]
           def docker_images = [
-            armhf: "px4io/px4-dev-armhf:2020-03-29",
-            base: "px4io/px4-dev-base-bionic:2020-03-29",
-            nuttx: "px4io/px4-dev-nuttx-bionic:2020-03-29",
-            snapdragon: "lorenzmeier/px4-dev-snapdragon:2020-03-29"
+            armhf: "px4io/px4-dev-armhf:2020-04-01",
+            base: "px4io/px4-dev-base-bionic:2020-04-01",
+            nuttx: "px4io/px4-dev-nuttx-bionic:2020-04-01",
+            snapdragon: "lorenzmeier/px4-dev-snapdragon:2020-04-01"
           ]
 
           def armhf_builds = [
@@ -98,7 +98,7 @@ pipeline {
     // TODO: actually upload artifacts to S3
     // stage('S3 Upload') {
     //   agent {
-    //     docker { image 'px4io/px4-dev-base-bionic:2020-03-29' }
+    //     docker { image 'px4io/px4-dev-base-bionic:2020-04-01' }
     //   }
     //   options {
     //         skipDefaultCheckout()
@@ -132,7 +132,7 @@ def createBuildNode(Boolean archive, String docker_image, String target) {
 
     // TODO: fix the snapdragon image
     bypass_entrypoint = ''
-    if (docker_image == 'lorenzmeier/px4-dev-snapdragon:2020-03-29') {
+    if (docker_image == 'lorenzmeier/px4-dev-snapdragon:2020-04-01') {
       bypass_entrypoint = ' --entrypoint=""'
     }
 

--- a/.ci/Jenkinsfile-hardware
+++ b/.ci/Jenkinsfile-hardware
@@ -12,7 +12,7 @@ pipeline {
             stage("build px4_fmu-v2_test") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-03-29'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -76,7 +76,7 @@ pipeline {
             stage("build px4_fmu-v3_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-03-29'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -149,7 +149,7 @@ pipeline {
             stage("build px4_fmu-v4_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-03-29'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -222,7 +222,7 @@ pipeline {
             stage("build px4_fmu-v4_optimized") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-03-29'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -295,7 +295,7 @@ pipeline {
             stage("build px4_fmu-v4pro_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-03-29'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -368,7 +368,7 @@ pipeline {
             stage("build px4_fmu-v5_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-03-29'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -441,7 +441,7 @@ pipeline {
             stage("build px4_fmu-v5_optimized") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-03-29'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -514,7 +514,7 @@ pipeline {
             stage("build modalai_fc-v1_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-03-29'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -587,7 +587,7 @@ pipeline {
             stage("build holybro_durandal-v1_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-03-29'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -661,7 +661,7 @@ pipeline {
             stage("build holybro_durandal-v1_stackcheck") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-03-29'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -748,7 +748,7 @@ pipeline {
             stage("build nxp_fmuk66-v3_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-03-29'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: px4io/px4-dev-nuttx-bionic:2020-03-29
+      - image: px4io/px4-dev-nuttx-bionic:2020-04-01
     steps:
       - checkout
       - run:

--- a/.github/workflows/bloaty.yml
+++ b/.github/workflows/bloaty.yml
@@ -26,7 +26,7 @@ jobs:
           px4_fmu-v5x_default,
           px4_io-v2_default,
           ]
-    container: px4io/px4-dev-nuttx-${{ matrix.ubuntu_release }}:2020-03-29
+    container: px4io/px4-dev-nuttx-${{ matrix.ubuntu_release }}:2020-04-01
     steps:
     - uses: actions/checkout@v1
       with:

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -17,7 +17,7 @@ jobs:
           bionic,
           focal
           ]
-    container: px4io/px4-dev-base-${{ matrix.ubuntu_release }}:2020-03-29
+    container: px4io/px4-dev-base-${{ matrix.ubuntu_release }}:2020-04-01
     steps:
     - uses: actions/checkout@v1
       with:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -17,7 +17,7 @@ jobs:
           bionic,
           focal
           ]
-    container: px4io/px4-dev-base-${{ matrix.ubuntu_release }}:2020-03-29
+    container: px4io/px4-dev-base-${{ matrix.ubuntu_release }}:2020-04-01
     steps:
     - uses: actions/checkout@v1
       with:

--- a/.github/workflows/compile_linux.yml
+++ b/.github/workflows/compile_linux.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: px4io/px4-dev-armhf:2020-03-29
+    container: px4io/px4-dev-armhf:2020-04-01
     strategy:
       matrix:
         config: [

--- a/.github/workflows/compile_nuttx.yml
+++ b/.github/workflows/compile_nuttx.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: px4io/px4-dev-nuttx-bionic:2020-03-29
+    container: px4io/px4-dev-nuttx-bionic:2020-04-01
     strategy:
       matrix:
         config: [

--- a/.github/workflows/sitl_tests.yml
+++ b/.github/workflows/sitl_tests.yml
@@ -17,7 +17,7 @@ jobs:
           bionic,
           focal
           ]
-    container: px4io/px4-dev-simulation-${{ matrix.ubuntu_release }}:2020-03-29
+    container: px4io/px4-dev-simulation-${{ matrix.ubuntu_release }}:2020-04-01
     steps:
     - uses: actions/checkout@v1
       with:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
         stage('Catkin build on ROS workspace') {
           agent {
             docker {
-              image 'px4io/px4-dev-ros-melodic:2020-03-29'
+              image 'px4io/px4-dev-ros-melodic:2020-04-01'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
             }
           }
@@ -52,7 +52,7 @@ pipeline {
         stage('Colcon build on ROS2 workspace') {
           agent {
             docker {
-              image 'px4io/px4-dev-ros2-dashing:2020-03-29'
+              image 'px4io/px4-dev-ros2-dashing:2020-04-01'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
             }
           }
@@ -83,7 +83,7 @@ pipeline {
 
         stage('Style check') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-03-29' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-04-01' }
           }
           steps {
             sh 'make check_format'
@@ -98,7 +98,7 @@ pipeline {
         stage('px4_fmu-v5 (no ninja)') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx-bionic:2020-03-29'
+              image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -124,7 +124,7 @@ pipeline {
         stage('px4_sitl (no ninja)') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx-bionic:2020-03-29'
+              image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -150,7 +150,7 @@ pipeline {
         stage('SITL unit tests') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2020-03-29'
+              image 'px4io/px4-dev-base-bionic:2020-04-01'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -190,7 +190,7 @@ pipeline {
         stage('Clang analyzer') {
           agent {
             docker {
-              image 'px4io/px4-dev-clang:2020-03-29'
+              image 'px4io/px4-dev-clang:2020-04-01'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -228,7 +228,7 @@ pipeline {
         stage('Clang tidy') {
           agent {
             docker {
-              image 'px4io/px4-dev-clang:2020-03-29'
+              image 'px4io/px4-dev-clang:2020-04-01'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -250,7 +250,7 @@ pipeline {
         stage('Cppcheck') {
           agent {
             docker {
-              image 'px4io/px4-dev-ros-melodic:2020-03-29'
+              image 'px4io/px4-dev-ros-melodic:2020-04-01'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -288,7 +288,7 @@ pipeline {
         stage('Check stack') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx-bionic:2020-03-29'
+              image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -308,7 +308,7 @@ pipeline {
         stage('ShellCheck') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx-bionic:2020-03-29'
+              image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -327,7 +327,7 @@ pipeline {
         stage('Module config validation') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2020-03-29'
+              image 'px4io/px4-dev-base-bionic:2020-04-01'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -352,7 +352,7 @@ pipeline {
 
         stage('Airframe') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-03-29' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-04-01' }
           }
           steps {
             sh 'make distclean'
@@ -371,7 +371,7 @@ pipeline {
 
         stage('Parameter') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-03-29' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-04-01' }
           }
           steps {
             sh 'make distclean'
@@ -390,7 +390,7 @@ pipeline {
 
         stage('Module') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-03-29' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-04-01' }
           }
           steps {
             sh 'make distclean'
@@ -410,7 +410,7 @@ pipeline {
         stage('uORB graphs') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx-bionic:2020-03-29'
+              image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -439,7 +439,7 @@ pipeline {
 
         stage('Devguide') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-03-29' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-04-01' }
           }
           steps {
             sh('export')
@@ -469,7 +469,7 @@ pipeline {
 
         stage('Userguide') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-03-29' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-04-01' }
           }
           steps {
             sh('export')
@@ -497,7 +497,7 @@ pipeline {
 
         stage('QGroundControl') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-03-29' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-04-01' }
           }
           steps {
             sh('export')
@@ -525,7 +525,7 @@ pipeline {
 
         stage('PX4 ROS msgs') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-03-29' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-04-01' }
           }
           steps {
             sh('export')
@@ -554,7 +554,7 @@ pipeline {
 
         stage('PX4 ROS2 bridge') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-03-29' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-04-01' }
           }
           steps {
             sh('export')
@@ -597,7 +597,7 @@ pipeline {
 
         stage('S3') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-03-29' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-04-01' }
           }
           steps {
             sh('export')

--- a/Tools/docker_run.sh
+++ b/Tools/docker_run.sh
@@ -4,22 +4,22 @@ if [ -z ${PX4_DOCKER_REPO+x} ]; then
 	echo "guessing PX4_DOCKER_REPO based on input";
 	if [[ $@ =~ .*px4_fmu.* ]]; then
 		# nuttx-px4fmu-v{1,2,3,4,5}
-		PX4_DOCKER_REPO="px4io/px4-dev-nuttx-bionic:2020-03-29"
+		PX4_DOCKER_REPO="px4io/px4-dev-nuttx-bionic:2020-04-01"
 	elif [[ $@ =~ .*ocpoc.* ]] || [[ $@ =~ .*navio2.* ]] || [[ $@ =~ .*raspberry.* ]] || [[ $@ =~ .*beaglebone.* ]]; then
 		# aerotenna_ocpoc_default, beaglebone_blue_default, emlid_navio2_default, px4_raspberrypi_default
-		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2020-03-29"
+		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2020-04-01"
 	elif [[ $@ =~ .*eagle.* ]] || [[ $@ =~ .*excelsior.* ]]; then
 		# eagle, excelsior
-		PX4_DOCKER_REPO="lorenzmeier/px4-dev-snapdragon:2020-03-29"
+		PX4_DOCKER_REPO="lorenzmeier/px4-dev-snapdragon:2020-04-01"
 	elif [[ $@ =~ .*ocpoc.* ]] || [[ $@ =~ .*navio2.* ]] || [[ $@ =~ .*raspberry.* ]] || [[ $@ =~ .*bebop.* ]]; then
 		# aerotenna_ocpoc_default, posix_rpi_cross, posix_bebop_default
-		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2020-03-29"
+		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2020-04-01"
 	elif [[ $@ =~ .*clang.* ]] || [[ $@ =~ .*scan-build.* ]]; then
 		# clang tools
-		PX4_DOCKER_REPO="px4io/px4-dev-clang:2020-03-29"
+		PX4_DOCKER_REPO="px4io/px4-dev-clang:2020-04-01"
 	elif [[ $@ =~ .*tests* ]]; then
 		# run all tests with simulation
-		PX4_DOCKER_REPO="px4io/px4-dev-simulation-bionic:2020-03-29"
+		PX4_DOCKER_REPO="px4io/px4-dev-simulation-bionic:2020-04-01"
 	fi
 else
 	echo "PX4_DOCKER_REPO is set to '$PX4_DOCKER_REPO'";
@@ -27,7 +27,7 @@ fi
 
 # otherwise default to nuttx
 if [ -z ${PX4_DOCKER_REPO+x} ]; then
-	PX4_DOCKER_REPO="px4io/px4-dev-nuttx-bionic:2020-03-29"
+	PX4_DOCKER_REPO="px4io/px4-dev-nuttx-bionic:2020-04-01"
 fi
 
 # docker hygiene

--- a/msg/templates/urtps/Publisher.cpp.em
+++ b/msg/templates/urtps/Publisher.cpp.em
@@ -101,13 +101,6 @@ bool @(topic)_Publisher::init()
     if(mp_participant == nullptr)
         return false;
 
-@[if ros2_distro and (ros2_distro == "dashing" or ros2_distro == "eloquent")]@
-    // Type name should match the expected type name on ROS2
-    // Note: the change is being done here since the 'fastrtpsgen' example
-    // generator does not allow to change the type naming on the template
-    @(topic)DataType.setName("@(package)::msg::dds_::@(topic)_");
-@[end if]@
-
     // Register the type
     Domain::registerType(mp_participant, static_cast<TopicDataType*>(&@(topic)DataType));
 

--- a/msg/templates/urtps/Subscriber.cpp.em
+++ b/msg/templates/urtps/Subscriber.cpp.em
@@ -101,14 +101,6 @@ bool @(topic)_Subscriber::init(uint8_t topic_ID, std::condition_variable* t_send
     if(mp_participant == nullptr)
             return false;
 
-@[if ros2_distro and (ros2_distro == "dashing" or ros2_distro == "eloquent")]@
-    // Type name should match the expected type name on ROS2
-    // Note: the change is being done here since the 'fastrtpsgen' example
-    // generator does not allow to change the type naming on the template of
-    // "*PubSubTypes.cpp" file
-    @(topic)DataType.setName("@(package)::msg::dds_::@(topic)_");
-@[end if]@
-
     //Register the type
     Domain::registerType(mp_participant, static_cast<TopicDataType*>(&@(topic)DataType));
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
Before, we were weren't able to connect our microRTPS bridge to ROS2 Dashing, since the generated type naming from `fastrtpsgen` was incompatible with the type naming expected in ROS2. While I found a workaround solution for this by overwriting the type naming directly in the Publisher and Subscriber templates (https://github.com/PX4/Firmware/pull/13907), this was more an hack than an actual solution.

**Describe your solution**
The solution was added first in a [PR to FastRTPSGen](https://github.com/eProsima/Fast-RTPS-Gen/pull/22), by adding an option to the script called `-typeros2`, which allows to generate the required type naming without having overwrite it in the Publisher and Subscriber templates.

**Test data / coverage**
Tested with px4_ros_com in SITL

**Additional context**
It requires release 1.0.4 of FastRTPSGen so to work (and that's why I updated the containers).
```
$ git clone --recursive https://github.com/eProsima/Fast-RTPS-Gen.git -b v1.0.4 /tmp/Fast-RTPS-Gen-1.0.4
$ cd /tmp/Fast-RTPS-Gen-1.0.4
$ gradle assemble
$ gradle install # might require sudo (sudo env "PATH=$PATH" gradle install)
$ rm -rf /tmp/*
```
