### PR TITLE
VTOL: disable transition command in certain flight modes

### DIFF
--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -159,7 +159,7 @@ VtolAttitudeControl::handle_command()
 	if (_vehicle_cmd.command == vehicle_command_s::VEHICLE_CMD_DO_VTOL_TRANSITION) {
 
 		vehicle_status_s vehicle_status = {};
-		_vehicle_status_sub.update(&vehicle_status);
+		_vehicle_status_sub.copy(&vehicle_status);
 
 		uint8_t result = vehicle_command_ack_s::VEHICLE_RESULT_ACCEPTED;
 

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -163,8 +163,11 @@ VtolAttitudeControl::handle_command()
 
 		uint8_t result = vehicle_command_ack_s::VEHICLE_RESULT_ACCEPTED;
 
-		// deny transition in auto takeoff mode
-		if (vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF) {
+		// deny any transition in auto takeoff mode, plus transition from RW to FW in land or RTL mode
+		if (vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF
+		    || (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING
+			&& (vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_LAND
+			    || vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_RTL))) {
 			result = vehicle_command_ack_s::VEHICLE_RESULT_TEMPORARILY_REJECTED;
 
 		} else {

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -156,18 +156,26 @@ VtolAttitudeControl::vehicle_cmd_poll()
 void
 VtolAttitudeControl::handle_command()
 {
-	// update transition command if necessary
 	if (_vehicle_cmd.command == vehicle_command_s::VEHICLE_CMD_DO_VTOL_TRANSITION) {
-		_transition_command = int(_vehicle_cmd.param1 + 0.5f);
 
-		// Report that we have received the command no matter what we actually do with it.
-		// This might not be optimal but is better than no response at all.
+		vehicle_status_s vehicle_status = {};
+		_vehicle_status_sub.update(&vehicle_status);
+
+		uint8_t result = vehicle_command_ack_s::VEHICLE_RESULT_ACCEPTED;
+
+		// deny transition in auto takeoff mode
+		if (vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF) {
+			result = vehicle_command_ack_s::VEHICLE_RESULT_TEMPORARILY_REJECTED;
+
+		} else {
+			_transition_command = int(_vehicle_cmd.param1 + 0.5f);
+		}
 
 		if (_vehicle_cmd.from_external) {
 			vehicle_command_ack_s command_ack{};
 			command_ack.timestamp = hrt_absolute_time();
 			command_ack.command = _vehicle_cmd.command;
-			command_ack.result = (uint8_t)vehicle_command_ack_s::VEHICLE_RESULT_ACCEPTED;
+			command_ack.result = result;
 			command_ack.target_system = _vehicle_cmd.source_system;
 			command_ack.target_component = _vehicle_cmd.source_component;
 

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -79,7 +79,7 @@
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_local_position_setpoint.h>
 #include <uORB/topics/vtol_vehicle_status.h>
-
+#include <uORB/topics/vehicle_status.h>
 #include "standard.h"
 #include "tailsitter.h"
 #include "tiltrotor.h"
@@ -146,6 +146,7 @@ private:
 	uORB::Subscription _v_att_sub{ORB_ID(vehicle_attitude)};		//vehicle attitude subscription
 	uORB::Subscription _v_control_mode_sub{ORB_ID(vehicle_control_mode)};	//vehicle control mode subscription
 	uORB::Subscription _vehicle_cmd_sub{ORB_ID(vehicle_command)};
+	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
 
 	uORB::Publication<actuator_controls_s>		_actuators_0_pub{ORB_ID(actuator_controls_0)};		//input for the mixer (roll,pitch,yaw,thrust)
 	uORB::Publication<actuator_controls_s>		_actuators_1_pub{ORB_ID(actuator_controls_1)};


### PR DESCRIPTION

**Describe problem solved by this pull request**
Transitions to fixed-wing mode close to ground are dangerous, plus the current px4 navigation logic doesn't handle it well if you transition in some flight stages (you can end up in a fly-away). I do not see any use case where a transition to FW would be needed during the takeoff or landing flight mode, and in Return mode it is at least controversial.

**Describe your solution**
- Disable transition during takeoff
- Disable transition to FW during Landing and Return mode

**Describe possible alternatives**
While preventing the transitions to FW in takeoff and land probably is of little controversy, doing so in the Return mode can be. E.g. you have a Quad-chute far away, the vehicle is though in hover and in Return. The user knows though that the fixed-wing system is okay, and it was only a wind gust that made the vehicle's bank angle exceed the limit. The user thus want to switch to FW to be able to reach home, and for that he would then need to "Pause" first, then transition, and then either resume the mission or switch to Return again.
I still think that this PR would increase the UX, as this is rather a corner case (quadchute, but vehicle's FW actuation still okay - pretty hard to judge by the user anyway), and I would rate the prevention of the danger of doing transitions in proximity of ground higher than this inconvenience for the user with one more action required. 

**Test data / coverage**
SITL tested.


@RomanBapst fyi
