### PR TITLE
ms5611: prevent starting as ms5607 on ms5611

### DIFF
--- a/src/drivers/barometer/ms5611/ms5611.cpp
+++ b/src/drivers/barometer/ms5611/ms5611.cpp
@@ -107,6 +107,11 @@ MS5611::init()
 				/* This is likely not this device, abort */
 				ret = -EINVAL;
 				break;
+
+			} else if (brp.pressure > 1500.0f) {
+				/* This is likely not this device, abort */
+				ret = -EINVAL;
+				break;
 			}
 		}
 


### PR DESCRIPTION
This fixes the baro misdetection on fmu-v3.

### Pixhawk 2 Cube master
``` Console
nsh> listener sensor_baro

TOPIC: sensor_baro 2 instances

Instance 0:
 sensor_baro_s
        timestamp: 35532668  (0.007856 seconds ago)
        error_count: 0
        device_id: 4063242 (Type: 0x3E, SPI:1 (0x00)) 
        pressure: 2028.9800
        temperature: 47.0000

Instance 1:
 sensor_baro_s
        timestamp: 35533604  (0.009471 seconds ago)
        error_count: 0
        device_id: 3997730 (Type: 0x3D, SPI:4 (0x00)) 
        pressure: 1014.1700
        temperature: 38.9600


INFO  [vehicle_air_data] selected barometer: 4063242 (0)
INFO  [ecl/validation] validator: best: 0, prev best: 0, failsafe: NO (0 events)
INFO  [ecl/validation] sensor #0, prio: 75, state: OK
INFO  [ecl/validation]  val: 202884.0000, lp: 202882.9531 mean dev:   1.6257 RMS:   6.6592 conf:   1.0000
INFO  [ecl/validation]  val:  46.9100, lp:  46.9129 mean dev:   0.0251 RMS:   0.0312 conf:   1.0000
INFO  [ecl/validation]  val:   0.0000, lp:   0.0000 mean dev:   0.0000 RMS:   0.0000 conf:   1.0000
INFO  [ecl/validation] sensor #1, prio: 75, state: OK
INFO  [ecl/validation]  val: 101415.0000, lp: 101412.6484 mean dev:   1.5330 RMS:   3.5353 conf:   1.0000
INFO  [ecl/validation]  val:  38.7500, lp:  38.7346 mean dev:   0.0563 RMS:   0.0412 conf:   1.0000
INFO  [ecl/validation]  val:   0.0000, lp:   0.0000 mean dev:   0.0000 RMS:   0.0000 conf:   1.0000
```

### Pixhawk 2 Cube PR
``` Console
nsh> listener sensor_baro

TOPIC: sensor_baro 2 instances

Instance 0:
 sensor_baro_s
        timestamp: 47864125  (0.017429 seconds ago)
        error_count: 0
        device_id: 3997706 (Type: 0x3D, SPI:1 (0x00)) 
        pressure: 1014.4800
        temperature: 47.5000

Instance 1:
 sensor_baro_s
        timestamp: 47878940  (0.003706 seconds ago)
        error_count: 0
        device_id: 3997730 (Type: 0x3D, SPI:4 (0x00)) 
        pressure: 1014.1400
        temperature: 39.6700


INFO  [vehicle_air_data] selected barometer: 3997706 (0)
INFO  [ecl/validation] validator: best: 0, prev best: 0, failsafe: NO (0 events)
INFO  [ecl/validation] sensor #0, prio: 75, state: OK
INFO  [ecl/validation]  val: 101438.9922, lp: 101437.6641 mean dev:   0.3301 RMS:   3.1607 conf:   1.0000
INFO  [ecl/validation]  val:  45.2100, lp:  45.1989 mean dev:   0.0481 RMS:   0.0300 conf:   1.0000
INFO  [ecl/validation]  val:   0.0000, lp:   0.0000 mean dev:   0.0000 RMS:   0.0000 conf:   1.0000
INFO  [ecl/validation] sensor #1, prio: 75, state: OK
INFO  [ecl/validation]  val: 101409.0000, lp: 101411.1953 mean dev:   1.8527 RMS:   3.3362 conf:   1.0000
INFO  [ecl/validation]  val:  36.0100, lp:  35.9612 mean dev:   0.0985 RMS:   0.0358 conf:   1.0000
INFO  [ecl/validation]  val:   0.0000, lp:   0.0000 mean dev:   0.0000 RMS:   0.0000 conf:   1.0000
```