### PR TITLE
Logic fixes in commander (takeoff data)

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1552,6 +1552,8 @@ Commander::run()
 
 		/* Update land detector */
 		if (_land_detector_sub.updated()) {
+			_was_landed = _land_detector.landed;
+			bool was_falling = _land_detector.freefall;
 			_land_detector_sub.copy(&_land_detector);
 
 			// Only take actions if armed
@@ -1573,15 +1575,12 @@ Commander::run()
 					}
 				}
 
-				if (_was_falling != _land_detector.freefall) {
+				if (was_falling != _land_detector.freefall) {
 					if (_land_detector.freefall) {
 						mavlink_and_console_log_info(&mavlink_log_pub, "Freefall detected");
 					}
 				}
 			}
-
-			_was_landed = _land_detector.landed;
-			_was_falling = _land_detector.freefall;
 		}
 
 

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2189,13 +2189,23 @@ Commander::run()
 		if (_was_armed != armed.armed) {
 			_status_changed = true;
 
-			if (!armed.armed) { // increase the flight uuid upon disarming
+			if (armed.armed) {
+				if (!_land_detector.landed) { // check if takeoff already detected upon arming
+					_have_taken_off_since_arming = true;
+				}
+
+			} else { // increase the flight uuid upon disarming
 				const int32_t flight_uuid = _param_flight_uuid.get() + 1;
 				_param_flight_uuid.set(flight_uuid);
 				_param_flight_uuid.commit_no_notification();
 
 				_last_disarmed_timestamp = hrt_absolute_time();
 			}
+		}
+
+		if (!armed.armed) {
+			/* Reset the flag if disarmed. */
+			_have_taken_off_since_arming = false;
 		}
 
 		_was_armed = armed.armed;
@@ -2358,11 +2368,6 @@ Commander::run()
 		}
 
 		_status_changed = false;
-
-		if (!armed.armed) {
-			/* Reset the flag if disarmed. */
-			_have_taken_off_since_arming = false;
-		}
 
 		arm_auth_update(now, params_updated || param_init_forced);
 

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -362,7 +362,6 @@ private:
 	bool		_status_changed{true};
 	bool		_arm_tune_played{false};
 	bool		_was_landed{true};
-	bool		_was_falling{false};
 	bool		_was_armed{false};
 	bool		_failsafe_old{false};	///< check which state machines for changes, clear "changed" flag
 	bool		_have_taken_off_since_arming{false};

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -365,6 +365,7 @@ private:
 	bool		_was_armed{false};
 	bool		_failsafe_old{false};	///< check which state machines for changes, clear "changed" flag
 	bool		_have_taken_off_since_arming{false};
+	bool		_should_set_home_on_takeoff{true};
 	bool		_flight_termination_printed{false};
 
 	main_state_t	_main_state_pre_offboard{commander_state_s::MAIN_STATE_MANUAL};


### PR DESCRIPTION
This brings 2 fixes:

- set _have_taken_off_since_arming when !landed upon arming

  If arming and already !landed, _have_taken_off_since_arming will not be set
and thus auto-disarm after 10s will be triggered (with default config).

  This can only happen due to quick state changes, as land detector generally
sets landed=true if !armed.

 - set _was_landed before _land_detector topic update

   Before _was_landed was set to the same value as the current
_land_detector.landed, thus outside of the update condition,
_was_landed && !_land_detector.landed could never be true.

   This affects setting the home position, which is now set upon arming AND
upon takeoff.
  According to the existing code this is how it was intended to work (not sure if we want that though).