### PR TITLE
VTOL: add parameter to set the PWM_OUTPUT_DEVICE_PATH

### DIFF
--- a/src/drivers/drv_pwm_output.h
+++ b/src/drivers/drv_pwm_output.h
@@ -61,6 +61,7 @@ __BEGIN_DECLS
  */
 #define PWM_OUTPUT_BASE_DEVICE_PATH "/dev/pwm_output"
 #define PWM_OUTPUT0_DEVICE_PATH	"/dev/pwm_output0"
+#define PWM_OUTPUT1_DEVICE_PATH	"/dev/pwm_output1"
 
 #define PWM_OUTPUT_MAX_CHANNELS 16
 

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -92,6 +92,7 @@ VtolAttitudeControl::VtolAttitudeControl() :
 
 	_params_handles.down_pitch_max = param_find("VT_DWN_PITCH_MAX");
 	_params_handles.forward_thrust_scale = param_find("VT_FWD_THRUST_SC");
+	_params_handles.vt_mc_on_fmu = param_find("VT_MC_ON_FMU");
 
 	/* fetch initial parameter values */
 	parameters_update();
@@ -296,6 +297,9 @@ VtolAttitudeControl::parameters_update()
 
 	param_get(_params_handles.dec_to_pitch_ff, &_params.dec_to_pitch_ff);
 	param_get(_params_handles.dec_to_pitch_i, &_params.dec_to_pitch_i);
+
+	param_get(_params_handles.vt_mc_on_fmu, &l);
+	_params.vt_mc_on_fmu = l;
 
 	// update the parameters of the instances of base VtolType
 	if (_vtol_type != nullptr) {

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -206,6 +206,7 @@ private:
 		param_t dec_to_pitch_ff;
 		param_t dec_to_pitch_i;
 		param_t back_trans_dec_sp;
+		param_t vt_mc_on_fmu;
 	} _params_handles{};
 
 	/* for multicopters it is usual to have a non-zero idle speed of the engines

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -342,3 +342,15 @@ PARAM_DEFINE_FLOAT(VT_B_DEC_FF, 0.12f);
  * @group VTOL Attitude Control
  */
 PARAM_DEFINE_FLOAT(VT_B_DEC_I, 0.1f);
+
+/**
+ * Enable the usage of AUX outputs for hover motors.
+ *
+ * Set this parameter to true if the vehicle's hover motors are connected to the FMU (AUX) port.
+ * Not required for boards that only have a FMU, and no IO.
+ * Only applies for standard VTOL and tiltrotor.
+ *
+ * @boolean
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_INT32(VT_MC_ON_FMU, 0);

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -317,7 +317,8 @@ bool VtolType::set_idle_fw()
 
 bool VtolType::apply_pwm_limits(struct pwm_output_values &pwm_values, pwm_limit_type type)
 {
-	const char *dev = PWM_OUTPUT0_DEVICE_PATH;
+	const char *dev = _params->vt_mc_on_fmu ? PWM_OUTPUT1_DEVICE_PATH : PWM_OUTPUT0_DEVICE_PATH;
+
 	int fd = px4_open(dev, 0);
 
 	if (fd < 0) {

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -75,6 +75,7 @@ struct Params {
 	float dec_to_pitch_ff;
 	float dec_to_pitch_i;
 	float back_trans_dec_sp;
+	bool vt_mc_on_fmu;
 };
 
 // Has to match 1:1 msg/vtol_vehicle_status.msg


### PR DESCRIPTION
This PR enables the use of the FMU (AUX) output for the multicopter motors on standard VTOL and tiltrotors.

The device path is needed to apply PWM limits on the motors that are not
used for FW flight (switch them off). With this parameter the device path can be set
to either IO or FMU, depending on whether the motors are on the IO or FMU port.