### PR TITLE
sensors: use sensor_gyro timestamp_sample for sensor_combined timestamp

### DIFF
--- a/src/modules/sensors/voted_sensors_update.cpp
+++ b/src/modules/sensors/voted_sensors_update.cpp
@@ -596,7 +596,7 @@ void VotedSensorsUpdate::gyroPoll(struct sensor_combined_s &raw)
 			_last_sensor_data[uorb_index].gyro_rad[1] = gyro_rate(1);
 			_last_sensor_data[uorb_index].gyro_rad[2] = gyro_rate(2);
 
-			_last_sensor_data[uorb_index].timestamp = gyro_report.timestamp;
+			_last_sensor_data[uorb_index].timestamp = gyro_report.timestamp_sample;
 			_gyro.voter.put(uorb_index, gyro_report.timestamp, _last_sensor_data[uorb_index].gyro_rad,
 					gyro_report.error_count, _gyro.priority[uorb_index]);
 		}


### PR DESCRIPTION
The timestamp actually used by ekf2 for IMU data is the sensor_combined timestamp, so we should be setting it with the actual sample timestamp, rather than the topic publication metadata.

Later the `sensor_combined` message will be replaced with `vehicle_imu` that carries a separate publication timestamp and raw sample timestamp.