### PR TITLE
Hex/Proficnc Cube Orange LSE fix, PLL comment fix

### DIFF
--- a/boards/hex/cube-orange/nuttx-config/include/board.h
+++ b/boards/hex/cube-orange/nuttx-config/include/board.h
@@ -60,7 +60,7 @@
 #define STM32_HSI_FREQUENCY     16000000ul
 #define STM32_LSI_FREQUENCY     32000
 #define STM32_HSE_FREQUENCY     STM32_BOARD_XTAL
-#define STM32_LSE_FREQUENCY     32768
+#define STM32_LSE_FREQUENCY     0
 
 /* Main PLL Configuration.
  *

--- a/boards/hex/cube-orange/nuttx-config/include/board.h
+++ b/boards/hex/cube-orange/nuttx-config/include/board.h
@@ -64,7 +64,7 @@
 
 /* Main PLL Configuration.
  *
- * PLL source is HSE = 16,000,000
+ * PLL source is HSE = 24,000,000
  *
  * PLL_VCOx = (STM32_HSE_FREQUENCY / PLLM) * PLLN
  * Subject to:
@@ -86,7 +86,7 @@
 
 /* PLL1, wide 4 - 8 MHz input, enable DIVP, DIVQ, DIVR
  *
- *   PLL1_VCO = (16,000,000 / 1) * 60 = 960 MHz
+ *   PLL1_VCO = (24,000,000 / 2) * 80 = 960 MHz
  *
  *   PLL1P = PLL1_VCO/2  = 960 MHz / 2   = 480 MHz
  *   PLL1Q = PLL1_VCO/4  = 960 MHz / 4   = 240 MHz


### PR DESCRIPTION
- Remove LSE because there is no LSE available in the Cube Orange
- Fix comment of PLL calc