### PR TITLE
logger: keep typical log path within a single mavlink message

### DIFF
--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1207,7 +1207,7 @@ void Logger::start_log_file(LogType type)
 
 	if (type == LogType::Full) {
 		/* print logging path, important to find log file later */
-		mavlink_log_info(&_mavlink_log_pub, "[logger] file:%s", file_name);
+		mavlink_log_info(&_mavlink_log_pub, "[logger] %s", file_name);
 	}
 
 	_writer.start_log_file(type, file_name);


### PR DESCRIPTION
![Screenshot from 2020-05-05 14-14-11](https://user-images.githubusercontent.com/84712/81100539-b6da5c80-8eda-11ea-976f-45603d8ce927.png)
