### PR TITLE
install bc for all simulations

### DIFF
--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -173,6 +173,11 @@ if [[ $INSTALL_SIM == "true" ]]; then
 	echo
 	echo "Installing PX4 simulation dependencies"
 
+	# General simulation dependencies
+	sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
+		bc \
+		;
+
 	# Java 8 (jmavsim or fastrtps)
 	sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
 		ant \


### PR DESCRIPTION
**Describe problem solved by this pull request**
bc is not always installed on ubuntu machines and since https://github.com/PX4/Firmware/commit/735749e341e51c31abe843593da7ba8f3bc97e0d it is required for the rcS script to run.

```
etc/init.d-posix/rcS: 198: etc/init.d-posix/rcS: bc: not found
COM_DL_LOSS_T set to 
ERROR [param] not enough arguments.
Try 'param set PARAM_NAME 3 [fail]'
etc/init.d-posix/rcS: 202: etc/init.d-posix/rcS: bc: not found
COM_RC_LOSS_T set to 
ERROR [param] not enough arguments.
Try 'param set PARAM_NAME 3 [fail]'
etc/init.d-posix/rcS: 206: etc/init.d-posix/rcS: bc: not found
```

**Describe your solution**
Install bc for all simulation targets.