### PR TITLE
mc_att_control: adjust attitude setpoint upon estimate reset

### DIFF
--- a/src/modules/mc_att_control/AttitudeControl/AttitudeControl.cpp
+++ b/src/modules/mc_att_control/AttitudeControl/AttitudeControl.cpp
@@ -52,8 +52,10 @@ void AttitudeControl::setProportionalGain(const matrix::Vector3f &proportional_g
 	}
 }
 
-matrix::Vector3f AttitudeControl::update(matrix::Quatf q, matrix::Quatf qd, const float yawspeed_feedforward)
+matrix::Vector3f AttitudeControl::update(matrix::Quatf q) const
 {
+	Quatf qd = _attitude_setpoint_q;
+
 	// ensure input quaternions are exactly normalized because acosf(1.00001) == NaN
 	q.normalize();
 	qd.normalize();
@@ -93,13 +95,13 @@ matrix::Vector3f AttitudeControl::update(matrix::Quatf q, matrix::Quatf qd, cons
 	matrix::Vector3f rate_setpoint = eq.emult(_proportional_gain);
 
 	// Feed forward the yaw setpoint rate.
-	// yaw_sp_move_rate is the feed forward commanded rotation around the world z-axis,
+	// yawspeed_setpoint is the feed forward commanded rotation around the world z-axis,
 	// but we need to apply it in the body frame (because _rates_sp is expressed in the body frame).
 	// Therefore we infer the world z-axis (expressed in the body frame) by taking the last column of R.transposed (== q.inversed)
-	// and multiply it by the yaw setpoint rate (yaw_sp_move_rate).
+	// and multiply it by the yaw setpoint rate (yawspeed_setpoint).
 	// This yields a vector representing the commanded rotatation around the world z-axis expressed in the body frame
 	// such that it can be added to the rates setpoint.
-	rate_setpoint += q.inversed().dcm_z() * yawspeed_feedforward;
+	rate_setpoint += q.inversed().dcm_z() * _yawspeed_setpoint;
 
 	// limit rates
 	for (int i = 0; i < 3; i++) {

--- a/src/modules/mc_att_control/AttitudeControl/AttitudeControl.hpp
+++ b/src/modules/mc_att_control/AttitudeControl/AttitudeControl.hpp
@@ -71,16 +71,24 @@ public:
 	void setRateLimit(const matrix::Vector3f &rate_limit) { _rate_limit = rate_limit; }
 
 	/**
+	 * Set a new attitude setpoint replacing the one tracked before
+	 * @param qd desired vehicle attitude setpoint
+	 * @param yawspeed_setpoint [rad/s] yaw feed forward angular rate in world frame
+	 */
+	void setAttitudeSetpoint(const matrix::Quatf &qd, const float yawspeed_setpoint) { _attitude_setpoint_q = qd; _yawspeed_setpoint = yawspeed_setpoint; }
+
+	/**
 	 * Run one control loop cycle calculation
 	 * @param q estimation of the current vehicle attitude unit quaternion
-	 * @param qd desired vehicle attitude setpoint
-	 * @param yawspeed_feedforward [rad/s] yaw feed forward angular rate in world frame
 	 * @return [rad/s] body frame 3D angular rate setpoint vector to be executed by the rate controller
 	 */
-	matrix::Vector3f update(matrix::Quatf q, matrix::Quatf qd, float yawspeed_feedforward);
+	matrix::Vector3f update(matrix::Quatf q) const;
 
 private:
 	matrix::Vector3f _proportional_gain;
 	matrix::Vector3f _rate_limit;
-	float _yaw_w{0.f}; /**< yaw weight [0,1] to prioritize roll and pitch */
+	float _yaw_w{0.f}; ///< yaw weight [0,1] to deprioritize caompared to roll and pitch
+
+	matrix::Quatf _attitude_setpoint_q; ///< latest known attitude setpoint e.g. from position control
+	float _yawspeed_setpoint{0.f}; ///< latest known yawspeed feed-forward setpoint
 };

--- a/src/modules/mc_att_control/AttitudeControl/AttitudeControl.hpp
+++ b/src/modules/mc_att_control/AttitudeControl/AttitudeControl.hpp
@@ -78,6 +78,13 @@ public:
 	void setAttitudeSetpoint(const matrix::Quatf &qd, const float yawspeed_setpoint) { _attitude_setpoint_q = qd; _yawspeed_setpoint = yawspeed_setpoint; }
 
 	/**
+	 * Adjust last known attitude setpoint by a delta rotation
+	 * Optional use to avoid glitches when attitude estimate reference e.g. heading changes.
+	 * @param q_delta delta rotation to apply
+	 */
+	void adaptAttitudeSetpoint(const matrix::Quatf &q_delta) { _attitude_setpoint_q = q_delta * _attitude_setpoint_q; }
+
+	/**
 	 * Run one control loop cycle calculation
 	 * @param q estimation of the current vehicle attitude unit quaternion
 	 * @return [rad/s] body frame 3D angular rate setpoint vector to be executed by the rate controller

--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -105,7 +105,7 @@ private:
 
 	AttitudeControl _attitude_control; ///< class for attitude control calculations
 
-	uORB::Subscription _v_att_sp_sub{ORB_ID(vehicle_attitude_setpoint)};		/**< vehicle attitude setpoint subscription */
+	uORB::Subscription _vehicle_attitude_setpoint_sub{ORB_ID(vehicle_attitude_setpoint)};
 	uORB::Subscription _v_rates_sp_sub{ORB_ID(vehicle_rates_setpoint)};		/**< vehicle rates setpoint subscription */
 	uORB::Subscription _v_control_mode_sub{ORB_ID(vehicle_control_mode)};		/**< vehicle control mode subscription */
 	uORB::Subscription _params_sub{ORB_ID(parameter_update)};			/**< parameter updates subscription */
@@ -119,7 +119,6 @@ private:
 	uORB::Publication<vehicle_attitude_setpoint_s>	_vehicle_attitude_setpoint_pub;
 
 	struct vehicle_attitude_s		_v_att {};		/**< vehicle attitude */
-	struct vehicle_attitude_setpoint_s	_v_att_sp {};		/**< vehicle attitude setpoint */
 	struct vehicle_rates_setpoint_s		_v_rates_sp {};		/**< vehicle rates setpoint */
 	struct manual_control_setpoint_s	_manual_control_sp {};	/**< manual control setpoint */
 	struct vehicle_control_mode_s		_v_control_mode {};	/**< vehicle control mode */
@@ -128,7 +127,8 @@ private:
 
 	perf_counter_t	_loop_perf;			/**< loop duration performance counter */
 
-	matrix::Vector3f _rates_sp;			/**< angular rates setpoint */
+	matrix::Vector3f _thrust_setpoint_body; ///< body frame 3D thrust vector
+	matrix::Vector3f _rates_sp; ///< angular rates setpoint
 
 	float _man_yaw_sp{0.f};				/**< current yaw setpoint in manual mode */
 	float _man_tilt_max;			/**< maximum tilt allowed for manual flight [rad] */

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -286,7 +286,9 @@ MulticopterAttitudeControl::Run()
 		// Check for a heading reset
 		if (prev_quat_reset_counter != _v_att.quat_reset_counter) {
 			// we only extract the heading change from the delta quaternion
-			_man_yaw_sp += Eulerf(Quatf(_v_att.delta_q_reset)).psi();
+			const Quatf delta_q_reset(_v_att.delta_q_reset);
+			_man_yaw_sp += Eulerf(delta_q_reset).psi();
+			_attitude_control.adaptAttitudeSetpoint(delta_q_reset);
 		}
 
 		const hrt_abstime now = hrt_absolute_time();


### PR DESCRIPTION
**Describe problem solved by this pull request**
When the attitude estimate quaternion is reset the attitude controller uses the new reference in the next loop iteration. But the attitude setpoint is not updates to the new reference until the position controller generates a new attitude setpoint but it runs in a much slower rate. As a result there are glitches in the output rate setpoint. See https://github.com/PX4/Firmware/pull/14676#issuecomment-617969679

**Describe your solution**
The internal setpoint copy is updated with the delta quaaternion upon attitude estimate reset. It will get overwritten with the next attitude setpoint change.

**Test data / coverage**
Completely untested, tests still REQUIRED.
