### PR TITLE
Use ground truth data for ground truth mavlink message

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -4925,10 +4925,10 @@ public:
 	}
 
 private:
-	uORB::Subscription _angular_velocity_sub{ORB_ID(vehicle_angular_velocity)};
-	uORB::Subscription _att_sub{ORB_ID(vehicle_attitude)};
-	uORB::Subscription _gpos_sub{ORB_ID(vehicle_global_position)};
-	uORB::Subscription _lpos_sub{ORB_ID(vehicle_local_position)};
+	uORB::Subscription _angular_velocity_sub{ORB_ID(vehicle_angular_velocity_groundtruth)};
+	uORB::Subscription _att_sub{ORB_ID(vehicle_attitude_groundtruth)};
+	uORB::Subscription _gpos_sub{ORB_ID(vehicle_global_position_groundtruth)};
+	uORB::Subscription _lpos_sub{ORB_ID(vehicle_local_position_groundtruth)};
 
 	/* do not allow top copying this class */
 	MavlinkStreamGroundTruth(MavlinkStreamGroundTruth &) = delete;


### PR DESCRIPTION
Previously the ground truth data that is published over the mavlink hil_state_quaternion message, were filled with information from non-groundtruth messages. Some of them such as `vehicle_global_position` message is sent by the EKF only after the passing checks. The ground truth gps coordinate was therefore not available from beginning and only for vehicle flying using GPS data for estimation. This is causing issues during integration tests. https://github.com/PX4/Firmware/issues/14760
Is there a reason why the non groundtruth messages were used?

This PR solves this by using the data from the already existing groundtruth variants that are available during simulation. This message is during simulation runs immediately available. From a conceptually standpoint this is also the correct choice. Since the `vehicle_global_position` is filled with the output from the estimator, it is not ground truth data. It is the estimator output which we want to check against some ground truth data.

**Issues**:
In the ground truth information from the simulator is no acceleration information available. This was previously available from the estimator.
It could be that there is a static offset in the global position between groundtruth and the output of the estimator. For the existing checks in the mavsdk tests, this is not a problem, since only groundtruth data is compared to groundtruth data.

**Testing**: 
Visualized message fields through mavlink inspector for ground_truth (plot 1) and estimate (plot) by running iris model in simulation.

Latitude (Attention: offset is visible)
![PX4_Latitude](https://user-images.githubusercontent.com/23532607/80811804-fcd7ad80-8bc6-11ea-98ff-7636bc14c806.png)

Velocity (Attention: HIL_STATE_QUATERNION's velocitty is in cm/s)
![PX4_vel](https://user-images.githubusercontent.com/23532607/80811915-36a8b400-8bc7-11ea-8c75-deb3eea63192.png)

Quaternion q0
![PX4_quaternion](https://user-images.githubusercontent.com/23532607/80811902-314b6980-8bc7-11ea-9560-a0666f7857e0.png)

Yawspeed
![PX4_yawspeed](https://user-images.githubusercontent.com/23532607/80811815-019c6180-8bc7-11ea-88bd-7ab830f75c31.png)

All tests are passing now with speedfactor 1:
Before:
![Screenshot from 2020-05-01 17-10-36](https://user-images.githubusercontent.com/23532607/80815940-d6b60b80-8bce-11ea-8106-700565b3dc6a.png)

After:
![Screenshot from 2020-05-01 16-31-28](https://user-images.githubusercontent.com/23532607/80812955-54771880-8bc9-11ea-97ec-a2aed6cd94a5.png)

For the non-gps model it is also not comparing 0 against 0 anymore.
![Screenshot from 2020-05-01 15-17-00](https://user-images.githubusercontent.com/23532607/80815953-de75b000-8bce-11ea-8368-96f129de2580.png)


