### PR TITLE
mavlink: lock sending messages outside

### DIFF
--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -318,7 +318,7 @@ public:
 	/**
 	 * This is the beginning of a MAVLINK_START_UART_SEND/MAVLINK_END_UART_SEND transaction
 	 */
-	void 			begin_send() { pthread_mutex_lock(&_send_mutex); }
+	void 			begin_send() {}
 
 	/**
 	 * Send bytes out on the link.
@@ -521,6 +521,8 @@ public:
 	struct ping_statistics_s &get_ping_statistics() { return _ping_stats; }
 
 	static hrt_abstime &get_first_start_time() { return _first_start_time; }
+
+	pthread_mutex_t &send_mutex() { return _send_mutex; }
 
 protected:
 	Mavlink			*next{nullptr};

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2910,6 +2910,8 @@ MavlinkReceiver::Run()
 		hrt_abstime t = hrt_absolute_time();
 
 		if (t - last_send_update > timeout * 1000) {
+
+			pthread_mutex_lock(&_mavlink->send_mutex());
 			_mission_manager.check_active_mission();
 			_mission_manager.send(t);
 
@@ -2920,6 +2922,8 @@ MavlinkReceiver::Run()
 			}
 
 			_mavlink_log_handler.send(t);
+			pthread_mutex_unlock(&_mavlink->send_mutex());
+
 			last_send_update = t;
 		}
 


### PR DESCRIPTION
This is an attempt to prevent any of the 3 parts of a MAVLink message to end up on the buffer without the other parts. When partial messages end up on the buffer it will cause message drops because the parser reads too far and will miss the subsequent message.

By locking around the full process and preventing races between the message senders in the receiver thread and the actual sending threads we prevent message drops which e.g. leads to a cleaner initial param download.

This is an alternative to #12967. The param download works equally well, so 100% for the tested cases but CPU usage of the MAVLink threads is almost doubled, so this PR is clearly much worse.
I'm not sure why that's the case though it must have something to do with the locking.

For the test data, check: https://docs.google.com/spreadsheets/d/1aAT58x1zVd6_5bL9NjCOnc87Eoy4Aa3QMd-cmwZXI8A