### PR TITLE
ROMFS: holybro s500 decrease filter defaults

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4015_holybro_s500
+++ b/ROMFS/px4fmu_common/init.d/airframes/4015_holybro_s500
@@ -18,8 +18,8 @@ set PWM_OUT 1234
 
 if [ $AUTOCNF = yes ]
 then
-	param set IMU_GYRO_CUTOFF 80
-	param set IMU_DGYRO_CUTOFF 40
+	param set IMU_GYRO_CUTOFF 60
+	param set IMU_DGYRO_CUTOFF 30
 	param set MC_ROLLRATE_P 0.14
 	param set MC_PITCHRATE_P 0.14
 	param set MC_ROLLRATE_I 0.3


### PR DESCRIPTION
This was problematic on @dakejahl's (stock?) holybro s500. Decreasing to a safer conservative default.