### PR TITLE
[DO NOT MERGE] PX4Accelerometer/PX4Gyroscope discard duplicate consecutive samples

### DIFF
--- a/src/lib/drivers/accelerometer/PX4Accelerometer.cpp
+++ b/src/lib/drivers/accelerometer/PX4Accelerometer.cpp
@@ -158,6 +158,12 @@ void PX4Accelerometer::update(hrt_abstime timestamp_sample, float x, float y, fl
 
 	const Vector3f raw{x, y, z};
 
+	if (matrix::isEqual(raw, _raw_prev)) {
+		return;
+	}
+
+	_raw_prev = raw;
+
 	// Clipping (check unscaled raw values)
 	for (int i = 0; i < 3; i++) {
 		if (fabsf(raw(i)) > _clip_limit) {

--- a/src/lib/drivers/accelerometer/PX4Accelerometer.hpp
+++ b/src/lib/drivers/accelerometer/PX4Accelerometer.hpp
@@ -116,6 +116,8 @@ private:
 	float			_scale{1.f};
 	float			_temperature{0.f};
 
+	matrix::Vector3f	_raw_prev{0.f, 0.f, 0.f};
+
 	int16_t			_clip_limit{(int16_t)(_range / _scale)};
 
 	uint64_t		_error_count{0};

--- a/src/lib/drivers/gyroscope/PX4Gyroscope.cpp
+++ b/src/lib/drivers/gyroscope/PX4Gyroscope.cpp
@@ -157,6 +157,12 @@ void PX4Gyroscope::update(hrt_abstime timestamp_sample, float x, float y, float 
 
 	const Vector3f raw{x, y, z};
 
+	if (matrix::isEqual(raw, _raw_prev)) {
+		return;
+	}
+
+	_raw_prev = raw;
+
 	// Clipping (check unscaled raw values)
 	for (int i = 0; i < 3; i++) {
 		if (fabsf(raw(i)) > _clip_limit) {

--- a/src/lib/drivers/gyroscope/PX4Gyroscope.hpp
+++ b/src/lib/drivers/gyroscope/PX4Gyroscope.hpp
@@ -117,6 +117,8 @@ private:
 	float			_scale{1.f};
 	float			_temperature{0.f};
 
+	matrix::Vector3f	_raw_prev{0.f, 0.f, 0.f};
+
 	int16_t			_clip_limit{(int16_t)(_range / _scale)};
 
 	uint64_t		_error_count{0};


### PR DESCRIPTION
This is a quick workaround to catch any potentially misbehaving drivers. Ideally we should only be doing this on a per driver basis if it makes sense in that case.