### PR TITLE
boards: fmu was renamed pwm_out

### DIFF
--- a/boards/px4/fmu-v4/init/rc.board_sensors
+++ b/boards/px4/fmu-v4/init/rc.board_sensors
@@ -11,7 +11,7 @@ adc start
 # schematic and BOM, leading to sensor brownouts
 # on boot. Original Pixracers following the
 # open hardware design do not require this.
-fmu sensor_reset 50
+pwm_out sensor_reset 50
 
 
 # External I2C bus

--- a/boards/uvify/core/init/rc.board_extras
+++ b/boards/uvify/core/init/rc.board_extras
@@ -8,7 +8,7 @@
 if param compare SYS_AUTOSTART 4071
 then
 	# Change rate to 400 Khz for fast barometer
-	#fmu i2c 1 400000
+	#pwm_out i2c 1 400000
 
 	# IFO has only external i2c barometer.
 	# It does not start EKF2 in the beginning which is strange behaviour. but 3 seconds hack.


### PR DESCRIPTION
Clearly `sensor_reset` seems out of place now.