### PR TITLE
microRTPS: fix topic name when ROS2 is not being used

### DIFF
--- a/msg/templates/urtps/Publisher.cpp.em
+++ b/msg/templates/urtps/Publisher.cpp.em
@@ -116,7 +116,7 @@ bool @(topic)_Publisher::init()
     Wparam.topic.topicName = "rt/@(topic)_PubSubTopic";
 @[    end if]@
 @[else]@
-    Wparam.topic.topicName = "@(topic)_PubSubTopic";
+    Wparam.topic.topicName = "@(topic)PubSubTopic";
 @[end if]@
     mp_publisher = Domain::createPublisher(mp_participant, Wparam, static_cast<PublisherListener*>(&m_listener));
     if(mp_publisher == nullptr)

--- a/msg/templates/urtps/Subscriber.cpp.em
+++ b/msg/templates/urtps/Subscriber.cpp.em
@@ -116,7 +116,7 @@ bool @(topic)_Subscriber::init(uint8_t topic_ID, std::condition_variable* t_send
     Rparam.topic.topicName = "rt/@(topic)_PubSubTopic";
 @[    end if]@
 @[else]@
-    Rparam.topic.topicName = "@(topic)_PubSubTopic";
+    Rparam.topic.topicName = "@(topic)PubSubTopic";
 @[end if]@
     mp_subscriber = Domain::createSubscriber(mp_participant, Rparam, static_cast<SubscriberListener*>(&m_listener));
     if(mp_subscriber == nullptr)


### PR DESCRIPTION
For a raw usage of the microRTPS bridge (without ROS2), the generated listener topic Subscriber wasn't matching the topic name we have on the Publisher/Subscriber template. This fixes it by removing the extra underscore in the naming.