### PR TITLE
Jenkins HIL test fix sensor timeouts

### DIFF
--- a/.ci/Jenkinsfile-hardware
+++ b/.ci/Jenkinsfile-hardware
@@ -809,6 +809,8 @@ void statusFTDI() {
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "uorb top -1 -a"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "ver all"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "work_queue status"'
+  // stop logger
+  sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "logger off"'
 }
 
 void statusSEGGER() {
@@ -868,6 +870,8 @@ void statusSEGGER() {
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-SEGGER_*` --cmd "uorb top -1 -a"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-SEGGER_*` --cmd "ver all"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-SEGGER_*` --cmd "work_queue status"'
+  // stop logger
+  sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-SEGGER_*` --cmd "logger off"'
 }
 
 void cleanupFTDI() {

--- a/src/systemcmds/tests/hrt_test/hrt_test_start.cpp
+++ b/src/systemcmds/tests/hrt_test/hrt_test_start.cpp
@@ -66,7 +66,7 @@ int hrt_test_main(int argc, char *argv[])
 
 		daemon_task = px4_task_spawn_cmd("hrttest",
 						 SCHED_DEFAULT,
-						 SCHED_PRIORITY_MAX - 5,
+						 SCHED_PRIORITY_DEFAULT,
 						 2000,
 						 PX4_MAIN,
 						 (argv) ? (char *const *)&argv[2] : (char *const *)nullptr);

--- a/src/systemcmds/tests/test_dataman.c
+++ b/src/systemcmds/tests/test_dataman.c
@@ -181,7 +181,7 @@ int test_dataman(int argc, char *argv[])
 		px4_sem_setprotocol(sems, SEM_PRIO_NONE);
 
 		/* start the task */
-		if ((task = px4_task_spawn_cmd("dataman", SCHED_DEFAULT, SCHED_PRIORITY_MAX - 5, 2048, task_main, av)) <= 0) {
+		if ((task = px4_task_spawn_cmd("dataman", SCHED_DEFAULT, SCHED_PRIORITY_DEFAULT, 2048, task_main, av)) <= 0) {
 			PX4_ERR("task start failed");
 		}
 	}

--- a/src/systemcmds/tests/test_hrt.cpp
+++ b/src/systemcmds/tests/test_hrt.cpp
@@ -61,7 +61,6 @@ int test_hrt(int argc, char *argv[])
 		       (unsigned long)prev, (unsigned long)tv1.tv_sec, (unsigned long)tv1.tv_usec,
 		       (unsigned long)now, (unsigned long)tv2.tv_sec, (unsigned long)tv2.tv_usec,
 		       (unsigned long)(hrt_absolute_time() - prev));
-		fflush(stdout);
 	}
 
 	px4_usleep(1000000);
@@ -76,7 +75,6 @@ int test_hrt(int argc, char *argv[])
 		}
 
 		printf("tick\n");
-		fflush(stdout);
 	}
 
 	return 0;


### PR DESCRIPTION
 - stop logger before running tests to prevent watchdog triggers
 - decrease test priorities
 - hrt test don't flush output
