### PR TITLE
mc_pos_control: align updates with ekf2

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -316,7 +316,8 @@ MulticopterPositionControl::init()
 		return false;
 	}
 
-	_local_pos_sub.set_interval_us(20_ms); // 50 Hz max update rate
+	// limit to every other vehicle_local_position update (~62.5 Hz)
+	_local_pos_sub.set_interval_us(16_ms);
 
 	_time_stamp_last_loop = hrt_absolute_time();
 


### PR DESCRIPTION
Currently ekf2 publishes `vehicle_local_position` at 125 Hz (8 ms interval). The multicopter position controller is scheduled on new `vehicle_local_position` publications, but we limit it by setting the orb interval. With the current 50 ms interval the module actually ends up running at a variable rate. 

At a glance I don't see anything that assumes a constant rate, so this might be one of those things that only feels like the right thing to do.