### PR TITLE
Fix gzserver hanging from multiple executions of gazebo SITL

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -104,9 +104,9 @@ elif [ "$program" == "gazebo" ] && [ ! -n "$no_sim" ]; then
 				gzserver "$PX4_SITL_WORLD" &
 			fi
 		fi
+		SIM_PID=`echo $!`
 		gz model --spawn-file="${src_path}/Tools/sitl_gazebo/models/${model}/${model}.sdf" --model-name=${model} -x 1.01 -y 0.98 -z 0.83
 
-		SIM_PID=`echo $!`
 
 		if [[ -n "$HEADLESS" ]]; then
 			echo "not running gazebo gui"


### PR DESCRIPTION
**Describe problem solved by this pull request**
When running gazebo SITL simulation multiple times, gzserver will sometimes silently fail. This is due to the fact that `gzserver` didn't exit cleanly from the previous session. The workaround was to run `pkill gzserver` when this happens.

**Describe your solution**
`SIM_PID` was supposed to work to clean the previous gzserver instance but was wrongly taking the pid of the model spawner and not the gzserver. This PR makes the `SIM_PID` take the pid of `gzserver`


**Test data / coverage**
Previously model spawning would sometimes hang when starting SITL. After this change, it seems much less likely. 
