### PR TITLE
Ubuntu.sh - report Ubuntu 20.04 in setup

### DIFF
--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -53,7 +53,7 @@ fi
 
 
 # check ubuntu version
-# instructions for 16.04, 18.04
+# instructions for 16.04, 18.04, 20.04
 # otherwise warn and point to docker?
 UBUNTU_RELEASE=`lsb_release -rs`
 
@@ -64,6 +64,8 @@ elif [[ "${UBUNTU_RELEASE}" == "16.04" ]]; then
 	echo "Ubuntu 16.04"
 elif [[ "${UBUNTU_RELEASE}" == "18.04" ]]; then
 	echo "Ubuntu 18.04"
+elif [[ "${UBUNTU_RELEASE}" == "20.04" ]]; then
+	echo "Ubuntu 20.04"
 fi
 
 


### PR DESCRIPTION
This just updates the script to state support for Ubuntu 20.04. This works in my testing.

Note, a problem was reported here, but I can't reproduce: https://github.com/PX4/Firmware/issues/14888