### PR TITLE
precland: set the previous position setpoint to invalid

### DIFF
--- a/src/modules/navigator/precland.cpp
+++ b/src/modules/navigator/precland.cpp
@@ -85,6 +85,7 @@ PrecLand::on_activation()
 	position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 
 	pos_sp_triplet->next.valid = false;
+	pos_sp_triplet->previous.valid = false;
 
 	// Check that the current position setpoint is valid, otherwise land at current position
 	if (!pos_sp_triplet->current.valid) {


### PR DESCRIPTION
**Describe problem solved by this pull request**
Previous and next position setpoint triplets are used by flight tasks to properly adjust the vehicle velocity depending on the prev-current-next path curving angle.

While performing precision landing there is no such concept as a path in horizontal plan. The goal is to land and to control the desired horizontal position setpoint.

Precland never adjusts previous setpoint so it will be stuck at whatever it was before precision landing for the whole precland procedure. During the precision landing the drone can get pushed away (wind) in any direction and prevoius sp being something old looses sense and can unnecessary impose wrong limits to the velocity sp.

**Proposed solution**
My suggestion is to set the previous triplet to invalid such that the flight task during precland always tries to reach the current setpoint starting from the current position.
Note: Flight task already sets the previous wp to current position if prev triplet is not valid.
