### PR TITLE
bmi088 remove dump of registers that causes driver to fail

### DIFF
--- a/src/drivers/imu/bmi088/BMI088_accel.cpp
+++ b/src/drivers/imu/bmi088/BMI088_accel.cpp
@@ -534,27 +534,6 @@ BMI088_accel::print_status()
 	perf_print_counter(_bad_transfers);
 	perf_print_counter(_bad_registers);
 	perf_print_counter(_duplicates);
-
-	::printf("checked_next: %u\n", _checked_next);
-
-	for (uint8_t i = 0; i < BMI088_ACCEL_NUM_CHECKED_REGISTERS; i++) {
-		uint8_t v = read_reg(_checked_registers[i]);
-
-		if (v != _checked_values[i]) {
-			::printf("reg %02x:%02x should be %02x\n",
-				 (unsigned)_checked_registers[i],
-				 (unsigned)v,
-				 (unsigned)_checked_values[i]);
-		}
-
-		if (v != _checked_bad[i]) {
-			::printf("reg %02x:%02x was bad %02x\n",
-				 (unsigned)_checked_registers[i],
-				 (unsigned)v,
-				 (unsigned)_checked_bad[i]);
-		}
-	}
-
 	_px4_accel.print_status();
 }
 

--- a/src/drivers/imu/bmi088/BMI088_gyro.cpp
+++ b/src/drivers/imu/bmi088/BMI088_gyro.cpp
@@ -422,26 +422,6 @@ BMI088_gyro::print_status()
 	perf_print_counter(_bad_registers);
 	perf_print_counter(_duplicates);
 
-	::printf("checked_next: %u\n", _checked_next);
-
-	for (uint8_t i = 0; i < BMI088_GYRO_NUM_CHECKED_REGISTERS; i++) {
-		uint8_t v = read_reg(_checked_registers[i]);
-
-		if (v != _checked_values[i]) {
-			::printf("reg %02x:%02x should be %02x\n",
-				 (unsigned)_checked_registers[i],
-				 (unsigned)v,
-				 (unsigned)_checked_values[i]);
-		}
-
-		if (v != _checked_bad[i]) {
-			::printf("reg %02x:%02x was bad %02x\n",
-				 (unsigned)_checked_registers[i],
-				 (unsigned)v,
-				 (unsigned)_checked_bad[i]);
-		}
-	}
-
 	_px4_gyro.print_status();
 }
 


### PR DESCRIPTION
Removed reading checked registers in status. The reading of the checked register in the breaks the driver and is of no value.