### PR TITLE
i2c_spi_buses.h: work around astyle version inconsistency

### DIFF
--- a/platforms/common/include/px4_platform_common/i2c_spi_buses.h
+++ b/platforms/common/include/px4_platform_common/i2c_spi_buses.h
@@ -236,13 +236,15 @@ protected:
 
 	virtual ~I2CSPIDriver() = default;
 
-	void Run() final {
+	// *INDENT-OFF* remove once there's astyle >3.1 in CI
+	void Run() final
+	{
 		static_cast<T *>(this)->RunImpl();
 
-		if (should_exit())
-		{
+		if (should_exit()) {
 			exit_and_cleanup();
 		}
 	}
+	// *INDENT-ON*
 private:
 };


### PR DESCRIPTION
**Describe problem solved by this pull request**
When running make format with astyle 3.1 (which is installed with the setup scripts) the style gets corrected the expected way but CI seems to use an older version that parses the bracketing wrong and corrects it again.

**Describe your solution**
To work around that I put a newline in between. This mutes the constantly failing style checks.

**Describe possible alternatives**
Astyle should be the same version in CI and setup scripts but in between we don't want to annoy developers with this issue.

**Test data / coverage**
Passes style check locally, let's see what CI decides.
