### PR TITLE
powerCheck: make 5V warning threshold 0.1V lower

### DIFF
--- a/src/modules/commander/Arming/PreFlightCheck/checks/powerCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/powerCheck.cpp
@@ -67,7 +67,7 @@ bool PreFlightCheck::powerCheck(orb_advert_t *mavlink_log_pub, const vehicle_sta
 							     (double)avionics_power_rail_voltage);
 				}
 
-			} else if (avionics_power_rail_voltage < 4.9f) {
+			} else if (avionics_power_rail_voltage < 4.8f) {
 				if (report_fail) {
 					mavlink_log_critical(mavlink_log_pub, "CAUTION: Avionics Power low: %6.2f Volt", (double)avionics_power_rail_voltage);
 				}


### PR DESCRIPTION
**Describe problem solved by this pull request**
Follow up closes https://github.com/PX4/Firmware/pull/14898

Because of warnings on every flight on setups without
any need for concern. Some even high quality supply voltage regulators
that are rated for 5V can with tolerances and load get lower than 4.9V.

**Describe your solution**
See discussion here: https://github.com/PX4/Firmware/pull/14898#issuecomment-628026895
