### PR TITLE
Improve front transition tracking & fix flyaway

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -615,29 +615,51 @@ FixedwingPositionControl::control_position(const Vector2f &curr_pos, const Vecto
 		_tecs.set_speed_weight(_param_fw_t_spdweight.get());
 		_tecs.set_time_const_throt(_param_fw_t_thro_const.get());
 
-		/* current waypoint (the one currently heading for) */
-		Vector2f curr_wp((float)pos_sp_curr.lat, (float)pos_sp_curr.lon);
+		Vector2f curr_wp{0.0f, 0.0f};
+		Vector2f prev_wp{0.0f, 0.0f};
+
+		if (_vehicle_status.in_transition_to_fw) {
+
+			if (!PX4_ISFINITE(_transition_waypoint(0))) {
+				double lat_transition, lon_transition;
+				// create a virtual waypoint HDG_HOLD_DIST_NEXT meters in front of the vehicle which the L1 controller can track
+				// during the transition
+				waypoint_from_heading_and_distance(_current_latitude, _current_longitude, _yaw, HDG_HOLD_DIST_NEXT, &lat_transition,
+								   &lon_transition);
+
+				_transition_waypoint(0) = (float)lat_transition;
+				_transition_waypoint(1) = (float)lon_transition;
+			}
+
+
+			curr_wp = prev_wp = _transition_waypoint;
+
+		} else {
+			/* current waypoint (the one currently heading for) */
+			curr_wp = Vector2f((float)pos_sp_curr.lat, (float)pos_sp_curr.lon);
+
+			if (pos_sp_prev.valid) {
+				prev_wp(0) = (float)pos_sp_prev.lat;
+				prev_wp(1) = (float)pos_sp_prev.lon;
+
+			} else {
+				/*
+				 * No valid previous waypoint, go for the current wp.
+				 * This is automatically handled by the L1 library.
+				 */
+				prev_wp(0) = (float)pos_sp_curr.lat;
+				prev_wp(1) = (float)pos_sp_curr.lon;
+			}
+
+
+			/* reset transition waypoint, will be set upon entering front transition */
+			_transition_waypoint.setNaN();
+		}
 
 		/* Initialize attitude controller integrator reset flags to 0 */
 		_att_sp.roll_reset_integral = false;
 		_att_sp.pitch_reset_integral = false;
 		_att_sp.yaw_reset_integral = false;
-
-		/* previous waypoint */
-		Vector2f prev_wp{0.0f, 0.0f};
-
-		if (pos_sp_prev.valid) {
-			prev_wp(0) = (float)pos_sp_prev.lat;
-			prev_wp(1) = (float)pos_sp_prev.lon;
-
-		} else {
-			/*
-			 * No valid previous waypoint, go for the current wp.
-			 * This is automatically handled by the L1 library.
-			 */
-			prev_wp(0) = (float)pos_sp_curr.lat;
-			prev_wp(1) = (float)pos_sp_curr.lon;
-		}
 
 		float mission_airspeed = _param_fw_airspd_trim.get();
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -253,6 +253,8 @@ private:
 
 	bool _vtol_tailsitter{false};
 
+	Vector2f _transition_waypoint{NAN, NAN};
+
 	// estimator reset counters
 	uint8_t _pos_reset_counter{0};				///< captures the number of times the estimator has reset the horizontal position
 	uint8_t _alt_reset_counter{0};				///< captures the number of times the estimator has reset the altitude state

--- a/src/modules/navigator/takeoff.cpp
+++ b/src/modules/navigator/takeoff.cpp
@@ -149,7 +149,12 @@ Takeoff::set_takeoff_position()
 		memset(rep, 0, sizeof(*rep));
 	}
 
-	_navigator->set_can_loiter_at_sp(true);
+	if (PX4_ISFINITE(pos_sp_triplet->current.lat) && PX4_ISFINITE(pos_sp_triplet->current.lon)) {
+		_navigator->set_can_loiter_at_sp(true);
+
+	} else {
+		_navigator->set_can_loiter_at_sp(false);
+	}
 
 	_navigator->set_position_setpoint_triplet_updated();
 }


### PR DESCRIPTION
**This PR contains the following improvement:**
At the start of a front transition the fixed wing position controller creates a virtual position setpoint which is located 1000m in front of the vehicle. This avoids the controller tracking waypoints which are too close to the vehicle, e.g. loiter waypoints.
It would of course be nicer if the navigator would automatically publish this setpoint. However, this would take quite some changes and I'm not comfortable with the attempt just before a release.
Also, the logic in the position controller is straight forward and can be removed very easily. 

**This PR fixes the following bug:**
A takeoff followed by a transition command lead to the vehicle doing a flyaway. This was because the takeoff code did not set valid latitude and longitude for the takeoff waypoint but still set the _can_loiter_at_sp flag to true. As a result the loiter code did not set a position setpoint but just copied over the NAN values.
Finally, the position controller did not know what to do with that and just did nothing.

I think this bug was introduced with flighttasks as they support of NAN position setpoint.

