### PR TITLE
navigator: allow mission items with same position (take 2)

### DIFF
--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -676,7 +676,6 @@ MissionFeasibilityChecker::checkDistancesBetweenWaypoints(const mission_s &missi
 
 	double last_lat = (double)NAN;
 	double last_lon = (double)NAN;
-	float last_alt = NAN;
 	int last_cmd = 0;
 
 	/* Go through all waypoints */
@@ -715,15 +714,16 @@ MissionFeasibilityChecker::checkDistancesBetweenWaypoints(const mission_s &missi
 
 				/* do not allow waypoints that are literally on top of each other */
 
-			} else if ((dist_between_waypoints < 0.05f && fabsf(last_alt - mission_item.altitude) < 0.05f) ||
-				   /* and do not allow condition gates that are at the same position as a navigation waypoint */
-				   (dist_between_waypoints < 0.05f && (mission_item.nav_cmd == NAV_CMD_CONDITION_GATE
-						   || last_cmd == NAV_CMD_CONDITION_GATE))) {
-				/* waypoints are at the exact same position,
-				 * which indicates an invalid mission and makes calculating
-				 * the direction from one waypoint to another impossible. */
+				/* and do not allow condition gates that are at the same position as a navigation waypoint */
+
+			} else if (dist_between_waypoints < 0.05f &&
+				   (mission_item.nav_cmd == NAV_CMD_CONDITION_GATE || last_cmd == NAV_CMD_CONDITION_GATE)) {
+
+				/* Waypoints and gate are at the exact same position, which indicates an
+				 * invalid mission and makes calculating the direction from one waypoint
+				 * to another impossible. */
 				mavlink_log_critical(_navigator->get_mavlink_log_pub(),
-						     "Distance between waypoints too close: %d meters",
+						     "Distance between waypoint and gate too close: %d meters",
 						     (int)dist_between_waypoints);
 
 				_navigator->get_mission_result()->warning = true;
@@ -733,7 +733,6 @@ MissionFeasibilityChecker::checkDistancesBetweenWaypoints(const mission_s &missi
 
 		last_lat = mission_item.lat;
 		last_lon = mission_item.lon;
-		last_alt = mission_item.altitude;
 		last_cmd = mission_item.nav_cmd;
 	}
 


### PR DESCRIPTION
This reverts the addition of a check against mission items that have the same position. This breaks existing MAVSDK implementations where a LOITER_TIME item is set right after a WAYPOINT with the same coordinates. It is an interim hack to allow the vehicle to hold still
during a photo is captured.

This leaves the check in place for gates where we need to be able to calculate the direction between gate and waypoint.

In my opinion this is a compromise between enabling the gate calculations added by the release and not breaking existing MAVSDK (and maybe other) implementations.

For the future I'm open to tightening to specs to disallow waypoints at the same location and making sure the current use cases can be achieved with existing implementations, DELAY, LOITER, as it makes sense.

Alternative to #14908 