### PR TITLE
FlightTaskAuto: update waypoints on every iteration when in offtrack state

### DIFF
--- a/src/lib/flight_tasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/flight_tasks/tasks/Auto/FlightTaskAuto.cpp
@@ -281,7 +281,7 @@ bool FlightTaskAuto::_evaluateTriplets()
 	State previous_state = _current_state;
 	_current_state = _getCurrentState();
 
-	if (triplet_update || (_current_state != previous_state)) {
+	if (triplet_update || (_current_state != previous_state) || _current_state == State::offtrack) {
 		_updateInternalWaypoints();
 		_mission_gear = _sub_triplet_setpoint.get().current.landing_gear;
 	}


### PR DESCRIPTION
The waypoints are updated whenever state changes or when triplets update. But, when the drone is offtrack, the target should be the closest point on the path prev-next, which changes every iteration due to the drone moving while offtrack.

In this case we have to update whenever closest point changes.

This had a significant effect in my case when the obstacle avoidance / collision prevention is active. Although we use our custom avoidance / prevention algorithms, I think the same holds for the px4 master case.
When collision prevention is actively changing the setpoints, the drone can get offtrack, and the target is saved at that moment when the state switches to offtrack. When the prevention stops interfering, the drone is at a different position and instead of going to the current closest point on the path it goes to the saved target which can be far "backwards".

Regardless of the avoidance/prevention, this fix should hold for any reason that caused the drone going offtrack, as the drone in general can move when its offtrack and should always aim for the current closest point on the path.