### PR TITLE
Update sitl_run to fetch the SDF filename from the model.config file

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -80,6 +80,13 @@ if [ "$program" == "jmavsim" ] && [ ! -n "$no_sim" ]; then
 	SIM_PID=`echo $!`
 elif [ "$program" == "gazebo" ] && [ ! -n "$no_sim" ]; then
 	if [ -x "$(command -v gazebo)" ]; then
+		# Get the model name
+		model_name="${model}"
+		# Check if a 'modelname-gen.sdf' file exist for the models using jinja and generating the SDF files
+		if [ -f "${src_path}/Tools/sitl_gazebo/models/${model}/${model}-gen.sdf" ]; then
+			model_name="${model}-gen"
+		fi
+
 		# Set the plugin path so Gazebo finds our model and sim
 		source "$src_path/Tools/setup_gazebo.bash" "${src_path}" "${build_path}"
 		if [ -z $PX4_SITL_WORLD ]; then
@@ -107,7 +114,7 @@ elif [ "$program" == "gazebo" ] && [ ! -n "$no_sim" ]; then
 		fi
 		SIM_PID=$!
 
-		while gz model --verbose --spawn-file="${src_path}/Tools/sitl_gazebo/models/${model}/${model}.sdf" --model-name=${model} -x 1.01 -y 0.98 -z 0.83 2>&1 | grep -q "An instance of Gazebo is not running."; do
+		while gz model --verbose --spawn-file="${src_path}/Tools/sitl_gazebo/models/${model}/${model_name}.sdf" --model-name=${model} -x 1.01 -y 0.98 -z 0.83 2>&1 | grep -q "An instance of Gazebo is not running."; do
 			echo "gzserver not ready yet, trying again!"
 			sleep 1
 		done


### PR DESCRIPTION
**Problem**
Since the seperation from the SITL Gazebo model and world files, there is no way to run a simulation on the jinja generated models. These models produce a file called `model-gen.sdf`, but currently it expects a file called `model.sdf`

**Solution**
The solution is to update the `sitl_run.sh` file to rather fetch the SDF filename from the `model.config` file, instead of assuming that the SDF filename is the same as the model's.

**Alternatives**
An alternative solution would be to just rename the generated SDF files to `model.sdf` and omit the `-gen` part. However, this means that these can't be ignored when pushing code and I don't think it is preferable to have generated code living in the codebase. Therefore, I think my current proposed solution is a better one.
