### PR TITLE
battery_params: relax maximum for capacity thresholds

### DIFF
--- a/src/lib/battery/battery_params_common.c
+++ b/src/lib/battery/battery_params_common.c
@@ -48,7 +48,7 @@
  * @group Battery Calibration
  * @unit norm
  * @min 0.12
- * @max 0.4
+ * @max 0.5
  * @decimal 2
  * @increment 0.01
  * @reboot_required true
@@ -65,7 +65,7 @@ PARAM_DEFINE_FLOAT(BAT_LOW_THR, 0.15f);
  * @group Battery Calibration
  * @unit norm
  * @min 0.05
- * @max 0.1
+ * @max 0.25
  * @decimal 2
  * @increment 0.01
  * @reboot_required true
@@ -82,7 +82,7 @@ PARAM_DEFINE_FLOAT(BAT_CRIT_THR, 0.07f);
  * @group Battery Calibration
  * @unit norm
  * @min 0.03
- * @max 0.07
+ * @max 0.1
  * @decimal 2
  * @increment 0.01
  * @reboot_required true


### PR DESCRIPTION
**Describe problem solved by this pull request**
Based on feedback from Thomas Stauber on slack: https://px4.slack.com/archives/C0V533X4N/p1591186808278700
the maxima for the battery capacity thresholds are a bit tight. 

**Describe your solution**
I don't see a problem with allowing earlier lower battery configurations although it's not useful in most cases they do not break anything.
