### PR TITLE
powerCheck: make 5V warning threshold configurable

### DIFF
--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -912,3 +912,16 @@ PARAM_DEFINE_FLOAT(COM_KILL_DISARM, 5.0f);
  * @increment 1
  */
 PARAM_DEFINE_FLOAT(COM_CPU_MAX, 90.0f);
+
+/**
+ * 5V Avionics rail voltage below which the operator gets warnings
+ *
+ * A negative value disables the warning.
+ *
+ * @group Commander
+ * @unit %
+ * @min -1
+ * @max 6
+ * @increment 0.1
+ */
+PARAM_DEFINE_FLOAT(COM_5V_WARN_THR, 4.9f);


### PR DESCRIPTION
**Describe problem solved by this pull request**
The 5V avionics rail is crucial for the flight control system and if a voltage below 4.5V is detected on that supply it errors out before you can take off. Additional to that there's a warning when the voltage level is below 4.9V. Since some supply regulators that are rated for 5V can with tolerances and load get lower than that value without any need for concern the warning could appear on every flight on a particular setup.

**Describe your solution**
To allow the operator to configure this warning threshold I introduced a parameter `COM_5V_WARN_THR`. Most of the time it should only need slight adjustment according to the particular setup but if set really low the warning can also be completely disabled.

**Test data / coverage**
Pixhawk4 powered only via USB with USB circuit breaker and without the USB connected check set shows
![image](https://user-images.githubusercontent.com/4668506/81815828-c9801180-952a-11ea-9b42-8d80873cf153.png)
when trying to arm.

After setting `COM_5V_WARN_THR` to 4.8V instead of the default 4.9V the warning is gone.
![image](https://user-images.githubusercontent.com/4668506/81815971-f92f1980-952a-11ea-8d14-0ef461447c6e.png)
