### PR TITLE
Speed up mavsdk integration tests

### DIFF
--- a/test/mavsdk_tests/autopilot_tester.cpp
+++ b/test/mavsdk_tests/autopilot_tester.cpp
@@ -124,10 +124,10 @@ void AutopilotTester::transition_to_multicopter()
 	REQUIRE(result == Action::Result::SUCCESS);
 }
 
-void AutopilotTester::wait_until_disarmed()
+void AutopilotTester::wait_until_disarmed(std::chrono::seconds timeout_duration)
 {
 	REQUIRE(poll_condition_with_timeout(
-	[this]() { return !_telemetry->armed(); }, std::chrono::seconds(60)));
+	[this]() { return !_telemetry->armed(); }, timeout_duration));
 }
 
 void AutopilotTester::wait_until_hovering()

--- a/test/mavsdk_tests/autopilot_tester.h
+++ b/test/mavsdk_tests/autopilot_tester.h
@@ -69,7 +69,7 @@ public:
 	void land();
 	void transition_to_fixedwing();
 	void transition_to_multicopter();
-	void wait_until_disarmed();
+	void wait_until_disarmed(std::chrono::seconds timeout_duration = std::chrono::seconds(60));
 	void wait_until_hovering();
 	void prepare_square_mission(MissionOptions mission_options);
 	void execute_mission();

--- a/test/mavsdk_tests/configs/sitl.json
+++ b/test/mavsdk_tests/configs/sitl.json
@@ -20,15 +20,13 @@
             "model": "iris_vision_velocity",
             "vehicle": "iris_vision",
             "test_filter": "[multicopter][offboard][nogps]",
-            "timeout_min": 10,
-            "max_speed_factor": 1
+            "timeout_min": 10
         },
         {
             "model": "iris_vision",
             "vehicle": "iris_vision",
             "test_filter": "[multicopter][offboard][nogps]",
-            "timeout_min": 10,
-            "max_speed_factor": 1
+            "timeout_min": 10
         },
         {
             "model": "standard_vtol",

--- a/test/mavsdk_tests/test_multicopter_mission.cpp
+++ b/test/mavsdk_tests/test_multicopter_mission.cpp
@@ -48,7 +48,8 @@ TEST_CASE("Takeoff and Land", "[multicopter][vtol]")
 	tester.takeoff();
 	tester.wait_until_hovering();
 	tester.land();
-	tester.wait_until_disarmed();
+	std::chrono::seconds until_disarmed_timeout = std::chrono::seconds(15);
+	tester.wait_until_disarmed(until_disarmed_timeout);
 }
 
 TEST_CASE("Fly square Multicopter Missions", "[multicopter][vtol]")

--- a/test/mavsdk_tests/test_multicopter_offboard.cpp
+++ b/test/mavsdk_tests/test_multicopter_offboard.cpp
@@ -47,9 +47,10 @@ TEST_CASE("Offboard takeoff and land", "[multicopter][offboard][nogps]")
 	tester.wait_until_ready_local_position_only();
 	tester.store_home();
 	tester.arm();
-	tester.offboard_goto(takeoff_position, 0.5f);
+	std::chrono::seconds goto_timeout = std::chrono::seconds(10);
+	tester.offboard_goto(takeoff_position, 0.5f, goto_timeout);
 	tester.offboard_land();
-	tester.wait_until_disarmed();
+	tester.wait_until_disarmed(goto_timeout);
 	tester.check_home_within(0.5f);
 }
 
@@ -64,12 +65,13 @@ TEST_CASE("Offboard position control", "[multicopter][offboard][nogps]")
 	tester.wait_until_ready_local_position_only();
 	tester.store_home();
 	tester.arm();
-	tester.offboard_goto(takeoff_position, 0.5f);
-	tester.offboard_goto(setpoint_1, 1.0f);
-	tester.offboard_goto(setpoint_2, 1.0f);
-	tester.offboard_goto(setpoint_3, 1.0f);
-	tester.offboard_goto(takeoff_position, 0.2f);
+	std::chrono::seconds goto_timeout = std::chrono::seconds(10);
+	tester.offboard_goto(takeoff_position, 0.5f, goto_timeout);
+	tester.offboard_goto(setpoint_1, 1.0f, goto_timeout);
+	tester.offboard_goto(setpoint_2, 1.0f, goto_timeout);
+	tester.offboard_goto(setpoint_3, 1.0f, goto_timeout);
+	tester.offboard_goto(takeoff_position, 0.2f, goto_timeout);
 	tester.offboard_land();
-	tester.wait_until_disarmed();
+	tester.wait_until_disarmed(goto_timeout);
 	tester.check_home_within(1.0f);
 }


### PR DESCRIPTION
At the moment the CI runs every testcase-vehicle combination of the MAVSDK three times. Each run takes around 8 minutes and 40 seconds.

With the newest fixes for the offboard & vision tests, the vision tests can also run with a speed factor bigger than one. I tested this with a speed-factor=20 40 times in a row without failure.

Additionally there are calls to `poll_condition_with_timeout` in several places. This function tests the condition 10 times during the timeout interval. For example in the `offboard_goto` call or `wait_until_disarmed` call. In those two methods the timeout is set fix to 60 seconds. So if the condition is not satisfied immediately, it will wait for 6 seconds until it will check the condition again.
This timeout should depend on the specific mission. For a takeoff-and-land scenario 60 seconds is way too much.
This is solved by passing the timeout from the mission as an argument. For simple cases the timeout is reduced to 10 or 15 seconds. This is tested for all combinations with the critical speed-factor of 1. 

These changes reduces the time of one complete MAVSDK test run by almost 3 minutes down to 6 minutes. So it saves roughly 3 x 3 minutes = 9 minutes for the complete sitl_test CI.

Outlook:
- It would make sense to scale these timeouts with the speed factor.
- In stead of running all models (also non-gps) in different locations, we could pass different locations to the test runner and run all gps models multiple times with different home locations. Therefore we do not run the non-gps  models unnecessarily multiple times.