### PR TITLE
rotation conversion: deconfuse roll 90 yaw 90

### DIFF
--- a/src/lib/conversion/rotation.cpp
+++ b/src/lib/conversion/rotation.cpp
@@ -173,8 +173,10 @@ rotate_3f(enum Rotation rot, float &x, float &y, float &z)
 		}
 
 	case ROTATION_ROLL_90_YAW_90: {
-			tmp = z; z = y; y = -tmp;
-			tmp = x; x = -y; y = tmp;
+			tmp = x;
+			x = z;
+			z = y;
+			y = tmp;
 			return;
 		}
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
Discussing with @baumanta, @julianoes, @RomanBapst over the coffee break some rotation implementations are just confusing with their extra steps.

**Describe your solution**
Do the minimal swapping which requires only one temporary variable and doesn't do unnecessary confusing assignments.

**Test data / coverage**
Untested, please review.

**Additional context**
https://github.com/PX4/Firmware/pull/14512#issuecomment-618441246
