### PR TITLE
ubuntu setup script: add gstreamer1.0-libav

### DIFF
--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -190,6 +190,7 @@ if [[ $INSTALL_SIM == "true" ]]; then
 		gstreamer1.0-plugins-base \
 		gstreamer1.0-plugins-good \
 		gstreamer1.0-plugins-ugly \
+		gstreamer1.0-libav \
 		libeigen3-dev \
 		libgazebo9-dev \
 		libgstreamer-plugins-base1.0-dev \


### PR DESCRIPTION
Gazebo video streaming on ubuntu wasn't working - as per http://dev.px4.io/master/en/simulation/gazebo.html#how-to-view-gazebo-video

I ran the gst-launch-1.0 instructions and it reported that gstreamer1.0-libav is missing. Once added, QGC video worked.

I'm not certain that this is the "right" way to fix the dependency though. 

After this fix, the `gst-launch-1.0` "test"  command at above no longer fails with the warning. It does only display a grey view though, as per https://github.com/PX4/Devguide/issues/1034