### PR TITLE
boards: px4/fmu-v4pro cleanup rc.board_sensors

### DIFF
--- a/boards/px4/fmu-v4pro/init/rc.board_sensors
+++ b/boards/px4/fmu-v4pro/init/rc.board_sensors
@@ -7,11 +7,11 @@ rgbled start -I
 
 adc start
 
-# Internal SPI bus ICM-20608-G
-icm20608g -s -R 8 start
-
-# Internal SPI bus ICM-20602
-icm20602 -s -R 8 start
+# Internal SPI bus ICM-20602 or ICM-20608-G
+if ! icm20602 -s -R 8 start
+then
+	icm20608g -s -R 8 start
+fi
 
 # Internal SPI bus mpu9250
 mpu9250 -s -R 8 start
@@ -19,12 +19,12 @@ mpu9250 -s -R 8 start
 # Internal SPI bus
 lis3mdl -s -R 0 start
 
-# Possible external compasses
-hmc5883 -T -X start
-qmc5883 -X start
-
-# RM3100
-rm3100 -X start
-
 # Internal SPI
 ms5611 -s start
+
+# Possible external compasses
+hmc5883 -T -X start
+lis3mdl -X start
+ist8310 -X start
+qmc5883 -X start
+rm3100 -X start


### PR DESCRIPTION
 - board has either an icm20602 or icm20608g, not both
 - probe all typical externally compasses
