### PR TITLE
Add aion robotics r1 rover as a sitl target for Gazebo

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/1061_r1_rover
+++ b/ROMFS/px4fmu_common/init.d-posix/1061_r1_rover
@@ -1,0 +1,38 @@
+!/bin/sh
+#
+# @name Aion Robotics R1 Rover
+# @type Rover
+# @class Rover
+
+sh /etc/init.d/rc.rover_defaults
+
+if [ $AUTOCNF = yes ]
+then
+	param set GND_L1_DIST 5
+	param set GND_SP_CTRL_MODE 1
+	param set GND_SPEED_D 3
+	param set GND_SPEED_I 0.001
+	param set GND_SPEED_IMAX 0.125
+	param set GND_SPEED_P 0.25
+	param set GND_SPEED_THR_SC 1
+	param set GND_SPEED_TRIM 4
+	param set GND_THR_CRUISE 0.3
+	param set GND_THR_IDLE 0
+	param set GND_THR_MAX 0.5
+	param set GND_THR_MIN 0
+
+	param set MIS_LTRMIN_ALT 0.01
+	param set MIS_TAKEOFF_ALT 0.01
+	param set NAV_ACC_RAD 0.5
+	param set NAV_LOITER_RAD 2
+
+	param set CBRK_AIRSPD_CHK 162128
+
+	param set GND_MAX_ANG 0.6
+	param set GND_WHEEL_BASE 2.0
+
+fi
+
+set MAV_TYPE 10
+
+set MIXER_FILE etc/mixers/generic_diff_rover.main.mix

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -79,7 +79,7 @@ set(models none shell
 	if750a iris iris_opt_flow iris_opt_flow_mockup iris_vision iris_rplidar iris_irlock iris_obs_avoid iris_rtps px4vision solo typhoon_h480
 	plane plane_cam plane_catapult plane_lidar
 	standard_vtol tailsitter tiltrotor
-	rover boat
+	rover r1_rover boat
 	uuv_hippocampus)
 set(worlds none empty baylands ksql_airport mcmillan_airfield sonoma_raceway warehouse)
 set(all_posix_vmd_make_targets)


### PR DESCRIPTION
**Describe problem solved by this pull request**
Previously, it was not possible to simulate a differential rover in PX4 SITL

**Describe your solution**
This PR adds a gazebo model based on the aion robotics r1 rover as a SITL target.

The models were imported from https://github.com/aionrobotics/r1_ugv_sim 

**Test data / coverage**
Here is the video of the rover running a mission in gazebo:

[![Demo](https://img.youtube.com/vi/cL7ZhvNvV3o/0.jpg)](https://youtu.be/cL7ZhvNvV3o) 

**Additional context**
- Model implemented in: https://github.com/PX4/sitl_gazebo/pull/394
- Fixes https://github.com/PX4/Firmware/issues/11955