### PR TITLE
posix rcS: always disable CPU load check in SITL

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -185,9 +185,9 @@ then
 	param set SYS_RESTART_TYPE 2
 
 	param set TRIG_INTERFACE 3
-
-	param set COM_CPU_MAX -1
 fi
+
+param set COM_CPU_MAX -1 # disable check, no CPU load reported on posix yet
 
 # Adapt timeout parameters if simulation runs faster or slower than realtime.
 if [ ! -z $PX4_SIM_SPEED_FACTOR ]; then

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -901,7 +901,7 @@ PARAM_DEFINE_INT32(COM_MOT_TEST_EN, 1);
 PARAM_DEFINE_FLOAT(COM_KILL_DISARM, 5.0f);
 
 /**
- * Maximum allowed CPU load to still allow arming
+ * Maximum allowed CPU load to still arm
  *
  * A negative value disables the check.
  *


### PR DESCRIPTION
**Describe problem solved by this pull request**
Multiple people reported that SITL wasn't arming anymore because the CPU load check was failing and that's because the parameter to disable the check in SITL is only set when the parameters are reset e.g. clean build.

**Describe your solution**
I set the parameter all the time now to prevent more people running into the problem.

**Describe possible alternatives**
SITL should also publish a CPU load but this is the hot fix.

**Test data / coverage**
I tested locally with an earlier configuration already built to reproduce the problem without the change and have it fixed with the change.

**Additional context**
#14570 
