### PR TITLE
Enable offboard attitude for coaxial airframes

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1393,7 +1393,7 @@ void MavlinkReceiver::fill_thrust(float *thrust_body_array, uint8_t vehicle_type
 	case MAV_TYPE_OCTOROTOR:
 	case MAV_TYPE_TRICOPTER:
 	case MAV_TYPE_HELICOPTER:
-	case MAV_TYPE_COAXIAL:		
+	case MAV_TYPE_COAXIAL:
 		thrust_body_array[2] = -thrust;
 		break;
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1393,6 +1393,7 @@ void MavlinkReceiver::fill_thrust(float *thrust_body_array, uint8_t vehicle_type
 	case MAV_TYPE_OCTOROTOR:
 	case MAV_TYPE_TRICOPTER:
 	case MAV_TYPE_HELICOPTER:
+	case MAV_TYPE_COAXIAL:		
 		thrust_body_array[2] = -thrust;
 		break;
 


### PR DESCRIPTION
Fills offboard attitude thrust setpoints with a coaxial airframe.

The thrust setpoint was silently ignored. We should either cast _mavlink->get_system_type() to the enum type to make sure all cases are covered, or add a default case that rejects the offboard mode.