### PR TITLE
px4_work_queue: sem_wait add loop as the wait may be interrupted by a signal

### DIFF
--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueue.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueue.hpp
@@ -84,7 +84,8 @@ private:
 	void work_unlock() { leave_critical_section(_flags); }
 	irqstate_t _flags;
 #else
-	void work_lock() { px4_sem_wait(&_qlock); }
+	// loop as the wait may be interrupted by a signal
+	void work_lock() { do {} while (px4_sem_wait(&_qlock) != 0); }
 	void work_unlock() { px4_sem_post(&_qlock); }
 	px4_sem_t _qlock;
 #endif

--- a/platforms/common/px4_work_queue/WorkQueue.cpp
+++ b/platforms/common/px4_work_queue/WorkQueue.cpp
@@ -149,7 +149,8 @@ void
 WorkQueue::Run()
 {
 	while (!should_exit()) {
-		px4_sem_wait(&_process_lock);
+		// loop as the wait may be interrupted by a signal
+		do {} while (px4_sem_wait(&_process_lock) != 0);
 
 		work_lock();
 


### PR DESCRIPTION
This is only a precaution, not something that seems to actually be happening normally.