### PR TITLE
Fixes max AUX number for MNT_MAN_ROLL, PITCH and YAW parameters

### DIFF
--- a/src/modules/vmount/vmount_params.c
+++ b/src/modules/vmount/vmount_params.c
@@ -123,7 +123,7 @@ PARAM_DEFINE_FLOAT(MNT_OB_LOCK_MODE, 0.0f);
 * @value 5 AUX5
 * @value 6 AUX6
 * @min 0
-* @max 5
+* @max 6
 * @group Mount
 */
 PARAM_DEFINE_INT32(MNT_MAN_ROLL, 0);
@@ -139,7 +139,7 @@ PARAM_DEFINE_INT32(MNT_MAN_ROLL, 0);
 * @value 5 AUX5
 * @value 6 AUX6
 * @min 0
-* @max 5
+* @max 6
 * @group Mount
 */
 PARAM_DEFINE_INT32(MNT_MAN_PITCH, 0);
@@ -155,7 +155,7 @@ PARAM_DEFINE_INT32(MNT_MAN_PITCH, 0);
 * @value 5 AUX5
 * @value 6 AUX6
 * @min 0
-* @max 5
+* @max 6
 * @group Mount
 */
 PARAM_DEFINE_INT32(MNT_MAN_YAW, 0);


### PR DESCRIPTION
**Describe problem solved by this pull request**
There are 6 AUXes that could be possibly used to control vmount's roll, pitch and yaw, but for some reason the maximum values of corresponding parameters were limited to 5. So you can't just choose AUX6 without forcing parameter save.

**Describe your solution**
Changed 5 to 6.

**Describe possible alternatives**
Force save of parameter in an old QGCs or using Mavlink console to set it.

**Test data / coverage**
It builds.
