### PR TITLE
Fix shibang of r1_rover airframe config

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/1061_r1_rover
+++ b/ROMFS/px4fmu_common/init.d-posix/1061_r1_rover
@@ -1,4 +1,4 @@
-!/bin/sh
+#!/bin/sh
 #
 # @name Aion Robotics R1 Rover
 # @type Rover


### PR DESCRIPTION
The shibang was missing in the previous commit where this file was added in https://github.com/PX4/Firmware/pull/14652
