### PR TITLE
add GNU screen to NUTTX dependencies in ubuntu setup

### DIFF
--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -130,6 +130,7 @@ if [[ $INSTALL_NUTTX == "true" ]]; then
 		libncurses-dev \
 		libtool \
 		pkg-config \
+		screen \
 		vim-common \
 		;
 


### PR DESCRIPTION
Using `make px4_fmu-vX_default blackmagic_console` under freshly setup ubuntu leads to an error because screen is not found. Therefore I would like to add screen to NuttX dependencies.

