### PR TITLE
UVify bootloader was not recognized properly because of wildcard

### DIFF
--- a/Tools/upload.sh
+++ b/Tools/upload.sh
@@ -15,7 +15,7 @@ SERIAL_PORTS="/dev/tty.usbmodemPX*,/dev/tty.usbmodem*"
 fi
 
 if [ $SYSTYPE = "Linux" ]; then
-SERIAL_PORTS="/dev/serial/by-id/*_PX4_*,/dev/serial/by-id/usb-3D_Robotics*,/dev/serial/by-id/usb-The_Autopilot*,/dev/serial/by-id/usb-Bitcraze*,/dev/serial/by-id/pci-Bitcraze*,/dev/serial/by-id/usb-Gumstix*,/dev/serial/by-id/usb-UVify_FMU_BL*,"
+SERIAL_PORTS="/dev/serial/by-id/*_PX4_*,/dev/serial/by-id/usb-3D_Robotics*,/dev/serial/by-id/usb-The_Autopilot*,/dev/serial/by-id/usb-Bitcraze*,/dev/serial/by-id/pci-Bitcraze*,/dev/serial/by-id/usb-Gumstix*,/dev/serial/by-id/usb-UVify*,"
 fi
 
 if [[ $SYSTYPE = *"CYGWIN"* ]]; then


### PR DESCRIPTION
**Describe problem solved by this pull request**
While our bootloader updated, we've simplified naming scheme so we update upload.sh to make the script detect boards properly.

**Test data / coverage**
Tested with different boards.