### PR TITLE
move mc_att_control to new wq:attitude_ctrl

### DIFF
--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
@@ -65,22 +65,23 @@ static constexpr wq_config_t I2C3{"wq:I2C3", 1472, -11};
 static constexpr wq_config_t I2C4{"wq:I2C4", 1472, -12};
 
 // PX4 att/pos controllers, highest priority after sensors.
-static constexpr wq_config_t att_pos_ctrl{"wq:att_pos_ctrl", 7200, -13};
+static constexpr wq_config_t attitude_ctrl{"wq:attitude_ctrl", 1500, -13};
+static constexpr wq_config_t navigation_and_controllers{"wq:navigation_and_controllers", 7200, -14};
 
-static constexpr wq_config_t hp_default{"wq:hp_default", 1900, -14};
+static constexpr wq_config_t hp_default{"wq:hp_default", 1900, -15};
 
-static constexpr wq_config_t uavcan{"wq:uavcan", 3000, -15};
+static constexpr wq_config_t uavcan{"wq:uavcan", 3000, -16};
 
-static constexpr wq_config_t UART0{"wq:UART0", 1400, -16};
-static constexpr wq_config_t UART1{"wq:UART1", 1400, -17};
-static constexpr wq_config_t UART2{"wq:UART2", 1400, -18};
-static constexpr wq_config_t UART3{"wq:UART3", 1400, -19};
-static constexpr wq_config_t UART4{"wq:UART4", 1400, -20};
-static constexpr wq_config_t UART5{"wq:UART5", 1400, -21};
-static constexpr wq_config_t UART6{"wq:UART6", 1400, -22};
-static constexpr wq_config_t UART7{"wq:UART7", 1400, -23};
-static constexpr wq_config_t UART8{"wq:UART8", 1400, -24};
-static constexpr wq_config_t UART_UNKNOWN{"wq:UART_UNKNOWN", 1400, -25};
+static constexpr wq_config_t UART0{"wq:UART0", 1400, -17};
+static constexpr wq_config_t UART1{"wq:UART1", 1400, -18};
+static constexpr wq_config_t UART2{"wq:UART2", 1400, -19};
+static constexpr wq_config_t UART3{"wq:UART3", 1400, -20};
+static constexpr wq_config_t UART4{"wq:UART4", 1400, -21};
+static constexpr wq_config_t UART5{"wq:UART5", 1400, -22};
+static constexpr wq_config_t UART6{"wq:UART6", 1400, -23};
+static constexpr wq_config_t UART7{"wq:UART7", 1400, -24};
+static constexpr wq_config_t UART8{"wq:UART8", 1400, -25};
+static constexpr wq_config_t UART_UNKNOWN{"wq:UART_UNKNOWN", 1400, -26};
 
 static constexpr wq_config_t lp_default{"wq:lp_default", 1700, -50};
 

--- a/platforms/common/include/px4_platform_common/tasks.h
+++ b/platforms/common/include/px4_platform_common/tasks.h
@@ -101,7 +101,7 @@ typedef struct {
 #endif
 
 // PX4 work queue starting high priority
-#define PX4_WQ_HP_BASE (SCHED_PRIORITY_MAX - 12)
+#define PX4_WQ_HP_BASE (SCHED_PRIORITY_MAX - 15)
 
 // Fast drivers - they need to run as quickly as possible to minimize control
 // latency.

--- a/src/modules/airspeed_selector/airspeed_selector_main.cpp
+++ b/src/modules/airspeed_selector/airspeed_selector_main.cpp
@@ -176,7 +176,7 @@ private:
 
 AirspeedModule::AirspeedModule():
 	ModuleParams(nullptr),
-	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::att_pos_ctrl)
+	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::navigation_and_controllers)
 {
 	// initialise parameters
 	update_params();

--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -166,7 +166,7 @@ private:
 
 AttitudeEstimatorQ::AttitudeEstimatorQ() :
 	ModuleParams(nullptr),
-	WorkItem(MODULE_NAME, px4::wq_configurations::att_pos_ctrl)
+	WorkItem(MODULE_NAME, px4::wq_configurations::navigation_and_controllers)
 {
 	_vel_prev.zero();
 	_pos_acc.zero();

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -542,7 +542,7 @@ private:
 
 Ekf2::Ekf2(bool replay_mode):
 	ModuleParams(nullptr),
-	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::att_pos_ctrl),
+	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::navigation_and_controllers),
 	_replay_mode(replay_mode),
 	_ekf_update_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": update")),
 	_params(_ekf.getParamHandle()),

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -42,7 +42,7 @@ using math::radians;
 
 FixedwingAttitudeControl::FixedwingAttitudeControl(bool vtol) :
 	ModuleParams(nullptr),
-	WorkItem(MODULE_NAME, px4::wq_configurations::att_pos_ctrl),
+	WorkItem(MODULE_NAME, px4::wq_configurations::attitude_ctrl),
 	_actuators_0_pub(vtol ? ORB_ID(actuator_controls_virtual_fw) : ORB_ID(actuator_controls_0)),
 	_attitude_sp_pub(vtol ? ORB_ID(fw_virtual_attitude_setpoint) : ORB_ID(vehicle_attitude_setpoint)),
 	_loop_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": cycle"))

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -37,7 +37,7 @@
 
 FixedwingPositionControl::FixedwingPositionControl(bool vtol) :
 	ModuleParams(nullptr),
-	WorkItem(MODULE_NAME, px4::wq_configurations::att_pos_ctrl),
+	WorkItem(MODULE_NAME, px4::wq_configurations::navigation_and_controllers),
 	_attitude_sp_pub(vtol ? ORB_ID(fw_virtual_attitude_setpoint) : ORB_ID(vehicle_attitude_setpoint)),
 	_loop_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")),
 	_launchDetector(this),

--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -47,7 +47,7 @@ namespace land_detector
 
 LandDetector::LandDetector() :
 	ModuleParams(nullptr),
-	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::att_pos_ctrl)
+	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::navigation_and_controllers)
 {}
 
 LandDetector::~LandDetector()

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -19,7 +19,7 @@ static const char *msg_label = "[lpe] ";	// rate of land detector correction
 
 BlockLocalPositionEstimator::BlockLocalPositionEstimator() :
 	ModuleParams(nullptr),
-	WorkItem(MODULE_NAME, px4::wq_configurations::att_pos_ctrl),
+	WorkItem(MODULE_NAME, px4::wq_configurations::navigation_and_controllers),
 
 	// this block has no parent, and has name LPE
 	SuperBlock(nullptr, "LPE"),

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -53,7 +53,7 @@ using namespace matrix;
 
 MulticopterAttitudeControl::MulticopterAttitudeControl(bool vtol) :
 	ModuleParams(nullptr),
-	WorkItem(MODULE_NAME, px4::wq_configurations::att_pos_ctrl),
+	WorkItem(MODULE_NAME, px4::wq_configurations::attitude_ctrl),
 	_vehicle_attitude_setpoint_pub(vtol ? ORB_ID(mc_virtual_attitude_setpoint) : ORB_ID(vehicle_attitude_setpoint)),
 	_loop_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": cycle"))
 {

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -284,7 +284,7 @@ private:
 MulticopterPositionControl::MulticopterPositionControl(bool vtol) :
 	SuperBlock(nullptr, "MPC"),
 	ModuleParams(nullptr),
-	WorkItem(MODULE_NAME, px4::wq_configurations::att_pos_ctrl),
+	WorkItem(MODULE_NAME, px4::wq_configurations::navigation_and_controllers),
 	_vehicle_attitude_setpoint_pub(vtol ? ORB_ID(mc_virtual_attitude_setpoint) : ORB_ID(vehicle_attitude_setpoint)),
 	_vel_x_deriv(this, "VELD"),
 	_vel_y_deriv(this, "VELD"),

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -199,7 +199,7 @@ private:
 
 Sensors::Sensors(bool hil_enabled) :
 	ModuleParams(nullptr),
-	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::att_pos_ctrl),
+	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::navigation_and_controllers),
 	_hil_enabled(hil_enabled),
 	_loop_perf(perf_alloc(PC_ELAPSED, "sensors")),
 	_voted_sensors_update(_parameters, hil_enabled)

--- a/src/modules/sensors/vehicle_acceleration/VehicleAcceleration.cpp
+++ b/src/modules/sensors/vehicle_acceleration/VehicleAcceleration.cpp
@@ -43,7 +43,7 @@ namespace sensors
 
 VehicleAcceleration::VehicleAcceleration() :
 	ModuleParams(nullptr),
-	WorkItem(MODULE_NAME, px4::wq_configurations::att_pos_ctrl),
+	WorkItem(MODULE_NAME, px4::wq_configurations::navigation_and_controllers),
 	_corrections(this, SensorCorrections::SensorType::Accelerometer)
 {
 	_lp_filter.set_cutoff_frequency(kInitialRateHz, _param_imu_accel_cutoff.get());

--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
@@ -43,7 +43,7 @@ static constexpr uint32_t SENSOR_TIMEOUT{300_ms};
 
 VehicleAirData::VehicleAirData() :
 	ModuleParams(nullptr),
-	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::att_pos_ctrl)
+	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::navigation_and_controllers)
 {
 	_voter.set_timeout(SENSOR_TIMEOUT);
 }

--- a/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
@@ -43,7 +43,7 @@ namespace sensors
 
 VehicleIMU::VehicleIMU(uint8_t accel_index, uint8_t gyro_index) :
 	ModuleParams(nullptr),
-	WorkItem(MODULE_NAME, px4::wq_configurations::att_pos_ctrl),
+	WorkItem(MODULE_NAME, px4::wq_configurations::navigation_and_controllers),
 	_sensor_accel_integrated_sub(this, ORB_ID(sensor_accel_integrated), accel_index),
 	_sensor_gyro_integrated_sub(this, ORB_ID(sensor_gyro_integrated), gyro_index),
 	_accel_corrections(this, SensorCorrections::SensorType::Accelerometer),


### PR DESCRIPTION
Ekf2 runs on every new IMU message (400 Hz sensor_combined) and publishes a new vehicle_attitude immediately, but only runs the filter update every 10 ms. Having mc_att_control in a separate higher priority thread allows it to run immediately on every vehicle_attitude publication.

We basically had this in the past when mc_att_control was a task, but temporarily lost it in an effort to reduce memory (and save a little bit of cpu). Workqueue threads are cheap and the current mc_att_control is cheaper than it used to be, so we can comfortably afford this.


Background: https://github.com/PX4/Firmware/pull/9832