### PR TITLE
Add options to spawn multiple vehicles in different worlds

### DIFF
--- a/Tools/gazebo_sitl_multiple_run.sh
+++ b/Tools/gazebo_sitl_multiple_run.sh
@@ -17,17 +17,19 @@ then
 	exit 1
 fi
 
-while getopts n:m: option
+while getopts n:m:w: option
 do
 	case "${option}"
 	in
 		n) NUM_VEHICLES=${OPTARG};;
 		m) VEHICLE_MODEL=${OPTARG};;
+		w) WORLD=${OPTARG};;
 	esac
 done
 
 num_vehicles=${NUM_VEHICLES:=3}
 export PX4_SIM_MODEL=${VEHICLE_MODEL:=iris}
+world=${WORLD:=empty}
 
 if [ "$PX4_SIM_MODEL" != "iris" ] && [ "$PX4_SIM_MODEL" != "plane" ] && [ "$PX4_SIM_MODEL" != "standard_vtol" ]
 then
@@ -47,7 +49,6 @@ src_path="$SCRIPT_DIR/.."
 build_path=${src_path}/build/px4_sitl_default
 mavlink_udp_port=14560
 mavlink_tcp_port=4560
-world="empty"
 
 echo "killing running instances"
 pkill -x px4 || true


### PR DESCRIPTION
**Describe problem solved by this pull request**
Since SITL gazebo now has a clean separation between worlds and vehicles, we can now spawn multiple vehicles to any world we want. 

**Describe your solution**
You can use the `-w` flag to specify which world the vehicle should be spawned in. If no `-w` flag is specified, then the script defaults to `empty.world` 

**Test data / coverage**
For e.g.
```
 Tools/gazebo_sitl_multiple_run.sh -w baylands
```

![Screenshot from 2020-04-26 15-21-30](https://user-images.githubusercontent.com/5248102/80309001-58262c00-87d2-11ea-8124-f4e0f833854c.png)

**Additional context**
This was enabled by separating worlds with models in gazebo definitions. This will also be something useful to test multivehicle fleets in "windy" environments when such worlds are added as in https://github.com/PX4/Firmware/pull/14737