### PR TITLE
new mpu6000/mpu6500/mpu9250 always schedule backup cycle if using data ready

### DIFF
--- a/src/drivers/imu/invensense/mpu6000/MPU6000.cpp
+++ b/src/drivers/imu/invensense/mpu6000/MPU6000.cpp
@@ -188,10 +188,13 @@ void MPU6000::RunImpl()
 	case STATE::FIFO_READ: {
 			hrt_abstime timestamp_sample = 0;
 
-			if (_data_ready_interrupt_enabled && (hrt_elapsed_time(&timestamp_sample) < (_fifo_empty_interval_us / 2))) {
+			if (_data_ready_interrupt_enabled) {
 				// re-schedule as watchdog timeout
 				ScheduleDelayed(10_ms);
+			}
 
+			if (_data_ready_interrupt_enabled && (hrt_elapsed_time(&timestamp_sample) < (_fifo_empty_interval_us / 2))) {
+				// use timestamp from data ready interrupt if enabled and seems valid
 				timestamp_sample = _fifo_watermark_interrupt_timestamp;
 
 			} else {

--- a/src/drivers/imu/invensense/mpu6500/MPU6500.cpp
+++ b/src/drivers/imu/invensense/mpu6500/MPU6500.cpp
@@ -188,10 +188,13 @@ void MPU6500::RunImpl()
 	case STATE::FIFO_READ: {
 			hrt_abstime timestamp_sample = 0;
 
-			if (_data_ready_interrupt_enabled && (hrt_elapsed_time(&timestamp_sample) < (_fifo_empty_interval_us / 2))) {
+			if (_data_ready_interrupt_enabled) {
 				// re-schedule as watchdog timeout
 				ScheduleDelayed(10_ms);
+			}
 
+			if (_data_ready_interrupt_enabled && (hrt_elapsed_time(&timestamp_sample) < (_fifo_empty_interval_us / 2))) {
+				// use timestamp from data ready interrupt if enabled and seems valid
 				timestamp_sample = _fifo_watermark_interrupt_timestamp;
 
 			} else {

--- a/src/drivers/imu/invensense/mpu9250/MPU9250.cpp
+++ b/src/drivers/imu/invensense/mpu9250/MPU9250.cpp
@@ -221,10 +221,13 @@ void MPU9250::RunImpl()
 	case STATE::FIFO_READ: {
 			hrt_abstime timestamp_sample = 0;
 
-			if (_data_ready_interrupt_enabled && (hrt_elapsed_time(&timestamp_sample) < (_fifo_empty_interval_us / 2))) {
+			if (_data_ready_interrupt_enabled) {
 				// re-schedule as watchdog timeout
 				ScheduleDelayed(10_ms);
+			}
 
+			if (_data_ready_interrupt_enabled && (hrt_elapsed_time(&timestamp_sample) < (_fifo_empty_interval_us / 2))) {
+				// use timestamp from data ready interrupt if enabled and seems valid
 				timestamp_sample = _fifo_watermark_interrupt_timestamp;
 
 			} else {


### PR DESCRIPTION
In the new InvenSense drivers we use the data ready interrupts if they're available. As a precaution there's also a backup scheduled call that in regular operation is pushed back another 10 milliseconds.

This PR fixes that logic in the mpu6000/mpu6500/mpu9250. It's a failure case I've never actually seen, but it's not impossible (eg sensor brownout, external IMU with intermittent connection, etc).