### PR TITLE
mavlink: DISTANCE_SENSOR: propagate signal_quality metric

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -716,10 +716,14 @@ MavlinkReceiver::handle_message_distance_sensor(mavlink_message_t *msg)
 	ds.q[1]             = dist_sensor.quaternion[1];
 	ds.q[2]             = dist_sensor.quaternion[2];
 	ds.q[3]             = dist_sensor.quaternion[3];
-	ds.signal_quality   = -1; // TODO: A dist_sensor.signal_quality field is missing from the mavlink message definition.
 	ds.type             = dist_sensor.type;
 	ds.id               = dist_sensor.id;
 	ds.orientation      = dist_sensor.orientation;
+
+	// MAVLink DISTANCE_SENSOR signal_quality value of 0 means unset/unknown
+	// quality value. Also it comes normalised between 1 and 100 while the uORB
+	// signal quality is normalised between 0 and 100.
+	ds.signal_quality = dist_sensor.signal_quality == 0 ? -1 : 100 * (dist_sensor.signal_quality - 1) / 99;
 
 	_distance_sensor_pub.publish(ds);
 }

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -1144,7 +1144,11 @@ int Simulator::publish_distance_topic(const mavlink_distance_sensor_t *dist_mavl
 	dist.type = dist_mavlink->type;
 	dist.id = dist_mavlink->id;
 	dist.variance = dist_mavlink->covariance * 1e-4f; // cm^2 to m^2
-	dist.signal_quality = -1;
+
+	// MAVLink DISTANCE_SENSOR signal_quality value of 0 means unset/unknown
+	// quality value. Also it comes normalised between 1 and 100 while the uORB
+	// signal quality is normalised between 0 and 100.
+	dist.signal_quality = dist_mavlink->signal_quality == 0 ? -1 : 100 * (dist_mavlink->signal_quality - 1) / 99;
 
 	switch (dist_mavlink->orientation) {
 	case MAV_SENSOR_ORIENTATION::MAV_SENSOR_ROTATION_PITCH_270:


### PR DESCRIPTION
**Describe problem solved by this pull request**
A range signal quality metric coming from Mavlink allows a proper evaluation of the range sensor being received from both simulation (Gazebo) and an external distance sensor connected to a companion computer.

**Describe your solution**
Following https://github.com/mavlink/mavlink/pull/1403 and https://github.com/PX4/sitl_gazebo/pull/528, this propagates the quality field, normalised to 0..100.

**Test data / coverage**
Tested in SITL with the `iris_opt_flow` Gazebo model. 
Example output of `listener distance_sensor` at the ground level:
```sh
pxh> listener distance_sensor

TOPIC: distance_sensor
 distance_sensor_s
	timestamp: 6248000  (0.012000 seconds ago)
	min_distance: 0.2000
	max_distance: 15.0000
	current_distance: 0.2000
	variance: 0.0000
	h_fov: 0.0524
	v_fov: 0.0524
	q: [0.7071, -0.0000, -0.7071, -0.0000]
	signal_quality: 0
	type: 0
	id: 0
	orientation: 25
```

Example output of `listener distance_sensor` at 2.5 meters:
```sh
pxh> listener distance_sensor

TOPIC: distance_sensor
 distance_sensor_s
	timestamp: 34224000  (0.012000 seconds ago)
	min_distance: 0.2000
	max_distance: 15.0000
	current_distance: 2.6900
	variance: 0.0000
	h_fov: 0.0524
	v_fov: 0.0524
	q: [0.7071, -0.0000, -0.7071, -0.0000]
	signal_quality: 64
	type: 0
	id: 0
	orientation: 25
```