### PR TITLE
mavsdk_tests: add iris_dual_gps to the test pipeline

### DIFF
--- a/test/mavsdk_tests/configs/sitl.json
+++ b/test/mavsdk_tests/configs/sitl.json
@@ -17,6 +17,12 @@
             "timeout_min": 10
         },
         {
+            "model": "iris_dual_gps",
+            "vehicle": "iris_dual_gps",
+            "test_filter": "[multicopter]",
+            "timeout_min": 10
+        },
+        {
             "model": "standard_vtol",
             "vehicle": "standard_vtol",
             "test_filter": "[multicopter][vtol]",


### PR DESCRIPTION
Following https://github.com/PX4/Firmware/pull/15106 and to make sure it gets into the test pipeline.
