### PR TITLE
Fix MAVSDK testing output

### DIFF
--- a/test/mavsdk_tests/configs/sitl.json
+++ b/test/mavsdk_tests/configs/sitl.json
@@ -7,23 +7,23 @@
         {
             "model": "iris",
             "test_filter": "[multicopter],[offboard]",
-            "timeout_min": 5
+            "timeout_min": 10
         },
         {
             "model": "iris_opt_flow_mockup",
             "test_filter": "[multicopter][offboard][nogps]",
-            "timeout_min": 5
+            "timeout_min": 10
         },
         {
             "model": "iris_vision",
             "test_filter": "[multicopter][offboard][nogps]",
-            "timeout_min": 5,
+            "timeout_min": 10,
             "max_speed_factor": 1
         },
         {
             "model": "standard_vtol",
             "test_filter": "[multicopter][vtol]",
-            "timeout_min": 5
+            "timeout_min": 10
         }
     ]
 }

--- a/test/mavsdk_tests/mavsdk_test_runner.py
+++ b/test/mavsdk_tests/mavsdk_test_runner.py
@@ -325,11 +325,12 @@ class Tester:
         test_timeout_s = test['timeout_min']*60
         while self.active_runners[-1].time_elapsed_s() < test_timeout_s:
             returncode = self.active_runners[-1].poll()
+
+            self.collect_runner_output()
+
             if returncode is not None:
                 is_success = (returncode == 0)
                 break
-
-            self.collect_runner_output()
 
         else:
             print(colorize(
@@ -439,14 +440,15 @@ class Tester:
         max_name = max(len(runner.name) for runner in self.active_runners)
 
         for runner in self.active_runners:
-            output = runner.get_output()
-            if not output:
-                continue
+            while True:
+                line = runner.get_output_line()
+                if not line:
+                    break
 
-            output = self.add_name_prefix(max_name, runner.name, output)
-            self.add_to_combined_log(output)
-            if self.verbose:
-                print(output, end="")
+                line = self.add_name_prefix(max_name, runner.name, line)
+                self.add_to_combined_log(line)
+                if self.verbose:
+                    print(line, end="")
 
     def start_combined_log(self, filename: str) -> None:
         self.log_fd = open(filename, 'w')

--- a/test/mavsdk_tests/process_helper.py
+++ b/test/mavsdk_tests/process_helper.py
@@ -72,6 +72,8 @@ class Runner:
             line = self.process.stdout.readline()
             if line == "\n":
                 continue
+            if not line:
+                continue
             self.output_queue.put(line)
             self.log_fd.write(line)
             self.log_fd.flush()
@@ -89,11 +91,12 @@ class Runner:
             print("stopped.")
             return errno.ETIMEDOUT
 
-    def get_output(self) -> Optional[str]:
-        try:
-            return self.output_queue.get(block=True, timeout=0.1)
-        except queue.Empty:
-            return None
+    def get_output_line(self) -> Optional[str]:
+        while True:
+            try:
+                return self.output_queue.get(block=True, timeout=0.1)
+            except queue.Empty:
+                return None
 
     def stop(self) -> int:
         atexit.unregister(self.stop)

--- a/test/mavsdk_tests/process_helper.py
+++ b/test/mavsdk_tests/process_helper.py
@@ -63,8 +63,10 @@ class Runner:
         self.thread = threading.Thread(target=self.process_output)
         self.thread.start()
         if self.wait_until_complete:
-            if self.wait(5.0) != 0:
-                raise TimeoutError("Command not completed")
+            timeout_s = 10.0
+            if self.wait(timeout_s) != 0:
+                raise TimeoutError("Command '{}' not completed within {}"
+                                   .format(self.cmd, timeout_s))
 
     def process_output(self) -> None:
         assert self.process.stdout is not None


### PR DESCRIPTION
This fixes the issue where the last lines of the log output was not printed in case of error or on the verbose setting. This meant that essentially the actual test error was not printed.

The fix involves two parts:
1. Firstly collect the output again even if a process has exited.
2. Collect all lines at once and not one line per iteration.

This also raises the timeout for the gazebospawn command.