### PR TITLE
boards: mRo Control Zero fix IMU rotations

### DIFF
--- a/boards/mro/ctrl-zero-f7/init/rc.board_sensors
+++ b/boards/mro/ctrl-zero-f7/init/rc.board_sensors
@@ -6,14 +6,14 @@
 adc start
 
 # Internal ICM-20602
-icm20602 -s -R 4 start
+icm20602 -s -R 8 start
 
 # Internal SPI bus BMI088 accel & gyro
 bmi088 -A -R 10 -s start
 bmi088 -G -R 10 -s start
 
 # Internal ICM-20948 (with magnetometer)
-icm20948 -s -R 2 -M start
+icm20948 -s -R 8 -M start
 
 # Interal DPS310 (barometer)
 dps310 -s start


### PR DESCRIPTION
Broken out of https://github.com/PX4/Firmware/pull/14999.