### PR TITLE
accelerometer/gyroscope: FIFO sampling start monitoring sensor clock difference

### DIFF
--- a/msg/sensor_accel_status.msg
+++ b/msg/sensor_accel_status.msg
@@ -3,6 +3,7 @@ uint64 timestamp          # time since system start (microseconds)
 uint32 device_id          # unique device ID for the sensor that does not change between power cycles
 
 uint64 error_count
+uint64 fifo_time_slip     # cumulative time difference between sensor and system (based on FIFO samples)
 
 float32 temperature
 

--- a/msg/sensor_gyro_status.msg
+++ b/msg/sensor_gyro_status.msg
@@ -3,6 +3,7 @@ uint64 timestamp          # time since system start (microseconds)
 uint32 device_id          # unique device ID for the sensor that does not change between power cycles
 
 uint64 error_count
+uint64 fifo_time_slip     # cumulative time difference between sensor and system (based on FIFO samples)
 
 float32 temperature
 

--- a/src/lib/drivers/accelerometer/PX4Accelerometer.cpp
+++ b/src/lib/drivers/accelerometer/PX4Accelerometer.cpp
@@ -324,6 +324,16 @@ void PX4Accelerometer::updateFIFO(const FIFOSample &sample)
 
 
 	PublishStatus();
+
+	// monitor time difference with sensor
+	_elapsed_time_fifo_sum += N * dt;
+
+	if (_elapsed_time_fifo_sum_start == 0) {
+		_elapsed_time_fifo_sum_start = sample.timestamp_sample - N * dt;
+	}
+
+	_fifo_time_slip = sample.timestamp_sample - _elapsed_time_fifo_sum_start - _elapsed_time_fifo_sum;
+	_fifo_time_ratio = (float)(sample.timestamp_sample - _elapsed_time_fifo_sum_start) / (float)_elapsed_time_fifo_sum;
 }
 
 void PX4Accelerometer::PublishStatus()
@@ -334,6 +344,7 @@ void PX4Accelerometer::PublishStatus()
 
 		status.device_id = _device_id;
 		status.error_count = _error_count;
+		status.fifo_time_slip = _fifo_time_slip;
 		status.full_scale_range = _range;
 		status.rotation = _rotation;
 		status.measure_rate_hz = _update_rate;
@@ -382,4 +393,9 @@ void PX4Accelerometer::print_status()
 		 (double)_calibration_scale(2));
 	PX4_INFO("calibration offset: %.5f %.5f %.5f", (double)_calibration_offset(0), (double)_calibration_offset(1),
 		 (double)_calibration_offset(2));
+
+	if (_fifo_time_slip != 0) {
+		PX4_INFO("FIFO time slip: %" PRId64 " us (%.3f%% clock difference)", _fifo_time_slip,
+			 100 - (double)_fifo_time_ratio * 100);
+	}
 }

--- a/src/lib/drivers/accelerometer/PX4Accelerometer.hpp
+++ b/src/lib/drivers/accelerometer/PX4Accelerometer.hpp
@@ -124,6 +124,11 @@ private:
 
 	uint16_t		_update_rate{1000};
 
+	hrt_abstime		_elapsed_time_fifo_sum{0};
+	hrt_abstime		_elapsed_time_fifo_sum_start{0};
+	hrt_abstime		_fifo_time_slip{0};
+	float			_fifo_time_ratio{0.f};
+
 	// integrator
 	hrt_abstime		_timestamp_sample_prev{0};
 	matrix::Vector3f	_integration_raw{};

--- a/src/lib/drivers/gyroscope/PX4Gyroscope.hpp
+++ b/src/lib/drivers/gyroscope/PX4Gyroscope.hpp
@@ -126,6 +126,11 @@ private:
 
 	uint16_t		_update_rate{1000};
 
+	hrt_abstime		_elapsed_time_fifo_sum{0};
+	hrt_abstime		_elapsed_time_fifo_sum_start{0};
+	hrt_abstime		_fifo_time_slip{0};
+	float			_fifo_time_ratio{0.f};
+
 	// integrator
 	hrt_abstime		_timestamp_sample_prev{0};
 	matrix::Vector3f	_integration_raw{};


### PR DESCRIPTION
Start monitoring time difference in sensors vs system. If this looks sane we could start adjusting the published dt.

