### PR TITLE
Slow down vision velocity mavsdk test

### DIFF
--- a/test/mavsdk_tests/autopilot_tester.cpp
+++ b/test/mavsdk_tests/autopilot_tester.cpp
@@ -262,6 +262,10 @@ bool AutopilotTester::ground_truth_horizontal_position_close_to(const Telemetry:
 	CHECK(std::isfinite(current_pos.latitude_deg));
 	CHECK(std::isfinite(current_pos.longitude_deg));
 	LocalCoordinate local_pos = ct.local_from_global(GlobalCoordinate{current_pos.latitude_deg, current_pos.longitude_deg});
+	const double distance = sqrt(sq(local_pos.north_m) + sq(local_pos.east_m));
 
-	return sq(local_pos.north_m) + sq(local_pos.east_m) < sq(acceptance_radius_m);
+	std::cout << "Target:  " << target_pos << std::endl;
+	std::cout << "Current: " << current_pos << std::endl;
+	std::cout << "Distance: " << distance << std::endl;
+	return distance < acceptance_radius_m;
 }

--- a/test/mavsdk_tests/configs/sitl.json
+++ b/test/mavsdk_tests/configs/sitl.json
@@ -20,7 +20,8 @@
             "model": "iris_vision_velocity",
             "vehicle": "iris_vision",
             "test_filter": "[multicopter][offboard][nogps]",
-            "timeout_min": 10
+            "timeout_min": 10,
+            "max_speed_factor": 1
         },
         {
             "model": "iris_vision",


### PR DESCRIPTION
Locally, the vision velocity test was failing from time to time. After limiting the speed factor to 1 for this model, I am under the impression that it got more robust. I just ran the tests for 10+ runs without failure, which was for me not possible before.

Additionally a printout in the comparison to the ground truth is added. This helps to investigate if there is something odd with the ground truth data. 