### PR TITLE
uORB: SubscriptionCallback add optional required updates for callback

### DIFF
--- a/src/modules/uORB/Subscription.hpp
+++ b/src/modules/uORB/Subscription.hpp
@@ -124,17 +124,19 @@ public:
 	 */
 	bool copy(void *dst) { return advertised() ? _node->copy(dst, _last_generation) : false; }
 
-	uint8_t		get_instance() const { return _instance; }
-	orb_id_t	get_topic() const { return get_orb_meta(_orb_id); }
-	ORB_PRIO	get_priority() { return advertised() ? _node->get_priority() : ORB_PRIO_UNINITIALIZED; }
+	uint8_t  get_instance() const { return _instance; }
+	unsigned get_last_generation() const { return _last_generation; }
+	ORB_PRIO get_priority() { return advertised() ? _node->get_priority() : ORB_PRIO_UNINITIALIZED; }
+	orb_id_t get_topic() const { return get_orb_meta(_orb_id); }
 
 protected:
 
 	friend class SubscriptionCallback;
+	friend class SubscriptionCallbackWorkItem;
 
-	DeviceNode		*get_node() { return _node; }
+	DeviceNode *get_node() { return _node; }
 
-	DeviceNode		*_node{nullptr};
+	DeviceNode *_node{nullptr};
 
 	unsigned _last_generation{0}; /**< last generation the subscriber has seen */
 


### PR DESCRIPTION
This is a new mechanism that allows uORB callbacks (how many modules are scheduled) to skip until a certain number of updates are available. This is useful when we want the scheduled module to run slower than the topic publication, but don't want to get complicate things with exact time interval limits.

Example (https://github.com/PX4/Firmware/pull/14906): perform IMU integration (delta angle, delta velocity) in the sensors module periodically (every 2-8) queued sensor_accel/sensor_gyro messages.

Broken out of https://github.com/PX4/Firmware/pull/14906.