### PR TITLE
Rover speed pid Ki and Kd parameters inversion

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/1060_rover
+++ b/ROMFS/px4fmu_common/init.d-posix/1060_rover
@@ -9,8 +9,8 @@ if [ $AUTOCNF = yes ]
 then
 	param set GND_L1_DIST 5
 	param set GND_SP_CTRL_MODE 1
-	param set GND_SPEED_D 3
-	param set GND_SPEED_I 0.001
+	param set GND_SPEED_D 0.001
+	param set GND_SPEED_I 3
 	param set GND_SPEED_IMAX 0.125
 	param set GND_SPEED_P 0.25
 	param set GND_SPEED_THR_SC 1

--- a/ROMFS/px4fmu_common/init.d-posix/1070_boat
+++ b/ROMFS/px4fmu_common/init.d-posix/1070_boat
@@ -9,8 +9,8 @@ if [ $AUTOCNF = yes ]
 then
 	param set GND_L1_DIST 5
 	param set GND_SP_CTRL_MODE 1
-	param set GND_SPEED_D 3
-	param set GND_SPEED_I 0.001
+	param set GND_SPEED_D 0.001
+	param set GND_SPEED_I 3
 	param set GND_SPEED_IMAX 0.125
 	param set GND_SPEED_P 0.25
 	param set GND_SPEED_THR_SC 1

--- a/ROMFS/px4fmu_common/init.d/airframes/50000_generic_ground_vehicle
+++ b/ROMFS/px4fmu_common/init.d/airframes/50000_generic_ground_vehicle
@@ -34,8 +34,8 @@ then
 	param set GND_L1_DIST 10
 	param set GND_SP_CTRL_MODE 1
 	param set GND_SPEED_P 0.25
-	param set GND_SPEED_I 0.001
-	param set GND_SPEED_D 3
+	param set GND_SPEED_I 3
+	param set GND_SPEED_D 0.001
 	param set GND_SPEED_IMAX 0.125
 	param set GND_SPEED_THR_SC 1
 	param set GND_THR_IDLE 0

--- a/ROMFS/px4fmu_common/init.d/airframes/50002_traxxas_stampede_2wd
+++ b/ROMFS/px4fmu_common/init.d/airframes/50002_traxxas_stampede_2wd
@@ -44,8 +44,8 @@ then
 	param set GND_THR_MAX 0.5
 	param set GND_THR_MIN 0
 	param set GND_SPEED_P 0.25
-	param set GND_SPEED_I 0.001
-	param set GND_SPEED_D 3
+	param set GND_SPEED_I 3
+	param set GND_SPEED_D 0.001
 	param set GND_SPEED_IMAX 0.125
 	param set GND_SPEED_THR_SC 1
 

--- a/ROMFS/px4fmu_common/init.d/airframes/50003_aion_robotics_r1_rover
+++ b/ROMFS/px4fmu_common/init.d/airframes/50003_aion_robotics_r1_rover
@@ -50,8 +50,8 @@ then
 	# to support negative throttle.
 	param set GND_THR_MIN 0.0
 	param set GND_SPEED_P 0.25
-	param set GND_SPEED_I 0.001
-	param set GND_SPEED_D 3
+	param set GND_SPEED_I 3
+	param set GND_SPEED_D 0.001
 	param set GND_SPEED_IMAX 0.125
 	param set GND_SPEED_THR_SC 1
 

--- a/ROMFS/px4fmu_common/init.d/airframes/50004_dfrobot_gpx_asurada
+++ b/ROMFS/px4fmu_common/init.d/airframes/50004_dfrobot_gpx_asurada
@@ -47,8 +47,8 @@ then
 	# to support negative throttle.
 	param set GND_THR_MIN 0.0
 	param set GND_SPEED_P 0.25
-	param set GND_SPEED_I 0.001
-	param set GND_SPEED_D 3
+	param set GND_SPEED_I 3
+	param set GND_SPEED_D 0.001
 	param set GND_SPEED_IMAX 0.125
 	param set GND_SPEED_THR_SC 1
 

--- a/src/modules/rover_pos_control/RoverPositionControl.cpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.cpp
@@ -86,8 +86,8 @@ void RoverPositionControl::parameters_update(bool force)
 		pid_init(&_speed_ctrl, PID_MODE_DERIVATIV_CALC, 0.01f);
 		pid_set_parameters(&_speed_ctrl,
 				   _param_speed_p.get(),
-				   _param_speed_d.get(),
 				   _param_speed_i.get(),
+				   _param_speed_d.get(),
 				   _param_speed_imax.get(),
 				   _param_gndspeed_max.get());
 	}

--- a/src/modules/rover_pos_control/rover_pos_control_params.c
+++ b/src/modules/rover_pos_control/rover_pos_control_params.c
@@ -191,7 +191,7 @@ PARAM_DEFINE_FLOAT(GND_SPEED_P, 2.0f);
  * @increment 0.005
  * @group Rover Position Control
  */
-PARAM_DEFINE_FLOAT(GND_SPEED_I, 0.1f);
+PARAM_DEFINE_FLOAT(GND_SPEED_I, 3.0f);
 
 /**
  * Speed proportional gain
@@ -205,7 +205,7 @@ PARAM_DEFINE_FLOAT(GND_SPEED_I, 0.1f);
  * @increment 0.005
  * @group Rover Position Control
  */
-PARAM_DEFINE_FLOAT(GND_SPEED_D, 0.0f);
+PARAM_DEFINE_FLOAT(GND_SPEED_D, 0.001f);
 
 /**
  * Speed integral maximum value


### PR DESCRIPTION
**Describe problem solved by this pull request**
Currently the rover speed pid initialisation reverse the integral and derivative parameters in the function pid_set_parameters. And all the rover related airframes are using GND_SPEED_I = 0.001 and GND_SPEED_D = 3.

**Describe your solution**
I swapped the Ki and Kd parameters in RoverPositionControl.cpp and in the airframes files. I also set 3 and 0.001 as default value for GND_SPEED_I and GND_SPEED_D parameters.

**Test data / coverage**
Tested with gazebo_rover.
