### PR TITLE
sensors/vehicle_angular_velocity: don't remove bias twice

### DIFF
--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
@@ -257,10 +257,7 @@ void VehicleAngularVelocity::Run()
 			const Vector3f val{sensor_data.x, sensor_data.y, sensor_data.z};
 
 			// correct for in-run bias errors
-			Vector3f angular_velocity_raw = _corrections.Correct(val) - _bias;
-
-			// correct for in-run bias errors
-			angular_velocity_raw -= _bias;
+			const Vector3f angular_velocity_raw = _corrections.Correct(val) - _bias;
 
 			// Differentiate angular velocity (after notch filter)
 			const Vector3f angular_velocity_notched{_notch_filter_velocity.apply(angular_velocity_raw)};


### PR DESCRIPTION
It looks like this snuck in a few months ago when the code was refactored, but the redundant bias removal on the next line was missed (discrepancy with trying to keep VehicleAcceleration and VehicleAngularVelocity roughly in sync).

https://github.com/PX4/Firmware/pull/14036