### PR TITLE
Github Actions limit checks to Ubuntu 20.04

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,7 +27,7 @@ jobs:
           "parameters_metadata",
         ]
         ubuntu_release: [
-          bionic,
+          #bionic,
           focal
           ]
     container: px4io/px4-dev-nuttx-${{ matrix.ubuntu_release }}:2020-04-01


### PR DESCRIPTION
Surprisingly the test resources are not unlimited...