### PR TITLE
imu/invensense: minor cleanup

### DIFF
--- a/src/drivers/imu/invensense/icm20602/ICM20602.hpp
+++ b/src/drivers/imu/invensense/icm20602/ICM20602.hpp
@@ -69,13 +69,9 @@ public:
 	int init() override;
 	void print_status() override;
 
-	void Start();
-	bool Reset();
-
-protected:
-	void custom_method(const BusCLIArguments &cli) override;
-	void exit_and_cleanup() override;
 private:
+	void exit_and_cleanup() override;
+
 	// Sensor Configuration
 	static constexpr float FIFO_SAMPLE_DT{125.f};
 	static constexpr uint32_t SAMPLES_PER_TRANSFER{2};       // ensure at least 1 new accel sample per transfer
@@ -99,6 +95,8 @@ private:
 	};
 
 	int probe() override;
+
+	bool Reset();
 
 	bool Configure();
 	void ConfigureAccel();

--- a/src/drivers/imu/invensense/icm20602/icm20602_main.cpp
+++ b/src/drivers/imu/invensense/icm20602/icm20602_main.cpp
@@ -36,15 +36,13 @@
 #include <px4_platform_common/getopt.h>
 #include <px4_platform_common/module.h>
 
-void
-ICM20602::print_usage()
+void ICM20602::print_usage()
 {
 	PRINT_MODULE_USAGE_NAME("icm20602", "driver");
 	PRINT_MODULE_USAGE_SUBCATEGORY("imu");
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(false, true);
 	PRINT_MODULE_USAGE_PARAM_INT('R', 0, 0, 35, "Rotation", true);
-	PRINT_MODULE_USAGE_COMMAND("reset");
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
@@ -65,11 +63,6 @@ I2CSPIDriverBase *ICM20602::instantiate(const BusCLIArguments &cli, const BusIns
 	}
 
 	return instance;
-}
-
-void ICM20602::custom_method(const BusCLIArguments &cli)
-{
-	Reset();
 }
 
 extern "C" int icm20602_main(int argc, char *argv[])
@@ -106,10 +99,6 @@ extern "C" int icm20602_main(int argc, char *argv[])
 
 	if (!strcmp(verb, "status")) {
 		return ThisDriver::module_status(iterator);
-	}
-
-	if (!strcmp(verb, "reset")) {
-		return ThisDriver::module_custom_method(cli, iterator);
 	}
 
 	ThisDriver::print_usage();

--- a/src/drivers/imu/invensense/icm20608g/ICM20608G.hpp
+++ b/src/drivers/imu/invensense/icm20608g/ICM20608G.hpp
@@ -69,13 +69,9 @@ public:
 	int init() override;
 	void print_status() override;
 
-	void Start();
-	bool Reset();
-
-protected:
-	void custom_method(const BusCLIArguments &cli) override;
-	void exit_and_cleanup() override;
 private:
+	void exit_and_cleanup() override;
+
 	// Sensor Configuration
 	static constexpr float FIFO_SAMPLE_DT{125.f};
 	static constexpr uint32_t SAMPLES_PER_TRANSFER{2};       // ensure at least 1 new accel sample per transfer
@@ -101,6 +97,8 @@ private:
 	};
 
 	int probe() override;
+
+	bool Reset();
 
 	bool Configure();
 	void ConfigureAccel();

--- a/src/drivers/imu/invensense/icm20608g/icm20608g_main.cpp
+++ b/src/drivers/imu/invensense/icm20608g/icm20608g_main.cpp
@@ -36,15 +36,13 @@
 #include <px4_platform_common/getopt.h>
 #include <px4_platform_common/module.h>
 
-void
-ICM20608G::print_usage()
+void ICM20608G::print_usage()
 {
 	PRINT_MODULE_USAGE_NAME("icm20608g", "driver");
 	PRINT_MODULE_USAGE_SUBCATEGORY("imu");
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(false, true);
 	PRINT_MODULE_USAGE_PARAM_INT('R', 0, 0, 35, "Rotation", true);
-	PRINT_MODULE_USAGE_COMMAND("reset");
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
@@ -65,11 +63,6 @@ I2CSPIDriverBase *ICM20608G::instantiate(const BusCLIArguments &cli, const BusIn
 	}
 
 	return instance;
-}
-
-void ICM20608G::custom_method(const BusCLIArguments &cli)
-{
-	Reset();
 }
 
 extern "C" int icm20608g_main(int argc, char *argv[])
@@ -106,10 +99,6 @@ extern "C" int icm20608g_main(int argc, char *argv[])
 
 	if (!strcmp(verb, "status")) {
 		return ThisDriver::module_status(iterator);
-	}
-
-	if (!strcmp(verb, "reset")) {
-		return ThisDriver::module_custom_method(cli, iterator);
 	}
 
 	ThisDriver::print_usage();

--- a/src/drivers/imu/invensense/icm20689/ICM20689.hpp
+++ b/src/drivers/imu/invensense/icm20689/ICM20689.hpp
@@ -69,13 +69,9 @@ public:
 	int init() override;
 	void print_status() override;
 
-	void Start();
-	bool Reset();
-
-protected:
-	void custom_method(const BusCLIArguments &cli) override;
-	void exit_and_cleanup() override;
 private:
+	void exit_and_cleanup() override;
+
 	// Sensor Configuration
 	static constexpr float FIFO_SAMPLE_DT{125.f};
 	static constexpr uint32_t SAMPLES_PER_TRANSFER{2}; // ensure at least 1 new accel sample per transfer
@@ -101,6 +97,8 @@ private:
 	};
 
 	int probe() override;
+
+	bool Reset();
 
 	bool Configure();
 	void ConfigureAccel();

--- a/src/drivers/imu/invensense/icm20689/icm20689_main.cpp
+++ b/src/drivers/imu/invensense/icm20689/icm20689_main.cpp
@@ -36,15 +36,13 @@
 #include <px4_platform_common/getopt.h>
 #include <px4_platform_common/module.h>
 
-void
-ICM20689::print_usage()
+void ICM20689::print_usage()
 {
 	PRINT_MODULE_USAGE_NAME("icm20689", "driver");
 	PRINT_MODULE_USAGE_SUBCATEGORY("imu");
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(false, true);
 	PRINT_MODULE_USAGE_PARAM_INT('R', 0, 0, 35, "Rotation", true);
-	PRINT_MODULE_USAGE_COMMAND("reset");
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
@@ -65,11 +63,6 @@ I2CSPIDriverBase *ICM20689::instantiate(const BusCLIArguments &cli, const BusIns
 	}
 
 	return instance;
-}
-
-void ICM20689::custom_method(const BusCLIArguments &cli)
-{
-	Reset();
 }
 
 extern "C" int icm20689_main(int argc, char *argv[])
@@ -106,10 +99,6 @@ extern "C" int icm20689_main(int argc, char *argv[])
 
 	if (!strcmp(verb, "status")) {
 		return ThisDriver::module_status(iterator);
-	}
-
-	if (!strcmp(verb, "reset")) {
-		return ThisDriver::module_custom_method(cli, iterator);
 	}
 
 	ThisDriver::print_usage();

--- a/src/drivers/imu/invensense/icm40609d/ICM40609D.hpp
+++ b/src/drivers/imu/invensense/icm40609d/ICM40609D.hpp
@@ -69,13 +69,9 @@ public:
 	int init() override;
 	void print_status() override;
 
-	void Start();
-	bool Reset();
-
-protected:
-	void custom_method(const BusCLIArguments &cli) override;
-	void exit_and_cleanup() override;
 private:
+	void exit_and_cleanup() override;
+
 	// Sensor Configuration
 	static constexpr float FIFO_SAMPLE_DT{125.f};
 	static constexpr uint32_t SAMPLES_PER_TRANSFER{1}; // ensure at least 1 new accel sample per transfer
@@ -102,6 +98,8 @@ private:
 	};
 
 	int probe() override;
+
+	bool Reset();
 
 	bool Configure();
 	void ConfigureAccel();

--- a/src/drivers/imu/invensense/icm40609d/icm40609d_main.cpp
+++ b/src/drivers/imu/invensense/icm40609d/icm40609d_main.cpp
@@ -43,7 +43,6 @@ void ICM40609D::print_usage()
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(false, true);
 	PRINT_MODULE_USAGE_PARAM_INT('R', 0, 0, 35, "Rotation", true);
-	PRINT_MODULE_USAGE_COMMAND("reset");
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
@@ -64,11 +63,6 @@ I2CSPIDriverBase *ICM40609D::instantiate(const BusCLIArguments &cli, const BusIn
 	}
 
 	return instance;
-}
-
-void ICM40609D::custom_method(const BusCLIArguments &cli)
-{
-	Reset();
 }
 
 extern "C" int icm40609d_main(int argc, char *argv[])
@@ -105,10 +99,6 @@ extern "C" int icm40609d_main(int argc, char *argv[])
 
 	if (!strcmp(verb, "status")) {
 		return ThisDriver::module_status(iterator);
-	}
-
-	if (!strcmp(verb, "reset")) {
-		return ThisDriver::module_custom_method(cli, iterator);
 	}
 
 	ThisDriver::print_usage();

--- a/src/drivers/imu/invensense/icm42688p/ICM42688P.hpp
+++ b/src/drivers/imu/invensense/icm42688p/ICM42688P.hpp
@@ -69,13 +69,9 @@ public:
 	int init() override;
 	void print_status() override;
 
-	void Start();
-	bool Reset();
-
-protected:
-	void custom_method(const BusCLIArguments &cli) override;
-	void exit_and_cleanup() override;
 private:
+	void exit_and_cleanup() override;
+
 	// Sensor Configuration
 	static constexpr float FIFO_SAMPLE_DT{125.f};
 	static constexpr uint32_t SAMPLES_PER_TRANSFER{1}; // ensure at least 1 new accel sample per transfer
@@ -102,6 +98,8 @@ private:
 	};
 
 	int probe() override;
+
+	bool Reset();
 
 	bool Configure();
 	void ConfigureAccel();

--- a/src/drivers/imu/invensense/icm42688p/icm42688p_main.cpp
+++ b/src/drivers/imu/invensense/icm42688p/icm42688p_main.cpp
@@ -43,7 +43,6 @@ void ICM42688P::print_usage()
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(false, true);
 	PRINT_MODULE_USAGE_PARAM_INT('R', 0, 0, 35, "Rotation", true);
-	PRINT_MODULE_USAGE_COMMAND("reset");
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
@@ -64,11 +63,6 @@ I2CSPIDriverBase *ICM42688P::instantiate(const BusCLIArguments &cli, const BusIn
 	}
 
 	return instance;
-}
-
-void ICM42688P::custom_method(const BusCLIArguments &cli)
-{
-	Reset();
 }
 
 extern "C" int icm42688p_main(int argc, char *argv[])
@@ -105,10 +99,6 @@ extern "C" int icm42688p_main(int argc, char *argv[])
 
 	if (!strcmp(verb, "status")) {
 		return ThisDriver::module_status(iterator);
-	}
-
-	if (!strcmp(verb, "reset")) {
-		return ThisDriver::module_custom_method(cli, iterator);
 	}
 
 	ThisDriver::print_usage();

--- a/src/drivers/imu/invensense/mpu6000/MPU6000.hpp
+++ b/src/drivers/imu/invensense/mpu6000/MPU6000.hpp
@@ -69,13 +69,9 @@ public:
 	int init() override;
 	void print_status() override;
 
-	void Start();
-	bool Reset();
-
-protected:
-	void custom_method(const BusCLIArguments &cli) override;
-	void exit_and_cleanup() override;
 private:
+	void exit_and_cleanup() override;
+
 	// Sensor Configuration
 	static constexpr float FIFO_SAMPLE_DT{125.f};
 	static constexpr uint32_t SAMPLES_PER_TRANSFER{8};       // ensure at least 1 new accel sample per transfer
@@ -99,6 +95,8 @@ private:
 	};
 
 	int probe() override;
+
+	bool Reset();
 
 	bool Configure();
 	void ConfigureAccel();

--- a/src/drivers/imu/invensense/mpu6000/mpu6000_main.cpp
+++ b/src/drivers/imu/invensense/mpu6000/mpu6000_main.cpp
@@ -36,15 +36,13 @@
 #include <px4_platform_common/getopt.h>
 #include <px4_platform_common/module.h>
 
-void
-MPU6000::print_usage()
+void MPU6000::print_usage()
 {
 	PRINT_MODULE_USAGE_NAME("mpu6000", "driver");
 	PRINT_MODULE_USAGE_SUBCATEGORY("imu");
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(false, true);
 	PRINT_MODULE_USAGE_PARAM_INT('R', 0, 0, 35, "Rotation", true);
-	PRINT_MODULE_USAGE_COMMAND("reset");
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
@@ -67,17 +65,12 @@ I2CSPIDriverBase *MPU6000::instantiate(const BusCLIArguments &cli, const BusInst
 	return instance;
 }
 
-void MPU6000::custom_method(const BusCLIArguments &cli)
-{
-	Reset();
-}
-
 extern "C" int mpu6000_main(int argc, char *argv[])
 {
 	int ch;
 	using ThisDriver = MPU6000;
 	BusCLIArguments cli{false, true};
-	cli.default_spi_frequency = InvenSense_MPU6000::SPI_SPEED;
+	cli.default_spi_frequency = SPI_SPEED;
 
 	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
@@ -106,10 +99,6 @@ extern "C" int mpu6000_main(int argc, char *argv[])
 
 	if (!strcmp(verb, "status")) {
 		return ThisDriver::module_status(iterator);
-	}
-
-	if (!strcmp(verb, "reset")) {
-		return ThisDriver::module_custom_method(cli, iterator);
 	}
 
 	ThisDriver::print_usage();

--- a/src/drivers/imu/invensense/mpu6500/MPU6500.hpp
+++ b/src/drivers/imu/invensense/mpu6500/MPU6500.hpp
@@ -69,13 +69,9 @@ public:
 	int init() override;
 	void print_status() override;
 
-	void Start();
-	bool Reset();
-
-protected:
-	void custom_method(const BusCLIArguments &cli) override;
-	void exit_and_cleanup() override;
 private:
+	void exit_and_cleanup() override;
+
 	// Sensor Configuration
 	static constexpr float FIFO_SAMPLE_DT{125.f};
 	static constexpr uint32_t SAMPLES_PER_TRANSFER{2};       // ensure at least 1 new accel sample per transfer
@@ -99,6 +95,8 @@ private:
 	};
 
 	int probe() override;
+
+	bool Reset();
 
 	bool Configure();
 	void ConfigureAccel();

--- a/src/drivers/imu/invensense/mpu6500/mpu6500_main.cpp
+++ b/src/drivers/imu/invensense/mpu6500/mpu6500_main.cpp
@@ -36,15 +36,13 @@
 #include <px4_platform_common/getopt.h>
 #include <px4_platform_common/module.h>
 
-void
-MPU6500::print_usage()
+void MPU6500::print_usage()
 {
 	PRINT_MODULE_USAGE_NAME("mpu9520", "driver");
 	PRINT_MODULE_USAGE_SUBCATEGORY("imu");
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(false, true);
 	PRINT_MODULE_USAGE_PARAM_INT('R', 0, 0, 35, "Rotation", true);
-	PRINT_MODULE_USAGE_COMMAND("reset");
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
@@ -65,11 +63,6 @@ I2CSPIDriverBase *MPU6500::instantiate(const BusCLIArguments &cli, const BusInst
 	}
 
 	return instance;
-}
-
-void MPU6500::custom_method(const BusCLIArguments &cli)
-{
-	Reset();
 }
 
 extern "C" int mpu6500_main(int argc, char *argv[])
@@ -106,10 +99,6 @@ extern "C" int mpu6500_main(int argc, char *argv[])
 
 	if (!strcmp(verb, "status")) {
 		return ThisDriver::module_status(iterator);
-	}
-
-	if (!strcmp(verb, "reset")) {
-		return ThisDriver::module_custom_method(cli, iterator);
 	}
 
 	ThisDriver::print_usage();

--- a/src/drivers/imu/invensense/mpu9250/MPU9250.hpp
+++ b/src/drivers/imu/invensense/mpu9250/MPU9250.hpp
@@ -71,13 +71,9 @@ public:
 	int init() override;
 	void print_status() override;
 
-	void Start();
-	bool Reset();
-
-protected:
-	void custom_method(const BusCLIArguments &cli) override;
-	void exit_and_cleanup() override;
 private:
+	void exit_and_cleanup() override;
+
 	// Sensor Configuration
 	static constexpr float FIFO_SAMPLE_DT{125.f};
 	static constexpr uint32_t SAMPLES_PER_TRANSFER{2};       // ensure at least 1 new accel sample per transfer
@@ -101,6 +97,8 @@ private:
 	};
 
 	int probe() override;
+
+	bool Reset();
 
 	bool Configure();
 	void ConfigureAccel();

--- a/src/drivers/imu/invensense/mpu9250/MPU9250_AK8963.hpp
+++ b/src/drivers/imu/invensense/mpu9250/MPU9250_AK8963.hpp
@@ -61,7 +61,6 @@ public:
 	~MPU9250_AK8963() override;
 
 	bool Init();
-	void Start();
 	void Stop();
 	bool Reset();
 	void PrintInfo();

--- a/src/drivers/imu/invensense/mpu9250/mpu9250_main.cpp
+++ b/src/drivers/imu/invensense/mpu9250/mpu9250_main.cpp
@@ -36,8 +36,7 @@
 #include <px4_platform_common/getopt.h>
 #include <px4_platform_common/module.h>
 
-void
-MPU9250::print_usage()
+void MPU9250::print_usage()
 {
 	PRINT_MODULE_USAGE_NAME("mpu9520", "driver");
 	PRINT_MODULE_USAGE_SUBCATEGORY("imu");
@@ -45,7 +44,6 @@ MPU9250::print_usage()
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(false, true);
 	PRINT_MODULE_USAGE_PARAM_FLAG('M', "Enable Magnetometer (AK8963)", true);
 	PRINT_MODULE_USAGE_PARAM_INT('R', 0, 0, 35, "Rotation", true);
-	PRINT_MODULE_USAGE_COMMAND("reset");
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
@@ -67,11 +65,6 @@ I2CSPIDriverBase *MPU9250::instantiate(const BusCLIArguments &cli, const BusInst
 	}
 
 	return instance;
-}
-
-void MPU9250::custom_method(const BusCLIArguments &cli)
-{
-	Reset();
 }
 
 extern "C" int mpu9250_main(int argc, char *argv[])
@@ -112,10 +105,6 @@ extern "C" int mpu9250_main(int argc, char *argv[])
 
 	if (!strcmp(verb, "status")) {
 		return ThisDriver::module_status(iterator);
-	}
-
-	if (!strcmp(verb, "reset")) {
-		return ThisDriver::module_custom_method(cli, iterator);
 	}
 
 	ThisDriver::print_usage();


### PR DESCRIPTION
 - remove leftover Start()
 - remove "reset" from command line (stop + start is sufficient)


Reset wasn't even used during development, so I'd rather not even expose it and then drop the custom_method plumbing (start + stop is equivalent). Less is more.