### PR TITLE
airframe markdown script: Improve generated information text

### DIFF
--- a/Tools/px4airframes/markdownout.py
+++ b/Tools/px4airframes/markdownout.py
@@ -5,9 +5,10 @@ import os
 class MarkdownTablesOutput():
     def __init__(self, groups, board, image_path):
         result = ("# Airframes Reference\n"
-                  "> **Note** **This list is auto-generated from the source code**.\n"
+                  "> **Note** **This list is [auto-generated](https://github.com/PX4/Firmware/edit/master/Tools/px4airframes/markdownout.py) from the source code**.\n"
                   "> \n"
-                  "> The **AUX** channels are only available on Pixhawk Boards (labeled with **AUX OUT**).\n"
+                  "> **AUX** channels may not be present on some flight controllers.\n"
+                  "> If present, PWM AUX channels are commonly labelled **AUX OUT**.\n"
                   "> \n"
                   "\n")
 


### PR DESCRIPTION
Fixes https://github.com/PX4/px4_user_guide/pull/718

This improves the (generated) introductory text in the airframes reference:
1. Provides link to generator script. Not essential, but makes it easier for anyone wanting to improve the generated docs. 
2. Fixes up statement about AUX ports - their existence has nothing to do with being pixhawk or not. Note that I specified PWM AUX ports because of course we might map AUX to some other bus in future.