### PR TITLE
sensors/vehicle_imu: only apply corrections once before publication

### DIFF
--- a/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
@@ -106,17 +106,12 @@ private:
 	unsigned _accel_last_generation{0};
 	unsigned _gyro_last_generation{0};
 
-	uint32_t _accel_error_count{0};
-	uint32_t _gyro_error_count{0};
-
 	matrix::Vector3f _delta_angle_prev{0.f, 0.f, 0.f};	// delta angle from the previous IMU measurement
 	matrix::Vector3f _delta_velocity_prev{0.f, 0.f, 0.f};	// delta velocity from the previous IMU measurement
-	float _accel_vibration_metric{0.f};	// high frequency vibration level in the IMU delta velocity data (m/s)
-	float _gyro_vibration_metric{0.f};	// high frequency vibration level in the IMU delta angle data (rad)
-	float _gyro_coning_vibration{0.f};	// Level of coning vibration in the IMU delta angles (rad^2)
+
+	vehicle_imu_status_s _status{};
 
 	uint8_t _delta_velocity_clipping{0};
-	uint32_t _delta_velocity_clipping_total[3] {};
 
 	bool _intervals_configured{false};
 

--- a/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
@@ -113,6 +113,7 @@ private:
 
 	uint8_t _delta_velocity_clipping{0};
 
+	bool _intervals_update{true};
 	bool _intervals_configured{false};
 
 	perf_counter_t _accel_update_perf{perf_alloc(PC_INTERVAL, MODULE_NAME": accel update interval")};


### PR DESCRIPTION
Minor optimization in sensors/vehicle_imu. The IMU corrections only need to be applied once before publication, not to every raw sample.