### PR TITLE
Jenkins hardware ignore nxp_fmuk66-v3 status failures

### DIFF
--- a/.ci/Jenkinsfile-hardware
+++ b/.ci/Jenkinsfile-hardware
@@ -723,7 +723,7 @@ pipeline {
                 stage("tests") {
                   steps {
                     // run tests
-                    sh './Tools/HIL/run_tests.py --device `find /dev/serial -name *usb-FTDI_*`'
+                    sh './Tools/HIL/run_tests.py --device `find /dev/serial -name *usb-FTDI_*` || true' // ignore failures for now (flaky console on test rack)
                   }
                 }
                 stage("reset") {


### PR DESCRIPTION
 - this particular hardware on the test rack has a flaky console
