### PR TITLE
Fix interactive shell with roslaunch with px4.launch

### DIFF
--- a/launch/px4.launch
+++ b/launch/px4.launch
@@ -11,8 +11,8 @@
 
     <env name="PX4_SIM_MODEL" value="$(arg vehicle)" />
     <env name="PX4_ESTIMATOR" value="$(arg est)" />
-    <arg unless="$(arg interactive)" name="px4_command_arg1" value=""/>
-    <arg     if="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+    <arg unless="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+    <arg     if="$(arg interactive)" name="px4_command_arg1" value=""/>
     <node name="sitl_$(arg ID)" pkg="px4" type="px4" output="screen" args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS -i $(arg ID) $(arg px4_command_arg1)">
     </node>
 </launch>


### PR DESCRIPTION
**Describe problem solved by this pull request**
I noticed that the px4 shell was not available when starting PX4 SITL with px4.launch. Starting px4 with `posix_sitl.launch` works without problems. 

**Describe your solution**
This seems to be due to the ordering of the sitl arguments. This PR fixes the odering, and the shell is working. 

**Additional context**
This is useful when starting px4 sitl through a roslaunch and using one of the airframe configs that exist upstream, but a model that doesn't exist upstream. 