### PR TITLE
Switch flightgear bridge submodule to px4 organization

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -47,4 +47,4 @@
 	url = https://github.com/ATLFlight/dspal.git
 [submodule "Tools/flightgear_bridge"]
 	path = Tools/flightgear_bridge
-	url = https://github.com/ThunderFly-aerospace/PX4-FlightGear-Bridge.git
+	url = https://github.com/PX4/PX4-FlightGear-Bridge.git


### PR DESCRIPTION
**Describe problem solved by this pull request**
SITL support for Flightgear was added in https://github.com/PX4/Firmware/pull/14539 thanks to the contribution from Thunderfly Aerospace! Thanks @kaklik @slimonslimon @roman-dvorak 

This brings the flightgear bridge submodule to a [fork](https://github.com/PX4/PX4-FlightGear-Bridge) of the [original repo](https://github.com/ThunderFly-aerospace/PX4-FlightGear-Bridge)  under the px4 organization