### PR TITLE
Feature: add support to FastRTPS 2.0.0 (Fast-DDS)

### DIFF
--- a/msg/templates/urtps/Publisher.cpp.em
+++ b/msg/templates/urtps/Publisher.cpp.em
@@ -90,7 +90,11 @@ bool @(topic)_Publisher::init()
 {
     // Create RTPSParticipant
     ParticipantAttributes PParam;
+@[if version.parse(fastrtps_version[:3]) < version.parse('2.0')]@
     PParam.rtps.builtin.domainId = 0;
+@[else]@
+    PParam.domainId = 0;
+@[end if]@
 @[if version.parse(fastrtps_version[:3]) <= version.parse('1.8')]@
     PParam.rtps.builtin.leaseDuration = c_TimeInfinite;
 @[else]@

--- a/msg/templates/urtps/Subscriber.cpp.em
+++ b/msg/templates/urtps/Subscriber.cpp.em
@@ -90,7 +90,11 @@ bool @(topic)_Subscriber::init(uint8_t topic_ID, std::condition_variable* t_send
 
     // Create RTPSParticipant
     ParticipantAttributes PParam;
-    PParam.rtps.builtin.domainId = 0; // MUST BE THE SAME AS IN THE PUBLISHER
+@[if version.parse(fastrtps_version[:3]) < version.parse('2.0')]@
+    PParam.rtps.builtin.domainId = 0;
+@[else]@
+    PParam.domainId = 0;
+@[end if]@
 @[if version.parse(fastrtps_version[:3]) <= version.parse('1.8')]@
     PParam.rtps.builtin.leaseDuration = c_TimeInfinite;
 @[else]@


### PR DESCRIPTION
This adds support to FastRTPS release v2.0.0, or the new called FastDDS. The changes on the RTPS API are minimal, and so this allows a simple port. Further iterations on the bridge might consider the complete support for DDS features and API, or simply explore the usage of Micro-XRCE DDS, which shares also some common API on the client proxy/agent side.

As an extra, this also allows bridging with ROS 2 Foxy.

Functionality tested with PX4 SITL and Gazebo. All working as expected.