### PR TITLE
px4_work_queue: WorkItem add simple rate limiter

### DIFF
--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueue.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueue.hpp
@@ -61,7 +61,7 @@ public:
 	bool Attach(WorkItem *item);
 	void Detach(WorkItem *item);
 
-	void Add(WorkItem *item);
+	bool Add(WorkItem *item);
 	void Remove(WorkItem *item);
 
 	void Clear();

--- a/platforms/common/px4_work_queue/WorkQueue.cpp
+++ b/platforms/common/px4_work_queue/WorkQueue.cpp
@@ -103,13 +103,15 @@ void WorkQueue::Detach(WorkItem *item)
 	work_unlock();
 }
 
-void WorkQueue::Add(WorkItem *item)
+bool WorkQueue::Add(WorkItem *item)
 {
 	work_lock();
-	_q.push(item);
+	bool ret = _q.push(item);
 	work_unlock();
 
 	SignalWorkerThread();
+
+	return ret;
 }
 
 void WorkQueue::SignalWorkerThread()

--- a/src/include/containers/IntrusiveQueue.hpp
+++ b/src/include/containers/IntrusiveQueue.hpp
@@ -56,11 +56,11 @@ public:
 		return sz;
 	}
 
-	void push(T newNode)
+	bool push(T newNode)
 	{
 		// error, node already queued or already inserted
 		if ((newNode->next_intrusive_queue_node() != nullptr) || (newNode == _tail)) {
-			return;
+			return false;
 		}
 
 		if (_head == nullptr) {
@@ -72,6 +72,7 @@ public:
 		}
 
 		_tail = newNode;
+		return true;
 	}
 
 	T pop()

--- a/src/lib/mixer_module/mixer_module.cpp
+++ b/src/lib/mixer_module/mixer_module.cpp
@@ -159,6 +159,9 @@ bool MixingOutput::updateSubscriptions(bool allow_wq_switch)
 			// TODO: this might need to be configurable depending on the module
 			_interface.ScheduleOnInterval(100_ms);
 		}
+
+		// prevent excessive back to back execution
+		_interface.set_minimum_interval_us(250_us);
 	}
 
 	_groups_subscribed = _groups_required;

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -125,6 +125,9 @@ VtolAttitudeControl::~VtolAttitudeControl()
 bool
 VtolAttitudeControl::init()
 {
+	// prevent excessive back to back execution
+	set_minimum_interval_us(2000);
+
 	if (!_actuator_inputs_mc.registerCallback()) {
 		PX4_ERR("MC actuator controls callback registration failed!");
 		return false;


### PR DESCRIPTION
This is a simple mechanism that allows you to put a safe limit on the WorkItem execution.

 Examples
 - pwm_out subscribing to multiple actuator controls from different sources https://github.com/PX4/Firmware/issues/15043
 - vtol_att_control runs on updates from both FW & MC controllers at different points