### PR TITLE
Tune down solo attitude rate controller

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/1014_solo
+++ b/ROMFS/px4fmu_common/init.d-posix/1014_solo
@@ -9,8 +9,8 @@ sh /etc/init.d/rc.mc_defaults
 
 if [ $AUTOCNF = yes ]
 then
-	param set MC_PITCHRATE_P 0.15
-	param set MC_ROLLRATE_P 0.15
+	param set MC_PITCHRATE_P 0.1
+	param set MC_ROLLRATE_P 0.1
 fi
 
 set MIXER quad_x


### PR DESCRIPTION
**Describe problem solved by this pull request**
The solo model was showing visible oscillations while flying. 

**Describe your solution**
Tuning down the rate controller removes the oscillations. 

**Test data / coverage**
Before PR: 
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/5248102/82563891-222d5b00-9b78-11ea-9c3b-191fa87a16eb.gif)
Log: https://review.px4.io/plot_app?log=4bd411a0-818e-4cdc-96d7-27f796088eb3

After PR: 
Log: https://review.px4.io/plot_app?log=9aafa587-8c42-4d85-bddb-8a3768d7171e

**Additional Context**
Fixes https://github.com/PX4/Firmware/issues/11405
