### PR TITLE
[RFC] Consider setting default IMU_GYRO_RATEMAX to 400 Hz

### DIFF
--- a/boards/mro/x21/init/rc.board_defaults
+++ b/boards/mro/x21/init/rc.board_defaults
@@ -3,11 +3,13 @@
 # mRo x21 specific board defaults
 #------------------------------------------------------------------------------
 
+# to minimize cpu usage on older boards limit inner loop to 400 Hz by default
+if param compare IMU_GYRO_RATEMAX 0
+then
+	param set IMU_GYRO_RATEMAX 400
+fi
 
 if [ $AUTOCNF = yes ]
 then
-
-	# to minimize cpu usage on older boards limit inner loop to 400 Hz
-	param set IMU_GYRO_RATEMAX 400
 
 fi

--- a/boards/px4/fmu-v2/init/rc.board_defaults
+++ b/boards/px4/fmu-v2/init/rc.board_defaults
@@ -22,10 +22,13 @@ then
 fi
 unset BL_FILE
 
+# to minimize cpu usage on older boards limit inner loop to 400 Hz by default
+if param compare IMU_GYRO_RATEMAX 0
+then
+	param set IMU_GYRO_RATEMAX 400
+fi
+
 if [ $AUTOCNF = yes ]
 then
-
-	# to minimize cpu usage on older boards limit inner loop to 400 Hz
-	param set IMU_GYRO_RATEMAX 400
 
 fi

--- a/boards/px4/fmu-v3/init/rc.board_defaults
+++ b/boards/px4/fmu-v3/init/rc.board_defaults
@@ -22,10 +22,13 @@ then
 fi
 unset BL_FILE
 
+# to minimize cpu usage on older boards limit inner loop to 400 Hz by default
+if param compare IMU_GYRO_RATEMAX 0
+then
+	param set IMU_GYRO_RATEMAX 400
+fi
+
 if [ $AUTOCNF = yes ]
 then
-
-	# to minimize cpu usage on older boards limit inner loop to 400 Hz
-	param set IMU_GYRO_RATEMAX 400
 
 fi


### PR DESCRIPTION
The new Invensense IMU drivers have the ability to actually run the driver at a slower (or faster) rate without sacrificing any raw data. The rate at which the driver runs and empties the FIFO is the maximum inner loop (rate controller) update rate (current default is 1000 Hz). Regardless of the configured rate the full FIFO with 8 kHz raw data is transferred (with DMA). 

With focus shifting to newer boards based on stm32f7/h7/imxrt/etc (pixhawk 4 launched 2 years ago) and quite a lot of development activity things have been getting tighter on older boards like fmu-v2/v3. For example, current master on a Pixhawk 2 Cube configured as generic multicopter only has around 15% idle cpu (depending on exact configuration). Configured as a VTOL (quadplane, tiltrotor, etc) it can easily drop below 10%.

If we lower the default rate (IMU_GYRO_RATEMAX=400) these numbers become a lot more comfortable (> 30% idle cpu). This is a (probably?) a more appropriate rate for most vehicles other than small multicopters and also synchronizes with typical 400 Hz PWM ESCs.

With a safe default in place we could then explore opting in to much higher rates for specific configurations. For multicopters many of these boards (including f4's like the pixracer) can handle 2 kHz. Newer boards like the Holybro Durandal (and F7s if you're careful) can even comfortably handle 4 kHz.

For historical context PX4's rate was fixed at 250 Hz up until v1.10 (released Dec 2019), so we've really come a long way.

