### PR TITLE
sensors/vehicle_imu: improve initial sensor interval monitoring

### DIFF
--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -636,6 +636,7 @@ int Sensors::print_status()
 
 	for (auto &i : _vehicle_imu_list) {
 		if (i != nullptr) {
+			PX4_INFO_RAW("\n");
 			i->PrintStatus();
 		}
 	}

--- a/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
@@ -39,6 +39,7 @@
 
 #include <lib/mathlib/math/Limits.hpp>
 #include <lib/matrix/matrix/math.hpp>
+#include <lib/perf/perf_counter.h>
 #include <px4_platform_common/log.h>
 #include <px4_platform_common/module_params.h>
 #include <px4_platform_common/px4_config.h>
@@ -102,6 +103,9 @@ private:
 	IntervalAverage _accel_interval{};
 	IntervalAverage _gyro_interval{};
 
+	unsigned _accel_last_generation{0};
+	unsigned _gyro_last_generation{0};
+
 	uint32_t _accel_error_count{0};
 	uint32_t _gyro_error_count{0};
 
@@ -113,6 +117,13 @@ private:
 
 	uint8_t _delta_velocity_clipping{0};
 	uint32_t _delta_velocity_clipping_total[3] {};
+
+	bool _intervals_configured{false};
+
+	perf_counter_t _accel_update_perf{perf_alloc(PC_INTERVAL, MODULE_NAME": accel update interval")};
+	perf_counter_t _accel_generation_gap_perf{perf_alloc(PC_COUNT, MODULE_NAME": accel data gap")};
+	perf_counter_t _gyro_update_perf{perf_alloc(PC_INTERVAL, MODULE_NAME": gyro update interval")};
+	perf_counter_t _gyro_generation_gap_perf{perf_alloc(PC_COUNT, MODULE_NAME": gyro data gap")};
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::IMU_INTEG_RATE>) _param_imu_integ_rate

--- a/src/modules/uORB/SubscriptionInterval.hpp
+++ b/src/modules/uORB/SubscriptionInterval.hpp
@@ -135,8 +135,9 @@ public:
 	bool		valid() const { return _subscription.valid(); }
 
 	uint8_t		get_instance() const { return _subscription.get_instance(); }
-	orb_id_t	get_topic() const { return _subscription.get_topic(); }
+	unsigned	get_last_generation() const { return _subscription.get_last_generation(); }
 	ORB_PRIO	get_priority() { return _subscription.get_priority(); }
+	orb_id_t	get_topic() const { return _subscription.get_topic(); }
 
 	/**
 	 * Set the interval in microseconds


### PR DESCRIPTION
The IMU integration now in the sensors module has to measure the actual sensor publication rate before relaxing its scheduling. With this PR `sensors/vehicle_imu` consumes every available queued sample until there's an initial measurement for the sensor publication interval.

I've also readded the perf counters for monitoring (they were helpful in https://github.com/PX4/Firmware/pull/15002 and https://github.com/PX4/Firmware/pull/14999). 
