### PR TITLE
Extend Failure Detector functionalities

### DIFF
--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -12,10 +12,11 @@ uint8 ARMING_STATE_MAX = 6
 
 # FailureDetector status
 uint8 FAILURE_NONE = 0
-uint8 FAILURE_ROLL = 1 	# (1 << 0)
-uint8 FAILURE_PITCH = 2	# (1 << 1)
-uint8 FAILURE_ALT = 4 	# (1 << 2)
-uint8 FAILURE_EXT = 8 	# (1 << 3)
+uint8 FAILURE_ROLL = 1 	        # (1 << 0)
+uint8 FAILURE_PITCH = 2	        # (1 << 1)
+uint8 FAILURE_ALT = 4 	        # (1 << 2)
+uint8 FAILURE_EXT = 8 	        # (1 << 3)
+uint8 FAILURE_ARM_ESC = 16      # (1 << 4)
 
 # HIL
 uint8 HIL_STATE_OFF = 0

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -210,6 +210,7 @@ private:
 		(ParamBool<px4::params::COM_MOT_TEST_EN>) _param_com_mot_test_en,
 
 		(ParamFloat<px4::params::COM_KILL_DISARM>) _param_com_kill_disarm,
+		(ParamFloat<px4::params::COM_LKDOWN_TKO>) _param_com_lkdown_tko,
 
 		// Engine failure
 		(ParamFloat<px4::params::COM_EF_THROT>) _param_ef_throttle_thres,

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -924,3 +924,19 @@ PARAM_DEFINE_FLOAT(COM_CPU_MAX, 90.0f);
  * @max 4
  */
 PARAM_DEFINE_INT32(COM_POWER_COUNT, 1);
+
+/**
+ * Timeout for detecting a failure after takeoff
+ *
+ * A non-zero, positive value specifies the timeframe in seconds within failure detector is allowed to put the vehicle into
+ * a lockdown state if attitude exceeds the limits defined in FD_FAIL_P and FD_FAIL_R.
+ * The check is not executed for flight modes that do support acrobatic maneuvers, e.g: Acro (MC/FW), Rattitude and Manual (FW).
+ * A zero or negative value means that the check is disabled.
+ *
+ * @group Commander
+ * @unit s
+ * @min -1.0
+ * @max 5.0
+ * @decimal 3
+ */
+PARAM_DEFINE_FLOAT(COM_LKDOWN_TKO, 3.0f);

--- a/src/modules/commander/failure_detector/FailureDetector.hpp
+++ b/src/modules/commander/failure_detector/FailureDetector.hpp
@@ -54,6 +54,7 @@
 #include <uORB/topics/vehicle_attitude_setpoint.h>
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/vehicle_status.h>
+#include <uORB/topics/esc_status.h>
 #include <uORB/topics/pwm_input.h>
 
 typedef enum {
@@ -62,6 +63,7 @@ typedef enum {
 	FAILURE_PITCH = vehicle_status_s::FAILURE_PITCH,
 	FAILURE_ALT = vehicle_status_s::FAILURE_ALT,
 	FAILURE_EXT = vehicle_status_s::FAILURE_EXT,
+	FAILURE_ARM_ESCS = vehicle_status_s::FAILURE_ARM_ESC
 } failure_detector_bitmak;
 
 using uORB::SubscriptionData;
@@ -84,11 +86,14 @@ private:
 		(ParamFloat<px4::params::FD_FAIL_R_TTRI>) _param_fd_fail_r_ttri,
 		(ParamFloat<px4::params::FD_FAIL_P_TTRI>) _param_fd_fail_p_ttri,
 		(ParamBool<px4::params::FD_EXT_ATS_EN>) _param_fd_ext_ats_en,
-		(ParamInt<px4::params::FD_EXT_ATS_TRIG>) _param_fd_ext_ats_trig
+		(ParamInt<px4::params::FD_EXT_ATS_TRIG>) _param_fd_ext_ats_trig,
+		(ParamInt<px4::params::FD_ESCS_EN>) _param_escs_en
+
 	)
 
 	// Subscriptions
 	uORB::Subscription _sub_vehicule_attitude{ORB_ID(vehicle_attitude)};
+	uORB::Subscription _sub_esc_status{ORB_ID(esc_status)};
 	uORB::Subscription _sub_pwm_input{ORB_ID(pwm_input)};
 
 
@@ -97,9 +102,11 @@ private:
 	systemlib::Hysteresis _roll_failure_hysteresis{false};
 	systemlib::Hysteresis _pitch_failure_hysteresis{false};
 	systemlib::Hysteresis _ext_ats_failure_hysteresis{false};
+	systemlib::Hysteresis _esc_failure_hysteresis{false};
 
-	bool resetStatus();
+	bool resetAttitudeStatus();
 	bool isAttitudeStabilized(const vehicle_status_s &vehicle_status);
 	bool updateAttitudeStatus();
 	bool updateExternalAtsStatus();
+	bool updateEscsStatus(const vehicle_status_s &vehicle_status);
 };

--- a/src/modules/commander/failure_detector/failure_detector_params.c
+++ b/src/modules/commander/failure_detector/failure_detector_params.c
@@ -129,3 +129,15 @@ PARAM_DEFINE_INT32(FD_EXT_ATS_EN, 0);
  * @group Failure Detector
  */
 PARAM_DEFINE_INT32(FD_EXT_ATS_TRIG, 1900);
+
+/**
+ * Enable checks on ESCs that report their arming state.
+ * If enabled, failure detector will verify that all the ESCs have successfully armed when the vehicle has transitioned to the armed state.
+ * Timeout for receiving an acknowledgement from the ESCs is 0.3s, if no feedback is received the failure detector will auto disarm the vehicle.
+ *
+ * @boolean
+ * @reboot_required true
+ *
+ * @group Failure Detector
+ */
+PARAM_DEFINE_INT32(FD_ESCS_EN, 1);


### PR DESCRIPTION
**Describe problem solved by this pull request**
Main goal of this PR is to extend Failure Detector logic to handle ESC arming state.

Some types of ESC require that you send them an arm command before they can actually spin.
If they succeed transitioning to the armed state, they will send back an acknowledgment to PX4.

This PR extends Failure Detector logic to handle this kind of information:
after the vehicle is armed Failure Detector will wait `300_ms` to get an answer from the ESCs.
If within this time window all the ESCs do not report to be armed Failure Detector will auto disarm the vehicle.

Checks are performed using `esc_status.esc_armed_flags` .

During the development of this PR i've also addressed the following points:
- Added autodisarm if system is in lockdown. Having the vehicle in lockdown but still armed can be really misleading from a UX standpoint. 

- Avoid triggering flight termination if vehicle is already in a lockdown state 

- Introduced a parameter COM_LKDOWN_TKO to extend/disable the "lockdown window". 
In some development cases it might be super useful having this logic disabled.




