### PR TITLE
navigator: always make sure that we set target lat/lon for fixed wing

### DIFF
--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -365,9 +365,9 @@ Navigator::run()
 					rep->current.lon = cmd.param6;
 
 				} else {
-					// If one of them is non-finite, reset both
-					rep->current.lat = (double)NAN;
-					rep->current.lon = (double)NAN;
+					// If one of them is non-finite set the current global position as target
+					rep->current.lat = get_global_position()->lat;
+					rep->current.lon = get_global_position()->lon;
 				}
 
 				rep->current.alt = cmd.param7;


### PR DESCRIPTION
Executing `commander takoeff` in SITL lead to the vehicle performing a nice flyaway as there was no lat or longitude set in the position setpoint triplet.
I assume that flighttask is handling this case for multirotor takeoff but fixed wing was broken.
This seems like the best fix to me but maybe there are other suggestions for other hackeries.