### PR TITLE
controllib: fix implicit cast warn with clang 10

### DIFF
--- a/src/lib/controllib/BlockRandGauss.hpp
+++ b/src/lib/controllib/BlockRandGauss.hpp
@@ -78,8 +78,8 @@ public:
 
 		if (phase == 0) {
 			do {
-				float U1 = (float)rand() / RAND_MAX;
-				float U2 = (float)rand() / RAND_MAX;
+				float U1 = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
+				float U2 = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
 				V1 = 2 * U1 - 1;
 				V2 = 2 * U2 - 1;
 				S = V1 * V1 + V2 * V2;

--- a/src/lib/controllib/BlockRandUniform.hpp
+++ b/src/lib/controllib/BlockRandUniform.hpp
@@ -75,7 +75,7 @@ public:
 	virtual ~BlockRandUniform() = default;
 	float update()
 	{
-		static float rand_max = RAND_MAX;
+		static float rand_max = static_cast<float>(RAND_MAX);
 		float rand_val = rand();
 		float bounds = getMax() - getMin();
 		return getMin() + (rand_val * bounds) / rand_max;


### PR DESCRIPTION
```
clang --version
clang version 10.0.0 
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```