### PR TITLE
{dshot,pwm_out}: allow mode_pwm4 for boards with 5 outputs

### DIFF
--- a/src/drivers/dshot/dshot.cpp
+++ b/src/drivers/dshot/dshot.cpp
@@ -1289,6 +1289,9 @@ DShotOutput::module_new_mode(PortMode new_mode)
 		/* select 6-pin PWM mode */
 		mode = DShotOutput::MODE_6PWM;
 		break;
+#endif
+
+#if defined(BOARD_HAS_PWM) && BOARD_HAS_PWM >= 5
 
 	case PORT_PWM5:
 		/* select 5-pin PWM mode */
@@ -1304,6 +1307,9 @@ DShotOutput::module_new_mode(PortMode new_mode)
 		break;
 
 #  endif
+#endif
+
+#if defined(BOARD_HAS_PWM) && BOARD_HAS_PWM >= 4
 
 	case PORT_PWM4:
 		/* select 4-pin PWM mode */

--- a/src/drivers/pwm_out/PWMOut.cpp
+++ b/src/drivers/pwm_out/PWMOut.cpp
@@ -1530,6 +1530,9 @@ int PWMOut::fmu_new_mode(PortMode new_mode)
 		/* select 6-pin PWM mode */
 		servo_mode = PWMOut::MODE_6PWM;
 		break;
+#endif
+
+#if defined(BOARD_HAS_PWM) && BOARD_HAS_PWM >= 5
 
 	case PORT_PWM5:
 		/* select 5-pin PWM mode */
@@ -1545,6 +1548,9 @@ int PWMOut::fmu_new_mode(PortMode new_mode)
 		break;
 
 #  endif
+#endif
+
+#if defined(BOARD_HAS_PWM) && BOARD_HAS_PWM >= 4
 
 	case PORT_PWM4:
 		/* select 4-pin PWM mode */


### PR DESCRIPTION
Required on durandal if camera triggering is enabled.

@mhkabir this fixes your initial issue, still good to add support for the capture pins though.