### PR TITLE
sensors: don't allow mavlink error spamming

### DIFF
--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
@@ -252,13 +252,18 @@ void VehicleAirData::Run()
 
 		} else {
 			if (failover_index != -1) {
-				mavlink_log_emergency(&_mavlink_log_pub, "sensor_baro:#%i failed: %s%s%s%s%s!, reconfiguring priorities",
-						      failover_index,
-						      ((flags & DataValidator::ERROR_FLAG_NO_DATA) ? " OFF" : ""),
-						      ((flags & DataValidator::ERROR_FLAG_STALE_DATA) ? " STALE" : ""),
-						      ((flags & DataValidator::ERROR_FLAG_TIMEOUT) ? " TIMEOUT" : ""),
-						      ((flags & DataValidator::ERROR_FLAG_HIGH_ERRCOUNT) ? " ERR CNT" : ""),
-						      ((flags & DataValidator::ERROR_FLAG_HIGH_ERRDENSITY) ? " ERR DNST" : ""));
+				const hrt_abstime now = hrt_absolute_time();
+
+				if (now - _last_error_message > 3_s) {
+					mavlink_log_emergency(&_mavlink_log_pub, "sensor_baro:#%i failed: %s%s%s%s%s!, reconfiguring priorities",
+							      failover_index,
+							      ((flags & DataValidator::ERROR_FLAG_NO_DATA) ? " OFF" : ""),
+							      ((flags & DataValidator::ERROR_FLAG_STALE_DATA) ? " STALE" : ""),
+							      ((flags & DataValidator::ERROR_FLAG_TIMEOUT) ? " TIMEOUT" : ""),
+							      ((flags & DataValidator::ERROR_FLAG_HIGH_ERRCOUNT) ? " ERR CNT" : ""),
+							      ((flags & DataValidator::ERROR_FLAG_HIGH_ERRDENSITY) ? " ERR DNST" : ""));
+					_last_error_message = now;
+				}
 
 				// reduce priority of failed sensor to the minimum
 				_priority[failover_index] = ORB_PRIO_MIN;

--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
@@ -87,6 +87,7 @@ private:
 
 	perf_counter_t _cycle_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")};
 
+	hrt_abstime _last_error_message{0};
 	orb_advert_t _mavlink_log_pub{nullptr};
 
 	DataValidatorGroup _voter{1};

--- a/src/modules/sensors/voted_sensors_update.h
+++ b/src/modules/sensors/voted_sensors_update.h
@@ -185,6 +185,7 @@ private:
 	SensorData _gyro{ORB_ID::sensor_gyro};
 	SensorData _mag{ORB_ID::sensor_mag};
 
+	hrt_abstime _last_error_message{0};
 	orb_advert_t _mavlink_log_pub{nullptr};
 
 	uORB::Publication<sensor_selection_s> _sensor_selection_pub{ORB_ID(sensor_selection)};	/**< handle to the sensor selection uORB topic */


### PR DESCRIPTION
 - in rare situations spewing these errors at high rate can actually
cause another sensor timeout

``` Console
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
ERROR [vehicle_air_data] sensor_baro:#0 failed:  TIMEOUT!, reconfiguring priorities
```