### PR TITLE
PositionControl: deconflict velocity control gains from thrust

### DIFF
--- a/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
@@ -164,11 +164,6 @@ public:
 	void resetIntegral() { _vel_int.setZero(); }
 
 	/**
-	 * @return the value of the velocity integrator
-	 */
-	matrix::Vector3f getIntegral() const { return _vel_int; }
-
-	/**
 	 * Get the controllers output local position setpoint
 	 * These setpoints are the ones which were executed on including PID output and feed-forward.
 	 * The acceleration or thrust setpoints can be used for attitude control.
@@ -205,7 +200,7 @@ private:
 	float _lim_thr_max{}; ///< Maximum collective thrust allowed as output [-1,0] e.g. -0.1
 	float _lim_tilt{}; ///< Maximum tilt from level the output attitude is allowed to have
 
-	float _hover_thrust{}; ///< Thrust [0,1] with which the vehicle hovers not aacelerating down or up with level orientation
+	float _hover_thrust{}; ///< Thrust [0,1] with which the vehicle hovers not accelerating down or up with level orientation
 
 	// States
 	matrix::Vector3f _pos; /**< current position */

--- a/src/modules/mc_pos_control/PositionControl/PositionControlTest.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControlTest.cpp
@@ -76,7 +76,7 @@ public:
 	PositionControlBasicTest()
 	{
 		_position_control.setPositionGains(Vector3f(1.f, 1.f, 1.f));
-		_position_control.setVelocityGains(Vector3f(1.f, 1.f, 1.f), Vector3f(1.f, 1.f, 1.f), Vector3f(1.f, 1.f, 1.f));
+		_position_control.setVelocityGains(Vector3f(20.f, 20.f, 20.f), Vector3f(20.f, 20.f, 20.f), Vector3f(20.f, 20.f, 20.f));
 		_position_control.setVelocityLimits(1.f, 1.f, 1.f);
 		_position_control.setThrustLimits(0.1f, 0.9f);
 		_position_control.setTiltLimit(1.f);
@@ -387,6 +387,4 @@ TEST_F(PositionControlBasicTest, UpdateHoverThrust)
 	// THEN: the integral is updated to avoid discontinuities and
 	// the output is still the same
 	EXPECT_EQ(_output_setpoint.thrust[2], -hover_thrust);
-	const Vector3f integrator_new(_position_control.getIntegral());
-	EXPECT_EQ(integrator_new(2) - hover_thrust_new, -hover_thrust);
 }

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -363,9 +363,12 @@ MulticopterPositionControl::parameters_update(bool force)
 		}
 
 		_control.setPositionGains(Vector3f(_param_mpc_xy_p.get(), _param_mpc_xy_p.get(), _param_mpc_z_p.get()));
-		_control.setVelocityGains(Vector3f(_param_mpc_xy_vel_p.get(), _param_mpc_xy_vel_p.get(), _param_mpc_z_vel_p.get()),
-					  Vector3f(_param_mpc_xy_vel_i.get(), _param_mpc_xy_vel_i.get(), _param_mpc_z_vel_i.get()),
-					  Vector3f(_param_mpc_xy_vel_d.get(), _param_mpc_xy_vel_d.get(), _param_mpc_z_vel_d.get()));
+		// backwards compatibility scale for velocity gains to non-acceleration based control, needs to be overcome with configuration conversion
+		const float hover_scale = 20.f;
+		_control.setVelocityGains(Vector3f(_param_mpc_xy_vel_p.get(), _param_mpc_xy_vel_p.get(),
+						   _param_mpc_z_vel_p.get()) * hover_scale,
+					  Vector3f(_param_mpc_xy_vel_i.get(), _param_mpc_xy_vel_i.get(), _param_mpc_z_vel_i.get()) * hover_scale,
+					  Vector3f(_param_mpc_xy_vel_d.get(), _param_mpc_xy_vel_d.get(), _param_mpc_z_vel_d.get()) * hover_scale);
 		_control.setVelocityLimits(_param_mpc_xy_vel_max.get(), _param_mpc_z_vel_max_up.get(), _param_mpc_z_vel_max_dn.get());
 		_control.setThrustLimits(_param_mpc_thr_min.get(), _param_mpc_thr_max.get());
 		_control.setTiltLimit(M_DEG_TO_RAD_F * _param_mpc_tiltmax_air.get()); // convert to radians!


### PR DESCRIPTION
**Describe problem solved by this pull request**
Before #14212 the velocity control gains used in the multicopter position controller were defined as a scale between velocity error in one axis (or it's integral and derivative respectively) and the unit thrust vector. The problem with this is that the normalization of the unit thrust vector changes per vehicle or even vehicle configuration as 0 and 100% thrust get a different physical response. That's why the gains are now defined as scale between velocity error (integral/derivative) and the output acceleration in m/s². E.g. with the default P horizontal velocity gain of 4 m/s² per m/s you would counteract a velocity error of 1m/s with 4m/s² actuation in order to accelerate to the desired velocity. This leads to less dependence of the velocity control tuning to the vehicles maximum thrust, output configuration and hover thrust.

In #14212 a backward compatibility factor was introduced to make the existing parameters backward compatible. This pull request aims at:
1. fixes #14720 
2. ~Make the parameters reflect that reproducible gain scale while still staying backwards compatible.~

**Describe your solution**
- Avoid constantly adjusting the velocity gains with the HTE
- Make sure the hover thrust integral update doesn't break
  even though its unit is acceleration and not unit thrust anymore
- ~Replace the existing parameters with new ones that directly reflect the correctly scaled values~

In horizontal direction it doesn't make sense to scale them with the hover thrust and in vertical direction the adjustments are already done in the acceleration to collective thrust conversion.

**Test data / coverage**
SITL tested and real world tested, see https://github.com/PX4/Firmware/pull/14749#issuecomment-623474947
