### PR TITLE
Hex/Proficnc CubeYellow/CubeOrange: fix default config for IMU heating

### DIFF
--- a/boards/hex/cube-orange/init/rc.board_defaults
+++ b/boards/hex/cube-orange/init/rc.board_defaults
@@ -31,8 +31,8 @@ then
 	param set BAT1_A_PER_V 17
 	param set BAT2_A_PER_V 17
 
-	# Enable IMU thermal control
-	param set SENS_EN_THERMAL -1
+	# Disable IMU thermal control
+	param set SENS_EN_THERMAL 0
 fi
 
 set LOGGER_BUF 64

--- a/boards/hex/cube-yellow/init/rc.board_defaults
+++ b/boards/hex/cube-yellow/init/rc.board_defaults
@@ -14,8 +14,8 @@ then
 	param set BAT1_A_PER_V 17
 	param set BAT2_A_PER_V 17
 
-	# Disable IMU thermal control by FMU
-	param set SENS_EN_THERMAL -1
+	# Disable IMU thermal control
+	param set SENS_EN_THERMAL 0
 fi
 
 set LOGGER_BUF 64


### PR DESCRIPTION
This PR solves the issue with ICM20948 zmag noise for the Hex CubeYellow and CubeOrange
![Screenshot from 2020-06-22 07-56-33](https://user-images.githubusercontent.com/10398007/85261990-6197e180-b46d-11ea-9d3e-06344dc9a3f0.png)
