### PR TITLE
Revert "kakutef7 spi: disable IMU drdy"

### DIFF
--- a/boards/holybro/kakutef7/src/spi.cpp
+++ b/boards/holybro/kakutef7/src/spi.cpp
@@ -43,9 +43,8 @@ constexpr px4_spi_bus_t px4_spi_buses[SPI_BUS_MAX_BUS_ITEMS] = {
 		initSPIDevice(DRV_OSD_DEVTYPE_ATXXXX, SPI::CS{GPIO::PortB, GPIO::Pin12}),
 	}),
 	initSPIBus(SPI::Bus::SPI4, {
-		// Note: DRDY is disabled as it caused bad IMU transfers (on a Kopis 2 with ICM20689)
-		initSPIDevice(DRV_IMU_DEVTYPE_ICM20689, SPI::CS{GPIO::PortE, GPIO::Pin4}),
-		initSPIDevice(DRV_IMU_DEVTYPE_MPU6000, SPI::CS{GPIO::PortE, GPIO::Pin4}),
+		initSPIDevice(DRV_IMU_DEVTYPE_ICM20689, SPI::CS{GPIO::PortE, GPIO::Pin4}, SPI::DRDY{GPIO::PortE, GPIO::Pin1}),
+		initSPIDevice(DRV_IMU_DEVTYPE_MPU6000, SPI::CS{GPIO::PortE, GPIO::Pin4}, SPI::DRDY{GPIO::PortE, GPIO::Pin1}),
 	}),
 };
 


### PR DESCRIPTION
This reverts commit 2069576a6ef4919f4e28e6a329bff83eb590c4d1.

PR #15004 fixed the problem.

```
nsh> icm20689 status
INFO  [SPI_I2C] Running on SPI Bus 4
INFO  [icm20689] FIFO empty interval: 500 us (2000.000 Hz)
icm20689: transfer: 221943 events, 17971155us elapsed, 80.97us avg, min 48us max 15011us 36.048us rms
icm20689: bad register: 0 events
icm20689: bad transfer: 0 events
icm20689: FIFO empty: 0 events
icm20689: FIFO overflow: 1 events
icm20689: FIFO reset: 2 events
icm20689: DRDY interval: 221970 events, 510.25us avg, min 152us max 15073us 151.185us rms
```