### PR TITLE
boards/modalai/fc_v1 - disable icm42688p for now

### DIFF
--- a/boards/modalai/fc-v1/default.cmake
+++ b/boards/modalai/fc-v1/default.cmake
@@ -25,7 +25,6 @@ px4_add_board(
 		dshot
 		gps
 		imu/bmi088
-		#imu/mpu6000
 		imu/invensense/icm20602
 		imu/invensense/icm42688p
 		irlock

--- a/boards/modalai/fc-v1/default.cmake
+++ b/boards/modalai/fc-v1/default.cmake
@@ -25,7 +25,8 @@ px4_add_board(
 		dshot
 		gps
 		imu/bmi088
-		imu/invensense/icm20602
+		imu/mpu6000
+		#imu/invensense/icm20602
 		imu/invensense/icm42688p
 		irlock
 		lights/blinkm

--- a/boards/modalai/fc-v1/default.cmake
+++ b/boards/modalai/fc-v1/default.cmake
@@ -25,8 +25,8 @@ px4_add_board(
 		dshot
 		gps
 		imu/bmi088
-		imu/mpu6000
-		#imu/invensense/icm20602
+		#imu/mpu6000
+		imu/invensense/icm20602
 		imu/invensense/icm42688p
 		irlock
 		lights/blinkm

--- a/boards/modalai/fc-v1/init/rc.board_sensors
+++ b/boards/modalai/fc-v1/init/rc.board_sensors
@@ -10,8 +10,7 @@ voxlpm -X -b 3 -T VBATT start
 voxlpm -X -b 3 -T P5VDC start
 
 # Internal SPI bus ICM-20602
-#icm20602 -R 12 -s start
-mpu6000 -R 6 -s -T 20602 start
+icm20602 -R 12 -s start
 
 # Internal SPI bus ICM-42688
 #icm42688p -R 12 -s start

--- a/boards/modalai/fc-v1/init/rc.board_sensors
+++ b/boards/modalai/fc-v1/init/rc.board_sensors
@@ -10,10 +10,10 @@ voxlpm -X -b 3 -T VBATT start
 voxlpm -X -b 3 -T P5VDC start
 
 # Internal SPI bus ICM-20602
-icm20602 -R 12 -s start
+mpu6000 -R 6 -s -T 20602 start
 
 # Internal SPI bus ICM-42688
-icm42688p -R 12 -s start
+#icm42688p -R 12 -s start
 
 # Internal SPI bus BMI088 accel
 bmi088 -A -R 4 -s start

--- a/boards/modalai/fc-v1/init/rc.board_sensors
+++ b/boards/modalai/fc-v1/init/rc.board_sensors
@@ -10,6 +10,7 @@ voxlpm -X -b 3 -T VBATT start
 voxlpm -X -b 3 -T P5VDC start
 
 # Internal SPI bus ICM-20602
+#icm20602 -R 12 -s start
 mpu6000 -R 6 -s -T 20602 start
 
 # Internal SPI bus ICM-42688


### PR DESCRIPTION
**Describe problem solved by this pull request**
The new invensense drivers are causing some flight instability.  Reverting back to the mpu6000 driver and turning off the 42688p for now was able to solve the issue (same as 1.10 configuration).  The plan is to do more testing and tweaking of register settings here shortly, but want to release a useable beta 1.11....

**Describe your solution**
Revert back to 'older' mpu6000 driver, disable 42688p for now.  Leaving the 42688p in the build but not starting it up.

**Describe possible alternatives**
Alternative to this is more testing and tweaking the 20602 and 42688 drivers, which we'll want to do, but I'd like to release 1.11 in stable way ;)

**Test data / coverage**
Flight tested and confirmed originally flight functionality.
