### PR TITLE
microRTPS: only use '-typeros2' FastRTPSGen option for Dashing and later ROS2 distros

### DIFF
--- a/msg/tools/generate_microRTPS_bridge.py
+++ b/msg/tools/generate_microRTPS_bridge.py
@@ -423,7 +423,7 @@ def generate_agent(out_dir):
     # the '-typeros2' option in fastrtpsgen.
     # .. note:: This is only available in FastRTPSGen 1.0.4 and above
     gen_ros2_typename = ""
-    if ros2_distro and fastrtpsgen_version >= version.Version("1.0.4"):
+    if ros2_distro and ros2_distro in ['dashing', 'eloquent', 'foxy'] and fastrtpsgen_version >= version.Version("1.0.4"):
         gen_ros2_typename = "-typeros2 "
 
     for idl_file in glob.glob(os.path.join(idl_dir, "*.idl")):


### PR DESCRIPTION
Fix required after `px4_ros_com` CI failed for ROS2 Bouncy and Crystal.
