### PR TITLE
fix param_translation: set address to 0 only on NuttX

### DIFF
--- a/src/lib/parameters/param_translation.cpp
+++ b/src/lib/parameters/param_translation.cpp
@@ -101,9 +101,13 @@ bool param_modify_on_import(bson_node_t node)
 	device_id.devid = (uint32_t) * ivalue;
 
 	// SPI board config translation
+#ifdef __PX4_NUTTX // only on NuttX the address is 0
+
 	if (device_id.devid_s.bus_type == device::Device::DeviceBusType_SPI) {
 		device_id.devid_s.address = 0;
 	}
+
+#endif
 
 	// deprecated ACC -> IMU translations
 	if (device_id.devid_s.devtype == DRV_ACC_DEVTYPE_MPU6000_LEGACY) {


### PR DESCRIPTION
On Linux it can be non-zero.

Fixes https://github.com/PX4/Firmware/issues/14649