### PR TITLE
Baro pressure received check in HITL Mode

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -48,6 +48,8 @@
 #include <ecl/geo/geo.h>
 #include <systemlib/px4_macros.h>
 
+#include <float.h>
+
 #include <math.h>
 #include <poll.h>
 
@@ -2181,7 +2183,7 @@ MavlinkReceiver::handle_message_hil_sensor(mavlink_message_t *msg)
 	}
 
 	/* baro */
-	{
+	if (imu.abs_pressure > FLT_MIN) {
 		if (_px4_baro == nullptr) {
 			// 6620172: DRV_BARO_DEVTYPE_BAROSIM, BUS: 1, ADDR: 4, TYPE: SIMULATION
 			_px4_baro = new PX4Barometer(6620172);


### PR DESCRIPTION
**Describe problem solved by this pull request**
Sometimes in HITL simulation Autopilot has a problem with Baro altitude and discards takeoff:
```bash
WARN  [ecl/EKF] baro hgt timeout - reset to baro  # Or WARN  [ecl/EKF] baro hgt timeout - reset to gps
...
INFO  [commander] DISARMED by Auto disarm initiated
```
Example Log:
https://review.px4.io/plot_app?log=80e804a4-e168-4e72-8132-b1e1adaba412

Estimated Altitude graph have a "noise" because of zero values filled in too:

![image](https://user-images.githubusercontent.com/13483534/84880203-e6ad8000-b094-11ea-9926-4469ff1e28f6.png)

This happens because of in `gazebo_mavlink_interface` plugin in most messages did not update baro values:
https://github.com/PX4/sitl_gazebo/blob/97106007eb5c934b902a5329afb55b45e94d5063/src/gazebo_mavlink_interface.cpp#L904

In my custom Airframe this problem happens at least 90% times but proposed modification resolves that.

**Describe your solution**
Check baro pressure in MAVLink receiver on Autopilot side and fill in only significant values.

Result:
https://review.px4.io/plot_app?log=6cf12e96-80ed-4788-8742-aa89e4e066e4

![image](https://user-images.githubusercontent.com/13483534/84881190-2f196d80-b096-11ea-8b24-103d16f4ec85.png)


**Describe possible alternatives**
Fill last baro values on Gazebo plugin side

**Test data / coverage**
Tested in HITL simulation.

