### PR TITLE
navigator: allow mission items with same position

### DIFF
--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -676,8 +676,6 @@ MissionFeasibilityChecker::checkDistancesBetweenWaypoints(const mission_s &missi
 
 	double last_lat = (double)NAN;
 	double last_lon = (double)NAN;
-	float last_alt = NAN;
-	int last_cmd = 0;
 
 	/* Go through all waypoints */
 	for (size_t i = 0; i < mission.count; i++) {
@@ -712,29 +710,11 @@ MissionFeasibilityChecker::checkDistancesBetweenWaypoints(const mission_s &missi
 
 				_navigator->get_mission_result()->warning = true;
 				return false;
-
-				/* do not allow waypoints that are literally on top of each other */
-
-			} else if ((dist_between_waypoints < 0.05f && fabsf(last_alt - mission_item.altitude) < 0.05f) ||
-				   /* and do not allow condition gates that are at the same position as a navigation waypoint */
-				   (dist_between_waypoints < 0.05f && (mission_item.nav_cmd == NAV_CMD_CONDITION_GATE
-						   || last_cmd == NAV_CMD_CONDITION_GATE))) {
-				/* waypoints are at the exact same position,
-				 * which indicates an invalid mission and makes calculating
-				 * the direction from one waypoint to another impossible. */
-				mavlink_log_critical(_navigator->get_mavlink_log_pub(),
-						     "Distance between waypoints too close: %d meters",
-						     (int)dist_between_waypoints);
-
-				_navigator->get_mission_result()->warning = true;
-				return false;
 			}
 		}
 
 		last_lat = mission_item.lat;
 		last_lon = mission_item.lon;
-		last_alt = mission_item.altitude;
-		last_cmd = mission_item.nav_cmd;
 	}
 
 	/* We ran through all waypoints and have not found any distances between waypoints that are too far. */


### PR DESCRIPTION
This reverts the addition of a check against mission items that have the same position. This breaks existing MAVSDK implementations where a LOITER_TIME item is set right after a WAYPOINT with the same coordinates. It is an interim hack to allow the vehicle to hold still during a photo is captured.

The question is where not having this check would currently lead to trouble in the waypoint navigation logic. If there are potential problems, I would like to address them. 

This is just a draft PR to check CI for now. 
Would fix #14904.