### PR TITLE
mc_pos_control: correct sign of acceleration state

### DIFF
--- a/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
@@ -145,7 +145,7 @@ void PositionControl::_velocityControl(const float dt)
 {
 	// PID velocity control
 	Vector3f vel_error = _vel_sp - _vel;
-	Vector3f acc_sp_velocity = vel_error.emult(_gain_vel_p) + _vel_int + _vel_dot.emult(_gain_vel_d);
+	Vector3f acc_sp_velocity = vel_error.emult(_gain_vel_p) + _vel_int - _vel_dot.emult(_gain_vel_d);
 
 	// For backwards compatibility of the gains to non-acceleration based control, needs to be overcome with configuration conversion
 	acc_sp_velocity *= CONSTANTS_ONE_G / _hover_thrust;

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -480,8 +480,8 @@ MulticopterPositionControl::set_vehicle_states(const float &vel_sp_z)
 	if (PX4_ISFINITE(_local_pos.vx) && PX4_ISFINITE(_local_pos.vy) && _local_pos.v_xy_valid) {
 		_states.velocity(0) = _local_pos.vx;
 		_states.velocity(1) = _local_pos.vy;
-		_states.acceleration(0) = _vel_x_deriv.update(-_states.velocity(0));
-		_states.acceleration(1) = _vel_y_deriv.update(-_states.velocity(1));
+		_states.acceleration(0) = _vel_x_deriv.update(_states.velocity(0));
+		_states.acceleration(1) = _vel_y_deriv.update(_states.velocity(1));
 
 	} else {
 		_states.velocity(0) = _states.velocity(1) = NAN;


### PR DESCRIPTION
**Describe problem solved by this pull request**
The sign of the acceleration state passed to the position controller is wrong because it's only used as the derivative of the error in the controller which is opposite sign. The variable should contain what the name says and not the negative value because of how it's used.

fixes #13887

**Describe your solution**
Non-functional change, just change the sign in the correct place to avoid further confusion.

**Test data / coverage**
Untested but I checked it's the only place the variable is used.
