### PR TITLE
boards: STM32F76xxx/STM32F77xxx linker add ITCM RAM and .ramfuncs handling

### DIFF
--- a/boards/av/x-v1/nuttx-config/scripts/script.ld
+++ b/boards/av/x-v1/nuttx-config/scripts/script.ld
@@ -71,11 +71,13 @@
 
 MEMORY
 {
-    itcm  (rwx) : ORIGIN = 0x00208000, LENGTH = 2016K
-    flash (rx)  : ORIGIN = 0x08008000, LENGTH = 2016K
-    dtcm  (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
-    sram1 (rwx) : ORIGIN = 0x20020000, LENGTH = 368K
-    sram2 (rwx) : ORIGIN = 0x2007c000, LENGTH = 16K
+    FLASH_ITCM (rx) : ORIGIN = 0x00208000, LENGTH = 2016K
+    FLASH_AXIM (rx) : ORIGIN = 0x08008000, LENGTH = 2016K
+
+    ITCM_RAM (rwx) : ORIGIN = 0x00000000, LENGTH = 16K
+    DTCM_RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
+    SRAM1    (rwx) : ORIGIN = 0x20020000, LENGTH = 368K
+    SRAM2    (rwx) : ORIGIN = 0x2007c000, LENGTH = 16K
 }
 
 OUTPUT_ARCH(arm)
@@ -118,7 +120,7 @@ SECTIONS
 		 * use the NuttX get_errno_ptr() function.
 		 */
 		__errno = get_errno_ptr;
-	} > flash
+	} > FLASH_AXIM
 
 	/*
 	 * Init functions (static constructors and the like)
@@ -127,7 +129,7 @@ SECTIONS
 		_sinit = ABSOLUTE(.);
 		KEEP(*(.init_array .init_array.*))
 		_einit = ABSOLUTE(.);
-	} > flash
+	} > FLASH_AXIM
 
 	/*
 	 * Construction data for parameters.
@@ -136,16 +138,16 @@ SECTIONS
 		__param_start = ABSOLUTE(.);
 		KEEP(*(__param*))
 		__param_end = ABSOLUTE(.);
-	} > flash
+	} > FLASH_AXIM
 
 	.ARM.extab : {
 		*(.ARM.extab*)
-	} > flash
+	} > FLASH_AXIM
 
 	__exidx_start = ABSOLUTE(.);
 	.ARM.exidx : {
 		*(.ARM.exidx*)
-	} > flash
+	} > FLASH_AXIM
 	__exidx_end = ABSOLUTE(.);
 
 	_eronly = ABSOLUTE(.);
@@ -156,7 +158,7 @@ SECTIONS
 		*(.gnu.linkonce.d.*)
 		CONSTRUCTORS
 		_edata = ABSOLUTE(.);
-	} > sram1 AT > flash
+	} > SRAM1 AT > FLASH_AXIM
 
 	.bss : {
 		_sbss = ABSOLUTE(.);
@@ -165,7 +167,7 @@ SECTIONS
 		*(COMMON)
 		. = ALIGN(4);
 		_ebss = ABSOLUTE(.);
-	} > sram1
+	} > SRAM1
 
 	/* Stabs debugging sections. */
 	.stab 0 : { *(.stab) }
@@ -180,4 +182,13 @@ SECTIONS
 	.debug_line 0 : { *(.debug_line) }
 	.debug_pubnames 0 : { *(.debug_pubnames) }
 	.debug_aranges 0 : { *(.debug_aranges) }
+
+	.ramfunc : {
+		_sramfuncs = .;
+		*(.ramfunc  .ramfunc.*)
+		. = ALIGN(4);
+		_eramfuncs = .;
+	} > ITCM_RAM AT > FLASH_AXIM
+
+	_framfuncs = LOADADDR(.ramfunc);
 }

--- a/boards/modalai/fc-v1/nuttx-config/scripts/script.ld
+++ b/boards/modalai/fc-v1/nuttx-config/scripts/script.ld
@@ -71,11 +71,13 @@
 
 MEMORY
 {
-    itcm  (rwx) : ORIGIN = 0x00208000, LENGTH = 2016K
-    flash (rx)  : ORIGIN = 0x08008000, LENGTH = 2016K
-    dtcm  (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
-    sram1 (rwx) : ORIGIN = 0x20020000, LENGTH = 368K
-    sram2 (rwx) : ORIGIN = 0x2007c000, LENGTH = 16K
+    FLASH_ITCM (rx) : ORIGIN = 0x00208000, LENGTH = 2016K
+    FLASH_AXIM (rx) : ORIGIN = 0x08008000, LENGTH = 2016K
+
+    ITCM_RAM (rwx) : ORIGIN = 0x00000000, LENGTH = 16K
+    DTCM_RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
+    SRAM1    (rwx) : ORIGIN = 0x20020000, LENGTH = 368K
+    SRAM2    (rwx) : ORIGIN = 0x2007c000, LENGTH = 16K
 }
 
 OUTPUT_ARCH(arm)
@@ -118,7 +120,7 @@ SECTIONS
 		 * use the NuttX get_errno_ptr() function.
 		 */
 		__errno = get_errno_ptr;
-	} > flash
+	} > FLASH_AXIM
 
 	/*
 	 * Init functions (static constructors and the like)
@@ -127,7 +129,7 @@ SECTIONS
 		_sinit = ABSOLUTE(.);
 		KEEP(*(.init_array .init_array.*))
 		_einit = ABSOLUTE(.);
-	} > flash
+	} > FLASH_AXIM
 
 	/*
 	 * Construction data for parameters.
@@ -136,16 +138,16 @@ SECTIONS
 		__param_start = ABSOLUTE(.);
 		KEEP(*(__param*))
 		__param_end = ABSOLUTE(.);
-	} > flash
+	} > FLASH_AXIM
 
 	.ARM.extab : {
 		*(.ARM.extab*)
-	} > flash
+	} > FLASH_AXIM
 
 	__exidx_start = ABSOLUTE(.);
 	.ARM.exidx : {
 		*(.ARM.exidx*)
-	} > flash
+	} > FLASH_AXIM
 	__exidx_end = ABSOLUTE(.);
 
 	_eronly = ABSOLUTE(.);
@@ -156,7 +158,7 @@ SECTIONS
 		*(.gnu.linkonce.d.*)
 		CONSTRUCTORS
 		_edata = ABSOLUTE(.);
-	} > sram1 AT > flash
+	} > SRAM1 AT > FLASH_AXIM
 
 	.bss : {
 		_sbss = ABSOLUTE(.);
@@ -165,7 +167,7 @@ SECTIONS
 		*(COMMON)
 		. = ALIGN(4);
 		_ebss = ABSOLUTE(.);
-	} > sram1
+	} > SRAM1
 
 	/* Stabs debugging sections. */
 	.stab 0 : { *(.stab) }
@@ -180,4 +182,13 @@ SECTIONS
 	.debug_line 0 : { *(.debug_line) }
 	.debug_pubnames 0 : { *(.debug_pubnames) }
 	.debug_aranges 0 : { *(.debug_aranges) }
+
+	.ramfunc : {
+		_sramfuncs = .;
+		*(.ramfunc  .ramfunc.*)
+		. = ALIGN(4);
+		_eramfuncs = .;
+	} > ITCM_RAM AT > FLASH_AXIM
+
+	_framfuncs = LOADADDR(.ramfunc);
 }

--- a/boards/mro/ctrl-zero-f7/nuttx-config/scripts/script.ld
+++ b/boards/mro/ctrl-zero-f7/nuttx-config/scripts/script.ld
@@ -71,11 +71,13 @@
 
 MEMORY
 {
-    itcm  (rwx) : ORIGIN = 0x00218000, LENGTH = 1952K
-    flash (rx)  : ORIGIN = 0x08018000, LENGTH = 1952K /* start on 4th sector (1st sector for bootloader, 2 for extra storage) */
-    dtcm  (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
-    sram1 (rwx) : ORIGIN = 0x20020000, LENGTH = 368K
-    sram2 (rwx) : ORIGIN = 0x2007c000, LENGTH = 16K
+    FLASH_ITCM (rx) : ORIGIN = 0x00218000, LENGTH = 1952K
+    FLASH_AXIM (rx) : ORIGIN = 0x08018000, LENGTH = 1952K /* start on 4th sector (1st sector for bootloader, 2 for extra storage) */
+
+    ITCM_RAM (rwx) : ORIGIN = 0x00000000, LENGTH = 16K
+    DTCM_RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
+    SRAM1    (rwx) : ORIGIN = 0x20020000, LENGTH = 368K
+    SRAM2    (rwx) : ORIGIN = 0x2007c000, LENGTH = 16K
 }
 
 OUTPUT_ARCH(arm)
@@ -118,7 +120,7 @@ SECTIONS
 		 * use the NuttX get_errno_ptr() function.
 		 */
 		__errno = get_errno_ptr;
-	} > flash
+	} > FLASH_AXIM
 
 	/*
 	 * Init functions (static constructors and the like)
@@ -127,7 +129,7 @@ SECTIONS
 		_sinit = ABSOLUTE(.);
 		KEEP(*(.init_array .init_array.*))
 		_einit = ABSOLUTE(.);
-	} > flash
+	} > FLASH_AXIM
 
 	/*
 	 * Construction data for parameters.
@@ -136,16 +138,16 @@ SECTIONS
 		__param_start = ABSOLUTE(.);
 		KEEP(*(__param*))
 		__param_end = ABSOLUTE(.);
-	} > flash
+	} > FLASH_AXIM
 
 	.ARM.extab : {
 		*(.ARM.extab*)
-	} > flash
+	} > FLASH_AXIM
 
 	__exidx_start = ABSOLUTE(.);
 	.ARM.exidx : {
 		*(.ARM.exidx*)
-	} > flash
+	} > FLASH_AXIM
 	__exidx_end = ABSOLUTE(.);
 
 	_eronly = ABSOLUTE(.);
@@ -156,7 +158,7 @@ SECTIONS
 		*(.gnu.linkonce.d.*)
 		CONSTRUCTORS
 		_edata = ABSOLUTE(.);
-	} > sram1 AT > flash
+	} > SRAM1 AT > FLASH_AXIM
 
 	.bss : {
 		_sbss = ABSOLUTE(.);
@@ -165,7 +167,7 @@ SECTIONS
 		*(COMMON)
 		. = ALIGN(4);
 		_ebss = ABSOLUTE(.);
-	} > sram1
+	} > SRAM1
 
 	/* Stabs debugging sections. */
 	.stab 0 : { *(.stab) }
@@ -180,4 +182,13 @@ SECTIONS
 	.debug_line 0 : { *(.debug_line) }
 	.debug_pubnames 0 : { *(.debug_pubnames) }
 	.debug_aranges 0 : { *(.debug_aranges) }
+
+	.ramfunc : {
+		_sramfuncs = .;
+		*(.ramfunc  .ramfunc.*)
+		. = ALIGN(4);
+		_eramfuncs = .;
+	} > ITCM_RAM AT > FLASH_AXIM
+
+	_framfuncs = LOADADDR(.ramfunc);
 }

--- a/boards/mro/x21-777/nuttx-config/scripts/script.ld
+++ b/boards/mro/x21-777/nuttx-config/scripts/script.ld
@@ -71,11 +71,13 @@
 
 MEMORY
 {
-    itcm  (rwx) : ORIGIN = 0x00208000, LENGTH = 2016K
-    flash (rx)  : ORIGIN = 0x08008000, LENGTH = 2016K
-    dtcm  (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
-    sram1 (rwx) : ORIGIN = 0x20020000, LENGTH = 368K
-    sram2 (rwx) : ORIGIN = 0x2007c000, LENGTH = 16K
+    FLASH_ITCM (rx) : ORIGIN = 0x00208000, LENGTH = 2016K
+    FLASH_AXIM (rx) : ORIGIN = 0x08008000, LENGTH = 2016K
+
+    ITCM_RAM (rwx) : ORIGIN = 0x00000000, LENGTH = 16K
+    DTCM_RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
+    SRAM1    (rwx) : ORIGIN = 0x20020000, LENGTH = 368K
+    SRAM2    (rwx) : ORIGIN = 0x2007c000, LENGTH = 16K
 }
 
 OUTPUT_ARCH(arm)
@@ -118,7 +120,7 @@ SECTIONS
 		 * use the NuttX get_errno_ptr() function.
 		 */
 		__errno = get_errno_ptr;
-	} > flash
+	} > FLASH_AXIM
 
 	/*
 	 * Init functions (static constructors and the like)
@@ -127,7 +129,7 @@ SECTIONS
 		_sinit = ABSOLUTE(.);
 		KEEP(*(.init_array .init_array.*))
 		_einit = ABSOLUTE(.);
-	} > flash
+	} > FLASH_AXIM
 
 	/*
 	 * Construction data for parameters.
@@ -136,16 +138,16 @@ SECTIONS
 		__param_start = ABSOLUTE(.);
 		KEEP(*(__param*))
 		__param_end = ABSOLUTE(.);
-	} > flash
+	} > FLASH_AXIM
 
 	.ARM.extab : {
 		*(.ARM.extab*)
-	} > flash
+	} > FLASH_AXIM
 
 	__exidx_start = ABSOLUTE(.);
 	.ARM.exidx : {
 		*(.ARM.exidx*)
-	} > flash
+	} > FLASH_AXIM
 	__exidx_end = ABSOLUTE(.);
 
 	_eronly = ABSOLUTE(.);
@@ -156,7 +158,7 @@ SECTIONS
 		*(.gnu.linkonce.d.*)
 		CONSTRUCTORS
 		_edata = ABSOLUTE(.);
-	} > sram1 AT > flash
+	} > SRAM1 AT > FLASH_AXIM
 
 	.bss : {
 		_sbss = ABSOLUTE(.);
@@ -165,7 +167,7 @@ SECTIONS
 		*(COMMON)
 		. = ALIGN(4);
 		_ebss = ABSOLUTE(.);
-	} > sram1
+	} > SRAM1
 
 	/* Stabs debugging sections. */
 	.stab 0 : { *(.stab) }
@@ -180,4 +182,13 @@ SECTIONS
 	.debug_line 0 : { *(.debug_line) }
 	.debug_pubnames 0 : { *(.debug_pubnames) }
 	.debug_aranges 0 : { *(.debug_aranges) }
+
+	.ramfunc : {
+		_sramfuncs = .;
+		*(.ramfunc  .ramfunc.*)
+		. = ALIGN(4);
+		_eramfuncs = .;
+	} > ITCM_RAM AT > FLASH_AXIM
+
+	_framfuncs = LOADADDR(.ramfunc);
 }

--- a/boards/px4/fmu-v5/nuttx-config/scripts/script.ld
+++ b/boards/px4/fmu-v5/nuttx-config/scripts/script.ld
@@ -71,11 +71,13 @@
 
 MEMORY
 {
-    itcm  (rwx) : ORIGIN = 0x00208000, LENGTH = 2016K
-    flash (rx)  : ORIGIN = 0x08008000, LENGTH = 2016K
-    dtcm  (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
-    sram1 (rwx) : ORIGIN = 0x20020000, LENGTH = 368K
-    sram2 (rwx) : ORIGIN = 0x2007c000, LENGTH = 16K
+    FLASH_ITCM (rx) : ORIGIN = 0x00208000, LENGTH = 2016K
+    FLASH_AXIM (rx) : ORIGIN = 0x08008000, LENGTH = 2016K
+
+    ITCM_RAM (rwx) : ORIGIN = 0x00000000, LENGTH = 16K
+    DTCM_RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
+    SRAM1    (rwx) : ORIGIN = 0x20020000, LENGTH = 368K
+    SRAM2    (rwx) : ORIGIN = 0x2007c000, LENGTH = 16K
 }
 
 OUTPUT_ARCH(arm)
@@ -118,7 +120,7 @@ SECTIONS
 		 * use the NuttX get_errno_ptr() function.
 		 */
 		__errno = get_errno_ptr;
-	} > flash
+	} > FLASH_AXIM
 
 	/*
 	 * Init functions (static constructors and the like)
@@ -127,7 +129,7 @@ SECTIONS
 		_sinit = ABSOLUTE(.);
 		KEEP(*(.init_array .init_array.*))
 		_einit = ABSOLUTE(.);
-	} > flash
+	} > FLASH_AXIM
 
 	/*
 	 * Construction data for parameters.
@@ -136,16 +138,16 @@ SECTIONS
 		__param_start = ABSOLUTE(.);
 		KEEP(*(__param*))
 		__param_end = ABSOLUTE(.);
-	} > flash
+	} > FLASH_AXIM
 
 	.ARM.extab : {
 		*(.ARM.extab*)
-	} > flash
+	} > FLASH_AXIM
 
 	__exidx_start = ABSOLUTE(.);
 	.ARM.exidx : {
 		*(.ARM.exidx*)
-	} > flash
+	} > FLASH_AXIM
 	__exidx_end = ABSOLUTE(.);
 
 	_eronly = ABSOLUTE(.);
@@ -156,7 +158,7 @@ SECTIONS
 		*(.gnu.linkonce.d.*)
 		CONSTRUCTORS
 		_edata = ABSOLUTE(.);
-	} > sram1 AT > flash
+	} > SRAM1 AT > FLASH_AXIM
 
 	.bss : {
 		_sbss = ABSOLUTE(.);
@@ -165,7 +167,7 @@ SECTIONS
 		*(COMMON)
 		. = ALIGN(4);
 		_ebss = ABSOLUTE(.);
-	} > sram1
+	} > SRAM1
 
 	/* Stabs debugging sections. */
 	.stab 0 : { *(.stab) }
@@ -180,4 +182,13 @@ SECTIONS
 	.debug_line 0 : { *(.debug_line) }
 	.debug_pubnames 0 : { *(.debug_pubnames) }
 	.debug_aranges 0 : { *(.debug_aranges) }
+
+	.ramfunc : {
+		_sramfuncs = .;
+		*(.ramfunc  .ramfunc.*)
+		. = ALIGN(4);
+		_eramfuncs = .;
+	} > ITCM_RAM AT > FLASH_AXIM
+
+	_framfuncs = LOADADDR(.ramfunc);
 }

--- a/boards/px4/fmu-v5x/nuttx-config/scripts/script.ld
+++ b/boards/px4/fmu-v5x/nuttx-config/scripts/script.ld
@@ -71,11 +71,13 @@
 
 MEMORY
 {
-    itcm  (rwx) : ORIGIN = 0x00208000, LENGTH = 2016K
-    flash (rx)  : ORIGIN = 0x08008000, LENGTH = 2016K
-    dtcm  (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
-    sram1 (rwx) : ORIGIN = 0x20020000, LENGTH = 368K
-    sram2 (rwx) : ORIGIN = 0x2007c000, LENGTH = 16K
+    FLASH_ITCM (rx) : ORIGIN = 0x00208000, LENGTH = 2016K
+    FLASH_AXIM (rx) : ORIGIN = 0x08008000, LENGTH = 2016K
+
+    ITCM_RAM (rwx) : ORIGIN = 0x00000000, LENGTH = 16K
+    DTCM_RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
+    SRAM1    (rwx) : ORIGIN = 0x20020000, LENGTH = 368K
+    SRAM2    (rwx) : ORIGIN = 0x2007c000, LENGTH = 16K
 }
 
 OUTPUT_ARCH(arm)
@@ -118,7 +120,7 @@ SECTIONS
 		 * use the NuttX get_errno_ptr() function.
 		 */
 		__errno = get_errno_ptr;
-	} > flash
+	} > FLASH_AXIM
 
 	/*
 	 * Init functions (static constructors and the like)
@@ -127,7 +129,7 @@ SECTIONS
 		_sinit = ABSOLUTE(.);
 		KEEP(*(.init_array .init_array.*))
 		_einit = ABSOLUTE(.);
-	} > flash
+	} > FLASH_AXIM
 
 	/*
 	 * Construction data for parameters.
@@ -136,16 +138,16 @@ SECTIONS
 		__param_start = ABSOLUTE(.);
 		KEEP(*(__param*))
 		__param_end = ABSOLUTE(.);
-	} > flash
+	} > FLASH_AXIM
 
 	.ARM.extab : {
 		*(.ARM.extab*)
-	} > flash
+	} > FLASH_AXIM
 
 	__exidx_start = ABSOLUTE(.);
 	.ARM.exidx : {
 		*(.ARM.exidx*)
-	} > flash
+	} > FLASH_AXIM
 	__exidx_end = ABSOLUTE(.);
 
 	_eronly = ABSOLUTE(.);
@@ -156,7 +158,7 @@ SECTIONS
 		*(.gnu.linkonce.d.*)
 		CONSTRUCTORS
 		_edata = ABSOLUTE(.);
-	} > sram1 AT > flash
+	} > SRAM1 AT > FLASH_AXIM
 
 	.bss : {
 		_sbss = ABSOLUTE(.);
@@ -165,7 +167,7 @@ SECTIONS
 		*(COMMON)
 		. = ALIGN(4);
 		_ebss = ABSOLUTE(.);
-	} > sram1
+	} > SRAM1
 
 	/* Stabs debugging sections. */
 	.stab 0 : { *(.stab) }
@@ -180,4 +182,13 @@ SECTIONS
 	.debug_line 0 : { *(.debug_line) }
 	.debug_pubnames 0 : { *(.debug_pubnames) }
 	.debug_aranges 0 : { *(.debug_aranges) }
+
+	.ramfunc : {
+		_sramfuncs = .;
+		*(.ramfunc  .ramfunc.*)
+		. = ALIGN(4);
+		_eramfuncs = .;
+	} > ITCM_RAM AT > FLASH_AXIM
+
+	_framfuncs = LOADADDR(.ramfunc);
 }


### PR DESCRIPTION
 - this doesn't currently change anything, but gets us ready to start
experimenting with using the small amount (16 kB) of instruction tightly coupled memory
on STM32F7
 - the .ramfuncs section works with NuttX CONFIG_ARCH_RAMFUNCS
 - these are all identical for stm32f76* and stm32f77* other than the mRo control zero which has another 2 reserved sectors after the bootloader
![Screenshot from 2020-04-05 10-37-45](https://user-images.githubusercontent.com/84712/78501378-89f32800-7729-11ea-9174-8abf6f62c01f.png)
