### PR TITLE
boards: px4_fmu-v4 fix lis3mdl rotations (internal & external)

### DIFF
--- a/boards/px4/fmu-v4/init/rc.board_sensors
+++ b/boards/px4/fmu-v4/init/rc.board_sensors
@@ -16,8 +16,8 @@ pwm_out sensor_reset 50
 
 # External I2C bus
 hmc5883 -T -X start
-lis3mdl -X start
-ist8310 -X start
+lis3mdl -X -R 2 start # mRo GPS
+ist8310 -X -R 2 start # mRo GPS
 qmc5883 -X start
 rm3100 -X start
 
@@ -27,7 +27,6 @@ ms5611 -s start
 # hmc5883 internal SPI bus is rotated 90 deg yaw
 if ! hmc5883 -T -s -R 2 start
 then
-	# lis3mdl internal SPI bus is rotated 90 deg yaw
 	lis3mdl -s start
 fi
 


### PR DESCRIPTION
![Screenshot from 2020-05-18 17-33-27](https://user-images.githubusercontent.com/84712/82261806-b5268500-992d-11ea-9a27-1a8a91b69dc1.png)

 - mag 0 (external lis3mdl) manually rotated yaw 90
 - mag 1 (external ist8310) 
 - mag 2 (internal lis3mdl) - no rotation, note y is aligned with mags 0 & 1 x

![Screenshot from 2020-05-18 17-34-59](https://user-images.githubusercontent.com/84712/82261912-eacb6e00-992d-11ea-8e22-14755921dcd2.png)

 - mag 2 (internal lis3mdl) -x aligns with mags 0 & 1 y



**EDIT** - mag2 is correct here. Mag0 (the default primary) is only correct after CAL_MAG0_ROT is applied, but `sensor_mag` is applied after.