### PR TITLE
mission: keep current heading if close to ROI while heading sp is invalid

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -1321,6 +1321,7 @@ Mission::heading_sp_update()
 		case vehicle_roi_s::ROI_TARGET:
 		case vehicle_roi_s::ROI_ENUM_END:
 		default: {
+				return;
 			}
 		}
 
@@ -1339,6 +1340,13 @@ Mission::heading_sp_update()
 			_mission_item.yaw = yaw;
 			pos_sp_triplet->current.yaw = _mission_item.yaw;
 			pos_sp_triplet->current.yaw_valid = true;
+
+		} else {
+			if (!pos_sp_triplet->current.yaw_valid) {
+				_mission_item.yaw = _navigator->get_local_position()->yaw;
+				pos_sp_triplet->current.yaw = _mission_item.yaw;
+				pos_sp_triplet->current.yaw_valid = true;
+			}
 		}
 
 		// we set yaw directly so we can run this in parallel to the FOH update


### PR DESCRIPTION
**Short recap of how things work:**
When uploading a mission item of type waypont a yaw setpoint can be provided and it can be set ether to some value or to NAN.
On the other hand the mission can also contain an ROI.

- If a mission doesnt have ROI set:
      - mission item yaw is used if not NAN
      - if mission item yaw is NAN then the yaw is computed based on a MPC_YAW_MODE 
        parameter
- If a mission contains the ROI, yaw sp is computed from the ROI and that overrides the heading sp from the mission item. If the drone is close to the ROI then no new heading sp is computed and the triplet is unchanged.

**The problem rises when the mission starts close to the ROI:**
Triplet yaw sp is set according to the mission item (NAN since ROI is used), and then when it is supposed to be overridden by the yaw computed from the ROI, its not, so it uses the MPC_YAW_MODE logic.

This causes the drone to yaw (for example toward the waypoint) until it is far enough from the ROI and then yaws back to towards the ROI.

In the extreme case i made an experiment where i sent the drone to the position (x,y,z,yaw_degrees):
(-6,0,4,180) and then uploaded a new mission to the waypoint (0,0,4,180) while the ROI was set to (x=-6,y=0, z=4). The drone shouldnt have changed the heading at all but what happened is that it yawed from 180 deg to 0 (towards waypoint) and then strait back from 0 to 180 deg (towards ROI).

**Describe your solution**
I am proposing that in case when the ROI is supposed to be used, but the yaw setpoint is invalid, there is no point in keeping the old setpoint since its invalid, NAN (ant triggers different logic), but keep the current local position yaw.

I added a return from this function `heading_sp_update()` in cases where the heading would be kept the same anyway so my changes dont override NAN yaw with the current yaw. I assume in those cases NAN is actually supposed to be sent (In ROI_NONE case it is).

**Test data / coverage**
Tested in simulation for the case where 2 missions were uploaded one after another both with yaw=NAN, and the roi of the second mission was the last waypoint of the first mission. With this fix the drone didnt unexpectedly yaw away from the ROI until it got far enough.
