### PR TITLE
powerCheck: add power redundancy check

### DIFF
--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -912,3 +912,15 @@ PARAM_DEFINE_FLOAT(COM_KILL_DISARM, 5.0f);
  * @increment 1
  */
 PARAM_DEFINE_FLOAT(COM_CPU_MAX, 90.0f);
+
+/**
+ * Required number of redundant power modules
+ *
+ * This configures the a check to verify the expected number of 5V rail power supplies are present. By default only one is expected.
+ * Note: CBRK_SUPPLY_CHK disables all power checks including this one.
+ *
+ * @group Commander
+ * @min 0
+ * @max 4
+ */
+PARAM_DEFINE_INT32(COM_POWER_COUNT, 1);


### PR DESCRIPTION
**Describe problem solved by this pull request**
The user is unaware of a broken or disconnected **redundant** power module.

**Describe your solution**
A parameter specifies what the redundancy level for 5V rail supply needs to be and a check makes sure that it's available before taking off.

**Test data / coverage**
Successfully tested with two INA266s and the redundancy level `COM_POWER_COUNT` on 2 and with defaults and just INA266 or ADC power module.

**Additional context**
Wider context is a closer review of possible power supply cases e.g. https://github.com/PX4/Firmware/pull/14899