### PR TITLE
Gyro filtering: apply IMU_GYRO_CUTOFF also to D-term

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -151,8 +151,6 @@ then
 	# LPE: GPS only mode
 	param set LPE_FUSION 145
 
-	# Simulator IMU data provided at 250 Hz
-	param set IMU_INTEG_RATE 250
 
 	param set MC_PITCH_P 6
 	param set MC_PITCHRATE_P 0.2
@@ -192,6 +190,9 @@ then
 fi
 
 param set COM_CPU_MAX -1 # disable check, no CPU load reported on posix yet
+
+# Simulator IMU data provided at 250 Hz
+param set IMU_INTEG_RATE 250
 
 # Adapt timeout parameters if simulation runs faster or slower than realtime.
 if [ ! -z $PX4_SIM_SPEED_FACTOR ]; then

--- a/ROMFS/px4fmu_common/init.d/airframes/4050_generic_250
+++ b/ROMFS/px4fmu_common/init.d/airframes/4050_generic_250
@@ -51,5 +51,8 @@ then
 	# disable RC filtering
 	param set RC_FLT_CUTOFF 0
 
+	param set IMU_DGYRO_CUTOFF 50
+	param set IMU_GYRO_CUTOFF 90
+
 	param set CBRK_IO_SAFETY 22027
 fi

--- a/ROMFS/px4fmu_common/init.d/airframes/4053_holybro_kopis2
+++ b/ROMFS/px4fmu_common/init.d/airframes/4053_holybro_kopis2
@@ -17,6 +17,8 @@ sh /etc/init.d/rc.mc_defaults
 set MIXER quad_x
 set PWM_OUT 1234
 
+set PARAM_DEFAULTS_VER 2
+
 if [ $AUTOCNF = yes ]
 then
 	param set BAT_N_CELLS 4
@@ -24,18 +26,19 @@ then
 	param set GPS_1_CONFIG 0
 	param set RC_PORT_CONFIG 201
 
-	param set IMU_GYRO_CUTOFF 120
-	param set IMU_DGYRO_CUTOFF 0
+	param set IMU_GYRO_CUTOFF 80
+	param set IMU_DGYRO_CUTOFF 50
+	param set IMU_GYRO_RATEMAX 2000
 
-	param set MC_ROLLRATE_P 0.075
+	param set MC_ROLLRATE_P 0.085
 	param set MC_ROLLRATE_I 0.25
-	param set MC_ROLLRATE_D 0.0015
+	param set MC_ROLLRATE_D 0.0008
 	param set MC_ROLLRATE_MAX 1600
 	param set MC_ROLL_P 10
 
-	param set MC_PITCHRATE_P 0.075
+	param set MC_PITCHRATE_P 0.085
 	param set MC_PITCHRATE_I 0.32
-	param set MC_PITCHRATE_D 0.0015
+	param set MC_PITCHRATE_D 0.0008
 	param set MC_PITCHRATE_MAX 1600
 	param set MC_PITCH_P 10
 

--- a/ROMFS/px4fmu_common/init.d/airframes/4070_aerofc
+++ b/ROMFS/px4fmu_common/init.d/airframes/4070_aerofc
@@ -70,7 +70,7 @@ then
 	param set SER_TEL2_BAUD 921600
 fi
 
-if param compare SYS_HITL 0
+if ! param greater SYS_HITL 0
 then
   tap_esc start -d /dev/ttyS0 -n 4
   usleep 300000

--- a/boards/holybro/kakutef7/src/spi.cpp
+++ b/boards/holybro/kakutef7/src/spi.cpp
@@ -43,8 +43,9 @@ constexpr px4_spi_bus_t px4_spi_buses[SPI_BUS_MAX_BUS_ITEMS] = {
 		initSPIDevice(DRV_OSD_DEVTYPE_ATXXXX, SPI::CS{GPIO::PortB, GPIO::Pin12}),
 	}),
 	initSPIBus(SPI::Bus::SPI4, {
-		initSPIDevice(DRV_IMU_DEVTYPE_ICM20689, SPI::CS{GPIO::PortE, GPIO::Pin4}, SPI::DRDY{GPIO::PortE, GPIO::Pin1}),
-		initSPIDevice(DRV_IMU_DEVTYPE_MPU6000, SPI::CS{GPIO::PortE, GPIO::Pin4}, SPI::DRDY{GPIO::PortE, GPIO::Pin1}),
+		// Note: DRDY is disabled as it caused bad IMU transfers (on a Kopis 2 with ICM20689)
+		initSPIDevice(DRV_IMU_DEVTYPE_ICM20689, SPI::CS{GPIO::PortE, GPIO::Pin4}),
+		initSPIDevice(DRV_IMU_DEVTYPE_MPU6000, SPI::CS{GPIO::PortE, GPIO::Pin4}),
 	}),
 };
 

--- a/src/lib/systemlib/system_params.c
+++ b/src/lib/systemlib/system_params.c
@@ -70,6 +70,11 @@ PARAM_DEFINE_INT32(SYS_AUTOCONFIG, 0);
  * or Simulation-In-Hardware (SIH) mode and not enable all sensors and checks.
  * When disabled the same vehicle can be flown normally.
  *
+ * Set to 'external HITL', if the system should perform as if it were a real
+ * vehicle (the only difference to a real system is then only the parameter
+ * value, which can be used for log analysis).
+ *
+ * @value -1 external HITL
  * @value 0 HITL and SIH disabled
  * @value 1 HITL enabled
  * @value 2 SIH enabled

--- a/src/modules/sensors/vehicle_angular_velocity/imu_gyro_parameters.c
+++ b/src/modules/sensors/vehicle_angular_velocity/imu_gyro_parameters.c
@@ -70,7 +70,7 @@ PARAM_DEFINE_FLOAT(IMU_GYRO_NF_BW, 20.0f);
 *
 * The cutoff frequency for the 2nd order butterworth filter on the primary gyro.
 * This only affects the angular velocity sent to the controllers, not the estimators.
-* Doesn't apply to the angular acceleration (D-Term filter), see IMU_DGYRO_CUTOFF.
+* It applies also to the angular acceleration (D-Term filter), see IMU_DGYRO_CUTOFF.
 *
 * A value of 0 disables the filter.
 *
@@ -109,7 +109,7 @@ PARAM_DEFINE_INT32(IMU_GYRO_RATEMAX, 0);
 * the time derivative of the measured angular velocity, also known as
 * the D-term filter in the rate controller. The D-term uses the derivative of
 * the rate and thus is the most susceptible to noise. Therefore, using
-* a D-term filter allows to decrease the driver-level filtering, which
+* a D-term filter allows to increase IMU_GYRO_CUTOFF, which
 * leads to reduced control latency and permits to increase the P gains.
 *
 * A value of 0 disables the filter.
@@ -120,4 +120,4 @@ PARAM_DEFINE_INT32(IMU_GYRO_RATEMAX, 0);
 * @reboot_required true
 * @group Sensors
 */
-PARAM_DEFINE_FLOAT(IMU_DGYRO_CUTOFF, 30.0f);
+PARAM_DEFINE_FLOAT(IMU_DGYRO_CUTOFF, 0.0f);


### PR DESCRIPTION
- flying master lately I noticed the D-term is considerably more suspectible to noise on different vehicles. Initially I attributed that to the removal of the on-chip DLPF.
- trying to fly the Kopis 2 on master, it was just unflyable. And no matter how much PID and filter tuning I did, I could not get it to fly.

I then made the filter change here, and it immediately improved things a lot (so apparently the ordering matters). With some further tuning it's flyable again.

Log: https://logs.px4.io/plot_app?log=65497f73-7350-4965-aec1-5ccdce1c628c

@dakejahl I'm pretty sure this helps on your S500 as well.

Some feedback if other people experience the same would be appreciated.