### PR TITLE
selectively increase the optimization level per module/library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,6 +181,18 @@ if(NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE ${PX4_BUILD_TYPE} CACHE STRING "Build type" FORCE)
 endif()
 
+if((CMAKE_BUILD_TYPE STREQUAL "Debug") OR (CMAKE_BUILD_TYPE STREQUAL "Coverage"))
+	set(MAX_CUSTOM_OPT_LEVEL -O0)
+elseif(CMAKE_BUILD_TYPE MATCHES "Sanitizer")
+	set(MAX_CUSTOM_OPT_LEVEL -O1)
+else()
+	if(px4_constrained_flash_build)
+		set(MAX_CUSTOM_OPT_LEVEL -Os)
+	else()
+		set(MAX_CUSTOM_OPT_LEVEL -O2)
+	endif()
+endif()
+
 set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug;Release;RelWithDebInfo;MinSizeRel;Coverage;AddressSanitizer;UndefinedBehaviorSanitizer")
 message(STATUS "cmake build type: ${CMAKE_BUILD_TYPE}")
 

--- a/boards/bitcraze/crazyflie/default.cmake
+++ b/boards/bitcraze/crazyflie/default.cmake
@@ -6,6 +6,7 @@ px4_add_board(
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
 	ROMFSROOT px4fmu_common
+	CONSTRAINED_FLASH
 	DRIVERS
 		barometer/lps25h
 		distance_sensor/vl53l0x

--- a/boards/holybro/durandal-v1/stackcheck.cmake
+++ b/boards/holybro/durandal-v1/stackcheck.cmake
@@ -7,7 +7,7 @@ px4_add_board(
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m7
 	ROMFSROOT px4fmu_common
-	BUILD_BOOTLOADER
+	#BUILD_BOOTLOADER
 	IO px4_io-v2_default
 	TESTING
 #	UAVCAN_INTERFACES 2  - No H7 or FD can support in UAVCAN
@@ -23,7 +23,7 @@ px4_add_board(
 		batt_smbus
 		#camera_capture
 		#camera_trigger
-		differential_pressure # all available differential pressure drivers
+		#differential_pressure # all available differential pressure drivers
 		distance_sensor # all available distance sensor drivers
 		#dshot
 		gps
@@ -65,6 +65,7 @@ px4_add_board(
 		commander
 		dataman
 		ekf2
+		#esc_battery
 		events
 		fw_att_control
 		fw_pos_control_l1
@@ -78,16 +79,17 @@ px4_add_board(
 		mc_hover_thrust_estimator
 		mc_pos_control
 		mc_rate_control
+		#micrortps_bridge
 		navigator
 		rc_update
 		#rover_pos_control
 		sensors
 		#sih
-		temperature_compensation
-		vmount
+		#temperature_compensation
+		#vmount
 		vtol_att_control
 	SYSTEMCMDS
-		bl_update
+		#bl_update
 		dmesg
 		dumpfile
 		esc_calib

--- a/boards/holybro/kakutef7/default.cmake
+++ b/boards/holybro/kakutef7/default.cmake
@@ -7,6 +7,7 @@ px4_add_board(
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m7
 	ROMFSROOT px4fmu_common
+	CONSTRAINED_FLASH
 	SERIAL_PORTS
 		TEL1:/dev/ttyS0 # UART1
 		TEL2:/dev/ttyS1 # UART2

--- a/boards/px4/fmu-v5/stackcheck.cmake
+++ b/boards/px4/fmu-v5/stackcheck.cmake
@@ -47,7 +47,7 @@ px4_add_board(
 		#pca9685
 		#power_monitor/ina226
 		#protocol_splitter
-		pwm_input
+		#pwm_input
 		pwm_out_sim
 		pwm_out
 		px4io
@@ -61,7 +61,7 @@ px4_add_board(
 		#uavcan
 	MODULES
 		airspeed_selector
-		attitude_estimator_q
+		#attitude_estimator_q
 		battery_status
 		#camera_feedback
 		commander
@@ -84,11 +84,11 @@ px4_add_board(
 		#micrortps_bridge
 		navigator
 		rc_update
-		rover_pos_control
+		#rover_pos_control
 		sensors
-		sih
-		temperature_compensation
-		vmount
+		#sih
+		#temperature_compensation
+		#vmount
 		vtol_att_control
 	SYSTEMCMDS
 		bl_update

--- a/boards/px4/io-v2/default.cmake
+++ b/boards/px4/io-v2/default.cmake
@@ -4,6 +4,7 @@ px4_add_board(
 	VENDOR px4
 	MODEL io-v2
 	TOOLCHAIN arm-none-eabi
+	CONSTRAINED_FLASH
 	ARCHITECTURE cortex-m3
 	DRIVERS
 	MODULES

--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
@@ -65,7 +65,7 @@ static constexpr wq_config_t I2C3{"wq:I2C3", 1472, -11};
 static constexpr wq_config_t I2C4{"wq:I2C4", 1472, -12};
 
 // PX4 att/pos controllers, highest priority after sensors.
-static constexpr wq_config_t attitude_ctrl{"wq:attitude_ctrl", 1536, -13};
+static constexpr wq_config_t attitude_ctrl{"wq:attitude_ctrl", 1600, -13};
 static constexpr wq_config_t navigation_and_controllers{"wq:navigation_and_controllers", 7200, -14};
 
 static constexpr wq_config_t hp_default{"wq:hp_default", 1900, -15};

--- a/platforms/common/px4_work_queue/CMakeLists.txt
+++ b/platforms/common/px4_work_queue/CMakeLists.txt
@@ -43,4 +43,5 @@ if(PX4_TESTING)
 	add_subdirectory(test)
 endif()
 
+target_compile_options(px4_work_queue PRIVATE ${MAX_CUSTOM_OPT_LEVEL})
 target_link_libraries(px4_work_queue PRIVATE px4_platform)

--- a/platforms/nuttx/src/px4/common/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/common/CMakeLists.txt
@@ -32,7 +32,7 @@
 ############################################################################
 
 # skip for px4_layer support on an IO board
-if (NOT ${PX4_BOARD} MATCHES "px4_io")
+if(NOT PX4_BOARD MATCHES "px4_io")
 
 	add_library(px4_layer
 		board_crashdump.c

--- a/platforms/nuttx/src/px4/stm/stm32_common/dshot/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/stm/stm32_common/dshot/CMakeLists.txt
@@ -34,3 +34,4 @@
 px4_add_library(arch_dshot
 	dshot.c
 )
+target_compile_options(arch_dshot PRIVATE ${MAX_CUSTOM_OPT_LEVEL})

--- a/platforms/nuttx/src/px4/stm/stm32_common/hrt/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/stm/stm32_common/hrt/CMakeLists.txt
@@ -34,5 +34,8 @@
 px4_add_library(arch_hrt
 	hrt.c
 )
-target_compile_options(arch_hrt PRIVATE -Wno-cast-align) # TODO: fix and enable
-
+target_compile_options(arch_hrt
+	PRIVATE
+		${MAX_CUSTOM_OPT_LEVEL}
+		-Wno-cast-align # TODO: fix and enable
+)

--- a/platforms/nuttx/src/px4/stm/stm32_common/io_pins/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/stm/stm32_common/io_pins/CMakeLists.txt
@@ -32,8 +32,9 @@
 ############################################################################
 
 px4_add_library(arch_io_pins
+	input_capture.c
 	io_timer.c
 	pwm_servo.c
 	pwm_trigger.c
-	input_capture.c
 )
+target_compile_options(arch_io_pins PRIVATE ${MAX_CUSTOM_OPT_LEVEL})

--- a/platforms/nuttx/src/px4/stm/stm32_common/spi/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/stm/stm32_common/spi/CMakeLists.txt
@@ -34,3 +34,4 @@
 px4_add_library(arch_spi
 	spi.cpp
 )
+target_compile_options(arch_spi PRIVATE ${MAX_CUSTOM_OPT_LEVEL})

--- a/src/lib/drivers/accelerometer/CMakeLists.txt
+++ b/src/lib/drivers/accelerometer/CMakeLists.txt
@@ -35,9 +35,5 @@ px4_add_library(drivers_accelerometer
 	PX4Accelerometer.cpp
 	PX4Accelerometer.hpp
 )
-target_link_libraries(drivers_accelerometer
-	PRIVATE
-		conversion
-		drivers__device
-		mathlib
-)
+target_compile_options(drivers_accelerometer PRIVATE ${MAX_CUSTOM_OPT_LEVEL})
+target_link_libraries(drivers_accelerometer PRIVATE conversion drivers__device)

--- a/src/lib/drivers/gyroscope/CMakeLists.txt
+++ b/src/lib/drivers/gyroscope/CMakeLists.txt
@@ -35,4 +35,5 @@ px4_add_library(drivers_gyroscope
 	PX4Gyroscope.cpp
 	PX4Gyroscope.hpp
 )
+target_compile_options(drivers_gyroscope PRIVATE ${MAX_CUSTOM_OPT_LEVEL})
 target_link_libraries(drivers_gyroscope PRIVATE conversion drivers__device)

--- a/src/lib/perf/CMakeLists.txt
+++ b/src/lib/perf/CMakeLists.txt
@@ -33,3 +33,4 @@
 
 add_library(perf perf_counter.cpp)
 add_dependencies(perf prebuild_targets)
+target_compile_options(perf PRIVATE ${MAX_CUSTOM_OPT_LEVEL})

--- a/src/lib/systemlib/CMakeLists.txt
+++ b/src/lib/systemlib/CMakeLists.txt
@@ -33,13 +33,17 @@
 
 set(SRCS
 	conversions.c
+	conversions.h
 	crc.c
+	crc.h
 	mavlink_log.cpp
+	mavlink_log.h
 )
 
 if(${PX4_PLATFORM} STREQUAL "nuttx")
 	list(APPEND SRCS
 		cpuload.c
+		cpuload.h
 		print_load_nuttx.c
 		otp.c
 	)
@@ -50,3 +54,4 @@ else()
 endif()
 
 px4_add_library(systemlib ${SRCS})
+target_compile_options(systemlib PRIVATE ${MAX_CUSTOM_OPT_LEVEL})

--- a/src/modules/mc_att_control/AttitudeControl/CMakeLists.txt
+++ b/src/modules/mc_att_control/AttitudeControl/CMakeLists.txt
@@ -33,10 +33,9 @@
 
 px4_add_library(AttitudeControl
 	AttitudeControl.cpp
+	AttitudeControl.hpp
 )
-target_include_directories(AttitudeControl
-	PUBLIC
-	${CMAKE_CURRENT_SOURCE_DIR}
-)
+target_compile_options(AttitudeControl PRIVATE ${MAX_CUSTOM_OPT_LEVEL})
+target_include_directories(AttitudeControl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 px4_add_unit_gtest(SRC AttitudeControlTest.cpp LINKLIBS AttitudeControl)

--- a/src/modules/mc_att_control/CMakeLists.txt
+++ b/src/modules/mc_att_control/CMakeLists.txt
@@ -37,10 +37,12 @@ px4_add_module(
 	MODULE modules__mc_att_control
 	MAIN mc_att_control
 	COMPILE_FLAGS
+		${MAX_CUSTOM_OPT_LEVEL}
 	SRCS
 		mc_att_control_main.cpp
+		mc_att_control.hpp
 	DEPENDS
-		mathlib
 		AttitudeControl
+		mathlib
 		px4_work_queue
 	)

--- a/src/modules/mc_rate_control/CMakeLists.txt
+++ b/src/modules/mc_rate_control/CMakeLists.txt
@@ -37,6 +37,7 @@ px4_add_module(
 	MODULE modules__mc_rate_control
 	MAIN mc_rate_control
 	COMPILE_FLAGS
+		${MAX_CUSTOM_OPT_LEVEL}
 	SRCS
 		MulticopterRateControl.cpp
 		MulticopterRateControl.hpp

--- a/src/modules/mc_rate_control/RateControl/CMakeLists.txt
+++ b/src/modules/mc_rate_control/RateControl/CMakeLists.txt
@@ -33,12 +33,10 @@
 
 px4_add_library(RateControl
 	RateControl.cpp
+	RateControl.hpp
 )
-target_include_directories(RateControl
-	PUBLIC
-	${CMAKE_CURRENT_SOURCE_DIR}
-)
-
+target_compile_options(RateControl PRIVATE ${MAX_CUSTOM_OPT_LEVEL})
+target_include_directories(RateControl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(RateControl PRIVATE mathlib)
 
 px4_add_unit_gtest(SRC RateControlTest.cpp LINKLIBS RateControl)

--- a/src/modules/sensors/sensor_corrections/CMakeLists.txt
+++ b/src/modules/sensors/sensor_corrections/CMakeLists.txt
@@ -35,3 +35,4 @@ px4_add_library(sensor_corrections
 	SensorCorrections.cpp
 	SensorCorrections.hpp
 )
+target_compile_options(sensor_corrections PRIVATE ${MAX_CUSTOM_OPT_LEVEL})

--- a/src/modules/sensors/vehicle_acceleration/CMakeLists.txt
+++ b/src/modules/sensors/vehicle_acceleration/CMakeLists.txt
@@ -35,6 +35,9 @@ px4_add_library(vehicle_acceleration
 	VehicleAcceleration.cpp
 	VehicleAcceleration.hpp
 )
+
+target_compile_options(vehicle_acceleration PRIVATE ${MAX_CUSTOM_OPT_LEVEL})
+
 target_link_libraries(vehicle_acceleration
 	PRIVATE
 		mathlib

--- a/src/modules/sensors/vehicle_angular_velocity/CMakeLists.txt
+++ b/src/modules/sensors/vehicle_angular_velocity/CMakeLists.txt
@@ -35,6 +35,9 @@ px4_add_library(vehicle_angular_velocity
 	VehicleAngularVelocity.cpp
 	VehicleAngularVelocity.hpp
 )
+
+target_compile_options(vehicle_angular_velocity PRIVATE ${MAX_CUSTOM_OPT_LEVEL})
+
 target_link_libraries(vehicle_angular_velocity
 	PRIVATE
 		mathlib

--- a/src/modules/sensors/vehicle_imu/CMakeLists.txt
+++ b/src/modules/sensors/vehicle_imu/CMakeLists.txt
@@ -37,4 +37,5 @@ px4_add_library(vehicle_imu
 	VehicleIMU.cpp
 	VehicleIMU.hpp
 )
+target_compile_options(vehicle_imu PRIVATE ${MAX_CUSTOM_OPT_LEVEL})
 target_link_libraries(vehicle_imu PRIVATE sensor_corrections px4_work_queue)

--- a/src/modules/uORB/CMakeLists.txt
+++ b/src/modules/uORB/CMakeLists.txt
@@ -31,7 +31,7 @@
 #
 ############################################################################
 
-if(NOT "${PX4_BOARD}" MATCHES "px4_io") # TODO: fix this hack (move uORB to platform layer)
+if(NOT PX4_BOARD MATCHES "px4_io") # TODO: fix this hack (move uORB to platform layer)
 
 	# this includes the generated topics directory
 	include_directories(${CMAKE_CURRENT_BINARY_DIR})
@@ -39,6 +39,8 @@ if(NOT "${PX4_BOARD}" MATCHES "px4_io") # TODO: fix this hack (move uORB to plat
 	px4_add_module(
 		MODULE modules__uORB
 		MAIN uorb
+		COMPILE_FLAGS
+			${MAX_CUSTOM_OPT_LEVEL}
 		SRCS
 			ORBSet.hpp
 			Publication.hpp


### PR DESCRIPTION
On an stm32f4 this saves about 4-8% cpu depending on the configuration at a cost of about 16 kB of extra flash.

As a comparison, building the entire system -O2 reduces cpu somewhere around 15% (px4_fmu-v4), but at a cost of several hundred kilobytes of flash (well over the 2MB limit).





### Master (px4_fmu-v4_default SYS_AUTOSTART=4001)

``` Console
 PID COMMAND                   CPU(ms) CPU(%)  USED/STACK PRIO(BASE) STATE FD
   0 Idle Task                   14746 25.616   244/  512   0 (  0)  READY  3
   1 hpwork                          0  0.000   344/ 1260 249 (249)  w:sig  3
   2 lpwork                          0  0.000   344/ 1612  50 ( 50)  w:sig  3
   3 init                         1420  0.000  2064/ 2924 100 (100)  w:sem  3
   4 wq:manager                      1  0.000   408/ 1252 255 (255)  w:sem  4
 440 mavlink_rcv_if0               215  0.362  2520/ 4060 175 (175)  w:sem  4
  15 wq:hp_default                 689  1.233  1072/ 1900 240 (240)  w:sem  4
  19 wq:lp_default                  32  0.000   912/ 1700 205 (205)  w:sem  4
 155 wq:SPI2                       307  0.580   968/ 2492 252 (252)  w:sem  4
 157 wq:SPI1                      9475 17.271  1748/ 2492 253 (253)  w:sem  4
 186 wq:navigation_and_contro    10801 19.883  5072/ 7196 241 (241)  w:sem  4
 188 wq:rate_ctrl                 6729 12.119  1128/ 1660 255 (255)  w:sem  4
 199 commander                     727  1.233  1280/ 3212 140 (140)  w:sig  6
 200 commander_low_prio              1  0.000   692/ 2996  50 ( 50)  w:sem  6
 206 mavlink_if0                  2786  4.862  1832/ 2572 100 (100)  READY  4
 210 mavlink_if1                  2391  4.136  1888/ 2540 100 (100)  READY  4
 212 mavlink_rcv_if1               243  0.435  2536/ 4060 175 (175)  w:sem  4
 265 gps                            47  0.072  1008/ 1676 205 (205)  w:sig  4
 301 mavlink_if2                   913  1.669  1832/ 2484 100 (100)  READY  4
 304 mavlink_rcv_if2               247  0.362  2536/ 4060 175 (175)  w:sem  4
 319 wq:UART4                      387  0.725   752/ 1396 234 (234)  w:sem  4
 561 top                          1463  3.338  1248/ 2028 239 (239)  RUN    3
 453 wq:attitude_ctrl              947  2.031  1060/ 1532 242 (242)  w:sem  4
 469 navigator                      57  0.145  1016/ 1764 105 (105)  w:sem  5
 534 logger                        288  0.507  1872/ 3644 230 (230)  w:sem  3
 535 log_writer_file                 0  0.000   368/ 1164  60 ( 60)  w:sem  3

Processes: 26 total, 5 running, 21 sleeping, max FDs: 15
CPU usage: 70.97% tasks, 3.41% sched, 25.62% idle
DMA Memory: 5120 total, 0 used 0 peak
Uptime: 57.126s total, 14.747s idle

```

### PR (px4_fmu-v4_default SYS_AUTOSTART=4001)

``` Console
 PID COMMAND                   CPU(ms) CPU(%)  USED/STACK PRIO(BASE) STATE FD
   0 Idle Task                   13983 32.173   244/  512   0 (  0)  READY  3
   1 hpwork                          0  0.000   344/ 1260 249 (249)  w:sig  3
   2 lpwork                          0  0.000   344/ 1612  50 ( 50)  w:sig  3
   3 init                         1421  0.000  2064/ 2924 100 (100)  w:sem  3
   4 wq:manager                      1  0.000   400/ 1252 255 (255)  w:sem  4
 440 mavlink_rcv_if0               167  0.362  2480/ 4060 175 (175)  w:sem  4
  15 wq:hp_default                 507  1.231  1224/ 1900 240 (240)  w:sem  4
  19 wq:lp_default                  25  0.072   872/ 1700 205 (205)  w:sem  4
 155 wq:SPI2                       230  0.579   840/ 2492 252 (252)  w:sem  4
 157 wq:SPI1                      6863 15.797  1824/ 2492 253 (253)  w:sem  4
 186 wq:navigation_and_contro     7309 17.173  5080/ 7196 241 (241)  w:sem  4
 188 wq:rate_ctrl                 4468 10.434  1192/ 1660 255 (255)  w:sem  4
 199 commander                     549  1.159  1280/ 3212 140 (140)  READY  6
 200 commander_low_prio              1  0.000   692/ 2996  50 ( 50)  w:sem  6
 206 mavlink_if0                  2156  5.000  1832/ 2572 100 (100)  w:sig  4
 210 mavlink_if1                  1849  4.347  1832/ 2540 100 (100)  w:sig  4
 212 mavlink_rcv_if1               185  0.434  2536/ 4060 175 (175)  w:sem  4
 265 gps                            36  0.072  1016/ 1676 205 (205)  w:sem  4
 301 mavlink_if2                   696  1.594  1832/ 2484 100 (100)  READY  4
 304 mavlink_rcv_if2               188  0.434  2536/ 4060 175 (175)  w:sem  4
 319 wq:UART4                      289  0.652   760/ 1396 234 (234)  READY  4
 555 top                          1335  3.333  1296/ 2028 239 (239)  RUN    3
 453 wq:attitude_ctrl              443  1.231  1280/ 1596 242 (242)  w:sem  4
 469 navigator                      41  0.144  1016/ 1764 105 (105)  READY  5
 534 logger                        213  0.507  1688/ 3644 230 (230)  w:sem  3
 535 log_writer_file                 0  0.000   368/ 1164  60 ( 60)  w:sem  3

Processes: 26 total, 6 running, 20 sleeping, max FDs: 15
CPU usage: 64.57% tasks, 3.26% sched, 32.17% idle
DMA Memory: 5120 total, 0 used 0 peak
Uptime: 44.550s total, 13.984s idle

```