### PR TITLE
Tools: fix ubuntu setup script

### DIFF
--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -146,7 +146,7 @@ if [ $(which arm-none-eabi-gcc) ]; then
 	GCC_FOUND_VER=$(echo $GCC_VER_STR | grep -c "${NUTTX_GCC_VERSION}")
 fi
 
-	if [ ! ${GCC_FOUND_VER+x} && $GCC_FOUND_VER -eq "1" ]; then
+	if [[ ! -z $GCC_FOUND_VER && $GCC_FOUND_VER -eq "1" ]]; then
 		echo "arm-none-eabi-gcc-${NUTTX_GCC_VERSION} found, skipping installation"
 
 	else


### PR DESCRIPTION
This fixes the error:
`line 149: [: missing `]'`

Fixes #14916, fixes #14888.