### PR TITLE
Commander: Add more documentation around USB reboots

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1442,10 +1442,14 @@ Commander::run()
 				/* if the USB hardware connection went away, reboot */
 				if (status_flags.usb_connected && !system_power.usb_connected && shutdown_if_allowed()) {
 					/*
-					 * apparently the USB cable went away but we are still powered,
-					 * so lets reset to a classic non-usb state.
+					 * Apparently the USB cable went away but we are still powered,
+					 * so we bring the system back to a nominal state for flight.
+					 * This is important to unload the USB stack of the OS which is
+					 * a relatively complex piece of software that is non-essential
+					 * for flight and continuing to run it would add a software risk
+					 * without a need. The clean approach to unload it is to reboot.
 					 */
-					mavlink_log_critical(&mavlink_log_pub, "USB disconnected, rebooting.")
+					mavlink_log_critical(&mavlink_log_pub, "USB disconnected, rebooting for flight safety")
 					px4_usleep(400000);
 					px4_shutdown_request(true, false);
 				}


### PR DESCRIPTION
If the user disconnects USB we reboot the system to bring it back into a nominal condition before arming. Otherwise we would either have the USB stack running without a cable connected (code running for no reason, which is violating the principle of not running unnecessary code in aviation). Or we would not allow to arm at all if USB was ever connected, which can be confusing if the system is powered off a battery.
