### PR TITLE
navigator_main.cpp: don't reset wv enable status

### DIFF
--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -891,6 +891,7 @@ Navigator::reset_position_setpoint(position_setpoint_s &sp)
 	sp.cruising_throttle = get_cruising_throttle();
 	sp.valid = false;
 	sp.type = position_setpoint_s::SETPOINT_TYPE_IDLE;
+	sp.disable_weather_vane = false;
 }
 
 float

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -891,7 +891,6 @@ Navigator::reset_position_setpoint(position_setpoint_s &sp)
 	sp.cruising_throttle = get_cruising_throttle();
 	sp.valid = false;
 	sp.type = position_setpoint_s::SETPOINT_TYPE_IDLE;
-	sp.disable_weather_vane = true;
 }
 
 float


### PR DESCRIPTION
This reset change 4 months ago destroyed the original WV working logic, which caused wv to no longer work under land / loiter, and this PR solved it. It has been tested in gazebo.

Extra thinking:
 Will the yaw setting generated by WV destroy RTL?
FYI ： @sfuhrer 