### PR TITLE
Add an optional stick tilt input filter

### DIFF
--- a/src/lib/flight_tasks/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
+++ b/src/lib/flight_tasks/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
@@ -341,6 +341,10 @@ void FlightTaskManualAltitude::_updateSetpoints()
 	// setpoint along z-direction, which is computed in PositionControl.cpp.
 
 	Vector2f sp(&_sticks(0));
+
+	_man_input_filter.setParameters(_deltatime, _param_mc_man_tilt_tau.get());
+	_man_input_filter.update(sp);
+	sp = _man_input_filter.getState();
 	_rotateIntoHeadingFrame(sp);
 
 	if (sp.length() > 1.0f) {

--- a/src/lib/flight_tasks/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
+++ b/src/lib/flight_tasks/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
@@ -40,6 +40,7 @@
 #pragma once
 
 #include "FlightTaskManual.hpp"
+#include <lib/ecl/EKF/AlphaFilter.hpp>
 
 class FlightTaskManualAltitude : public FlightTaskManual
 {
@@ -83,7 +84,8 @@ protected:
 					(ParamFloat<px4::params::MPC_LAND_SPEED>)
 					_param_mpc_land_speed, /**< desired downwards speed when approaching the ground */
 					(ParamFloat<px4::params::MPC_TKO_SPEED>)
-					_param_mpc_tko_speed /**< desired upwards speed when still close to the ground */
+					_param_mpc_tko_speed, /**< desired upwards speed when still close to the ground */
+					(ParamFloat<px4::params::MC_MAN_TILT_TAU>) _param_mc_man_tilt_tau
 				       )
 private:
 	bool _isYawInput();
@@ -137,4 +139,6 @@ private:
 	 * _dist_to_ground_lock.
 	 */
 	float _dist_to_ground_lock = NAN;
+
+	AlphaFilter<matrix::Vector2f> _man_input_filter;
 };

--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -54,6 +54,7 @@
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/vehicle_land_detected.h>
 #include <vtol_att_control/vtol_type.h>
+#include <lib/ecl/EKF/AlphaFilter.hpp>
 
 #include <AttitudeControl.hpp>
 
@@ -130,6 +131,9 @@ private:
 	matrix::Vector3f _rates_sp;			/**< angular rates setpoint */
 
 	float _man_yaw_sp{0.f};				/**< current yaw setpoint in manual mode */
+	float _man_tilt_max;			/**< maximum tilt allowed for manual flight [rad] */
+	AlphaFilter<float> _man_x_input_filter;
+	AlphaFilter<float> _man_y_input_filter;
 
 	hrt_abstime _last_run{0};
 
@@ -157,12 +161,10 @@ private:
 		_param_mpc_thr_hover,			/**< throttle at which vehicle is at hover equilibrium */
 		(ParamInt<px4::params::MPC_THR_CURVE>) _param_mpc_thr_curve,				/**< throttle curve behavior */
 
-		(ParamInt<px4::params::MC_AIRMODE>) _param_mc_airmode
+		(ParamInt<px4::params::MC_AIRMODE>) _param_mc_airmode,
+		(ParamFloat<px4::params::MC_MAN_TILT_TAU>) _param_mc_man_tilt_tau
 	)
 
 	bool _is_tailsitter{false};
-
-	float _man_tilt_max;			/**< maximum tilt allowed for manual flight [rad] */
-
 };
 

--- a/src/modules/mc_att_control/mc_att_control_params.c
+++ b/src/modules/mc_att_control/mc_att_control_params.c
@@ -163,3 +163,15 @@ PARAM_DEFINE_FLOAT(MC_YAWRATE_MAX, 200.0f);
  * @group Multicopter Attitude Control
  */
 PARAM_DEFINE_FLOAT(MC_RATT_TH, 0.8f);
+
+/**
+ * Manual tilt input filter time constant
+ * Setting this parameter to 0 disables the filter
+ *
+ * @unit s
+ * @min 0.0
+ * @max 2.0
+ * @decimal 2
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MC_MAN_TILT_TAU, 0.0f);

--- a/src/modules/rc_update/params.c
+++ b/src/modules/rc_update/params.c
@@ -2228,26 +2228,3 @@ PARAM_DEFINE_FLOAT(RC_STAB_TH, 0.5f);
  * @group Radio Switches
  */
 PARAM_DEFINE_FLOAT(RC_MAN_TH, 0.75f);
-
-/**
- * Sample rate of the remote control values for the low pass filter on roll, pitch, yaw and throttle
- *
- * Has an influence on the cutoff frequency precision.
- *
- * @min 1.0
- * @unit Hz
- * @group Radio Calibration
- */
-PARAM_DEFINE_FLOAT(RC_FLT_SMP_RATE, 50.0f);
-
-/**
- * Cutoff frequency for the low pass filter on roll, pitch, yaw and throttle
- *
- * Does not get set unless below RC_FLT_SMP_RATE/2 because of filter instability characteristics.
- * Set to 0 to disable the filter.
- *
- * @min 0
- * @unit Hz
- * @group Radio Calibration
- */
-PARAM_DEFINE_FLOAT(RC_FLT_CUTOFF, 10.0f);

--- a/src/modules/rc_update/rc_update.cpp
+++ b/src/modules/rc_update/rc_update.cpp
@@ -106,19 +106,6 @@ RCUpdate::init()
 void
 RCUpdate::parameters_updated()
 {
-	if (_param_rc_flt_smp_rate.get() < 1.0f) {
-		_param_rc_flt_smp_rate.set(1.0f);
-		_param_rc_flt_smp_rate.commit_no_notification();
-	}
-
-	// make sure the filter is in its stable region -> fc < fs/2
-	const float flt_cutoff_max = _param_rc_flt_smp_rate.get() / 2.0f - 1.0f;
-
-	if (_param_rc_flt_cutoff.get() > flt_cutoff_max) {
-		_param_rc_flt_cutoff.set(flt_cutoff_max);
-		_param_rc_flt_cutoff.commit_no_notification();
-	}
-
 	// rc values
 	for (unsigned int i = 0; i < RC_MAX_CHAN_COUNT; i++) {
 
@@ -185,16 +172,6 @@ RCUpdate::update_rc_functions()
 	for (int i = 0; i < rc_parameter_map_s::RC_PARAM_MAP_NCHAN; i++) {
 		_rc.function[rc_channels_s::RC_CHANNELS_FUNCTION_PARAM_1 + i] = _parameters.rc_map_param[i] - 1;
 	}
-
-	/* update the RC low pass filter frequencies */
-	_filter_roll.set_cutoff_frequency(_param_rc_flt_smp_rate.get(), _param_rc_flt_cutoff.get());
-	_filter_pitch.set_cutoff_frequency(_param_rc_flt_smp_rate.get(), _param_rc_flt_cutoff.get());
-	_filter_yaw.set_cutoff_frequency(_param_rc_flt_smp_rate.get(), _param_rc_flt_cutoff.get());
-	_filter_throttle.set_cutoff_frequency(_param_rc_flt_smp_rate.get(), _param_rc_flt_cutoff.get());
-	_filter_roll.reset(0.f);
-	_filter_pitch.reset(0.f);
-	_filter_yaw.reset(0.f);
-	_filter_throttle.reset(0.f);
 }
 
 void
@@ -480,12 +457,6 @@ RCUpdate::Run()
 			manual.aux4 = get_rc_value(rc_channels_s::RC_CHANNELS_FUNCTION_AUX_4, -1.0, 1.0);
 			manual.aux5 = get_rc_value(rc_channels_s::RC_CHANNELS_FUNCTION_AUX_5, -1.0, 1.0);
 			manual.aux6 = get_rc_value(rc_channels_s::RC_CHANNELS_FUNCTION_AUX_6, -1.0, 1.0);
-
-			/* filter controls */
-			manual.y = math::constrain(_filter_roll.apply(manual.y), -1.f, 1.f);
-			manual.x = math::constrain(_filter_pitch.apply(manual.x), -1.f, 1.f);
-			manual.r = math::constrain(_filter_yaw.apply(manual.r), -1.f, 1.f);
-			manual.z = math::constrain(_filter_throttle.apply(manual.z), 0.f, 1.f);
 
 			if (_param_rc_map_fltmode.get() > 0) {
 				/* number of valid slots */

--- a/src/modules/rc_update/rc_update.h
+++ b/src/modules/rc_update/rc_update.h
@@ -166,11 +166,6 @@ private:
 
 	hrt_abstime _last_rc_to_param_map_time = 0;
 
-	math::LowPassFilter2p _filter_roll{50.0f, 10.f}; /**< filters for the main 4 stick inputs */
-	math::LowPassFilter2p _filter_pitch{50.0f, 10.f}; /** we want smooth setpoints as inputs to the controllers */
-	math::LowPassFilter2p _filter_yaw{50.0f, 10.f};
-	math::LowPassFilter2p _filter_throttle{50.0f, 10.f};
-
 	perf_counter_t		_loop_perf;			/**< loop performance counter */
 
 	DEFINE_PARAMETERS(
@@ -222,9 +217,6 @@ private:
 		(ParamFloat<px4::params::RC_STAB_TH>) _param_rc_stab_th,
 		(ParamFloat<px4::params::RC_MAN_TH>) _param_rc_man_th,
 		(ParamFloat<px4::params::RC_RETURN_TH>) _param_rc_return_th,
-
-		(ParamFloat<px4::params::RC_FLT_SMP_RATE>) _param_rc_flt_smp_rate,
-		(ParamFloat<px4::params::RC_FLT_CUTOFF>) _param_rc_flt_cutoff,
 
 		(ParamInt<px4::params::RC_CHAN_CNT>) _param_rc_chan_cnt
 	)


### PR DESCRIPTION
**Describe problem solved by this pull request**
An always reoccurring pattern seems people detuning the rate and attitude control loops because "the drone flies too aggressive when moving the sticks".

These are two separate things:
1. The controller trying to follow the setpoint as close as possible and in an ideal world would achieve perfect tracking even with disturbances like wind, motor tolerances and friction, unconsidered aerodynamic effects of the propellers, unbalanced mass distribution, ...
2. Considering perfect tracking of the controller how would the vehicle move given a certain user input. In other words how the setpoint changes when you move the stick.

**Describe your solution**
As discussed with @bresch I used a simple first-order IIR low pass to filter the "x, y" stick input that determines the tilt angle of the setpoint. As we've seen with the yaw speed setpoint filter this results in intuitive flight characteristics that feel like the vehicle dynamics are a bit slower e.g. like a heavier vehicle see https://github.com/PX4/Firmware/blob/8804dae4808ebcb849c02b78b446ea01f4aa45ad/src/lib/flight_tasks/tasks/ManualAltitude/FlightTaskManualAltitude.cpp#L101-L104

![image](https://user-images.githubusercontent.com/4668506/81690248-52c81300-945b-11ea-9f3e-8c550b1ae3fe.png)

**Test data / coverage**
Tested in SITL, QAV250 and a bigger vehicle with all kinds of settings. `MC_MAN_TILT_TAU` of 0.15 seems to be a sweet spot between filtering crazy input but keeping high responsiveness to stick input.

**Additional context**
In order to fully resolve https://github.com/PX4/Firmware/issues/12971 I'll also implement a solution for altitude mode.