### PR TITLE
gps: workaround spurious GCC 10.1 warning

### DIFF
--- a/src/drivers/gps/CMakeLists.txt
+++ b/src/drivers/gps/CMakeLists.txt
@@ -38,6 +38,7 @@ px4_add_module(
 	MAIN gps
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
+		-Wno-stringop-overflow # due to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91707
 	SRCS
 		gps.cpp
 		devices/src/gps_helper.cpp


### PR DESCRIPTION
This is a workaround for a warning in GCC 10.1:
```
src/drivers/gps/devices/src/ubx.cpp:520:8: error: writing 4 bytes into a region of size 0 [-Werror=stringop-overflow=]
```

Also see:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91707

Closes #14908.