### PR TITLE
commander: add check for VTOL airfame on fmu-v2

### DIFF
--- a/src/modules/commander/Arming/PreFlightCheck/CMakeLists.txt
+++ b/src/modules/commander/Arming/PreFlightCheck/CMakeLists.txt
@@ -43,6 +43,7 @@ px4_add_library(PreFlightCheck
 	checks/airspeedCheck.cpp
 	checks/rcCalibrationCheck.cpp
 	checks/powerCheck.cpp
+	checks/airframeCheck.cpp
 	checks/ekf2Check.cpp
 	checks/failureDetectorCheck.cpp
 	checks/manualControlCheck.cpp

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
@@ -80,6 +80,11 @@ bool PreFlightCheck::preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_statu
 
 	bool failed = false;
 
+	/* ---- SYSTEM POWER ---- */
+	if (!airframeCheck(mavlink_log_pub, status)) {
+		failed = true;
+	}
+
 	/* ---- MAG ---- */
 	if (checkSensors) {
 		int32_t sys_has_mag = 1;

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
@@ -80,10 +80,7 @@ bool PreFlightCheck::preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_statu
 
 	bool failed = false;
 
-	/* ---- SYSTEM POWER ---- */
-	if (!airframeCheck(mavlink_log_pub, status)) {
-		failed = true;
-	}
+	failed = failed || !airframeCheck(mavlink_log_pub, status);
 
 	/* ---- MAG ---- */
 	if (checkSensors) {

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
@@ -114,4 +114,5 @@ private:
 					 const bool prearm);
 	static bool check_calibration(const char *param_template, const int32_t device_id);
 	static bool manualControlCheck(orb_advert_t *mavlink_log_pub, const bool report_fail);
+	static bool airframeCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_s &status);
 };

--- a/src/modules/commander/Arming/PreFlightCheck/checks/airframeCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/airframeCheck.cpp
@@ -1,0 +1,58 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "../PreFlightCheck.hpp"
+
+#include <drivers/drv_hrt.h>
+#include <systemlib/mavlink_log.h>
+#include <uORB/Subscription.hpp>
+
+using namespace time_literals;
+
+bool PreFlightCheck::airframeCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_s &status)
+{
+	bool success = true;
+
+#ifdef CONFIG_ARCH_BOARD_PX4_FMU_V2
+
+	// We no longer support VTOL on fmu-v2, so we need to warn existing users.
+	if (status.is_vtol) {
+		mavlink_log_critical(mavlink_log_pub,
+				     "VTOL is not supported with fmu-v2, see docs.px4.io/master/en/config/firmware.html#bootloader");
+		success = false;
+	}
+
+#endif
+
+	return success;
+}


### PR DESCRIPTION
This adds a preflight check when a VTOL airframe is configured on a fmu-v2 where VTOL is no longer included.

Resolves https://github.com/PX4/Firmware/issues/14381.