### PR TITLE
drivers/pwm_out: cleanup for multi-platform use

### DIFF
--- a/src/drivers/pwm_out/CMakeLists.txt
+++ b/src/drivers/pwm_out/CMakeLists.txt
@@ -34,6 +34,7 @@ px4_add_module(
 	MODULE drivers__pwm_out
 	MAIN pwm_out
 	COMPILE_FLAGS
+		-Wno-error=unused-variable
 	SRCS
 		PWMOut.cpp
 		PWMOut.hpp

--- a/src/lib/cdev/CDev.hpp
+++ b/src/lib/cdev/CDev.hpp
@@ -311,4 +311,11 @@ private:
 
 } // namespace cdev
 
+// class instance for primary driver of each class
+enum CLASS_DEVICE {
+	CLASS_DEVICE_PRIMARY = 0,
+	CLASS_DEVICE_SECONDARY = 1,
+	CLASS_DEVICE_TERTIARY = 2
+};
+
 #endif /* _CDEV_HPP */

--- a/src/lib/drivers/device/CDev.hpp
+++ b/src/lib/drivers/device/CDev.hpp
@@ -90,11 +90,4 @@ public:
 
 } // namespace device
 
-// class instance for primary driver of each class
-enum CLASS_DEVICE {
-	CLASS_DEVICE_PRIMARY = 0,
-	CLASS_DEVICE_SECONDARY = 1,
-	CLASS_DEVICE_TERTIARY = 2
-};
-
 #endif /* _DEVICE_CDEV_HPP */


### PR DESCRIPTION
This is a quick cleanup of `drivers/pwm_out` that will enable it to be used on Linux platforms like the BeagleBone Blue, Emlid Navio2, Aerotenna Ocpoc if low level PWM routines are implemented.

 - up_pwm_servo_init()
 - up_pwm_servo_arm()
 - up_pwm_servo_set()
 - up_pwm_update()
 - up_pwm_servo_deinit()


