### PR TITLE
Enable testing in windy environments

### DIFF
--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -66,7 +66,7 @@ set(models none shell
 	standard_vtol tailsitter tiltrotor
 	rover boat
 	uuv_hippocampus)
-set(worlds none empty baylands ksql_airport mcmillan_airfield sonoma_raceway warehouse)
+set(worlds none empty baylands ksql_airport mcmillan_airfield sonoma_raceway warehouse windy)
 set(all_posix_vmd_make_targets)
 foreach(viewer ${viewers})
 	foreach(debugger ${debuggers})


### PR DESCRIPTION
**Describe problem solved by this pull request**
Previously, wind was a gazebo model plugin since wind was simulated by applying "force" on a link. Since wind was a element inside the model, models could have different wind simulated even if they are in the same world.

However, this has changed since https://github.com/PX4/sitl_gazebo/pull/462. Therefore, we can make the wind a property of the "world" and make different vehicles be affected to this no matter which vehicle is spawned in the world.

**Describe your solution**
To simulate a windy world, simply run the following.
```
make px4_sitl gazebo_plane__windy
```

**Test data / coverage**
Log: https://review.px4.io/plot_app?log=04b3ea46-2489-424d-904c-3e2aadf820cc

**Additional context**
Depends on PR https://github.com/PX4/sitl_gazebo/pull/462