### PR TITLE
Implement MAV_CMD_REQUEST_MESSAGE

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1143,8 +1143,8 @@ Mavlink::send_statustext_emergency(const char *string)
 	mavlink_log_emergency(&_mavlink_log_pub, "%s", string);
 }
 
-void
-Mavlink::send_autopilot_capabilites()
+bool
+Mavlink::send_autopilot_capabilities()
 {
 	uORB::Subscription status_sub{ORB_ID(vehicle_status)};
 	vehicle_status_s status;
@@ -1207,7 +1207,10 @@ Mavlink::send_autopilot_capabilites()
 		msg.uid2[0] += mavlink_system.sysid - 1;
 #endif /* CONFIG_ARCH_BOARD_PX4_SITL */
 		mavlink_msg_autopilot_version_send_struct(get_channel(), &msg);
+		return true;
 	}
+
+	return false;
 }
 
 void
@@ -2203,7 +2206,7 @@ Mavlink::task_main(int argc, char *argv[])
 
 	/* if the protocol is serial, we send the system version blindly */
 	if (get_protocol() == Protocol::SERIAL) {
-		send_autopilot_capabilites();
+		send_autopilot_capabilities();
 	}
 
 	/* start the MAVLink receiver last to avoid a race */

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1266,11 +1266,6 @@ Mavlink::configure_stream(const char *stream_name, const float rate)
 		}
 	}
 
-	if (interval == 0) {
-		/* stream was not active and is requested to be disabled, do nothing */
-		return OK;
-	}
-
 	// search for stream with specified name in supported streams list
 	// create new instance if found
 	MavlinkStream *stream = create_mavlink_stream(stream_name, this);

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -387,7 +387,7 @@ public:
 	/**
 	 * Send the capabilities of this autopilot in terms of the MAVLink spec
 	 */
-	void 			send_autopilot_capabilites();
+	bool 			send_autopilot_capabilities();
 
 	/**
 	 * Send the protocol version of MAVLink

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -46,6 +46,7 @@
 #include "mavlink_high_latency2.h"
 
 #include "streams/autopilot_version.h"
+#include "streams/flight_information.h"
 #include "streams/protocol_version.h"
 #include "streams/storage_information.h"
 

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -45,6 +45,8 @@
 #include "mavlink_simple_analyzer.h"
 #include "mavlink_high_latency2.h"
 
+#include "streams/autopilot_version.h"
+#include "streams/protocol_version.h"
 #include "streams/storage_information.h"
 
 #include <commander/px4_custom_mode.h>

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -5264,6 +5264,9 @@ static const StreamListItem streams_list[] = {
 	create_stream_list_item<MavlinkStreamPing>(),
 	create_stream_list_item<MavlinkStreamOrbitStatus>(),
 	create_stream_list_item<MavlinkStreamObstacleDistance>(),
+	create_stream_list_item<MavlinkStreamAutopilotVersion>(),
+	create_stream_list_item<MavlinkStreamProtocolVersion>(),
+	create_stream_list_item<MavlinkStreamFlightInformation>(),
 	create_stream_list_item<MavlinkStreamStorageInformation>()
 };
 

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -45,6 +45,8 @@
 #include "mavlink_simple_analyzer.h"
 #include "mavlink_high_latency2.h"
 
+#include "streams/storage_information.h"
+
 #include <commander/px4_custom_mode.h>
 #include <drivers/drv_pwm_output.h>
 #include <lib/conversion/rotation.h>
@@ -5196,103 +5198,6 @@ protected:
 		}
 
 		return false;
-	}
-};
-
-#ifdef __PX4_DARWIN
-#include <sys/param.h>
-#include <sys/mount.h>
-#else
-#include <sys/statfs.h>
-#endif
-
-class MavlinkStreamStorageInformation : public MavlinkStream
-{
-public:
-	const char *get_name() const override
-	{
-		return MavlinkStreamStorageInformation::get_name_static();
-	}
-
-	static constexpr const char *get_name_static()
-	{
-		return "STORAGE_INFORMATION";
-	}
-
-	static constexpr uint16_t get_id_static()
-	{
-		return MAVLINK_MSG_ID_STORAGE_INFORMATION;
-	}
-
-	uint16_t get_id() override
-	{
-		return get_id_static();
-	}
-
-	static MavlinkStream *new_instance(Mavlink *mavlink)
-	{
-		return new MavlinkStreamStorageInformation(mavlink);
-	}
-
-	unsigned get_size() override
-	{
-		return MAVLINK_MSG_ID_STORAGE_INFORMATION_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
-	}
-
-	bool request_message(float param1 = 0.0, float param2 = 0.0, float param3 = 0.0, float param4 = 0.0,
-			     float param5 = 0.0, float param6 = 0.0, float param7 = 0.0) override
-	{
-		storage_id = (int)roundf(param2);
-		return send(hrt_absolute_time());
-	}
-private:
-	int storage_id = 0;
-
-	/* do not allow top copying this class */
-	MavlinkStreamStorageInformation(MavlinkStreamStorageInformation &) = delete;
-	MavlinkStreamStorageInformation &operator = (const MavlinkStreamStorageInformation &) = delete;
-
-
-protected:
-	explicit MavlinkStreamStorageInformation(Mavlink *mavlink) : MavlinkStream(mavlink)
-	{}
-
-	bool send(const hrt_abstime t) override
-	{
-		mavlink_storage_information_t storage_info{};
-		const char *microsd_dir = PX4_STORAGEDIR;
-
-		if (storage_id == 0 || storage_id == 1) { // request is for all or the first storage
-			storage_info.storage_id = 1;
-
-			struct statfs statfs_buf;
-			uint64_t total_bytes = 0;
-			uint64_t avail_bytes = 0;
-
-			if (statfs(microsd_dir, &statfs_buf) == 0) {
-				total_bytes = (uint64_t)statfs_buf.f_blocks * statfs_buf.f_bsize;
-				avail_bytes = (uint64_t)statfs_buf.f_bavail * statfs_buf.f_bsize;
-			}
-
-			if (total_bytes == 0) { // on NuttX we get 0 total bytes if no SD card is inserted
-				storage_info.storage_count = 0;
-				storage_info.status = 0; // not available
-
-			} else {
-				storage_info.storage_count = 1;
-				storage_info.status = 2; // available & formatted
-				storage_info.total_capacity = total_bytes / 1024. / 1024.;
-				storage_info.available_capacity = avail_bytes / 1024. / 1024.;
-				storage_info.used_capacity = (total_bytes - avail_bytes) / 1024. / 1024.;
-			}
-
-		} else {
-			return false; // results in MAV_RESULT_DENIED
-		}
-
-		storage_info.time_boot_ms = t / 1000;
-		mavlink_msg_storage_information_send_struct(_mavlink->get_channel(), &storage_info);
-		return true;
 	}
 };
 

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -5199,6 +5199,103 @@ protected:
 	}
 };
 
+#ifdef __PX4_DARWIN
+#include <sys/param.h>
+#include <sys/mount.h>
+#else
+#include <sys/statfs.h>
+#endif
+
+class MavlinkStreamStorageInformation : public MavlinkStream
+{
+public:
+	const char *get_name() const override
+	{
+		return MavlinkStreamStorageInformation::get_name_static();
+	}
+
+	static constexpr const char *get_name_static()
+	{
+		return "STORAGE_INFORMATION";
+	}
+
+	static constexpr uint16_t get_id_static()
+	{
+		return MAVLINK_MSG_ID_STORAGE_INFORMATION;
+	}
+
+	uint16_t get_id() override
+	{
+		return get_id_static();
+	}
+
+	static MavlinkStream *new_instance(Mavlink *mavlink)
+	{
+		return new MavlinkStreamStorageInformation(mavlink);
+	}
+
+	unsigned get_size() override
+	{
+		return MAVLINK_MSG_ID_STORAGE_INFORMATION_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
+	}
+
+	virtual bool request_message(float param1 = 0.0, float param2 = 0.0, float param3 = 0.0, float param4 = 0.0,
+				     float param5 = 0.0, float param6 = 0.0, float param7 = 0.0)
+	{
+		storage_id = (int)roundf(param2);
+		return send(hrt_absolute_time());
+	}
+private:
+	int storage_id = 0;
+
+	/* do not allow top copying this class */
+	MavlinkStreamStorageInformation(MavlinkStreamStorageInformation &) = delete;
+	MavlinkStreamStorageInformation &operator = (const MavlinkStreamStorageInformation &) = delete;
+
+
+protected:
+	explicit MavlinkStreamStorageInformation(Mavlink *mavlink) : MavlinkStream(mavlink)
+	{}
+
+	bool send(const hrt_abstime t) override
+	{
+		mavlink_storage_information_t storage_info{};
+		const char *microsd_dir = PX4_STORAGEDIR;
+
+		if (storage_id == 0 || storage_id == 1) { // request is for all or the first storage
+			storage_info.storage_id = storage_id; // replace by 1
+
+			struct statfs statfs_buf;
+			uint64_t total_bytes = 0;
+			uint64_t avail_bytes = 0;
+
+			if (statfs(microsd_dir, &statfs_buf) == 0) {
+				total_bytes = (uint64_t)statfs_buf.f_blocks * statfs_buf.f_bsize;
+				avail_bytes = (uint64_t)statfs_buf.f_bavail * statfs_buf.f_bsize;
+			}
+
+			if (total_bytes == 0) { // on NuttX we get 0 total bytes if no SD card is inserted
+				storage_info.storage_count = 0;
+				storage_info.status = 0; // not available
+
+			} else {
+				storage_info.storage_count = 1;
+				storage_info.status = 2; // available & formatted
+				storage_info.total_capacity = total_bytes / 1024. / 1024.;
+				storage_info.available_capacity = avail_bytes / 1024. / 1024.;
+				storage_info.used_capacity = (total_bytes - avail_bytes) / 1024. / 1024.;
+			}
+
+		} else {
+			return false; // results in MAV_RESULT_DENIED
+		}
+
+		storage_info.time_boot_ms = t / 1000;
+		mavlink_msg_storage_information_send_struct(_mavlink->get_channel(), &storage_info);
+		return true;
+	}
+};
+
 static const StreamListItem streams_list[] = {
 	create_stream_list_item<MavlinkStreamHeartbeat>(),
 	create_stream_list_item<MavlinkStreamStatustext>(),
@@ -5258,7 +5355,8 @@ static const StreamListItem streams_list[] = {
 	create_stream_list_item<MavlinkStreamGroundTruth>(),
 	create_stream_list_item<MavlinkStreamPing>(),
 	create_stream_list_item<MavlinkStreamOrbitStatus>(),
-	create_stream_list_item<MavlinkStreamObstacleDistance>()
+	create_stream_list_item<MavlinkStreamObstacleDistance>(),
+	create_stream_list_item<MavlinkStreamStorageInformation>()
 };
 
 const char *get_stream_name(const uint16_t msg_id)
@@ -5281,6 +5379,18 @@ MavlinkStream *create_mavlink_stream(const char *stream_name, Mavlink *mavlink)
 			if (strcmp(stream_name, stream.get_name()) == 0) {
 				return stream.new_instance(mavlink);
 			}
+		}
+	}
+
+	return nullptr;
+}
+
+MavlinkStream *create_mavlink_stream(const uint16_t msg_id, Mavlink *mavlink)
+{
+	// search for stream with specified name in supported streams list
+	for (const auto &stream : streams_list) {
+		if (msg_id == stream.get_id()) {
+			return stream.new_instance(mavlink);
 		}
 	}
 

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -5239,8 +5239,8 @@ public:
 		return MAVLINK_MSG_ID_STORAGE_INFORMATION_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
 	}
 
-	virtual bool request_message(float param1 = 0.0, float param2 = 0.0, float param3 = 0.0, float param4 = 0.0,
-				     float param5 = 0.0, float param6 = 0.0, float param7 = 0.0)
+	bool request_message(float param1 = 0.0, float param2 = 0.0, float param3 = 0.0, float param4 = 0.0,
+			     float param5 = 0.0, float param6 = 0.0, float param7 = 0.0) override
 	{
 		storage_id = (int)roundf(param2);
 		return send(hrt_absolute_time());
@@ -5263,7 +5263,7 @@ protected:
 		const char *microsd_dir = PX4_STORAGEDIR;
 
 		if (storage_id == 0 || storage_id == 1) { // request is for all or the first storage
-			storage_info.storage_id = storage_id; // replace by 1
+			storage_info.storage_id = 1;
 
 			struct statfs statfs_buf;
 			uint64_t total_bytes = 0;

--- a/src/modules/mavlink/mavlink_messages.h
+++ b/src/modules/mavlink/mavlink_messages.h
@@ -68,6 +68,7 @@ static StreamListItem create_stream_list_item()
 
 const char *get_stream_name(const uint16_t msg_id);
 MavlinkStream *create_mavlink_stream(const char *stream_name, Mavlink *mavlink);
+MavlinkStream *create_mavlink_stream(const uint16_t msg_id, Mavlink *mavlink);
 
 void get_mavlink_navigation_mode(const struct vehicle_status_s *const status, uint8_t *mavlink_base_mode,
 				 union px4_custom_mode *custom_mode);

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -516,10 +516,12 @@ uint8_t MavlinkReceiver::handle_request_message_command(uint16_t message_id, flo
 		float param5, float param6, float param7)
 {
 	bool stream_found = false;
+	bool message_sent = false;
 
 	for (const auto &stream : _mavlink->get_streams()) {
 		if (stream->get_id() == message_id) {
-			stream_found = stream->request_message(param2, param3, param4, param5, param6, param7);
+			stream_found = true;
+			message_sent = stream->request_message(param2, param3, param4, param5, param6, param7);
 			break;
 		}
 	}
@@ -534,14 +536,14 @@ uint8_t MavlinkReceiver::handle_request_message_command(uint16_t message_id, flo
 			// Now we try again to send it.
 			for (const auto &stream : _mavlink->get_streams()) {
 				if (stream->get_id() == message_id) {
-					stream_found = stream->request_message(param2, param3, param4, param5, param6, param7);
+					message_sent = stream->request_message(param2, param3, param4, param5, param6, param7);
 					break;
 				}
 			}
 		}
 	}
 
-	return (stream_found ? vehicle_command_ack_s::VEHICLE_RESULT_ACCEPTED : vehicle_command_ack_s::VEHICLE_RESULT_DENIED);
+	return (message_sent ? vehicle_command_ack_s::VEHICLE_RESULT_ACCEPTED : vehicle_command_ack_s::VEHICLE_RESULT_DENIED);
 }
 
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -347,23 +347,6 @@ MavlinkReceiver::evaluate_target_ok(int command, int target_system, int target_c
 }
 
 void
-MavlinkReceiver::send_flight_information()
-{
-	mavlink_flight_information_t flight_info{};
-	flight_info.flight_uuid = static_cast<uint64_t>(_param_com_flight_uuid.get());
-
-	actuator_armed_s actuator_armed{};
-	bool ret = _actuator_armed_sub.copy(&actuator_armed);
-
-	if (ret && actuator_armed.timestamp != 0) {
-		flight_info.arming_time_utc = flight_info.takeoff_time_utc = actuator_armed.armed_time_ms;
-	}
-
-	flight_info.time_boot_ms = hrt_absolute_time() / 1000;
-	mavlink_msg_flight_information_send_struct(_mavlink->get_channel(), &flight_info);
-}
-
-void
 MavlinkReceiver::handle_message_command_long(mavlink_message_t *msg)
 {
 	/* command */
@@ -445,9 +428,6 @@ void MavlinkReceiver::handle_message_command_both(mavlink_message_t *msg, const 
 
 	} else if (cmd_mavlink.command == MAV_CMD_GET_MESSAGE_INTERVAL) {
 		get_message_interval((int)roundf(cmd_mavlink.param1));
-
-	} else if (cmd_mavlink.command == MAV_CMD_REQUEST_FLIGHT_INFORMATION) {
-		send_flight_information();
 
 	} else if (cmd_mavlink.command == MAV_CMD_REQUEST_MESSAGE) {
 		uint16_t message_id = (uint16_t)roundf(cmd_mavlink.param1);

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -435,15 +435,7 @@ void MavlinkReceiver::handle_message_command_both(mavlink_message_t *msg, const 
 		return;
 	}
 
-	if (cmd_mavlink.command == MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES) {
-		/* send autopilot version message */
-		_mavlink->send_autopilot_capabilites();
-
-	} else if (cmd_mavlink.command == MAV_CMD_REQUEST_PROTOCOL_VERSION) {
-		/* send protocol version message */
-		_mavlink->send_protocol_version();
-
-	} else if (cmd_mavlink.command == MAV_CMD_GET_HOME_POSITION) {
+	if (cmd_mavlink.command == MAV_CMD_GET_HOME_POSITION) {
 		_mavlink->configure_stream_threadsafe("HOME_POSITION", 0.5f);
 
 	} else if (cmd_mavlink.command == MAV_CMD_SET_MESSAGE_INTERVAL) {

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -517,7 +517,7 @@ uint8_t MavlinkReceiver::handle_request_message_command(uint16_t message_id, flo
 {
 	bool stream_found = false;
 
-	for (const auto stream : _mavlink->get_streams()) {
+	for (const auto &stream : _mavlink->get_streams()) {
 		if (stream->get_id() == message_id) {
 			stream_found = stream->request_message(param2, param3, param4, param5, param6, param7);
 			break;
@@ -532,7 +532,7 @@ uint8_t MavlinkReceiver::handle_request_message_command(uint16_t message_id, flo
 			_mavlink->configure_stream_threadsafe(stream_name, 0.0f);
 
 			// Now we try again to send it.
-			for (const auto stream : _mavlink->get_streams()) {
+			for (const auto &stream : _mavlink->get_streams()) {
 				if (stream->get_id() == message_id) {
 					stream_found = stream->request_message(param2, param3, param4, param5, param6, param7);
 					break;

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -430,7 +430,11 @@ void MavlinkReceiver::handle_message_command_both(mavlink_message_t *msg, const 
 		get_message_interval((int)roundf(cmd_mavlink.param1));
 
 	} else if (cmd_mavlink.command == MAV_CMD_REQUEST_MESSAGE) {
-		result = handle_request_message_command(vehicle_command);
+
+		uint16_t message_id = (uint16_t)roundf(vehicle_command.param1);
+		result = handle_request_message_command(message_id,
+							vehicle_command.param2, vehicle_command.param3, vehicle_command.param4,
+							vehicle_command.param5, vehicle_command.param6, vehicle_command.param7);
 
 	} else if (cmd_mavlink.command == MAV_CMD_SET_CAMERA_ZOOM) {
 		struct actuator_controls_s actuator_controls = {};
@@ -494,17 +498,16 @@ void MavlinkReceiver::handle_message_command_both(mavlink_message_t *msg, const 
 	}
 }
 
-uint8_t MavlinkReceiver::handle_request_message_command(const vehicle_command_s &vehicle_command)
+uint8_t MavlinkReceiver::handle_request_message_command(uint16_t message_id, float param2, float param3, float param4,
+		float param5, float param6, float param7)
 {
-	uint16_t message_id = (uint16_t)roundf(vehicle_command.param1);
 	bool stream_found = false;
 
 	uint8_t result = vehicle_command_ack_s::VEHICLE_RESULT_ACCEPTED;
 
 	for (const auto stream : _mavlink->get_streams()) {
 		if (stream->get_id() == message_id) {
-			stream_found = stream->request_message(vehicle_command.param1, vehicle_command.param2, vehicle_command.param3,
-							       vehicle_command.param4, vehicle_command.param5, vehicle_command.param6, vehicle_command.param7);
+			stream_found = stream->request_message(param2, param3, param4, param5, param6, param7);
 			break;
 		}
 	}
@@ -516,8 +519,7 @@ uint8_t MavlinkReceiver::handle_request_message_command(const vehicle_command_s 
 			result = vehicle_command_ack_s::VEHICLE_RESULT_DENIED;
 
 		} else {
-			bool message_sent = stream->request_message(vehicle_command.param1, vehicle_command.param2, vehicle_command.param3,
-					    vehicle_command.param4, vehicle_command.param5, vehicle_command.param6, vehicle_command.param7);
+			bool message_sent = stream->request_message(param2, param3, param4, param5, param6, param7);
 
 			if (!message_sent) {
 				result = vehicle_command_ack_s::VEHICLE_RESULT_DENIED;

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -418,8 +418,22 @@ void MavlinkReceiver::handle_message_command_both(mavlink_message_t *msg, const 
 		return;
 	}
 
-	if (cmd_mavlink.command == MAV_CMD_GET_HOME_POSITION) {
-		_mavlink->configure_stream_threadsafe("HOME_POSITION", 0.5f);
+	// First we handle legacy support requests which were used before we had
+	// the generic MAV_CMD_REQUEST_MESSAGE.
+	if (cmd_mavlink.command == MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES) {
+		result = handle_request_message_command(MAVLINK_MSG_ID_AUTOPILOT_VERSION);
+
+	} else if (cmd_mavlink.command == MAV_CMD_REQUEST_PROTOCOL_VERSION) {
+		result = handle_request_message_command(MAVLINK_MSG_ID_PROTOCOL_VERSION);
+
+	} else if (cmd_mavlink.command == MAV_CMD_GET_HOME_POSITION) {
+		result = handle_request_message_command(MAVLINK_MSG_ID_HOME_POSITION);
+
+	} else if (cmd_mavlink.command == MAV_CMD_REQUEST_FLIGHT_INFORMATION) {
+		result = handle_request_message_command(MAVLINK_MSG_ID_FLIGHT_INFORMATION);
+
+	} else if (cmd_mavlink.command == MAV_CMD_REQUEST_STORAGE_INFORMATION) {
+		result = handle_request_message_command(MAVLINK_MSG_ID_STORAGE_INFORMATION);
 
 	} else if (cmd_mavlink.command == MAV_CMD_SET_MESSAGE_INTERVAL) {
 		if (set_message_interval((int)roundf(cmd_mavlink.param1), cmd_mavlink.param2, cmd_mavlink.param3)) {

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2074,9 +2074,6 @@ MavlinkReceiver::set_message_interval(int msgId, float interval, int data_rate)
 
 	bool found_id = false;
 
-
-	// The interval between two messages is in microseconds.
-	// Set to -1 to disable and 0 to request default rate
 	if (msgId != 0) {
 		const char *stream_name = get_stream_name(msgId);
 

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -129,7 +129,9 @@ private:
 	void handle_message_command_both(mavlink_message_t *msg, const T &cmd_mavlink,
 					 const vehicle_command_s &vehicle_command);
 
-	uint8_t handle_request_message_command(const vehicle_command_s &vehicle_command);
+	uint8_t handle_request_message_command(uint16_t message_id, float param2 = 0.0f, float param3 = 0.0f,
+					       float param4 = 0.0f,
+					       float param5 = 0.0f, float param6 = 0.0f, float param7 = 0.0f);
 
 	void handle_message(mavlink_message_t *msg);
 

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -204,9 +204,6 @@ private:
 
 	bool evaluate_target_ok(int command, int target_system, int target_component);
 
-	void send_flight_information();
-	void send_storage_information(int storage_id);
-
 	void fill_thrust(float *thrust_body_array, uint8_t vehicle_type, float thrust);
 
 	void schedule_tune(const char *tune);

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -129,6 +129,8 @@ private:
 	void handle_message_command_both(mavlink_message_t *msg, const T &cmd_mavlink,
 					 const vehicle_command_s &vehicle_command);
 
+	uint8_t handle_request_message_command(const vehicle_command_s &vehicle_command);
+
 	void handle_message(mavlink_message_t *msg);
 
 	void handle_message_adsb_vehicle(mavlink_message_t *msg);

--- a/src/modules/mavlink/mavlink_stream.h
+++ b/src/modules/mavlink/mavlink_stream.h
@@ -99,8 +99,7 @@ public:
 	virtual bool request_message(float param2 = 0.0, float param3 = 0.0, float param4 = 0.0,
 				     float param5 = 0.0, float param6 = 0.0, float param7 = 0.0)
 	{
-		reset_last_sent();
-		return true;
+		return send(hrt_absolute_time());
 	}
 
 	/**

--- a/src/modules/mavlink/mavlink_stream.h
+++ b/src/modules/mavlink/mavlink_stream.h
@@ -96,8 +96,12 @@ public:
 	 * This function is called in response to a MAV_CMD_REQUEST_MESSAGE command. The default implementation is to
 	 * just reset the counter to immediately send one message.
 	 */
-	virtual void request_message(float param1 = 0.0, float param2 = 0.0, float param3 = 0.0, float param4 = 0.0,
-				     float param5 = 0.0, float param6 = 0.0, float param7 = 0.0) { reset_last_sent(); }
+	virtual bool request_message(float param1 = 0.0, float param2 = 0.0, float param3 = 0.0, float param4 = 0.0,
+				     float param5 = 0.0, float param6 = 0.0, float param7 = 0.0)
+	{
+		reset_last_sent();
+		return true;
+	}
 
 	/**
 	 * Get the average message size

--- a/src/modules/mavlink/mavlink_stream.h
+++ b/src/modules/mavlink/mavlink_stream.h
@@ -93,8 +93,7 @@ public:
 	virtual unsigned get_size() = 0;
 
 	/**
-	 * This function is called in response to a MAV_CMD_REQUEST_MESSAGE command. The default implementation is to
-	 * just reset the counter to immediately send one message.
+	 * This function is called in response to a MAV_CMD_REQUEST_MESSAGE command.
 	 */
 	virtual bool request_message(float param2 = 0.0, float param3 = 0.0, float param4 = 0.0,
 				     float param5 = 0.0, float param6 = 0.0, float param7 = 0.0)

--- a/src/modules/mavlink/mavlink_stream.h
+++ b/src/modules/mavlink/mavlink_stream.h
@@ -96,7 +96,7 @@ public:
 	 * This function is called in response to a MAV_CMD_REQUEST_MESSAGE command. The default implementation is to
 	 * just reset the counter to immediately send one message.
 	 */
-	virtual bool request_message(float param1 = 0.0, float param2 = 0.0, float param3 = 0.0, float param4 = 0.0,
+	virtual bool request_message(float param2 = 0.0, float param3 = 0.0, float param4 = 0.0,
 				     float param5 = 0.0, float param6 = 0.0, float param7 = 0.0)
 	{
 		reset_last_sent();

--- a/src/modules/mavlink/streams/autopilot_version.h
+++ b/src/modules/mavlink/streams/autopilot_version.h
@@ -1,5 +1,37 @@
-#ifndef MAVLINK_STREAM_AUTOPILOT_VERSION_H
-#define MAVLINK_STREAM_AUTOPILOT_VERSION_H
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
 
 #include "../mavlink_messages.h"
 
@@ -51,5 +83,3 @@ protected:
 		return _mavlink->send_autopilot_capabilities();
 	}
 };
-
-#endif

--- a/src/modules/mavlink/streams/autopilot_version.h
+++ b/src/modules/mavlink/streams/autopilot_version.h
@@ -36,11 +36,6 @@ public:
 		return MAVLINK_MSG_ID_AUTOPILOT_VERSION_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
 	}
 
-	bool request_message(float param2, float param3, float param4,
-			     float param5, float param6, float param7) override
-	{
-		return send(hrt_absolute_time());
-	}
 private:
 	/* do not allow top copying this class */
 	MavlinkStreamAutopilotVersion(MavlinkStreamAutopilotVersion &) = delete;

--- a/src/modules/mavlink/streams/autopilot_version.h
+++ b/src/modules/mavlink/streams/autopilot_version.h
@@ -1,0 +1,60 @@
+#ifndef MAVLINK_STREAM_AUTOPILOT_VERSION_H
+#define MAVLINK_STREAM_AUTOPILOT_VERSION_H
+
+#include "../mavlink_messages.h"
+
+class MavlinkStreamAutopilotVersion : public MavlinkStream
+{
+public:
+	const char *get_name() const override
+	{
+		return MavlinkStreamAutopilotVersion::get_name_static();
+	}
+
+	static constexpr const char *get_name_static()
+	{
+		return "AUTOPILOT_VERSION";
+	}
+
+	static constexpr uint16_t get_id_static()
+	{
+		return MAVLINK_MSG_ID_AUTOPILOT_VERSION;
+	}
+
+	uint16_t get_id() override
+	{
+		return get_id_static();
+	}
+
+	static MavlinkStream *new_instance(Mavlink *mavlink)
+	{
+		return new MavlinkStreamAutopilotVersion(mavlink);
+	}
+
+	unsigned get_size() override
+	{
+		return MAVLINK_MSG_ID_AUTOPILOT_VERSION_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
+	}
+
+	bool request_message(float param1, float param2, float param3, float param4,
+			     float param5, float param6, float param7) override
+	{
+		return send(hrt_absolute_time());
+	}
+private:
+	/* do not allow top copying this class */
+	MavlinkStreamAutopilotVersion(MavlinkStreamAutopilotVersion &) = delete;
+	MavlinkStreamAutopilotVersion &operator = (const MavlinkStreamAutopilotVersion &) = delete;
+
+
+protected:
+	explicit MavlinkStreamAutopilotVersion(Mavlink *mavlink) : MavlinkStream(mavlink)
+	{}
+
+	bool send(const hrt_abstime t) override
+	{
+		return _mavlink->send_autopilot_capabilities();
+	}
+};
+
+#endif

--- a/src/modules/mavlink/streams/autopilot_version.h
+++ b/src/modules/mavlink/streams/autopilot_version.h
@@ -36,7 +36,7 @@ public:
 		return MAVLINK_MSG_ID_AUTOPILOT_VERSION_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
 	}
 
-	bool request_message(float param1, float param2, float param3, float param4,
+	bool request_message(float param2, float param3, float param4,
 			     float param5, float param6, float param7) override
 	{
 		return send(hrt_absolute_time());

--- a/src/modules/mavlink/streams/flight_information.h
+++ b/src/modules/mavlink/streams/flight_information.h
@@ -71,13 +71,17 @@ public:
 	}
 private:
 	uORB::Subscription _armed_sub{ORB_ID(actuator_armed)};
+	param_t _param_com_flight_uuid;
 
 	/* do not allow top copying this class */
 	MavlinkStreamFlightInformation(MavlinkStreamFlightInformation &) = delete;
 	MavlinkStreamFlightInformation &operator = (const MavlinkStreamFlightInformation &) = delete;
 protected:
 	explicit MavlinkStreamFlightInformation(Mavlink *mavlink) : MavlinkStream(mavlink)
-	{}
+	{
+
+		_param_com_flight_uuid = param_find("COM_FLIGHT_UUID");
+	}
 
 	bool send(const hrt_abstime t) override
 	{
@@ -85,9 +89,8 @@ protected:
 		bool ret = _armed_sub.copy(&actuator_armed);
 
 		if (ret && actuator_armed.timestamp != 0) {
-			const param_t param_com_flight_uuid = param_find("COM_FLIGHT_UUID");
 			int32_t flight_uuid;
-			param_get(param_com_flight_uuid, &flight_uuid);
+			param_get(_param_com_flight_uuid, &flight_uuid);
 
 			mavlink_flight_information_t flight_info{};
 			flight_info.flight_uuid = static_cast<uint64_t>(flight_uuid);

--- a/src/modules/mavlink/streams/flight_information.h
+++ b/src/modules/mavlink/streams/flight_information.h
@@ -1,0 +1,77 @@
+#ifndef MAVLINK_STREAM_FLIGHT_INFORMATION_H
+#define MAVLINK_STREAM_FLIGHT_INFORMATION_H
+
+#include "../mavlink_messages.h"
+
+#include <uORB/topics/actuator_armed.h>
+
+class MavlinkStreamFlightInformation : public MavlinkStream
+{
+public:
+	const char *get_name() const override
+	{
+		return MavlinkStreamFlightInformation::get_name_static();
+	}
+
+	static constexpr const char *get_name_static()
+	{
+		return "FLIGHT_INFORMATION";
+	}
+
+	static constexpr uint16_t get_id_static()
+	{
+		return MAVLINK_MSG_ID_FLIGHT_INFORMATION;
+	}
+
+	uint16_t get_id() override
+	{
+		return get_id_static();
+	}
+
+	static MavlinkStream *new_instance(Mavlink *mavlink)
+	{
+		return new MavlinkStreamFlightInformation(mavlink);
+	}
+
+	unsigned get_size() override
+	{
+		return MAVLINK_MSG_ID_FLIGHT_INFORMATION_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
+	}
+
+	bool request_message(float param1, float param2, float param3, float param4,
+			     float param5, float param6, float param7) override
+	{
+		return send(hrt_absolute_time());
+	}
+private:
+	uORB::Subscription _armed_sub{ORB_ID(actuator_armed)};
+
+	/* do not allow top copying this class */
+	MavlinkStreamFlightInformation(MavlinkStreamFlightInformation &) = delete;
+	MavlinkStreamFlightInformation &operator = (const MavlinkStreamFlightInformation &) = delete;
+protected:
+	explicit MavlinkStreamFlightInformation(Mavlink *mavlink) : MavlinkStream(mavlink)
+	{}
+
+	bool send(const hrt_abstime t) override
+	{
+		actuator_armed_s actuator_armed{};
+		bool ret = _armed_sub.copy(&actuator_armed);
+
+		if (ret && actuator_armed.timestamp != 0) {
+			const param_t param_com_flight_uuid = param_find("COM_FLIGHT_UUID");
+			int32_t flight_uuid;
+			param_get(param_com_flight_uuid, &flight_uuid);
+
+			mavlink_flight_information_t flight_info{};
+			flight_info.flight_uuid = static_cast<uint64_t>(flight_uuid);
+			flight_info.arming_time_utc = flight_info.takeoff_time_utc = actuator_armed.armed_time_ms;
+			flight_info.time_boot_ms = hrt_absolute_time() / 1000;
+			mavlink_msg_flight_information_send_struct(_mavlink->get_channel(), &flight_info);
+		}
+
+		return ret;
+	}
+};
+
+#endif

--- a/src/modules/mavlink/streams/flight_information.h
+++ b/src/modules/mavlink/streams/flight_information.h
@@ -37,12 +37,6 @@ public:
 	{
 		return MAVLINK_MSG_ID_FLIGHT_INFORMATION_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
 	}
-
-	bool request_message(float param2, float param3, float param4,
-			     float param5, float param6, float param7) override
-	{
-		return send(hrt_absolute_time());
-	}
 private:
 	uORB::Subscription _armed_sub{ORB_ID(actuator_armed)};
 

--- a/src/modules/mavlink/streams/flight_information.h
+++ b/src/modules/mavlink/streams/flight_information.h
@@ -38,7 +38,7 @@ public:
 		return MAVLINK_MSG_ID_FLIGHT_INFORMATION_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
 	}
 
-	bool request_message(float param1, float param2, float param3, float param4,
+	bool request_message(float param2, float param3, float param4,
 			     float param5, float param6, float param7) override
 	{
 		return send(hrt_absolute_time());

--- a/src/modules/mavlink/streams/flight_information.h
+++ b/src/modules/mavlink/streams/flight_information.h
@@ -1,5 +1,37 @@
-#ifndef MAVLINK_STREAM_FLIGHT_INFORMATION_H
-#define MAVLINK_STREAM_FLIGHT_INFORMATION_H
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
 
 #include "../mavlink_messages.h"
 
@@ -67,5 +99,3 @@ protected:
 		return ret;
 	}
 };
-
-#endif

--- a/src/modules/mavlink/streams/protocol_version.h
+++ b/src/modules/mavlink/streams/protocol_version.h
@@ -1,0 +1,62 @@
+#ifndef MAVLINK_STREAM_PROTOCOL_VERSION_H
+#define MAVLINK_STREAM_PROTOCOL_VERSION_H
+
+#include "../mavlink_messages.h"
+
+class MavlinkStreamProtocolVersion : public MavlinkStream
+{
+public:
+	const char *get_name() const override
+	{
+		return MavlinkStreamProtocolVersion::get_name_static();
+	}
+
+	static constexpr const char *get_name_static()
+	{
+		return "PROTOCOL_VERSION";
+	}
+
+	static constexpr uint16_t get_id_static()
+	{
+		return MAVLINK_MSG_ID_PROTOCOL_VERSION;
+	}
+
+	uint16_t get_id() override
+	{
+		return get_id_static();
+	}
+
+	static MavlinkStream *new_instance(Mavlink *mavlink)
+	{
+		return new MavlinkStreamProtocolVersion(mavlink);
+	}
+
+	unsigned get_size() override
+	{
+		return MAVLINK_MSG_ID_PROTOCOL_VERSION_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
+	}
+
+	bool request_message(float param1, float param2, float param3, float param4,
+			     float param5, float param6, float param7) override
+	{
+		return send(hrt_absolute_time());
+	}
+private:
+	/* do not allow top copying this class */
+	MavlinkStreamProtocolVersion(MavlinkStreamProtocolVersion &) = delete;
+	MavlinkStreamProtocolVersion &operator = (const MavlinkStreamProtocolVersion &) = delete;
+
+
+protected:
+	explicit MavlinkStreamProtocolVersion(Mavlink *mavlink) : MavlinkStream(mavlink)
+	{}
+
+	bool send(const hrt_abstime t) override
+	{
+		_mavlink->send_protocol_version();
+		return true;
+	}
+};
+
+#endif
+

--- a/src/modules/mavlink/streams/protocol_version.h
+++ b/src/modules/mavlink/streams/protocol_version.h
@@ -1,5 +1,37 @@
-#ifndef MAVLINK_STREAM_PROTOCOL_VERSION_H
-#define MAVLINK_STREAM_PROTOCOL_VERSION_H
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
 
 #include "../mavlink_messages.h"
 
@@ -52,6 +84,3 @@ protected:
 		return true;
 	}
 };
-
-#endif
-

--- a/src/modules/mavlink/streams/protocol_version.h
+++ b/src/modules/mavlink/streams/protocol_version.h
@@ -36,11 +36,6 @@ public:
 		return MAVLINK_MSG_ID_PROTOCOL_VERSION_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
 	}
 
-	bool request_message(float param2, float param3, float param4,
-			     float param5, float param6, float param7) override
-	{
-		return send(hrt_absolute_time());
-	}
 private:
 	/* do not allow top copying this class */
 	MavlinkStreamProtocolVersion(MavlinkStreamProtocolVersion &) = delete;

--- a/src/modules/mavlink/streams/protocol_version.h
+++ b/src/modules/mavlink/streams/protocol_version.h
@@ -36,7 +36,7 @@ public:
 		return MAVLINK_MSG_ID_PROTOCOL_VERSION_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
 	}
 
-	bool request_message(float param1, float param2, float param3, float param4,
+	bool request_message(float param2, float param3, float param4,
 			     float param5, float param6, float param7) override
 	{
 		return send(hrt_absolute_time());

--- a/src/modules/mavlink/streams/storage_information.h
+++ b/src/modules/mavlink/streams/storage_information.h
@@ -45,7 +45,7 @@ public:
 		return MAVLINK_MSG_ID_STORAGE_INFORMATION_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
 	}
 
-	bool request_message(float param1, float param2, float param3, float param4,
+	bool request_message(float param2, float param3, float param4,
 			     float param5, float param6, float param7) override
 	{
 		storage_id = (int)roundf(param2);

--- a/src/modules/mavlink/streams/storage_information.h
+++ b/src/modules/mavlink/streams/storage_information.h
@@ -80,11 +80,11 @@ public:
 	bool request_message(float param2, float param3, float param4,
 			     float param5, float param6, float param7) override
 	{
-		storage_id = (int)roundf(param2);
+		_storage_id = (int)roundf(param2);
 		return send(hrt_absolute_time());
 	}
 private:
-	int storage_id = 0;
+	int _storage_id = 0;
 
 	/* do not allow top copying this class */
 	MavlinkStreamStorageInformation(MavlinkStreamStorageInformation &) = delete;
@@ -100,7 +100,7 @@ protected:
 		mavlink_storage_information_t storage_info{};
 		const char *microsd_dir = PX4_STORAGEDIR;
 
-		if (storage_id == 0 || storage_id == 1) { // request is for all or the first storage
+		if (_storage_id == 0 || _storage_id == 1) { // request is for all or the first storage
 			storage_info.storage_id = 1;
 
 			struct statfs statfs_buf;

--- a/src/modules/mavlink/streams/storage_information.h
+++ b/src/modules/mavlink/streams/storage_information.h
@@ -10,6 +10,8 @@
 #include <sys/statfs.h>
 #endif
 
+#include <math.h>
+
 class MavlinkStreamStorageInformation : public MavlinkStream
 {
 public:

--- a/src/modules/mavlink/streams/storage_information.h
+++ b/src/modules/mavlink/streams/storage_information.h
@@ -1,0 +1,103 @@
+#ifndef MAVLINK_STREAM_STORAGE_INFORMATION_H
+#define MAVLINK_STREAM_STORAGE_INFORMATION_H
+
+#include "../mavlink_messages.h"
+
+#ifdef __PX4_DARWIN
+#include <sys/param.h>
+#include <sys/mount.h>
+#else
+#include <sys/statfs.h>
+#endif
+
+class MavlinkStreamStorageInformation : public MavlinkStream
+{
+public:
+	const char *get_name() const override
+	{
+		return MavlinkStreamStorageInformation::get_name_static();
+	}
+
+	static constexpr const char *get_name_static()
+	{
+		return "STORAGE_INFORMATION";
+	}
+
+	static constexpr uint16_t get_id_static()
+	{
+		return MAVLINK_MSG_ID_STORAGE_INFORMATION;
+	}
+
+	uint16_t get_id() override
+	{
+		return get_id_static();
+	}
+
+	static MavlinkStream *new_instance(Mavlink *mavlink)
+	{
+		return new MavlinkStreamStorageInformation(mavlink);
+	}
+
+	unsigned get_size() override
+	{
+		return MAVLINK_MSG_ID_STORAGE_INFORMATION_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
+	}
+
+	bool request_message(float param1, float param2, float param3, float param4,
+			     float param5, float param6, float param7) override
+	{
+		storage_id = (int)roundf(param2);
+		return send(hrt_absolute_time());
+	}
+private:
+	int storage_id = 0;
+
+	/* do not allow top copying this class */
+	MavlinkStreamStorageInformation(MavlinkStreamStorageInformation &) = delete;
+	MavlinkStreamStorageInformation &operator = (const MavlinkStreamStorageInformation &) = delete;
+
+
+protected:
+	explicit MavlinkStreamStorageInformation(Mavlink *mavlink) : MavlinkStream(mavlink)
+	{}
+
+	bool send(const hrt_abstime t) override
+	{
+		mavlink_storage_information_t storage_info{};
+		const char *microsd_dir = PX4_STORAGEDIR;
+
+		if (storage_id == 0 || storage_id == 1) { // request is for all or the first storage
+			storage_info.storage_id = 1;
+
+			struct statfs statfs_buf;
+			uint64_t total_bytes = 0;
+			uint64_t avail_bytes = 0;
+
+			if (statfs(microsd_dir, &statfs_buf) == 0) {
+				total_bytes = (uint64_t)statfs_buf.f_blocks * statfs_buf.f_bsize;
+				avail_bytes = (uint64_t)statfs_buf.f_bavail * statfs_buf.f_bsize;
+			}
+
+			if (total_bytes == 0) { // on NuttX we get 0 total bytes if no SD card is inserted
+				storage_info.storage_count = 0;
+				storage_info.status = 0; // not available
+
+			} else {
+				storage_info.storage_count = 1;
+				storage_info.status = 2; // available & formatted
+				storage_info.total_capacity = total_bytes / 1024. / 1024.;
+				storage_info.available_capacity = avail_bytes / 1024. / 1024.;
+				storage_info.used_capacity = (total_bytes - avail_bytes) / 1024. / 1024.;
+			}
+
+		} else {
+			return false; // results in MAV_RESULT_DENIED
+		}
+
+		storage_info.time_boot_ms = t / 1000;
+		mavlink_msg_storage_information_send_struct(_mavlink->get_channel(), &storage_info);
+		return true;
+	}
+};
+
+#endif

--- a/src/modules/mavlink/streams/storage_information.h
+++ b/src/modules/mavlink/streams/storage_information.h
@@ -1,5 +1,37 @@
-#ifndef MAVLINK_STREAM_STORAGE_INFORMATION_H
-#define MAVLINK_STREAM_STORAGE_INFORMATION_H
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
 
 #include "../mavlink_messages.h"
 
@@ -101,5 +133,3 @@ protected:
 		return true;
 	}
 };
-
-#endif


### PR DESCRIPTION
**Describe problem solved by this pull request**
Implementing the MAV_CMD_REQUEST_MESSAGE as described in https://github.com/PX4/Firmware/issues/11441. So far only STORAGE_INFORMATION is supported.

I would like to use the opportunity and remind about one other PR, where all mavlink streams get their own file instead of having one bloated mavlink_messages.cpp: https://github.com/PX4/Firmware/pull/14259/commits/c1175e0d54cf60a655d2ce4db0323838a596a9cd
This would be helpful to get merged, otherwise I have double work here.

**Describe your solution**
When there is a stream with the same message ID, send the message once. Otherwise create a new stream, send the message once and delete the stream again.

**Test data / coverage**
Tested with QGC custom command file https://pastebin.com/maHNSQ1A:
![image](https://user-images.githubusercontent.com/164396/80911462-d2a4fd80-8d36-11ea-942d-f0911c6ab359.png)
