### PR TITLE
Default config does not slow down close to ground in position mode

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -347,7 +347,7 @@ PARAM_DEFINE_FLOAT(MPC_TILTMAX_LND, 12.0f);
 PARAM_DEFINE_FLOAT(MPC_LAND_SPEED, 0.7f);
 
 /**
- * Maximum horizontal velocity during landing
+ * Maximum horizontal position mode velocity when close to ground/home altitude
  * Set the value higher than the otherwise expected maximum to disable any slowdown.
  *
  * @unit m/s
@@ -355,7 +355,7 @@ PARAM_DEFINE_FLOAT(MPC_LAND_SPEED, 0.7f);
  * @decimal 1
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_LAND_VEL_XY, 2.f);
+PARAM_DEFINE_FLOAT(MPC_LAND_VEL_XY, 10.0f);
 
 /**
  * Enable user assisted descent speed for autonomous land routine.


### PR DESCRIPTION
**Describe problem solved by this pull request**
I heared several times that the ground slow down is not something people expect to see by default. Hence I'm proposing to not slow down at all with default parameters.

People that found it confusing I still remember were: @igalloway on slack https://px4.slack.com/archives/C39C4E709/p1588275046070800, @baumanta , @priseborough (today), ...

I brought it up in the dev call before:
https://discuss.px4.io/t/px4-dev-call-may-06-2020/16511
First question under "Multicopter".

**Describe your solution**
Set the ground slow down speed to the default maximum speed. This results in no change with defaults but a slow down to 10m/s if the maxiumum speed is set higher than that.

**Additional context**
Original feature pr: https://github.com/PX4/Firmware/pull/13561
