### PR TITLE
stm32_common:board_hw_rev_ver Fix printing of REV/VER = 10

### DIFF
--- a/platforms/nuttx/src/px4/stm/stm32_common/board_hw_info/board_hw_rev_ver.c
+++ b/platforms/nuttx/src/px4/stm/stm32_common/board_hw_info/board_hw_rev_ver.c
@@ -341,8 +341,13 @@ int board_determine_hw_info()
 	int rv = determine_hw_info(&hw_revision, &hw_version);
 
 	if (rv == OK) {
-		hw_info[HW_INFO_INIT_REV] = board_get_hw_revision() + '0';
-		hw_info[HW_INFO_INIT_VER] = board_get_hw_version() + '0';
+
+		hw_info[HW_INFO_INIT_REV] = board_get_hw_revision() < 10 ?
+					    board_get_hw_revision() + '0' :
+					    board_get_hw_revision() + 'a' - 10;
+		hw_info[HW_INFO_INIT_VER] = board_get_hw_version()  < 10 ?
+					    board_get_hw_version() + '0' :
+					    board_get_hw_version()  + 'a' - 10;
 	}
 
 	return rv;


### PR DESCRIPTION
Code point 10 (0xa) was mis-printed.
REV 0..10 is shown below
```
HW type:   V6X00
HW type:   V6X01
HW type:   V6X02
HW type:   V6X03
HW type:   V6X04
HW type:   V6X05
HW type:   V6X06
HW type:   V6X07
HW type:   V6X08
HW type:   V6X09
HW type:   V6X0a
```