### PR TITLE
Revise INA226 return codes to allow negative current

### DIFF
--- a/src/drivers/power_monitor/ina226/ina226.cpp
+++ b/src/drivers/power_monitor/ina226/ina226.cpp
@@ -279,14 +279,13 @@ INA226::collect()
 			0.0
 		);
 		ret = -1;
-		perf_count(_comms_errors);
 	}
 
 	if (ret != OK) {
 		PX4_DEBUG("error reading from sensor: %d", ret);
+		perf_count(_comms_errors);
 	}
 
-	perf_count(_comms_errors);
 	perf_end(_sample_perf);
 	return ret;
 }

--- a/src/drivers/power_monitor/ina226/ina226.h
+++ b/src/drivers/power_monitor/ina226/ina226.h
@@ -129,7 +129,7 @@ public:
 	 * Tries to call the init() function. If it fails, then it will schedule to retry again in
 	 * INA226_INIT_RETRY_INTERVAL_US microseconds. It will keep retrying at this interval until initialization succeeds.
 	 *
-	 * @return OK if initialization succeeded on the first try. Negative value otherwise.
+	 * @return PX4_OK if initialization succeeded on the first try. Negative value otherwise.
 	 */
 	int force_init();
 
@@ -171,16 +171,8 @@ private:
 	uORB::Subscription  _actuators_sub{ORB_ID(actuator_controls_0)};
 	uORB::Subscription  _parameters_sub{ORB_ID(parameter_update)};
 
-
-	/**
-	* Test whetpower_monitorhe device supported by the driver is present at a
-	* specific address.
-	*
-	* @param address	The I2C bus address to read or write.
-	* @return			.
-	*/
-	int               read(uint8_t address);
-	int               write(uint8_t address, uint16_t data);
+	int read(uint8_t address);
+	int write(uint8_t address, uint16_t data);
 
 	/**
 	* Initialise the automatic measurement state machine and start it.

--- a/src/drivers/power_monitor/ina226/ina226.h
+++ b/src/drivers/power_monitor/ina226/ina226.h
@@ -153,8 +153,8 @@ private:
 	perf_counter_t 		_measure_errors;
 
 	int16_t           _bus_voltage{0};
-	int16_t           _power{-1};
-	int16_t           _current{-1};
+	int16_t           _power{0};
+	int16_t           _current{0};
 	int16_t           _shunt{0};
 	int16_t           _cal{0};
 	bool              _mode_triggered{false};
@@ -171,7 +171,7 @@ private:
 	uORB::Subscription  _actuators_sub{ORB_ID(actuator_controls_0)};
 	uORB::Subscription  _parameters_sub{ORB_ID(parameter_update)};
 
-	int read(uint8_t address);
+	int read(uint8_t address, int16_t &data);
 	int write(uint8_t address, uint16_t data);
 
 	/**

--- a/src/drivers/power_monitor/ina226/ina226_main.cpp
+++ b/src/drivers/power_monitor/ina226/ina226_main.cpp
@@ -16,11 +16,11 @@ I2CSPIDriverBase *INA226::instantiate(const BusCLIArguments &cli, const BusInsta
 	}
 
 	if (cli.custom1 == 1) {
-		if (instance->force_init() != OK) {
+		if (instance->force_init() != PX4_OK) {
 			PX4_INFO("Failed to init INA226 on bus %d, but will try again periodically.", iterator.bus());
 		}
 
-	} else if (OK != instance->init()) {
+	} else if (instance->init() != PX4_OK) {
 		delete instance;
 		return nullptr;
 	}


### PR DESCRIPTION
**Describe problem solved by this pull request**
One vehicle we tested can generate temporary negative current draw because of active braking of the ESCs/motors. Whenever this occurred the battery was considered gone because the driver is returning negative error codes the same way as sensor measurements and therefore any negative value is considered an error.

**Describe your solution**
- `read()` just like `write()` handles the data to operate on as a parameter now and the return value is solely to report success or error. The errors get handled accordingly.
- Some general refactoring and simplifications of `collect()` function.

**Test data / coverage**
I bench tested the changes on an fmu v5x board on both power module ports.