### PR TITLE
Update uuv_att_control.cpp

### DIFF
--- a/src/modules/uuv_att_control/uuv_att_control.cpp
+++ b/src/modules/uuv_att_control/uuv_att_control.cpp
@@ -235,7 +235,7 @@ void UUVAttitudeControl::control_attitude_geo(const vehicle_attitude_s &att, con
 	*/
 
 	// take thrust as
-	thrust_u = _param_direct_thrust.get();
+	thrust_u = _vehicle_attitude_sp.thrust_body[0];
 
 	constrain_actuator_commands(roll_u, pitch_u, yaw_u, thrust_u);
 	/* Geometric Controller END*/


### PR DESCRIPTION
Modified the thruster value to be accessed from attitude setpoint message instead of parameters

https://discuss.px4.io/t/questions-about-the-hippocampus-uuv-sitl-module/16998/4

**Describe problem solved by this pull request**
The thruster value was accessed from the parameters setting before, which was default to 0. In this case, the uuv can't move if we send a thruster value in the attitude setpoint message. 

**Describe your solution**
The modified version solved this problem by accessing the thruster value from the attitude setpoint message

**Test data / coverage**
This was tested using ROS to send a list of attitude setpoints with the same orientation and thruster. The trajectory was checked on the log review.

