### PR TITLE
mavlink_messages for HUD: send EAS instead of IAS

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -1540,7 +1540,7 @@ protected:
 			_airspeed_validated_sub.copy(&airspeed_validated);
 
 			mavlink_vfr_hud_t msg{};
-			msg.airspeed = airspeed_validated.indicated_airspeed_m_s;
+			msg.airspeed = airspeed_validated.equivalent_airspeed_m_s;
 			msg.groundspeed = sqrtf(lpos.vx * lpos.vx + lpos.vy * lpos.vy);
 			msg.heading = math::degrees(wrap_2pi(lpos.yaw));
 


### PR DESCRIPTION
This PR makes the MavlinkStreamVFRHUD send true_airspeed_m_s instead of indicated_airspeed_m_s for HUD on groundstation. This makes especially sense when your airspeed setup needs a scale factor (between indicated to equivalent), as otherwise the HUD displays another airspeed than the one that's used in the control modules.

Alternatively we could also display equivalent and not true airspeed. I would prefer true airspeed, such that it is comparable to the groundspeed.

EDIT: it would now send EAS and not TAS.

