### PR TITLE
Hex/Proficnc Cube Yellow: align firmware location in flash memory to …

### DIFF
--- a/boards/hex/cube-yellow/nuttx-config/scripts/script.ld
+++ b/boards/hex/cube-yellow/nuttx-config/scripts/script.ld
@@ -65,14 +65,14 @@
  * where the code expects to begin execution by jumping to the entry point in
  * the 0x0800:0000 address range.
  *
- * Bootloader reserves the first 32K bank (2 Mbytes Flash memory single bank)
+ * Bootloader reserves three 32K banks (2 Mbytes Flash memory single bank)
  * organization (256 bits read width)
  */
 
 MEMORY
 {
-    FLASH_ITCM (rx) : ORIGIN = 0x00208000, LENGTH = 2016K
-    FLASH_AXIM (rx) : ORIGIN = 0x08008000, LENGTH = 2016K
+    FLASH_ITCM (rx) : ORIGIN = 0x00218000, LENGTH = 1952K
+    FLASH_AXIM (rx) : ORIGIN = 0x08018000, LENGTH = 1952K
 
     ITCM_RAM (rwx) : ORIGIN = 0x00000000, LENGTH = 16K
     DTCM_RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 128K


### PR DESCRIPTION
…be able to use the default bootloader

The default bootloader installed on Cube Yellow reserves 3 * 32k of flash memory https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef/CubeYellow/hwdef-bl.dat#L54 . To be able to use the default bootloader, the Firmware location is moved behind these 96k in the flash. We will loose 64k of flash but can use the default bootloader. Otherwise we have to reflash the bootloader to be able to run PX4 on a Cube Yellow with only 32k used for the bootloader.