### PR TITLE
Add cansat support in PX4 Softawre-in-The-Loop Gazebo Sim

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/1080_cansat
+++ b/ROMFS/px4fmu_common/init.d-posix/1080_cansat
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+# @name Cansat SITL
+#
+# @type Quadrotor Wide
+#
+# @maintainer Jaeyoung Lim <jaeyoung@auterion.com>
+#
+
+sh /etc/init.d/rc.mc_defaults
+
+set MIXER quad_w
+

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -65,6 +65,7 @@ set(models none shell
 	plane plane_cam plane_catapult
 	standard_vtol tailsitter tiltrotor
 	rover boat
+	cansat
 	uuv_hippocampus)
 set(worlds none empty baylands ksql_airport mcmillan_airfield sonoma_raceway warehouse)
 set(all_posix_vmd_make_targets)


### PR DESCRIPTION
**Describe problem solved by this pull request**
Cansats are a educational platform for students studying satellites.

**Describe your solution**
This PR adds a Software-In-The-Loop simulation target for PX4 SITL

To try it, run
```
make px4_sitl gazebo_cansat
```

**Test data / coverage**

**Additional context**
