### PR TITLE
fix nav_delay issue

### DIFF
--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -450,8 +450,12 @@ MissionBlock::is_mission_item_reached()
 
 	// all acceptance criteria must be met in the same iteration
 	_waypoint_position_reached_previously = _waypoint_position_reached;
-	_waypoint_position_reached = false;
-	_waypoint_yaw_reached = false;
+
+	if (!(_mission_item.nav_cmd == NAV_CMD_DELAY)) {
+		_waypoint_position_reached = false;
+		_waypoint_yaw_reached = false;
+	}
+
 	return false;
 }
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
Fixes issue https://github.com/PX4/Firmware/issues/14909. 

**Describe your solution**
The mission item NAV_CMD_DELAY sets waypoint_position_reached and waypoint_yaw_reached to true, because it does not have positional information. If it is not long enough at the waypoint, then waypoint_position_reached and waypoint_yaw_reached are set to false causing oscillating flight towards to and away from the waypoint.