### PR TITLE
boards: centralize optional external I2C sensor start

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -21,31 +21,6 @@ fi
 #                           Begin Optional drivers                            #
 ###############################################################################
 
-if [ ${VEHICLE_TYPE} = fw -o ${VEHICLE_TYPE} = vtol ]
-then
-	if param compare CBRK_AIRSPD_CHK 0
-	then
-		sdp3x_airspeed start -X
-		sdp3x_airspeed start -X -a 0x22
-
-		# Pixhawk 2.1 has a MS5611 on I2C which gets wrongly
-		# detected as MS5525 because the chip manufacturer was so
-		# clever to assign the same I2C address and skip a WHO_AM_I
-		# register.
-		if [ $BOARD_FMUV3 = 21 ]
-		then
-			ms5525_airspeed start -X -b 2
-		else
-			ms5525_airspeed start -X
-		fi
-
-		ms4525_airspeed start -X
-
-		ets_airspeed start -X
-
-	fi
-fi
-
 if param compare -s SENS_EN_BATT 1
 then
 	batt_smbus start -X
@@ -120,10 +95,47 @@ then
 	paw3902 -S start
 fi
 
+# probe for optional external I2C devices
+if param compare SENS_EXT_I2C_PRB 1
+then
+	# compasses
+	ak09916 -X -R 6 start # external AK09916 (Here2) is rotated 270 degrees yaw
+	hmc5883 -T -X start
+	ist8308 -X start
+	ist8310 -X start
+	lis2mdl -X start
+	lis3mdl -X start
+	qmc5883 -X start
+	rm3100 -X start
+
+	# differential pressure sensors
+	if [ ${VEHICLE_TYPE} = fw -o ${VEHICLE_TYPE} = vtol ]
+	then
+		if param compare CBRK_AIRSPD_CHK 0
+		then
+			sdp3x_airspeed start -X
+			sdp3x_airspeed start -X -a 0x22
+
+			# Pixhawk 2.1 has a MS5611 on I2C which gets wrongly
+			# detected as MS5525 because the chip manufacturer was so
+			# clever to assign the same I2C address and skip a WHO_AM_I
+			# register.
+			if [ $BOARD_FMUV3 = 21 ]
+			then
+				ms5525_airspeed start -X -b 2
+			else
+				ms5525_airspeed start -X
+			fi
+
+			ms4525_airspeed start -X
+
+			ets_airspeed start -X
+		fi
+	fi
+fi
+
 ###############################################################################
 #                            End Optional drivers                             #
 ###############################################################################
 
-# Wait 20 ms for sensors (because we need to wait for the HRT and work queue callbacks to fire)
-usleep 20000
 sensors start

--- a/boards/airmind/mindpx-v2/init/rc.board_sensors
+++ b/boards/airmind/mindpx-v2/init/rc.board_sensors
@@ -5,10 +5,6 @@
 
 adc start
 
-# External I2C bus
-hmc5883 -T -X start
-qmc5883 -X start
-
 # Internal I2C bus
 hmc5883 -T -I -R 12 start
 qmc5883 -I -R 12 start

--- a/boards/av/x-v1/init/rc.board_sensors
+++ b/boards/av/x-v1/init/rc.board_sensors
@@ -18,8 +18,3 @@ then
 	# try to start adis16497 only if pmw3901 isn't enabled, or parameter doesn't exists
 	adis16497 -S start
 fi
-
-# Possible external compasses
-ist8310 -X start
-hmc5883 -T -X start
-qmc5883 -X start

--- a/boards/bitcraze/crazyflie/init/rc.board_defaults
+++ b/boards/bitcraze/crazyflie/init/rc.board_defaults
@@ -14,6 +14,6 @@ fi
 
 if [ $AUTOCNF = yes ]
 then
-
+	# don't probe external I2C
+	param set SENS_EXT_I2C_PRB 0
 fi
-

--- a/boards/cuav/x7pro/init/rc.board_sensors
+++ b/boards/cuav/x7pro/init/rc.board_sensors
@@ -17,10 +17,3 @@ ms5611 -s -b 4 start
 # SPI6 (internal)
 icm20649 -s -b 6 -R 2 start
 ms5611 -s -b 6 start
-
-
-# Possible external compasses
-ist8310 -X start
-hmc5883 -T -X start
-qmc5883 -X start
-lis3mdl -X start

--- a/boards/hex/cube-orange/init/rc.board_sensors
+++ b/boards/hex/cube-orange/init/rc.board_sensors
@@ -12,9 +12,3 @@ icm20649 -s -b 1 start
 ms5611 -s -b 4 start
 icm20602 -s -b 4 -R 12 start
 icm20948 -s -b 4 -R 10 -M start
-
-# Possible external compasses
-ist8310 -X start
-hmc5883 -T -X start
-qmc5883 -X start
-lis3mdl -X start

--- a/boards/hex/cube-yellow/init/rc.board_sensors
+++ b/boards/hex/cube-yellow/init/rc.board_sensors
@@ -12,9 +12,3 @@ icm20649 -s -b 1 start
 ms5611 -s -b 4 start
 icm20602 -s -b 4 -R 12 start
 icm20948 -s -b 4 -R 10 -M start
-
-# Possible external compasses
-ist8310 -X start
-hmc5883 -T -X start
-qmc5883 -X start
-lis3mdl -X start

--- a/boards/holybro/durandal-v1/init/rc.board_sensors
+++ b/boards/holybro/durandal-v1/init/rc.board_sensors
@@ -7,19 +7,11 @@ adc start
 # Internal SPI bus ICM-20689
 icm20689 -R 2 -s start
 
-# Internal SPI bus BMI088 accel
+# Internal SPI bus BMI088 accel/gyro
 bmi088 -A -R 10 -s start
-
-# Internal SPI bus BMI088 gyro
 bmi088 -G -R 10 -s start
 
-# Possible external compasses
-ist8310 -X start
-hmc5883 -T -X start
-qmc5883 -X start
-lis3mdl -X start
-
-# Possible internal compass
+# internal compass
 ist8310 -I start
 
 # Baro on internal SPI

--- a/boards/holybro/kakutef7/init/rc.board_sensors
+++ b/boards/holybro/kakutef7/init/rc.board_sensors
@@ -13,8 +13,3 @@ fi
 
 # Onboard Baro
 bmp280 -X start
-
-# Possible external compasses
-ist8310 -X start
-hmc5883 -T -X start
-qmc5883 -X start

--- a/boards/intel/aerofc-v1/init/rc.board_sensors
+++ b/boards/intel/aerofc-v1/init/rc.board_sensors
@@ -12,9 +12,6 @@ fi
 
 mpu9250 -s -R 0 start
 
-# Possible external compasses
-hmc5883 -X start
-
 ist8310 -I -R 4 start
 
 ll40ls start -X

--- a/boards/modalai/fc-v1/init/rc.board_sensors
+++ b/boards/modalai/fc-v1/init/rc.board_sensors
@@ -15,19 +15,9 @@ icm20602 -R 12 -s start
 # Internal SPI bus ICM-42688
 icm42688p -R 12 -s start
 
-# Internal SPI bus BMI088 accel
+# Internal SPI bus BMI088 accel/gyro
 bmi088 -A -R 4 -s start
-
-# Internal SPI bus BMI088 gyro
 bmi088 -G -R 4 -s start
-
-# Possible external compasses
-ist8310 -X start
-hmc5883 -T -X start
-qmc5883 -X start
 
 # Internal I2C Baro
 bmp388 -I start
-
-# External RM3100
-rm3100 -X start

--- a/boards/mro/ctrl-zero-f7/init/rc.board_sensors
+++ b/boards/mro/ctrl-zero-f7/init/rc.board_sensors
@@ -17,10 +17,3 @@ icm20948 -s -R 8 -M start
 
 # Interal DPS310 (barometer)
 dps310 -s start
-
-# Possible external compasses
-ist8310 -X start
-hmc5883 -T -X start
-qmc5883 -X start
-lis3mdl -X start
-rm3100 -X start

--- a/boards/mro/x21-777/init/rc.board_sensors
+++ b/boards/mro/x21-777/init/rc.board_sensors
@@ -13,9 +13,3 @@ icm20602 -s -R 8 start
 
 # Internal SPI bus mpu9250
 mpu9250 -s -R 8 start
-
-# Possible external compasses
-ist8310 -X start
-hmc5883 -T -X start
-qmc5883 -X start
-lis3mdl -X start

--- a/boards/mro/x21/init/rc.board_sensors
+++ b/boards/mro/x21/init/rc.board_sensors
@@ -5,12 +5,6 @@
 
 adc start
 
-# External I2C bus
-hmc5883 -T -X start
-lis3mdl -X start
-ist8310 -X start
-qmc5883 -X start
-
 # Internal SPI bus ICM-20608-G
 icm20608g -s -R 8 start
 

--- a/boards/nxp/fmuk66-v3/init/rc.board_sensors
+++ b/boards/nxp/fmuk66-v3/init/rc.board_sensors
@@ -5,12 +5,6 @@
 
 adc start
 
-# Possible external compasses
-hmc5883 -X start
-lis3mdl -X start
-ist8310 -X start
-qmc5883 -X start
-
 # Internal Mag I2C bus roll 180, yaw 90
 bmm150 -I -R 10 start
 

--- a/boards/nxp/fmurt1062-v1/init/rc.board_sensors
+++ b/boards/nxp/fmurt1062-v1/init/rc.board_sensors
@@ -23,26 +23,11 @@ icm20602 -R 2 -s start
 # Internal SPI bus ICM-20689
 icm20689 -R 2 -s start
 
-# Internal SPI bus BMI055 accel
+# Internal SPI bus BMI055 accel/gyro
 bmi055 -A -R 10 -s start
-
-# Internal SPI bus BMI055 gyro
 bmi055 -G -R 10 -s start
 
-# Possible external compasses
-ist8310 -X start
-hmc5883 -T -X start
-qmc5883 -X start
-lis3mdl -X start
-
-# ICM20948 as external magnetometer on I2C (e.g. Here GPS)
-if ! icm20948 -X -R 6 start
-then
-	# external emulated AK09916 (Here2) is rotated 270 degrees yaw
-	ak09916 -X -R 6 start
-fi
-
-# Possible internal compass
+# internal compass
 ist8310 -I start
 
 # Baro on internal SPI

--- a/boards/omnibus/f4sd/init/rc.board_sensors
+++ b/boards/omnibus/f4sd/init/rc.board_sensors
@@ -11,7 +11,4 @@ then
 	icm20602 -s -R 6 start
 fi
 
-# Possible external compasses
-hmc5883 -X start
-
 bmp280 -s start

--- a/boards/px4/fmu-v2/init/rc.board_sensors
+++ b/boards/px4/fmu-v2/init/rc.board_sensors
@@ -7,13 +7,6 @@ rgbled start -I
 
 adc start
 
-# External I2C bus
-hmc5883 -T -X start
-lis3mdl -X start
-ist8310 -X start
-qmc5883 -X start
-rm3100 -X start
-
 # Internal I2C bus
 hmc5883 -T -I -R 4 start
 
@@ -70,13 +63,6 @@ if [ $BOARD_FMUV3 != 0 ]
 then
 	# sensor heating is available, but we disable it for now
 	param set SENS_EN_THERMAL 0
-
-	# ICM20948 as external magnetometer on I2C (e.g. Here GPS)
-	if ! icm20948 -X -R 6 start
-	then
-		# external emulated AK09916 (Here2) is rotated 270 degrees yaw
-		ak09916 -X -R 6 start
-	fi
 
 	# l3gd20 (external/isolated SPI4)
 	l3gd20 -s -b 4 -R 4 start

--- a/boards/px4/fmu-v3/init/rc.board_sensors
+++ b/boards/px4/fmu-v3/init/rc.board_sensors
@@ -7,13 +7,6 @@ rgbled start -I
 
 adc start
 
-# External I2C bus
-hmc5883 -T -X start
-lis3mdl -X start
-ist8310 -X start
-qmc5883 -X start
-rm3100 -X start
-
 # Internal I2C bus
 hmc5883 -T -I -R 4 start
 
@@ -70,13 +63,6 @@ if [ $BOARD_FMUV3 != 0 ]
 then
 	# sensor heating is available, but we disable it for now
 	param set SENS_EN_THERMAL 0
-
-	# ICM20948 as external magnetometer on I2C (e.g. Here GPS)
-	if ! icm20948 -X -R 6 start
-	then
-		# external emulated AK09916 (Here2) is rotated 270 degrees yaw
-		ak09916 -X -R 6 start
-	fi
 
 	# l3gd20 (external/isolated SPI4)
 	l3gd20 -s -b 4 -R 4 start

--- a/boards/px4/fmu-v4/init/rc.board_sensors
+++ b/boards/px4/fmu-v4/init/rc.board_sensors
@@ -13,14 +13,6 @@ adc start
 # open hardware design do not require this.
 pwm_out sensor_reset 50
 
-
-# External I2C bus
-hmc5883 -T -X start
-lis3mdl -X start
-ist8310 -X start
-qmc5883 -X start
-rm3100 -X start
-
 # Internal SPI
 ms5611 -s start
 

--- a/boards/px4/fmu-v4pro/init/rc.board_sensors
+++ b/boards/px4/fmu-v4pro/init/rc.board_sensors
@@ -21,10 +21,3 @@ lis3mdl -s -R 0 start
 
 # Internal SPI
 ms5611 -s start
-
-# Possible external compasses
-hmc5883 -T -X start
-lis3mdl -X start
-ist8310 -X start
-qmc5883 -X start
-rm3100 -X start

--- a/boards/px4/fmu-v5/init/rc.board_sensors
+++ b/boards/px4/fmu-v5/init/rc.board_sensors
@@ -11,30 +11,12 @@ icm20602 -s -R 2 start
 # Internal SPI bus ICM-20689
 icm20689 -s -R 2 start
 
-# Internal SPI bus BMI055 accel
+# Internal SPI bus BMI055 accel/gyro
 bmi055 -A -R 10 -s start
-
-# Internal SPI bus BMI055 gyro
 bmi055 -G -R 10 -s start
 
-# Possible external compasses
-ist8310 -X start
-hmc5883 -T -X start
-qmc5883 -X start
-lis3mdl -X start
-
-# ICM20948 as external magnetometer on I2C (e.g. Here GPS)
-if ! icm20948 -X -R 6 start
-then
-	# external emulated AK09916 (Here2) is rotated 270 degrees yaw
-	ak09916 -X -R 6 start
-fi
-
-# Possible internal compass
+# internal compass
 ist8310 -I start
 
 # Baro on internal SPI
 ms5611 -s start
-
-# External RM3100
-rm3100 -X start

--- a/boards/px4/fmu-v5x/init/rc.board_sensors
+++ b/boards/px4/fmu-v5x/init/rc.board_sensors
@@ -15,16 +15,9 @@ icm20602 -R 2 -s start
 # Internal SPI bus ISM300DLC
 ism330dlc -s start
 
-# Internal SPI bus BMI088 accel
+# Internal SPI bus BMI088 accel/gyro
 bmi088 -A -R 12 -s start
-
-# Internal SPI bus BMI088 gyro
 bmi088 -G -R 12 -s start
-
-# Possible external compasses
-ist8310 -X start
-hmc5883 -T -X start
-qmc5883 -X start
 
 # Possible internal compass
 bmm150 -I start
@@ -35,6 +28,3 @@ bmp388 -I -a 0x77 start
 
 # Baro on I2C3
 ms5611 -X start
-
-# External RM3100
-rm3100 -X start

--- a/boards/px4/fmu-v6x/init/rc.board_sensors
+++ b/boards/px4/fmu-v6x/init/rc.board_sensors
@@ -15,16 +15,9 @@ icm20649 -R 2 -s start
 # Internal SPI bus ISM300DLC
 ism330dlc -s start
 
-# Internal SPI bus BMI088 accel
+# Internal SPI bus BMI088 accel/gyro
 bmi088 -A -R 12 -s start
-
-# Internal SPI bus BMI088 gyro
 bmi088 -G -R 12 -s start
-
-# Possible external compasses
-ist8310 -X start
-hmc5883 -T -X start
-qmc5883 -X start
 
 # Possible internal compass
 bmm150 -I start
@@ -35,6 +28,3 @@ bmp388 -I -a 0x77 start
 
 # Baro on I2C3
 ms5611 -X start
-
-# External RM3100
-rm3100 -X start

--- a/boards/uvify/core/init/rc.board_defaults
+++ b/boards/uvify/core/init/rc.board_defaults
@@ -9,5 +9,6 @@ then
 	# Disable safety switch by default
 	param set CBRK_IO_SAFETY 22027
 
+	# don't probe external I2C
+	param set SENS_EXT_I2C_PRB 0
 fi
-

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -191,3 +191,14 @@ PARAM_DEFINE_FLOAT(SENS_BOARD_Z_OFF, 0.0f);
  * @group Sensors
  */
 PARAM_DEFINE_INT32(SENS_EN_THERMAL, -1);
+
+/**
+ * External I2C probe.
+ *
+ * Probe for optional external I2C devices.
+ *
+ * @boolean
+ * @category system
+ * @group Sensors
+ */
+PARAM_DEFINE_INT32(SENS_EXT_I2C_PRB, 1);


### PR DESCRIPTION
This is a quick idea to centralize all the optional external mags. The goal is consistency between boards.

 - configured with new parameter SENS_EXT_I2C_PRB
