### PR TITLE
Small fix for Hex CubeYellow

### DIFF
--- a/boards/hex/cube-orange/default.cmake
+++ b/boards/hex/cube-orange/default.cmake
@@ -37,7 +37,6 @@ px4_add_board(
 		imu/invensense/icm20602
 		imu/invensense/icm20649
 		imu/invensense/icm20948
-		imu/lsm303d
 		irlock
 		lights/blinkm
 		lights/rgbled

--- a/boards/hex/cube-orange/src/board_config.h
+++ b/boards/hex/cube-orange/src/board_config.h
@@ -89,10 +89,6 @@
 /* HW has to large of R termination on ADC todo:change when HW value is chosen */
 #define BOARD_ADC_OPEN_CIRCUIT_V     (5.6f)
 
-/* CAN Silence Silent mode control */
-#define GPIO_CAN1_SILENT_S0  /* PH2  */ (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTH|GPIO_PIN2)
-#define GPIO_CAN2_SILENT_S1  /* PH3  */ (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTH|GPIO_PIN3)
-
 /* PWM */
 #define DIRECT_PWM_OUTPUT_CHANNELS  6
 #define GPIO_PWM_VOLT_SEL    /* PB4  */ (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTB|GPIO_PIN4)
@@ -161,8 +157,6 @@
 		GPIO_CAN1_RX,                     \
 		GPIO_CAN2_TX,                     \
 		GPIO_CAN2_RX,                     \
-		GPIO_CAN1_SILENT_S0,              \
-		GPIO_CAN2_SILENT_S1,              \
 		GPIO_PWM_VOLT_SEL,                \
 		GPIO_nVDD_BRICK1_VALID,           \
 		GPIO_nVDD_BRICK1_VALID,           \

--- a/boards/hex/cube-orange/src/board_config.h
+++ b/boards/hex/cube-orange/src/board_config.h
@@ -110,7 +110,7 @@
 #define RCC_APB1ENR_TIM5EN		RCC_APB1LENR_TIM5EN /* This is stupid and only applies for H7 */
 #define RCC_APB1RSTR_TIM5RST		RCC_APB1LRSTR_TIM5RST /* This is stupid and only applies for H7 */
 #define TONE_ALARM_TIMER        2  /* timer 2 */
-#define TONE_ALARM_CHANNEL      1  /* PE15 TIM2_CH1 */
+#define TONE_ALARM_CHANNEL      1  /* PA15 TIM2_CH1 */
 
 #define GPIO_BUZZER_1           /* PA15 */ (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTA|GPIO_PIN15) // ALARM
 

--- a/boards/hex/cube-orange/src/spi.cpp
+++ b/boards/hex/cube-orange/src/spi.cpp
@@ -49,7 +49,6 @@ constexpr px4_spi_bus_t px4_spi_buses[SPI_BUS_MAX_BUS_ITEMS] = {
 		initSPIDevice(DRV_IMU_DEVTYPE_ICM20948, SPI::CS{GPIO::PortE, GPIO::Pin4}),  // MPU_EXT_CS
 		initSPIDevice(DRV_IMU_DEVTYPE_ICM20602, SPI::CS{GPIO::PortC, GPIO::Pin13}), // GYRO_EXT_CS
 		initSPIDevice(DRV_BARO_DEVTYPE_MS5611, 	SPI::CS{GPIO::PortC, GPIO::Pin14}), // BARO_EXT_CS
-		initSPIDevice(DRV_IMU_DEVTYPE_LSM303D, 	SPI::CS{GPIO::PortC, GPIO::Pin15}), // ACCEL_MAG_EXT_CS
 	}),
 };
 


### PR DESCRIPTION
- The new IMU board in the CubeYellow has no LSM303D, pin PC15 is not used
- CAN Silence Silent mode control is not used
- Small naming fix for tone alarm pin


