### PR TITLE
msg: timestamp_sample print elapsed from timestamp

### DIFF
--- a/msg/templates/uorb/msg.cpp.em
+++ b/msg/templates/uorb/msg.cpp.em
@@ -89,6 +89,9 @@ void print_message(const @uorb_struct &message)
 	PX4_INFO_RAW("Not implemented on flash constrained hardware\n");
 @[else]
 	PX4_INFO_RAW(" @(uorb_struct)\n");
+
+	const hrt_abstime now = hrt_absolute_time();
+
 @[for field in sorted_fields]@
 	@( print_field(field) )@
 @[end for]@

--- a/msg/tools/px_generate_uorb_topic_helper.py
+++ b/msg/tools/px_generate_uorb_topic_helper.py
@@ -298,7 +298,9 @@ def print_field(field):
     if field.name == 'timestamp':
         print(("if (message.timestamp != 0) {\n\t\tPX4_INFO_RAW(\"\\t" + field.name +
               ": " + c_type + "  (%.6f seconds ago)\\n\", " + field_name +
-              ", hrt_elapsed_time(&message.timestamp) / 1e6);\n\t} else {\n\t\tPX4_INFO_RAW(\"\\n\");\n\t}"))
+              ", (now - message.timestamp) / 1e6);\n\t} else {\n\t\tPX4_INFO_RAW(\"\\n\");\n\t}"))
+    elif field.name == 'timestamp_sample':
+        print(("\n\tPX4_INFO_RAW(\"\\t" + field.name + ": " + c_type + "  (" + c_type + " us before timestamp)\\n\", " + field_name + ", message.timestamp - message.timestamp_sample);\n\t"))
     elif field.name == 'device_id':
         print("char device_id_buffer[80];")
         print("device::Device::device_id_print_buffer(device_id_buffer, sizeof(device_id_buffer), message.device_id);")


### PR DESCRIPTION
This is useful for casually inspecting latency across a few areas of the system.

``` Console
nsh> listener sensor_gyro

TOPIC: sensor_gyro 3 instances

Instance 0:
 sensor_gyro_s
        timestamp: 4122951146  (0.007275 seconds ago)
        timestamp_sample: 4122950938  (208 us before timestamp)
        device_id: 3670026 (Type: 0x38, SPI:1 (0x00)) 
        x: 0.0065
        y: -0.0150
        z: 0.0040
        temperature: 38.4425

Instance 1:
 sensor_gyro_s
        timestamp: 4122953026  (0.006588 seconds ago)
        timestamp_sample: 4122952846  (180 us before timestamp)
        device_id: 3932170 (Type: 0x3C, SPI:1 (0x00)) 
        x: 0.0033
        y: 0.0212
        z: -0.0001
        temperature: 38.1701

Instance 2:
 sensor_gyro_s
        timestamp: 4122958142  (0.004024 seconds ago)
        timestamp_sample: 4122958116  (26 us before timestamp)
        device_id: 4325386 (Type: 0x42, SPI:1 (0x00)) 
        x: 0.0085
        y: 0.0106
        z: 0.0031
        temperature: 37.0000

```

This example roughly shows the large transfer time when using IMUs with FIFOs.


