### PR TITLE
commander: update EKF accel & gyro bias arming limits

### DIFF
--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -569,7 +569,7 @@ PARAM_DEFINE_FLOAT(COM_ARM_EKF_YAW, 0.5f);
  * @decimal 4
  * @increment 0.0001
  */
-PARAM_DEFINE_FLOAT(COM_ARM_EKF_AB, 1.73e-3f);
+PARAM_DEFINE_FLOAT(COM_ARM_EKF_AB, 0.0022f);
 
 /**
  * Maximum value of EKF gyro delta angle bias estimate that will allow arming
@@ -578,10 +578,10 @@ PARAM_DEFINE_FLOAT(COM_ARM_EKF_AB, 1.73e-3f);
  * @unit rad
  * @min 0.0001
  * @max 0.0017
- * @decimal 5
+ * @decimal 4
  * @increment 0.0001
  */
-PARAM_DEFINE_FLOAT(COM_ARM_EKF_GB, 8.7e-4f);
+PARAM_DEFINE_FLOAT(COM_ARM_EKF_GB, 0.0011f);
 
 /**
  * Maximum accelerometer inconsistency between IMU units that will allow arming


### PR DESCRIPTION
 - these should have been rescaled when the ecl/EKF filter update period
changed from 8 ms -> 10 ms


### COM_ARM_EKF_AB
`1.73e-3 m/s / 0.008 s = 0.21625 m/s/s`

Keeping the same ~ 0.22 m/s^2 accel bias limit for arming means a new COM_ARM_EKF_AB value of `0.0022 m/s`.
