### PR TITLE
Fix tiltrotor scaling for sitl gazebo

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/1042_tiltrotor
+++ b/ROMFS/px4fmu_common/init.d-posix/1042_tiltrotor
@@ -36,8 +36,9 @@ then
 
 	param set VT_F_TRANS_DUR 5.0
 	param set VT_F_TRANS_THR 0.75
-	param set VT_TILT_FW 3.1415
-	param set VT_TILT_TRANS 1.2
+	param set VT_FWD_THRUST_SC 1.1
+	param set VT_TILT_FW 1
+	param set VT_TILT_TRANS 0.6
 	param set VT_ELEV_MC_LOCK 0
 	param set VT_TYPE 1
 	param set VT_B_TRANS_DUR 8


### PR DESCRIPTION


**Describe problem solved by this pull request**
Previously, the tilt actuator inputs were being set as a 1 to 1 to the joint poisiton.

This is a problem since the tilt angle ranges [-3.14, 3.14] compared to actuator setpoints [-1, 1]

As a workaround, the firmware was scaling inputs on the firmware side by setting the parameter `VT_TILT_FW` as done in https://github.com/PX4/Firmware/blob/master/ROMFS/px4fmu_common/init.d-posix/1042_tiltrotor#L39

**Describe your solution**
This PR sets the input scale on the model side by changing the input scale.

**Additional context**
Depends on https://github.com/PX4/sitl_gazebo/pull/468