### PR TITLE
build tools: bring GNU Arm Embedded Toolchain Version 9 to CI and setup scripts

### DIFF
--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -8,7 +8,7 @@ pipeline {
     stage('Build') {
       agent {
         docker {
-          image 'px4io/px4-dev-ros-melodic:2020-04-01'
+          image 'px4io/px4-dev-ros-melodic:2020-04-02'
           args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
         }
       }
@@ -133,7 +133,7 @@ def createTestNode(Map test_def) {
   return {
     node {
       cleanWs()
-      docker.image("px4io/px4-dev-ros-melodic:2020-04-01").inside('-e HOME=${WORKSPACE}') {
+      docker.image("px4io/px4-dev-ros-melodic:2020-04-02").inside('-e HOME=${WORKSPACE}') {
         stage(test_def.name) {
           def run_script = test_def.get('run_script', 'rostest_px4_run.sh')
           def test_ok = true

--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -8,7 +8,7 @@ pipeline {
     stage('Build') {
       agent {
         docker {
-          image 'px4io/px4-dev-ros-melodic:2020-04-02'
+          image 'px4io/px4-dev-ros-melodic:2020-05-28'
           args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
         }
       }
@@ -133,7 +133,7 @@ def createTestNode(Map test_def) {
   return {
     node {
       cleanWs()
-      docker.image("px4io/px4-dev-ros-melodic:2020-04-02").inside('-e HOME=${WORKSPACE}') {
+      docker.image("px4io/px4-dev-ros-melodic:2020-05-28").inside('-e HOME=${WORKSPACE}') {
         stage(test_def.name) {
           def run_script = test_def.get('run_script', 'rostest_px4_run.sh')
           def test_ok = true

--- a/.ci/Jenkinsfile-SITL_tests_ASan
+++ b/.ci/Jenkinsfile-SITL_tests_ASan
@@ -8,7 +8,7 @@ pipeline {
     stage('Build') {
       agent {
         docker {
-          image 'px4io/px4-dev-ros-melodic:2020-04-02'
+          image 'px4io/px4-dev-ros-melodic:2020-05-28'
           args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
         }
       }
@@ -134,7 +134,7 @@ def createTestNode(Map test_def) {
   return {
     node {
       cleanWs()
-      docker.image("px4io/px4-dev-ros-melodic:2020-04-02").inside('-e HOME=${WORKSPACE}') {
+      docker.image("px4io/px4-dev-ros-melodic:2020-05-28").inside('-e HOME=${WORKSPACE}') {
         stage(test_def.name) {
           def run_script = test_def.get('run_script', 'rostest_px4_run.sh')
           def test_ok = true

--- a/.ci/Jenkinsfile-SITL_tests_ASan
+++ b/.ci/Jenkinsfile-SITL_tests_ASan
@@ -8,7 +8,7 @@ pipeline {
     stage('Build') {
       agent {
         docker {
-          image 'px4io/px4-dev-ros-melodic:2020-04-01'
+          image 'px4io/px4-dev-ros-melodic:2020-04-02'
           args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
         }
       }
@@ -134,7 +134,7 @@ def createTestNode(Map test_def) {
   return {
     node {
       cleanWs()
-      docker.image("px4io/px4-dev-ros-melodic:2020-04-01").inside('-e HOME=${WORKSPACE}') {
+      docker.image("px4io/px4-dev-ros-melodic:2020-04-02").inside('-e HOME=${WORKSPACE}') {
         stage(test_def.name) {
           def run_script = test_def.get('run_script', 'rostest_px4_run.sh')
           def test_ok = true

--- a/.ci/Jenkinsfile-SITL_tests_coverage
+++ b/.ci/Jenkinsfile-SITL_tests_coverage
@@ -96,7 +96,7 @@ pipeline {
         stage('code coverage (python)') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2020-04-01'
+              image 'px4io/px4-dev-base-bionic:2020-04-02'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -116,7 +116,7 @@ pipeline {
         stage('unit tests') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2020-04-01'
+              image 'px4io/px4-dev-base-bionic:2020-04-02'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -154,7 +154,7 @@ def createTestNode(Map test_def) {
   return {
     node {
       cleanWs()
-      docker.image("px4io/px4-dev-ros-melodic:2020-04-01").inside('-e HOME=${WORKSPACE}') {
+      docker.image("px4io/px4-dev-ros-melodic:2020-04-02").inside('-e HOME=${WORKSPACE}') {
         stage(test_def.name) {
           def test_ok = true
           sh('export')

--- a/.ci/Jenkinsfile-SITL_tests_coverage
+++ b/.ci/Jenkinsfile-SITL_tests_coverage
@@ -96,7 +96,7 @@ pipeline {
         stage('code coverage (python)') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2020-04-02'
+              image 'px4io/px4-dev-base-bionic:2020-05-28'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -116,7 +116,7 @@ pipeline {
         stage('unit tests') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2020-04-02'
+              image 'px4io/px4-dev-base-bionic:2020-05-28'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -154,7 +154,7 @@ def createTestNode(Map test_def) {
   return {
     node {
       cleanWs()
-      docker.image("px4io/px4-dev-ros-melodic:2020-04-02").inside('-e HOME=${WORKSPACE}') {
+      docker.image("px4io/px4-dev-ros-melodic:2020-05-28").inside('-e HOME=${WORKSPACE}') {
         stage(test_def.name) {
           def test_ok = true
           sh('export')

--- a/.ci/Jenkinsfile-compile
+++ b/.ci/Jenkinsfile-compile
@@ -9,10 +9,10 @@ pipeline {
         script {
           def build_nodes = [:]
           def docker_images = [
-            armhf: "px4io/px4-dev-armhf:2020-04-01",
-            base: "px4io/px4-dev-base-bionic:2020-04-01",
-            nuttx: "px4io/px4-dev-nuttx-bionic:2020-04-01",
-            snapdragon: "lorenzmeier/px4-dev-snapdragon:2020-04-01"
+            armhf: "px4io/px4-dev-armhf:2020-04-02",
+            base: "px4io/px4-dev-base-bionic:2020-04-02",
+            nuttx: "px4io/px4-dev-nuttx-bionic:2020-04-02",
+            snapdragon: "lorenzmeier/px4-dev-snapdragon:2020-04-02"
           ]
 
           def armhf_builds = [
@@ -101,7 +101,7 @@ pipeline {
     // TODO: actually upload artifacts to S3
     // stage('S3 Upload') {
     //   agent {
-    //     docker { image 'px4io/px4-dev-base-bionic:2020-04-01' }
+    //     docker { image 'px4io/px4-dev-base-bionic:2020-04-02' }
     //   }
     //   options {
     //         skipDefaultCheckout()
@@ -135,7 +135,7 @@ def createBuildNode(Boolean archive, String docker_image, String target) {
 
     // TODO: fix the snapdragon image
     bypass_entrypoint = ''
-    if (docker_image == 'lorenzmeier/px4-dev-snapdragon:2020-04-01') {
+    if (docker_image == 'lorenzmeier/px4-dev-snapdragon:2020-04-02') {
       bypass_entrypoint = ' --entrypoint=""'
     }
 

--- a/.ci/Jenkinsfile-compile
+++ b/.ci/Jenkinsfile-compile
@@ -9,10 +9,10 @@ pipeline {
         script {
           def build_nodes = [:]
           def docker_images = [
-            armhf: "px4io/px4-dev-armhf:2020-04-02",
-            base: "px4io/px4-dev-base-bionic:2020-04-02",
-            nuttx: "px4io/px4-dev-nuttx-bionic:2020-04-02",
-            snapdragon: "lorenzmeier/px4-dev-snapdragon:2020-04-02"
+            armhf: "px4io/px4-dev-armhf:2020-05-28",
+            base: "px4io/px4-dev-base-bionic:2020-05-28",
+            nuttx: "px4io/px4-dev-nuttx-bionic:2020-05-28",
+            snapdragon: "lorenzmeier/px4-dev-snapdragon:2020-05-28"
           ]
 
           def armhf_builds = [
@@ -101,7 +101,7 @@ pipeline {
     // TODO: actually upload artifacts to S3
     // stage('S3 Upload') {
     //   agent {
-    //     docker { image 'px4io/px4-dev-base-bionic:2020-04-02' }
+    //     docker { image 'px4io/px4-dev-base-bionic:2020-05-28' }
     //   }
     //   options {
     //         skipDefaultCheckout()
@@ -135,7 +135,7 @@ def createBuildNode(Boolean archive, String docker_image, String target) {
 
     // TODO: fix the snapdragon image
     bypass_entrypoint = ''
-    if (docker_image == 'lorenzmeier/px4-dev-snapdragon:2020-04-02') {
+    if (docker_image == 'lorenzmeier/px4-dev-snapdragon:2020-05-28') {
       bypass_entrypoint = ' --entrypoint=""'
     }
 

--- a/.ci/Jenkinsfile-hardware
+++ b/.ci/Jenkinsfile-hardware
@@ -12,7 +12,7 @@ pipeline {
             stage("build px4_fmu-v2_test") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -80,7 +80,7 @@ pipeline {
             stage("build px4_fmu-v3_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -154,7 +154,7 @@ pipeline {
             stage("build px4_fmu-v4_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -227,7 +227,7 @@ pipeline {
             stage("build px4_fmu-v4pro_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -301,7 +301,7 @@ pipeline {
             stage("build px4_fmu-v5_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -375,7 +375,7 @@ pipeline {
             stage("build px4_fmu-v5_optimized") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -448,7 +448,7 @@ pipeline {
             stage("build px4_fmu-v5_stackcheck") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -523,7 +523,7 @@ pipeline {
             stage("build modalai_fc-v1_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -596,7 +596,7 @@ pipeline {
             stage("build holybro_durandal-v1_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -671,7 +671,7 @@ pipeline {
             stage("build nxp_fmuk66-v3_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }

--- a/.ci/Jenkinsfile-hardware
+++ b/.ci/Jenkinsfile-hardware
@@ -12,7 +12,7 @@ pipeline {
             stage("build px4_fmu-v2_test") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-05-28'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -80,7 +80,7 @@ pipeline {
             stage("build px4_fmu-v3_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-05-28'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -154,7 +154,7 @@ pipeline {
             stage("build px4_fmu-v4_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-05-28'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -227,7 +227,7 @@ pipeline {
             stage("build px4_fmu-v4pro_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-05-28'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -301,7 +301,7 @@ pipeline {
             stage("build px4_fmu-v5_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-05-28'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -375,7 +375,7 @@ pipeline {
             stage("build px4_fmu-v5_optimized") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-05-28'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -448,7 +448,7 @@ pipeline {
             stage("build px4_fmu-v5_stackcheck") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-05-28'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -523,7 +523,7 @@ pipeline {
             stage("build modalai_fc-v1_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-05-28'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -596,7 +596,7 @@ pipeline {
             stage("build holybro_durandal-v1_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-05-28'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -671,7 +671,7 @@ pipeline {
             stage("build nxp_fmuk66-v3_default") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
+                  image 'px4io/px4-dev-nuttx-bionic:2020-05-28'
                   args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: px4io/px4-dev-nuttx-bionic:2020-04-01
+      - image: px4io/px4-dev-nuttx-bionic:2020-04-02
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: px4io/px4-dev-nuttx-bionic:2020-04-02
+      - image: px4io/px4-dev-nuttx-bionic:2020-05-28
     steps:
       - checkout
       - run:

--- a/.github/workflows/bloaty.yml
+++ b/.github/workflows/bloaty.yml
@@ -26,7 +26,7 @@ jobs:
           px4_fmu-v5x_default,
           px4_io-v2_default,
           ]
-    container: px4io/px4-dev-nuttx-${{ matrix.ubuntu_release }}:2020-04-01
+    container: px4io/px4-dev-nuttx-${{ matrix.ubuntu_release }}:2020-04-02
     steps:
     - uses: actions/checkout@v1
       with:

--- a/.github/workflows/bloaty.yml
+++ b/.github/workflows/bloaty.yml
@@ -26,7 +26,7 @@ jobs:
           px4_fmu-v5x_default,
           px4_io-v2_default,
           ]
-    container: px4io/px4-dev-nuttx-${{ matrix.ubuntu_release }}:2020-04-02
+    container: px4io/px4-dev-nuttx-${{ matrix.ubuntu_release }}:2020-05-28
     steps:
     - uses: actions/checkout@v1
       with:

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -17,7 +17,7 @@ jobs:
           bionic,
           focal
           ]
-    container: px4io/px4-dev-base-${{ matrix.ubuntu_release }}:2020-04-01
+    container: px4io/px4-dev-base-${{ matrix.ubuntu_release }}:2020-04-02
     steps:
     - uses: actions/checkout@v1
       with:

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -17,7 +17,7 @@ jobs:
           bionic,
           focal
           ]
-    container: px4io/px4-dev-base-${{ matrix.ubuntu_release }}:2020-04-02
+    container: px4io/px4-dev-base-${{ matrix.ubuntu_release }}:2020-05-28
     steps:
     - uses: actions/checkout@v1
       with:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -17,7 +17,7 @@ jobs:
           bionic,
           focal
           ]
-    container: px4io/px4-dev-base-${{ matrix.ubuntu_release }}:2020-04-01
+    container: px4io/px4-dev-base-${{ matrix.ubuntu_release }}:2020-04-02
     steps:
     - uses: actions/checkout@v1
       with:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -17,7 +17,7 @@ jobs:
           bionic,
           focal
           ]
-    container: px4io/px4-dev-base-${{ matrix.ubuntu_release }}:2020-04-02
+    container: px4io/px4-dev-base-${{ matrix.ubuntu_release }}:2020-05-28
     steps:
     - uses: actions/checkout@v1
       with:

--- a/.github/workflows/compile_linux.yml
+++ b/.github/workflows/compile_linux.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: px4io/px4-dev-armhf:2020-04-01
+    container: px4io/px4-dev-armhf:2020-04-02
     strategy:
       matrix:
         config: [

--- a/.github/workflows/compile_linux.yml
+++ b/.github/workflows/compile_linux.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: px4io/px4-dev-armhf:2020-04-02
+    container: px4io/px4-dev-armhf:2020-05-28
     strategy:
       matrix:
         config: [

--- a/.github/workflows/compile_nuttx.yml
+++ b/.github/workflows/compile_nuttx.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: px4io/px4-dev-nuttx-bionic:2020-04-01
+    container: px4io/px4-dev-nuttx-bionic:2020-04-02
     strategy:
       matrix:
         config: [

--- a/.github/workflows/compile_nuttx.yml
+++ b/.github/workflows/compile_nuttx.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: px4io/px4-dev-nuttx-bionic:2020-04-02
+    container: px4io/px4-dev-nuttx-bionic:2020-05-28
     strategy:
       matrix:
         config: [

--- a/.github/workflows/sitl_tests.yml
+++ b/.github/workflows/sitl_tests.yml
@@ -18,7 +18,7 @@ jobs:
           focal
           ]
     container:
-      image: px4io/px4-dev-simulation-${{ matrix.ubuntu_release }}:2020-04-01
+      image: px4io/px4-dev-simulation-${{ matrix.ubuntu_release }}:2020-04-02
       options: --privileged --ulimit core=-1 --security-opt seccomp=unconfined
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/sitl_tests.yml
+++ b/.github/workflows/sitl_tests.yml
@@ -18,7 +18,7 @@ jobs:
           focal
           ]
     container:
-      image: px4io/px4-dev-simulation-${{ matrix.ubuntu_release }}:2020-04-02
+      image: px4io/px4-dev-simulation-${{ matrix.ubuntu_release }}:2020-05-28
       options: --privileged --ulimit core=-1 --security-opt seccomp=unconfined
     steps:
     - uses: actions/checkout@v1

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
         // stage('Catkin build on ROS workspace') {
         //   agent {
         //     docker {
-        //       image 'px4io/px4-dev-ros-melodic:2020-04-01'
+        //       image 'px4io/px4-dev-ros-melodic:2020-04-02'
         //       args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
         //     }
         //   }
@@ -53,7 +53,7 @@ pipeline {
         // stage('Colcon build on ROS2 workspace') {
         //   agent {
         //     docker {
-        //       image 'px4io/px4-dev-ros2-dashing:2020-04-01'
+        //       image 'px4io/px4-dev-ros2-dashing:2020-04-02'
         //       args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
         //     }
         //   }
@@ -84,7 +84,7 @@ pipeline {
 
         stage('Style check') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-04-01' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-04-02' }
           }
           steps {
             sh 'make check_format'
@@ -99,7 +99,7 @@ pipeline {
         stage('px4_fmu-v5 (no ninja)') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
+              image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -125,7 +125,7 @@ pipeline {
         stage('px4_sitl (no ninja)') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
+              image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -151,7 +151,7 @@ pipeline {
         stage('SITL unit tests') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2020-04-01'
+              image 'px4io/px4-dev-base-bionic:2020-04-02'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -191,7 +191,7 @@ pipeline {
         stage('Clang analyzer') {
           agent {
             docker {
-              image 'px4io/px4-dev-clang:2020-04-01'
+              image 'px4io/px4-dev-clang:2020-04-02'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -229,7 +229,7 @@ pipeline {
         stage('Clang tidy') {
           agent {
             docker {
-              image 'px4io/px4-dev-clang:2020-04-01'
+              image 'px4io/px4-dev-clang:2020-04-02'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -251,7 +251,7 @@ pipeline {
         stage('Cppcheck') {
           agent {
             docker {
-              image 'px4io/px4-dev-ros-melodic:2020-04-01'
+              image 'px4io/px4-dev-ros-melodic:2020-04-02'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -289,7 +289,7 @@ pipeline {
         stage('Check stack') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
+              image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -309,7 +309,7 @@ pipeline {
         stage('ShellCheck') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
+              image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -328,7 +328,7 @@ pipeline {
         stage('Module config validation') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2020-04-01'
+              image 'px4io/px4-dev-base-bionic:2020-04-02'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -353,7 +353,7 @@ pipeline {
 
         stage('Airframe') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-04-01' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-04-02' }
           }
           steps {
             sh 'make distclean'
@@ -372,7 +372,7 @@ pipeline {
 
         stage('Parameter') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-04-01' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-04-02' }
           }
           steps {
             sh 'make distclean'
@@ -391,7 +391,7 @@ pipeline {
 
         stage('Module') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-04-01' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-04-02' }
           }
           steps {
             sh 'make distclean'
@@ -411,7 +411,7 @@ pipeline {
         stage('uORB graphs') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx-bionic:2020-04-01'
+              image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -440,7 +440,7 @@ pipeline {
 
         stage('Devguide') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-04-01' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-04-02' }
           }
           steps {
             sh('export')
@@ -470,7 +470,7 @@ pipeline {
 
         stage('Userguide') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-04-01' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-04-02' }
           }
           steps {
             sh('export')
@@ -498,7 +498,7 @@ pipeline {
 
         stage('QGroundControl') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-04-01' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-04-02' }
           }
           steps {
             sh('export')
@@ -526,7 +526,7 @@ pipeline {
 
         stage('PX4 ROS msgs') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-04-01' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-04-02' }
           }
           steps {
             sh('export')
@@ -555,7 +555,7 @@ pipeline {
 
         stage('PX4 ROS2 bridge') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-04-01' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-04-02' }
           }
           steps {
             sh('export')
@@ -598,7 +598,7 @@ pipeline {
 
         stage('S3') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-04-01' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-04-02' }
           }
           steps {
             sh('export')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
         // stage('Catkin build on ROS workspace') {
         //   agent {
         //     docker {
-        //       image 'px4io/px4-dev-ros-melodic:2020-04-02'
+        //       image 'px4io/px4-dev-ros-melodic:2020-05-28'
         //       args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
         //     }
         //   }
@@ -53,7 +53,7 @@ pipeline {
         // stage('Colcon build on ROS2 workspace') {
         //   agent {
         //     docker {
-        //       image 'px4io/px4-dev-ros2-dashing:2020-04-02'
+        //       image 'px4io/px4-dev-ros2-dashing:2020-05-28'
         //       args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
         //     }
         //   }
@@ -84,7 +84,7 @@ pipeline {
 
         stage('Style check') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-04-02' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-05-28' }
           }
           steps {
             sh 'make check_format'
@@ -99,7 +99,7 @@ pipeline {
         stage('px4_fmu-v5 (no ninja)') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
+              image 'px4io/px4-dev-nuttx-bionic:2020-05-28'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -125,7 +125,7 @@ pipeline {
         stage('px4_sitl (no ninja)') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
+              image 'px4io/px4-dev-nuttx-bionic:2020-05-28'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -151,7 +151,7 @@ pipeline {
         stage('SITL unit tests') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2020-04-02'
+              image 'px4io/px4-dev-base-bionic:2020-05-28'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -191,7 +191,7 @@ pipeline {
         stage('Clang analyzer') {
           agent {
             docker {
-              image 'px4io/px4-dev-clang:2020-04-02'
+              image 'px4io/px4-dev-clang:2020-05-28'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -229,7 +229,7 @@ pipeline {
         stage('Clang tidy') {
           agent {
             docker {
-              image 'px4io/px4-dev-clang:2020-04-02'
+              image 'px4io/px4-dev-clang:2020-05-28'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -251,7 +251,7 @@ pipeline {
         stage('Cppcheck') {
           agent {
             docker {
-              image 'px4io/px4-dev-ros-melodic:2020-04-02'
+              image 'px4io/px4-dev-ros-melodic:2020-05-28'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -289,7 +289,7 @@ pipeline {
         stage('Check stack') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
+              image 'px4io/px4-dev-nuttx-bionic:2020-05-28'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -309,7 +309,7 @@ pipeline {
         stage('ShellCheck') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
+              image 'px4io/px4-dev-nuttx-bionic:2020-05-28'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -328,7 +328,7 @@ pipeline {
         stage('Module config validation') {
           agent {
             docker {
-              image 'px4io/px4-dev-base-bionic:2020-04-02'
+              image 'px4io/px4-dev-base-bionic:2020-05-28'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -353,7 +353,7 @@ pipeline {
 
         stage('Airframe') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-04-02' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-05-28' }
           }
           steps {
             sh 'make distclean'
@@ -372,7 +372,7 @@ pipeline {
 
         stage('Parameter') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-04-02' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-05-28' }
           }
           steps {
             sh 'make distclean'
@@ -391,7 +391,7 @@ pipeline {
 
         stage('Module') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-04-02' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-05-28' }
           }
           steps {
             sh 'make distclean'
@@ -411,7 +411,7 @@ pipeline {
         stage('uORB graphs') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx-bionic:2020-04-02'
+              image 'px4io/px4-dev-nuttx-bionic:2020-05-28'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -440,7 +440,7 @@ pipeline {
 
         stage('Devguide') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-04-02' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-05-28' }
           }
           steps {
             sh('export')
@@ -470,7 +470,7 @@ pipeline {
 
         stage('Userguide') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-04-02' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-05-28' }
           }
           steps {
             sh('export')
@@ -498,7 +498,7 @@ pipeline {
 
         stage('QGroundControl') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-04-02' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-05-28' }
           }
           steps {
             sh('export')
@@ -526,7 +526,7 @@ pipeline {
 
         stage('PX4 ROS msgs') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-04-02' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-05-28' }
           }
           steps {
             sh('export')
@@ -555,7 +555,7 @@ pipeline {
 
         stage('PX4 ROS2 bridge') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-04-02' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-05-28' }
           }
           steps {
             sh('export')
@@ -598,7 +598,7 @@ pipeline {
 
         stage('S3') {
           agent {
-            docker { image 'px4io/px4-dev-base-bionic:2020-04-02' }
+            docker { image 'px4io/px4-dev-base-bionic:2020-05-28' }
           }
           steps {
             sh('export')

--- a/Tools/docker_run.sh
+++ b/Tools/docker_run.sh
@@ -4,22 +4,22 @@ if [ -z ${PX4_DOCKER_REPO+x} ]; then
 	echo "guessing PX4_DOCKER_REPO based on input";
 	if [[ $@ =~ .*px4_fmu.* ]]; then
 		# nuttx-px4fmu-v{1,2,3,4,5}
-		PX4_DOCKER_REPO="px4io/px4-dev-nuttx-bionic:2020-04-01"
+		PX4_DOCKER_REPO="px4io/px4-dev-nuttx-bionic:2020-04-02"
 	elif [[ $@ =~ .*ocpoc.* ]] || [[ $@ =~ .*navio2.* ]] || [[ $@ =~ .*raspberry.* ]] || [[ $@ =~ .*beaglebone.* ]]; then
 		# aerotenna_ocpoc_default, beaglebone_blue_default, emlid_navio2_default, px4_raspberrypi_default
-		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2020-04-01"
+		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2020-04-02"
 	elif [[ $@ =~ .*eagle.* ]] || [[ $@ =~ .*excelsior.* ]]; then
 		# eagle, excelsior
-		PX4_DOCKER_REPO="lorenzmeier/px4-dev-snapdragon:2020-04-01"
+		PX4_DOCKER_REPO="lorenzmeier/px4-dev-snapdragon:2020-04-02"
 	elif [[ $@ =~ .*ocpoc.* ]] || [[ $@ =~ .*navio2.* ]] || [[ $@ =~ .*raspberry.* ]] || [[ $@ =~ .*bebop.* ]]; then
 		# aerotenna_ocpoc_default, posix_rpi_cross, posix_bebop_default
-		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2020-04-01"
+		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2020-04-02"
 	elif [[ $@ =~ .*clang.* ]] || [[ $@ =~ .*scan-build.* ]]; then
 		# clang tools
-		PX4_DOCKER_REPO="px4io/px4-dev-clang:2020-04-01"
+		PX4_DOCKER_REPO="px4io/px4-dev-clang:2020-04-02"
 	elif [[ $@ =~ .*tests* ]]; then
 		# run all tests with simulation
-		PX4_DOCKER_REPO="px4io/px4-dev-simulation-bionic:2020-04-01"
+		PX4_DOCKER_REPO="px4io/px4-dev-simulation-bionic:2020-04-02"
 	fi
 else
 	echo "PX4_DOCKER_REPO is set to '$PX4_DOCKER_REPO'";
@@ -27,7 +27,7 @@ fi
 
 # otherwise default to nuttx
 if [ -z ${PX4_DOCKER_REPO+x} ]; then
-	PX4_DOCKER_REPO="px4io/px4-dev-nuttx-bionic:2020-04-01"
+	PX4_DOCKER_REPO="px4io/px4-dev-nuttx-bionic:2020-04-02"
 fi
 
 # docker hygiene

--- a/Tools/docker_run.sh
+++ b/Tools/docker_run.sh
@@ -4,22 +4,22 @@ if [ -z ${PX4_DOCKER_REPO+x} ]; then
 	echo "guessing PX4_DOCKER_REPO based on input";
 	if [[ $@ =~ .*px4_fmu.* ]]; then
 		# nuttx-px4fmu-v{1,2,3,4,5}
-		PX4_DOCKER_REPO="px4io/px4-dev-nuttx-bionic:2020-04-02"
+		PX4_DOCKER_REPO="px4io/px4-dev-nuttx-bionic:2020-05-28"
 	elif [[ $@ =~ .*ocpoc.* ]] || [[ $@ =~ .*navio2.* ]] || [[ $@ =~ .*raspberry.* ]] || [[ $@ =~ .*beaglebone.* ]]; then
 		# aerotenna_ocpoc_default, beaglebone_blue_default, emlid_navio2_default, px4_raspberrypi_default
-		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2020-04-02"
+		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2020-05-28"
 	elif [[ $@ =~ .*eagle.* ]] || [[ $@ =~ .*excelsior.* ]]; then
 		# eagle, excelsior
-		PX4_DOCKER_REPO="lorenzmeier/px4-dev-snapdragon:2020-04-02"
+		PX4_DOCKER_REPO="lorenzmeier/px4-dev-snapdragon:2020-05-28"
 	elif [[ $@ =~ .*ocpoc.* ]] || [[ $@ =~ .*navio2.* ]] || [[ $@ =~ .*raspberry.* ]] || [[ $@ =~ .*bebop.* ]]; then
 		# aerotenna_ocpoc_default, posix_rpi_cross, posix_bebop_default
-		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2020-04-02"
+		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2020-05-28"
 	elif [[ $@ =~ .*clang.* ]] || [[ $@ =~ .*scan-build.* ]]; then
 		# clang tools
-		PX4_DOCKER_REPO="px4io/px4-dev-clang:2020-04-02"
+		PX4_DOCKER_REPO="px4io/px4-dev-clang:2020-05-28"
 	elif [[ $@ =~ .*tests* ]]; then
 		# run all tests with simulation
-		PX4_DOCKER_REPO="px4io/px4-dev-simulation-bionic:2020-04-02"
+		PX4_DOCKER_REPO="px4io/px4-dev-simulation-bionic:2020-05-28"
 	fi
 else
 	echo "PX4_DOCKER_REPO is set to '$PX4_DOCKER_REPO'";
@@ -27,7 +27,7 @@ fi
 
 # otherwise default to nuttx
 if [ -z ${PX4_DOCKER_REPO+x} ]; then
-	PX4_DOCKER_REPO="px4io/px4-dev-nuttx-bionic:2020-04-02"
+	PX4_DOCKER_REPO="px4io/px4-dev-nuttx-bionic:2020-05-28"
 fi
 
 # docker hygiene

--- a/Tools/setup/arch.sh
+++ b/Tools/setup/arch.sh
@@ -90,7 +90,7 @@ if [[ $INSTALL_NUTTX == "true" ]]; then
 	sudo pacman -R modemmanager --noconfirm
 
 	# arm-none-eabi-gcc
-	NUTTX_GCC_VERSION="7-2017-q4-major"
+	NUTTX_GCC_VERSION="9-2019-q4-major-x86_64"
 	GCC_VER_STR=$(arm-none-eabi-gcc --version)
 	STATUSRETVAL=$(echo $GCC_VER_STR | grep -c "${NUTTX_GCC_VERSION}")
 
@@ -98,17 +98,26 @@ if [[ $INSTALL_NUTTX == "true" ]]; then
 		echo "arm-none-eabi-gcc-${NUTTX_GCC_VERSION} found, skipping installation"
 	else
 		echo "Installing arm-none-eabi-gcc-${NUTTX_GCC_VERSION}";
-		wget -O /tmp/gcc-arm-none-eabi-${NUTTX_GCC_VERSION}-linux.tar.bz2 https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/7-2017q4/gcc-arm-none-eabi-${NUTTX_GCC_VERSION}-linux.tar.bz2 && \
+		wget -O /tmp/gcc-arm-none-eabi-${NUTTX_GCC_VERSION}-linux.tar.bz2 https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-${NUTTX_GCC_VERSION}-linux.tar.bz2 && \
 			sudo tar -jxf /tmp/gcc-arm-none-eabi-${NUTTX_GCC_VERSION}-linux.tar.bz2 -C /opt/;
 
 		# add arm-none-eabi-gcc to user's PATH
-		exportline="export PATH=/opt/gcc-arm-none-eabi-${NUTTX_GCC_VERSION}/bin:\$PATH"
+		exportline="export PATH=\/opt\/gcc-arm-none-eabi-"
+		exportline_with_version="export PATH=/opt/gcc-arm-none-eabi-${NUTTX_GCC_VERSION}/bin:\$PATH"
 
-		if grep -Fxq "$exportline" $HOME/.profile;
+		if grep -q "$exportline" $HOME/.profile;
 		then
-			echo "${NUTTX_GCC_VERSION} path already set.";
+			existing_export_line="$(grep -q "$NUTTX_GCC_VERSION" $HOME/.profile)" | tr -d '\n'
+			if [[ $existing_export_line == $exportline_with_version ]];
+			then
+				echo "A previous version was already set. Updating path..."
+				sed "/${exportline}/d" $HOME/.profile
+				echo $exportline_with_version >> $HOME/.profile
+			else
+				echo "${NUTTX_GCC_VERSION} path already set.";
+			fi
 		else
-			echo $exportline >> $HOME/.profile;
+			echo $exportline_with_version >> $HOME/.profile
 		fi
 	fi
 fi

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -139,7 +139,7 @@ if [[ $INSTALL_NUTTX == "true" ]]; then
 	fi
 
 	# arm-none-eabi-gcc
-	NUTTX_GCC_VERSION="7-2017-q4-major"
+	NUTTX_GCC_VERSION="9-2019-q4-major-x86_64"
 
 if [ $(which arm-none-eabi-gcc) ]; then
 	GCC_VER_STR=$(arm-none-eabi-gcc --version)
@@ -151,17 +151,26 @@ fi
 
 	else
 		echo "Installing arm-none-eabi-gcc-${NUTTX_GCC_VERSION}";
-		wget -O /tmp/gcc-arm-none-eabi-${NUTTX_GCC_VERSION}-linux.tar.bz2 https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/7-2017q4/gcc-arm-none-eabi-${NUTTX_GCC_VERSION}-linux.tar.bz2 && \
+		wget -O /tmp/gcc-arm-none-eabi-${NUTTX_GCC_VERSION}-linux.tar.bz2 https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-${NUTTX_GCC_VERSION}-linux.tar.bz2 && \
 			sudo tar -jxf /tmp/gcc-arm-none-eabi-${NUTTX_GCC_VERSION}-linux.tar.bz2 -C /opt/;
 
 		# add arm-none-eabi-gcc to user's PATH
-		exportline="export PATH=/opt/gcc-arm-none-eabi-${NUTTX_GCC_VERSION}/bin:\$PATH"
+		exportline="export PATH=\/opt\/gcc-arm-none-eabi-"
+		exportline_with_version="export PATH=/opt/gcc-arm-none-eabi-${NUTTX_GCC_VERSION}/bin:\$PATH"
 
-		if grep -Fxq "$exportline" $HOME/.profile;
+		if grep -q "$exportline" $HOME/.profile;
 		then
-			echo "${NUTTX_GCC_VERSION} path already set.";
+			existing_export_line="$(grep -q "$NUTTX_GCC_VERSION" $HOME/.profile)" | tr -d '\n'
+			if [[ $existing_export_line == $exportline_with_version ]];
+			then
+				echo "A previous version was already set. Updating path..."
+				sed "/${exportline}/d" $HOME/.profile
+				echo $exportline_with_version >> $HOME/.profile
+			else
+				echo "${NUTTX_GCC_VERSION} path already set.";
+			fi
 		else
-			echo $exportline >> $HOME/.profile;
+			echo $exportline_with_version >> $HOME/.profile
 		fi
 	fi
 

--- a/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
@@ -219,7 +219,7 @@ void VehicleIMU::Run()
 
 			// rotate sensor clip counts into vehicle body frame
 			const Vector3f clipping{_accel_corrections.getBoardRotation() *
-				Vector3f{(float)accel.clip_counter[0], (float)accel.clip_counter[1], (float)accel.clip_counter[2]}};
+						Vector3f{(float)accel.clip_counter[0], (float)accel.clip_counter[1], (float)accel.clip_counter[2]}};
 
 			// round to get reasonble clip counts per axis (after board rotation)
 			const uint8_t clip_x = roundf(fabsf(clipping(0)));


### PR DESCRIPTION
**Describe problem solved by this pull request**
Following the validation of the binaries built with GNU Arm Embedded Toolchain Version 9-2019-q4-major in https://github.com/PX4/Firmware/issues/14580, I am bringing the new version to both CI and setup scripts.

**Describe your solution**
1. Update container tags with the tag that brought version 9 to `px4-dev-nuttx-bionic` and `px4-dev-nuttx-focal`;
2. Update setup scripts, with a verification for an existing version there, and if it isn't version 9, then it does a replacement inline with the new path for the version 9.


