### PR TITLE
Preflight checks: home position and action switches

### DIFF
--- a/src/modules/commander/Arming/PreFlightCheck/CMakeLists.txt
+++ b/src/modules/commander/Arming/PreFlightCheck/CMakeLists.txt
@@ -45,6 +45,7 @@ px4_add_library(PreFlightCheck
 	checks/powerCheck.cpp
 	checks/ekf2Check.cpp
 	checks/failureDetectorCheck.cpp
+	checks/manualControlCheck.cpp
 )
 target_include_directories(PreFlightCheck PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(PreFlightCheck PUBLIC ArmAuthorization HealthFlags)

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
@@ -295,6 +295,8 @@ bool PreFlightCheck::preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_statu
 		failed = true;
 	}
 
+	failed = failed || !manualControlCheck(mavlink_log_pub, reportFailures);
+
 	/* Report status */
 	return !failed;
 }

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
@@ -113,4 +113,5 @@ private:
 	static bool failureDetectorCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_s &status, const bool report_fail,
 					 const bool prearm);
 	static bool check_calibration(const char *param_template, const int32_t device_id);
+	static bool manualControlCheck(orb_advert_t *mavlink_log_pub, const bool report_fail);
 };

--- a/src/modules/commander/Arming/PreFlightCheck/checks/manualControlCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/manualControlCheck.cpp
@@ -1,0 +1,87 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "../PreFlightCheck.hpp"
+
+#include <systemlib/mavlink_log.h>
+#include <uORB/Subscription.hpp>
+#include <uORB/topics/manual_control_setpoint.h>
+
+using namespace time_literals;
+
+bool PreFlightCheck::manualControlCheck(orb_advert_t *mavlink_log_pub, const bool report_fail)
+{
+	bool success = true;
+
+	uORB::SubscriptionData<manual_control_setpoint_s> manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
+	manual_control_setpoint_sub.update();
+	const manual_control_setpoint_s &manual_control = manual_control_setpoint_sub.get();
+
+	if (hrt_elapsed_time(&manual_control.timestamp) < 1_s) {
+
+		//check action switches
+		if (manual_control.return_switch == manual_control_setpoint_s::SWITCH_POS_ON) {
+			success = false;
+
+			if (report_fail) {
+				mavlink_log_critical(mavlink_log_pub, "Failure: RTL switch engaged");
+			}
+		}
+
+		if (manual_control.kill_switch == manual_control_setpoint_s::SWITCH_POS_ON) {
+			success = false;
+
+			if (report_fail) {
+				mavlink_log_critical(mavlink_log_pub, "Failure: Kill switch engaged");
+			}
+		}
+
+		if (manual_control.gear_switch == manual_control_setpoint_s::SWITCH_POS_ON) {
+			success = false;
+
+			if (report_fail) {
+				mavlink_log_critical(mavlink_log_pub, "Failure: Landing gear switch set in UP position");
+			}
+		}
+
+		if (manual_control.transition_switch == manual_control_setpoint_s::SWITCH_POS_ON) {
+			success = false;
+
+			if (report_fail) {
+				mavlink_log_critical(mavlink_log_pub, "Failure: VTOL transition switch engaged");
+			}
+		}
+	}
+
+	return success;
+}

--- a/src/modules/commander/Arming/PreFlightCheck/checks/preArmCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/preArmCheck.cpp
@@ -103,6 +103,14 @@ bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_st
 
 			prearm_ok = false;
 		}
+
+		if (!status_flags.condition_home_position_valid) {
+			if (prearm_ok) {
+				if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! Home position invalid"); }
+			}
+
+			prearm_ok = false;
+		}
 	}
 
 	// safety button


### PR DESCRIPTION
New preflight checks:

- for home position: There were quite some cases where people took off in altitude without a valid home position and then had issues with RTL. Check is disabled by default, so no behavior change.

- for action switches: Not allowed to arm anymore if KILL, RETURN, GEAR or TRANSITION switch is active.