### PR TITLE
Add FW hand launch / catapult launch to testing

### DIFF
--- a/.github/workflows/mavros_mission_tests.yml
+++ b/.github/workflows/mavros_mission_tests.yml
@@ -18,6 +18,7 @@ jobs:
           - {vehicle: "iris",          mission: "MC_mission_box",  build_type: "RelWithDebInfo"}
           - {vehicle: "rover",         mission: "rover_mission_1", build_type: "RelWithDebInfo"}
           - {vehicle: "plane",         mission: "FW_mission_1",    build_type: "RelWithDebInfo"}
+          - {vehicle: "plane_catapult",mission: "FW_mission_1",    build_type: "RelWithDebInfo"}
           - {vehicle: "standard_vtol", mission: "VTOL_mission_1",  build_type: "RelWithDebInfo"}
           - {vehicle: "standard_vtol", mission: "VTOL_mission_1",  build_type: "Coverage"}
           - {vehicle: "standard_vtol", mission: "VTOL_mission_1",  build_type: "AddressSanitizer"}

--- a/test/mavros_posix_tests_missions.test
+++ b/test/mavros_posix_tests_missions.test
@@ -18,6 +18,7 @@
     </include>
     <!-- ROStest -->
     <test test-name="FW_mission_1" pkg="px4" type="mission_test.py" time-limit="300.0" args="FW_mission_1.plan" vehicle="plane"/>
+    <test test-name="FW_mission_1" pkg="px4" type="mission_test.py" time-limit="300.0" args="FW_mission_1.plan" vehicle="plane_catapult"/>
     <test test-name="MC_mission_box" pkg="px4" type="mission_test.py" time-limit="300.0" args="MC_mission_box.plan" vehicle="iris"/>
     <test test-name="VTOL_mission_1" pkg="px4" type="mission_test.py" time-limit="300.0" args="VTOL_mission_1.plan" vehicle="standard_vtol"/>
     <test test-name="VTOL_mission_1" pkg="px4" type="mission_test.py" time-limit="300.0" args="VTOL_mission_1.plan" vehicle="tailsitter"/>


### PR DESCRIPTION
**Describe problem solved by this pull request**
Previously, the fw hand launch /catapult launch was not part of the tests.

**Describe your solution**
This PR adds `plane_catapult` model in gazebo SITL to test the hand / catapult launch feature for fixed wing

**Additional context**
- This is a continuation of https://github.com/PX4/Firmware/pull/14418 moving from Jenkins to github actions
- This PR contains a fix for the plane catapult plugin https://github.com/PX4/sitl_gazebo/pull/529