### PR TITLE
Jenkins compile keep in sync with Github Actions NuttX build

### DIFF
--- a/.ci/Jenkinsfile-compile
+++ b/.ci/Jenkinsfile-compile
@@ -66,8 +66,9 @@ pipeline {
                      "px4_fmu-v5_rover",
                      "px4_fmu-v5_rtps",
                      "px4_fmu-v5_stackcheck",
-                     "px4_fmu-v5x_default",
                      "px4_fmu-v5x_base_phy_DP83848C",
+                     "px4_fmu-v5x_default",
+                     "px4_fmu-v6x_default",
                      "px4_io-v2_default",
                      "uvify_core_default"
             ],

--- a/.github/workflows/compile_nuttx.yml
+++ b/.github/workflows/compile_nuttx.yml
@@ -52,8 +52,8 @@ jobs:
           px4_fmu-v5_rover,
           px4_fmu-v5_rtps,
           px4_fmu-v5_stackcheck,
-          px4_fmu-v5x_default,
           px4_fmu-v5x_base_phy_DP83848C,
+          px4_fmu-v5x_default,
           px4_fmu-v6x_default,
           px4_io-v2_default,
           uvify_core_default


### PR DESCRIPTION
 - jenkins is still responsible for master/beta/stable S3 uploads


TODO:
  - move deploy to github actions and put Jenkins (mostly) to rest