### PR TITLE
Add core dumps to CI for MAVSDK SITL tests

### DIFF
--- a/.github/workflows/sitl_tests.yml
+++ b/.github/workflows/sitl_tests.yml
@@ -17,7 +17,9 @@ jobs:
           bionic,
           focal
           ]
-    container: px4io/px4-dev-simulation-${{ matrix.ubuntu_release }}:2020-04-01
+    container:
+      image: px4io/px4-dev-simulation-${{ matrix.ubuntu_release }}:2020-04-01
+      options: --privileged --ulimit core=-1 --security-opt seccomp=unconfined
     steps:
     - uses: actions/checkout@v1
       with:
@@ -39,6 +41,10 @@ jobs:
       run: DONT_RUN=1 make px4_sitl PX4_CMAKE_BUILD_TYPE=Coverage gazebo mavsdk_tests
     - name: ccache post-run
       run: ccache -s && ccache -z
+    - name: Core dump settings
+      run: |
+          ulimit -c unlimited
+          echo '/tmp/core.%e.%t' > /proc/sys/kernel/core_pattern
     - name: Run SITL tests
       run:  test/mavsdk_tests/mavsdk_test_runner.py --speed-factor 20 --abort-early test/mavsdk_tests/configs/sitl.json
     - name: Run SITL tests in Southern hemisphere
@@ -47,6 +53,12 @@ jobs:
     - name: Run SITL tests far in the West
       run: PX4_HOME_LAT=59.6176928 PX4_HOME_LON=-151.1453163 PX4_HOME_ALT=48 |
         test/mavsdk_tests/mavsdk_test_runner.py --speed-factor 20 --abort-early test/mavsdk_tests/configs/sitl.json
+    - name: Show core files
+      if: always()
+      run: find /tmp -name "core*"
+    - name: Look for core files
+      if: always()
+      run: find /tmp -name "core.px4.*" | xargs -I '{}' gdb build/px4_sitl_default/bin/px4 '{}' -ex "thread apply all bt" -ex "quit"
 
     # Report test coverage
     - name: disable the keychain credential helper

--- a/.github/workflows/sitl_tests.yml
+++ b/.github/workflows/sitl_tests.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Core dump settings
       run: |
           ulimit -c unlimited
-          echo '/tmp/core.%e.%t' > /proc/sys/kernel/core_pattern
+          echo '/tmp/%e.core' > /proc/sys/kernel/core_pattern
     - name: Run SITL tests
       run:  test/mavsdk_tests/mavsdk_test_runner.py --speed-factor 20 --abort-early test/mavsdk_tests/configs/sitl.json
     - name: Run SITL tests in Southern hemisphere
@@ -53,12 +53,21 @@ jobs:
     - name: Run SITL tests far in the West
       run: PX4_HOME_LAT=59.6176928 PX4_HOME_LON=-151.1453163 PX4_HOME_ALT=48 |
         test/mavsdk_tests/mavsdk_test_runner.py --speed-factor 20 --abort-early test/mavsdk_tests/configs/sitl.json
-    - name: Show core files
-      if: always()
-      run: find /tmp -name "core*"
-    - name: Look for core files
-      if: always()
-      run: find /tmp -name "core.px4.*" | xargs -I '{}' gdb build/px4_sitl_default/bin/px4 '{}' -ex "thread apply all bt" -ex "quit"
+    - name: Look at core files
+      if: failure()
+      run: gdb build/px4_sitl_default/bin/px4 /tmp/px4.core -ex "thread apply all bt" -ex "quit"
+    - name: Upload px4 coredump
+      if: failure()
+      uses: actions/upload-artifact@v1
+      with:
+        name: coredump
+        path: /tmp/px4.core
+    - name: Upload px4 binary
+      if: failure()
+      uses: actions/upload-artifact@v1
+      with:
+        name: binary
+        path: build/px4_sitl_default/bin/px4
 
     # Report test coverage
     - name: disable the keychain credential helper

--- a/.github/workflows/sitl_tests.yml
+++ b/.github/workflows/sitl_tests.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Core dump settings
       run: |
           ulimit -c unlimited
-          echo '/tmp/%e.core' > /proc/sys/kernel/core_pattern
+          echo "`pwd`/%e.core" > /proc/sys/kernel/core_pattern
     - name: Run SITL tests
       run:  test/mavsdk_tests/mavsdk_test_runner.py --speed-factor 20 --abort-early test/mavsdk_tests/configs/sitl.json
     - name: Run SITL tests in Southern hemisphere
@@ -55,13 +55,13 @@ jobs:
         test/mavsdk_tests/mavsdk_test_runner.py --speed-factor 20 --abort-early test/mavsdk_tests/configs/sitl.json
     - name: Look at core files
       if: failure()
-      run: gdb build/px4_sitl_default/bin/px4 /tmp/px4.core -ex "thread apply all bt" -ex "quit"
+      run: gdb build/px4_sitl_default/bin/px4 px4.core -ex "thread apply all bt" -ex "quit"
     - name: Upload px4 coredump
       if: failure()
       uses: actions/upload-artifact@v1
       with:
         name: coredump
-        path: /tmp/px4.core
+        path: px4.core
     - name: Upload px4 binary
       if: failure()
       uses: actions/upload-artifact@v1

--- a/.github/workflows/sitl_tests.yml
+++ b/.github/workflows/sitl_tests.yml
@@ -58,13 +58,13 @@ jobs:
       run: gdb build/px4_sitl_default/bin/px4 px4.core -ex "thread apply all bt" -ex "quit"
     - name: Upload px4 coredump
       if: failure()
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2-preview
       with:
         name: coredump
         path: px4.core
     - name: Upload px4 binary
       if: failure()
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2-preview
       with:
         name: binary
         path: build/px4_sitl_default/bin/px4

--- a/platforms/posix/src/px4/common/main.cpp
+++ b/platforms/posix/src/px4/common/main.cpp
@@ -93,7 +93,6 @@ void init_once();
 }
 
 static void sig_int_handler(int sig_num);
-static void sig_fpe_handler(int sig_num);
 
 static void register_sig_handler();
 static void set_cpu_scaling();
@@ -404,11 +403,6 @@ void register_sig_handler()
 	sig_int.sa_handler = sig_int_handler;
 	sig_int.sa_flags = 0;// not SA_RESTART!
 
-	// SIGFPE
-	struct sigaction sig_fpe {};
-	sig_fpe.sa_handler = sig_fpe_handler;
-	sig_fpe.sa_flags = 0;// not SA_RESTART!
-
 	// SIGPIPE
 	// We want to ignore if a PIPE has been closed.
 	struct sigaction sig_pipe {};
@@ -423,7 +417,6 @@ void register_sig_handler()
 #endif
 
 	sigaction(SIGTERM, &sig_int, nullptr);
-	sigaction(SIGFPE, &sig_fpe, nullptr);
 	sigaction(SIGPIPE, &sig_pipe, nullptr);
 }
 
@@ -431,15 +424,6 @@ void sig_int_handler(int sig_num)
 {
 	fflush(stdout);
 	printf("\nPX4 Exiting...\n");
-	fflush(stdout);
-	px4_daemon::Pxh::stop();
-	_exit_requested = true;
-}
-
-void sig_fpe_handler(int sig_num)
-{
-	fflush(stdout);
-	printf("\nfloating point exception\n");
 	fflush(stdout);
 	px4_daemon::Pxh::stop();
 	_exit_requested = true;

--- a/test/mavsdk_tests/process_helper.py
+++ b/test/mavsdk_tests/process_helper.py
@@ -132,6 +132,10 @@ class Runner:
     def time_elapsed_s(self) -> float:
         return time.time() - self.start_time
 
+    def add_to_env_if_set(self, var: str) -> None:
+        if var in os.environ:
+            self.env[var] = os.environ[var]
+
 
 class Px4Runner(Runner):
     def __init__(self, workspace_dir: str, log_dir: str,
@@ -189,8 +193,8 @@ class GzserverRunner(Runner):
                     workspace_dir + "/build/px4_sitl_default/build_gazebo",
                     "GAZEBO_MODEL_PATH":
                     workspace_dir + "/Tools/sitl_gazebo/models",
-                    "PX4_SIM_SPEED_FACTOR": str(speed_factor),
-                    "DISPLAY": os.environ['DISPLAY']}
+                    "PX4_SIM_SPEED_FACTOR": str(speed_factor)}
+        self.add_to_env_if_set("DISPLAY")
         self.add_to_env_if_set("PX4_HOME_LAT")
         self.add_to_env_if_set("PX4_HOME_LON")
         self.add_to_env_if_set("PX4_HOME_ALT")
@@ -198,10 +202,6 @@ class GzserverRunner(Runner):
         self.args = ["--verbose",
                      workspace_dir + "/Tools/sitl_gazebo/worlds/" +
                      "empty.world"]
-
-    def add_to_env_if_set(self, var: str) -> None:
-        if var in os.environ:
-            self.env[var] = os.environ[var]
 
 
 class GzmodelspawnRunner(Runner):
@@ -219,8 +219,8 @@ class GzmodelspawnRunner(Runner):
                     "GAZEBO_PLUGIN_PATH":
                     workspace_dir + "/build/px4_sitl_default/build_gazebo",
                     "GAZEBO_MODEL_PATH":
-                    workspace_dir + "/Tools/sitl_gazebo/models",
-                    "DISPLAY": os.environ['DISPLAY']}
+                    workspace_dir + "/Tools/sitl_gazebo/models"}
+        self.add_to_env_if_set("DISPLAY")
         self.cmd = "gz"
         self.args = ["model", "--spawn-file", workspace_dir +
                      "/Tools/sitl_gazebo/models/" +
@@ -242,8 +242,8 @@ class GzclientRunner(Runner):
         self.env = {"PATH": os.environ['PATH'],
                     "HOME": os.environ['HOME'],
                     "GAZEBO_MODEL_PATH":
-                    workspace_dir + "/Tools/sitl_gazebo/models",
-                    "DISPLAY": os.environ['DISPLAY']}
+                    workspace_dir + "/Tools/sitl_gazebo/models"}
+        self.add_to_env_if_set("DISPLAY")
         self.cmd = "gzclient"
         self.args = ["--verbose"]
 


### PR DESCRIPTION
Work to get core dumps, backtrace in CI and get core dumps saved as a GitHub workflow artifact.