### PR TITLE
Add translation of rpm uORB message to Mavlink

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1596,6 +1596,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("PING", 0.1f);
 		configure_stream_local("POSITION_TARGET_GLOBAL_INT", 1.0f);
 		configure_stream_local("POSITION_TARGET_LOCAL_NED", 1.5f);
+		configure_stream_local("RAW_RPM", 2.0f);
 		configure_stream_local("RC_CHANNELS", 5.0f);
 		configure_stream_local("SERVO_OUTPUT_RAW_0", 1.0f);
 		configure_stream_local("SYS_STATUS", 1.0f);

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1639,6 +1639,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("PING", 1.0f);
 		configure_stream_local("POSITION_TARGET_GLOBAL_INT", 10.0f);
 		configure_stream_local("POSITION_TARGET_LOCAL_NED", 10.0f);
+		configure_stream_local("RAW_RPM", 5.0f);
 		configure_stream_local("RC_CHANNELS", 20.0f);
 		configure_stream_local("SERVO_OUTPUT_RAW_0", 10.0f);
 		configure_stream_local("SYS_STATUS", 5.0f);

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -2549,17 +2549,17 @@ protected:
 		if (_mavlink->odometry_loopback_enabled()) {
 			odom_updated = _vodom_sub.update(&odom);
 			// frame matches the external vision system
-			msg.frame_id = MAV_FRAME_VISION_NED;
+			msg.frame_id = MAV_FRAME_RESERVED_16;
 
 		} else {
 			odom_updated = _odom_sub.update(&odom);
 			// frame matches the PX4 local NED frame
-			msg.frame_id = MAV_FRAME_ESTIM_NED;
+			msg.frame_id = MAV_FRAME_RESERVED_18;
 		}
 
 		if (odom_updated) {
 			msg.time_usec = odom.timestamp_sample;
-			msg.child_frame_id = MAV_FRAME_BODY_FRD;
+			msg.child_frame_id = MAV_FRAME_RESERVED_12;
 
 			// Current position
 			msg.x = odom.x;

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -2550,17 +2550,17 @@ protected:
 		if (_mavlink->odometry_loopback_enabled()) {
 			odom_updated = _vodom_sub.update(&odom);
 			// frame matches the external vision system
-			msg.frame_id = MAV_FRAME_RESERVED_16;
+			msg.frame_id = MAV_FRAME_RESERVED_16; // MAV_FRAME_VISION_NED
 
 		} else {
 			odom_updated = _odom_sub.update(&odom);
 			// frame matches the PX4 local NED frame
-			msg.frame_id = MAV_FRAME_RESERVED_18;
+			msg.frame_id = MAV_FRAME_RESERVED_18; // MAV_FRAME_ESTIM_NED
 		}
 
 		if (odom_updated) {
 			msg.time_usec = odom.timestamp_sample;
-			msg.child_frame_id = MAV_FRAME_RESERVED_12;
+			msg.child_frame_id = MAV_FRAME_RESERVED_12; // MAV_FRAME_BODY_FRD
 
 			// Current position
 			msg.x = odom.x;

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1335,7 +1335,7 @@ MavlinkReceiver::handle_message_odometry(mavlink_message_t *msg)
 	 * local NED frame. The angular velocity needs to be expressed in the
 	 * body (fcu_frd) frame.
 	 */
-	if (odom.child_frame_id == MAV_FRAME_RESERVED_12) {
+	if (odom.child_frame_id == MAV_FRAME_RESERVED_12) {  // MAV_FRAME_BODY_FRD
 		/* Linear velocity has to be rotated to the local NED frame
 		 * Angular velocities are already in the right body frame  */
 		const matrix::Dcmf R_body_to_local = matrix::Dcmf(q_body_to_local);
@@ -1377,7 +1377,7 @@ MavlinkReceiver::handle_message_odometry(mavlink_message_t *msg)
 	if (odom.frame_id == MAV_FRAME_LOCAL_FRD) {
 		_visual_odometry_pub.publish(odometry);
 
-	} else if (odom.frame_id == MAV_FRAME_RESERVED_14) {
+	} else if (odom.frame_id == MAV_FRAME_RESERVED_14) {  // MAV_FRAME_MOCAP_NED
 		_mocap_odometry_pub.publish(odometry);
 
 	} else {

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1335,7 +1335,7 @@ MavlinkReceiver::handle_message_odometry(mavlink_message_t *msg)
 	 * local NED frame. The angular velocity needs to be expressed in the
 	 * body (fcu_frd) frame.
 	 */
-	if (odom.child_frame_id == MAV_FRAME_BODY_FRD) {
+	if (odom.child_frame_id == MAV_FRAME_RESERVED_12) {
 		/* Linear velocity has to be rotated to the local NED frame
 		 * Angular velocities are already in the right body frame  */
 		const matrix::Dcmf R_body_to_local = matrix::Dcmf(q_body_to_local);
@@ -1377,7 +1377,7 @@ MavlinkReceiver::handle_message_odometry(mavlink_message_t *msg)
 	if (odom.frame_id == MAV_FRAME_LOCAL_FRD) {
 		_visual_odometry_pub.publish(odometry);
 
-	} else if (odom.frame_id == MAV_FRAME_MOCAP_NED) {
+	} else if (odom.frame_id == MAV_FRAME_RESERVED_14) {
 		_mocap_odometry_pub.publish(odometry);
 
 	} else {


### PR DESCRIPTION
Hi, this PR translates uORB rpm message (for example from RPM sensor #14018) to MavLink RAW_RPM message. It is verified that it works.
![Snímek z 2020-05-07 23-04-02](https://user-images.githubusercontent.com/5196729/81349263-f910c300-90bf-11ea-83de-1189d3adaa87.png)

I have updated the MavLink library. And then I noticed a problem that the names of the existing values in the MAV_FRAME message had changed.

I changed names of values according to their descriptions:
https://github.com/mavlink/mavlink/blob/master/message_definitions/v1.0/common.xml#L879-L919

It comes from this commit https://github.com/mavlink/mavlink/commit/81d7a874efcc3bab6f09f8336056350154d8de8f