### PR TITLE
Fix `-jN` argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,9 @@ ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 MAKE_PID := $(shell echo $$PPID)
 j := $(shell ps T | sed -n 's/.*$(MAKE_PID).*$(MAKE).* \(-j\|--jobs\) *\([0-9][0-9]*\).*/\2/p')
 
+# Default j for clang-tidy
+j_clang_tidy := $(or $(j),4)
+
 NINJA_BIN := ninja
 ifndef NO_NINJA_BUILD
 	NINJA_BUILD := $(shell $(NINJA_BIN) --version 2>/dev/null)
@@ -429,16 +432,16 @@ px4_sitl_default-clang:
 	@$(PX4_MAKE) -C "$(SRC_DIR)"/build/px4_sitl_default-clang
 
 clang-tidy: px4_sitl_default-clang
-	@cd "$(SRC_DIR)"/build/px4_sitl_default-clang && "$(SRC_DIR)"/Tools/run-clang-tidy.py -header-filter=".*\.hpp" -j$(j) -p .
+	@cd "$(SRC_DIR)"/build/px4_sitl_default-clang && "$(SRC_DIR)"/Tools/run-clang-tidy.py -header-filter=".*\.hpp" -j$(j_clang_tidy) -p .
 
 # to automatically fix a single check at a time, eg modernize-redundant-void-arg
 #  % run-clang-tidy-4.0.py -fix -j4 -checks=-\*,modernize-redundant-void-arg -p .
 clang-tidy-fix: px4_sitl_default-clang
-	@cd "$(SRC_DIR)"/build/px4_sitl_default-clang && "$(SRC_DIR)"/Tools/run-clang-tidy.py -header-filter=".*\.hpp" -j$(j) -fix -p .
+	@cd "$(SRC_DIR)"/build/px4_sitl_default-clang && "$(SRC_DIR)"/Tools/run-clang-tidy.py -header-filter=".*\.hpp" -j$(j_clang_tidy) -fix -p .
 
 # modified version of run-clang-tidy.py to return error codes and only output relevant results
 clang-tidy-quiet: px4_sitl_default-clang
-	@cd "$(SRC_DIR)"/build/px4_sitl_default-clang && "$(SRC_DIR)"/Tools/run-clang-tidy.py -header-filter=".*\.hpp" -j$(j) -p .
+	@cd "$(SRC_DIR)"/build/px4_sitl_default-clang && "$(SRC_DIR)"/Tools/run-clang-tidy.py -header-filter=".*\.hpp" -j$(j_clang_tidy) -p .
 
 # TODO: Fix cppcheck errors then try --enable=warning,performance,portability,style,unusedFunction or --enable=all
 cppcheck: px4_sitl_default

--- a/Makefile
+++ b/Makefile
@@ -92,9 +92,9 @@ ifdef NINJA_BUILD
 	PX4_MAKE := $(NINJA_BIN)
 
 	ifdef VERBOSE
-		PX4_MAKE_ARGS := -v
+		PX4_MAKE_ARGS := -j $(j) -v
 	else
-		PX4_MAKE_ARGS :=
+		PX4_MAKE_ARGS := -j $(j)
 	endif
 else
 	ifdef SYSTEMROOT

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ############################################################################
 #
-# Copyright (c) 2015 - 2019 PX4 Development Team. All rights reserved.
+# Copyright (c) 2015 - 2020 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -69,7 +69,13 @@ space := $(subst ,, )
 # by cmake in the subdirectory
 FIRST_ARG := $(firstword $(MAKECMDGOALS))
 ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
-j ?= 4
+
+# Get -j or --jobs argument as suggested in:
+# https://stackoverflow.com/a/33616144/8548472
+MAKE_PID := $(shell echo $$PPID)
+j := $(shell ps T | sed -n 's/.*$(MAKE_PID).*$(MAKE).* \(-j\|--jobs\) *\([0-9][0-9]*\).*/\2/p')
+# Default to 4
+j := $(or $(j),4)
 
 NINJA_BIN := ninja
 ifndef NO_NINJA_BUILD

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,6 @@ ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 # https://stackoverflow.com/a/33616144/8548472
 MAKE_PID := $(shell echo $$PPID)
 j := $(shell ps T | sed -n 's/.*$(MAKE_PID).*$(MAKE).* \(-j\|--jobs\) *\([0-9][0-9]*\).*/\2/p')
-# Default to 4
-j := $(or $(j),4)
 
 NINJA_BIN := ninja
 ifndef NO_NINJA_BUILD
@@ -92,9 +90,14 @@ ifdef NINJA_BUILD
 	PX4_MAKE := $(NINJA_BIN)
 
 	ifdef VERBOSE
-		PX4_MAKE_ARGS := -j $(j) -v
+		PX4_MAKE_ARGS := -v
 	else
-		PX4_MAKE_ARGS := -j $(j)
+		PX4_MAKE_ARGS :=
+	endif
+
+	# Only override ninja default if -j is set.
+	ifneq ($(j),)
+		PX4_MAKE_ARGS := $(PX4_MAKE_ARGS) -j$(j)
 	endif
 else
 	ifdef SYSTEMROOT
@@ -103,6 +106,9 @@ else
 	else
 		PX4_CMAKE_GENERATOR := "Unix\ Makefiles"
 	endif
+
+	# For non-ninja builds we default to -j4
+	j := $(or $(j),4)
 	PX4_MAKE = $(MAKE)
 	PX4_MAKE_ARGS = -j$(j) --no-print-directory
 endif


### PR DESCRIPTION
It turns out the `-jN` argument was never actually used in the Makefile but always set to 4 for Makefile build. Ninja seemed to run with whatever is the system default.

With this change both Makefile and Ninja builds will now adhere to the j argument if it is set.

This should allow to build the Gazebo plugins will less core in order not to run out of RAM.
Related to:
https://github.com/PX4/Firmware/issues/14747
https://github.com/PX4/Firmware/issues/14430
https://github.com/PX4/Firmware/issues/14943