### PR TITLE
Remove gps noise multiplier parameter for simulation

### DIFF
--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -285,7 +285,6 @@ private:
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::SIM_BAT_DRAIN>) _param_sim_bat_drain, ///< battery drain interval
 		(ParamFloat<px4::params::SIM_BAT_MIN_PCT>) _param_bat_min_pct, //< minimum battery percentage
-		(ParamFloat<px4::params::SIM_GPS_NOISE_X>) _param_sim_gps_noise_x,
 		(ParamBool<px4::params::SIM_GPS_BLOCK>) _param_sim_gps_block,
 		(ParamBool<px4::params::SIM_ACCEL_BLOCK>) _param_sim_accel_block,
 		(ParamBool<px4::params::SIM_GYRO_BLOCK>) _param_sim_gyro_block,

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -309,13 +309,6 @@ void Simulator::handle_message_hil_gps(const mavlink_message_t *msg)
 		gps.satellites_used = hil_gps.satellites_visible;
 		gps.s_variance_m_s = 0.25f;
 
-		// use normal distribution for noise
-		if (_param_sim_gps_noise_x.get() > 0.0f) {
-			std::normal_distribution<float> normal_distribution(0.0f, 1.0f);
-			gps.lat += (int32_t)(_param_sim_gps_noise_x.get() * normal_distribution(_gen));
-			gps.lon += (int32_t)(_param_sim_gps_noise_x.get() * normal_distribution(_gen));
-		}
-
 		_vehicle_gps_position_pub.publish(gps);
 	}
 }

--- a/src/modules/simulator/simulator_params.c
+++ b/src/modules/simulator/simulator_params.c
@@ -66,18 +66,6 @@ PARAM_DEFINE_FLOAT(SIM_BAT_DRAIN, 60);
 PARAM_DEFINE_FLOAT(SIM_BAT_MIN_PCT, 50.0f);
 
 /**
- * Simulator GPS noise multiplier.
- *
- * @min 0
- * @max 10
- * @increment 0.1
- * @unit %
- *
- * @group SITL
- */
-PARAM_DEFINE_FLOAT(SIM_GPS_NOISE_X, 0.0f);
-
-/**
  * Simulator block GPS data.
  *
  * Enable to block the publication of any incoming simulation GPS data.


### PR DESCRIPTION
**Describe problem solved by this pull request**
This removes the gps noise multiplier parameter that can be set on the firmware side. I can see why this can be useful, but I think it creates more confusion and point of failure than give value.

IMHO, the gps noise should be fully configured from the simulation side. Otherwise we should have this for every sensor but I don't think this makes much sense

**Describe your solution**
Remove functionality

**Additional Context**
Update: I realized the feature was introduced recently from @dagar in https://github.com/PX4/Firmware/pull/13854
