### PR TITLE
Feature: add multi-GPS input from simulation

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/10020_if750a
+++ b/ROMFS/px4fmu_common/init.d-posix/10020_if750a
@@ -8,5 +8,10 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_x
+if [ $AUTOCNF = yes ]
+then
+	# EKF2: Multi GPS blending (as the model has 2 GPS's)
+	param set EKF2_GPS_MASK 7 # Uses speed, hpos and vpos accuracy
+fi
 
+set MIXER quad_x

--- a/ROMFS/px4fmu_common/init.d-posix/1019_iris_dual_gps
+++ b/ROMFS/px4fmu_common/init.d-posix/1019_iris_dual_gps
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# @name 3DR Iris Quadrotor SITL (Dual GPS)
+#
+# @type Quadrotor Wide
+#
+
+sh /etc/init.d-posix/10016_iris
+
+if [ $AUTOCNF = yes ]
+then
+	# EKF2: Multi GPS blending
+	param set EKF2_GPS_MASK 7 # Uses speed, hpos and vpos accuracy
+fi

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -76,7 +76,7 @@ ExternalProject_Add(flightgear_bridge
 set(viewers none jmavsim gazebo)
 set(debuggers none ide gdb lldb ddd valgrind callgrind)
 set(models none shell
-	if750a iris iris_opt_flow iris_opt_flow_mockup iris_vision iris_rplidar iris_irlock iris_obs_avoid iris_rtps px4vision solo typhoon_h480
+	if750a iris iris_dual_gps iris_opt_flow iris_opt_flow_mockup iris_vision iris_rplidar iris_irlock iris_obs_avoid iris_rtps px4vision solo typhoon_h480
 	plane plane_cam plane_catapult plane_lidar
 	standard_vtol tailsitter tiltrotor
 	rover r1_rover boat

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -248,7 +248,8 @@ private:
 	uORB::Publication<input_rc_s>			_input_rc_pub{ORB_ID(input_rc)};
 
 	// HIL GPS
-	uORB::Publication<vehicle_gps_position_s>	_vehicle_gps_position_pub{ORB_ID(vehicle_gps_position)};
+	uORB::PublicationMulti<vehicle_gps_position_s>	*_vehicle_gps_position_pubs[ORB_MULTI_MAX_INSTANCES] {};
+	uint8_t _gps_ids[ORB_MULTI_MAX_INSTANCES] {};
 	std::default_random_engine _gen{};
 
 	// uORB subscription handlers


### PR DESCRIPTION
**Describe problem solved by this pull request**
This add the ability to test GPS blending through simulation by adding the ability to handle multi-GPS sensor streams.

**Describe your solution**
This is done by checking the ID field in the `HIL_GPS` Mavlink message and then create a multi-topic publisher, where each ID is mapped to a specific `vehicle_gps_position` topic.

This also adds an `iris_dual_gps` model to tweak and verify this implementation.

This also required a major refactor on the `sitl_gazebo` side - https://github.com/PX4/sitl_gazebo/pull/517.

**Test data / coverage**

Log of a flight with the `iris_dual_gps`: https://logs.px4.io/plot_app?log=c3304662-4e15-476a-874e-57df1a360b0b.

An example output of `listener vehicle_gps_position`: (note that the data is the same as the GPS's are being modeled the same, but this can be changed by tweaking the noise and random walk values in one of the GPS models)

```sh
pxh> listener vehicle_gps_position

TOPIC: vehicle_gps_position 2 instances

Instance 0:
 vehicle_gps_position_s
	timestamp: 79372000  (0.140000 seconds ago)
	time_utc_usec: 82796000
	lat: 473977600
	lon: 85456085
	alt: 512986
	alt_ellipsoid: 0
	s_variance_m_s: 0.2500
	c_variance_rad: 0.0000
	eph: 1.0000
	epv: 1.0000
	hdop: 0.0000
	vdop: 0.0000
	noise_per_ms: 0
	jamming_indicator: 0
	vel_m_s: 0.2700
	vel_n_m_s: -0.1600
	vel_e_m_s: 0.2900
	vel_d_m_s: 0.6100
	cog_rad: 2.0850
	timestamp_time_relative: 0
	heading: 0.0000
	heading_offset: 0.0000
	fix_type: 3
	vel_ned_valid: False
	satellites_used: 10

Instance 1:
 vehicle_gps_position_s
	timestamp: 79376000  (0.136000 seconds ago)
	time_utc_usec: 82796000
	lat: 473977600
	lon: 85456085
	alt: 512986
	alt_ellipsoid: 0
	s_variance_m_s: 0.2500
	c_variance_rad: 0.0000
	eph: 1.0000
	epv: 1.0000
	hdop: 0.0000
	vdop: 0.0000
	noise_per_ms: 0
	jamming_indicator: 0
	vel_m_s: 0.2700
	vel_n_m_s: -0.1600
	vel_e_m_s: 0.2900
	vel_d_m_s: 0.6100
	cog_rad: 2.0850
	timestamp_time_relative: 0
	heading: 0.0000
	heading_offset: 0.0000
	fix_type: 3
	vel_ned_valid: False
	satellites_used: 10
```