### PR TITLE
publish battery_dangerous message if battery level is dangerous

### DIFF
--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -1042,12 +1042,12 @@ void battery_failsafe(orb_advert_t *mavlink_log_pub, const vehicle_status_s &sta
 			if (status_flags.condition_global_position_valid && status_flags.condition_home_position_valid) {
 				internal_state->main_state = commander_state_s::MAIN_STATE_AUTO_RTL;
 				internal_state->timestamp = hrt_absolute_time();
-				mavlink_log_critical(mavlink_log_pub, "%s, executing RTL", battery_critical);
+				mavlink_log_critical(mavlink_log_pub, "%s, executing RTL", battery_dangerous);
 
 			} else {
 				internal_state->main_state = commander_state_s::MAIN_STATE_AUTO_LAND;
 				internal_state->timestamp = hrt_absolute_time();
-				mavlink_log_emergency(mavlink_log_pub, "%s, can't execute RTL, landing instead", battery_critical);
+				mavlink_log_emergency(mavlink_log_pub, "%s, can't execute RTL, landing instead", battery_dangerous);
 			}
 
 			break;
@@ -1058,7 +1058,7 @@ void battery_failsafe(orb_advert_t *mavlink_log_pub, const vehicle_status_s &sta
 		case LOW_BAT_ACTION::LAND:
 			internal_state->main_state = commander_state_s::MAIN_STATE_AUTO_LAND;
 			internal_state->timestamp = hrt_absolute_time();
-			mavlink_log_emergency(mavlink_log_pub, "%s, landing", battery_critical);
+			mavlink_log_emergency(mavlink_log_pub, "%s, landing", battery_dangerous);
 
 			break;
 		}


### PR DESCRIPTION
I found it highly confusing that even though the battery_level can be "dangerous" the commander does not always use the battery_dangerous message to report the current state.
In fact it made me think that there is a problem in the state machine because when battery level was clearly dangerous, commander was still only reporting the critical message.