### PR TITLE
enable precision landing at the end of RTL

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -143,6 +143,10 @@ Mission::on_inactivation()
 	cmd.param1 = -1.0f;
 	cmd.param3 = 1.0f;
 	_navigator->publish_vehicle_cmd(&cmd);
+
+	if (_navigator->get_precland()->is_activated()) {
+		_navigator->get_precland()->on_inactivation();
+	}
 }
 
 void
@@ -174,17 +178,6 @@ Mission::on_activation()
 void
 Mission::on_active()
 {
-	if (_work_item_type == WORK_ITEM_TYPE_PRECISION_LAND) {
-		// switch out of precision land once landed
-		if (_navigator->get_land_detected()->landed) {
-			_navigator->get_precland()->on_inactivation();
-			_work_item_type = WORK_ITEM_TYPE_DEFAULT;
-
-		} else {
-			_navigator->get_precland()->on_active();
-		}
-	}
-
 	check_mission_valid(false);
 
 	/* check if anything has changed */
@@ -269,6 +262,13 @@ Mission::on_active()
 	    && (_navigator->abort_landing())) {
 
 		do_abort_landing();
+	}
+
+	if (_work_item_type == WORK_ITEM_TYPE_PRECISION_LAND) {
+		_navigator->get_precland()->on_active();
+
+	} else if (_navigator->get_precland()->is_activated()) {
+		_navigator->get_precland()->on_inactivation();
 	}
 }
 

--- a/src/modules/navigator/precland.cpp
+++ b/src/modules/navigator/precland.cpp
@@ -101,6 +101,8 @@ PrecLand::on_activation()
 	_last_slewrate_time = 0;
 
 	switch_to_state_start();
+
+	_is_activated = true;
 }
 
 void
@@ -156,6 +158,12 @@ PrecLand::on_active()
 		break;
 	}
 
+}
+
+void
+PrecLand::on_inactivation()
+{
+	_is_activated = false;
 }
 
 void

--- a/src/modules/navigator/precland.h
+++ b/src/modules/navigator/precland.h
@@ -72,10 +72,13 @@ public:
 
 	void on_activation() override;
 	void on_active() override;
+	void on_inactivation() override;
 
 	void set_mode(PrecLandMode mode) { _mode = mode; };
 
 	PrecLandMode get_mode() { return _mode; };
+
+	bool is_activated() { return _is_activated; };
 
 private:
 
@@ -124,6 +127,8 @@ private:
 	PrecLandState _state{PrecLandState::Start};
 
 	PrecLandMode _mode{PrecLandMode::Opportunistic};
+
+	bool _is_activated {false}; /**< indicates if precland is activated */
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::PLD_BTOUT>) _param_pld_btout,

--- a/src/modules/navigator/rtl.h
+++ b/src/modules/navigator/rtl.h
@@ -70,6 +70,7 @@ public:
 
 	~RTL() = default;
 
+	void on_inactivation() override;
 	void on_inactive() override;
 	void on_activation() override;
 	void on_active() override;
@@ -137,6 +138,7 @@ private:
 		(ParamFloat<px4::params::RTL_LAND_DELAY>) _param_rtl_land_delay,
 		(ParamFloat<px4::params::RTL_MIN_DIST>) _param_rtl_min_dist,
 		(ParamInt<px4::params::RTL_TYPE>) _param_rtl_type,
-		(ParamInt<px4::params::RTL_CONE_ANG>) _param_rtl_cone_half_angle_deg
+		(ParamInt<px4::params::RTL_CONE_ANG>) _param_rtl_cone_half_angle_deg,
+		(ParamInt<px4::params::RTL_PLD_MD>) _param_rtl_pld_md
 	)
 };

--- a/src/modules/navigator/rtl_params.c
+++ b/src/modules/navigator/rtl_params.c
@@ -135,3 +135,15 @@ PARAM_DEFINE_INT32(RTL_TYPE, 0);
  * @group Return Mode
  */
 PARAM_DEFINE_INT32(RTL_CONE_ANG, 0);
+
+/**
+ * RTL precision land mode
+ *
+ * Use precision landing when doing an RTL landing phase.
+ *
+ * @value 0 No precision landing
+ * @value 1 Opportunistic precision landing
+ * @value 2 Required precision landing
+ * @group Return To Land
+ */
+PARAM_DEFINE_INT32(RTL_PLD_MD, 0);


### PR DESCRIPTION
**Describe problem solved by this pull request**
Enables precision landing at the end of RTL, configurable with a parameter

Also mission precland call logic is cleaned up to be more readable, and switched to be at the end of mission on_active, so it can perform an iteration of precland as soon as it switches to using it, keeping precland on_inactiavtion being handled properly.
