### PR TITLE
Github Actions MacOS skip SITL tests

### DIFF
--- a/.github/workflows/compile_macos.yml
+++ b/.github/workflows/compile_macos.yml
@@ -15,7 +15,8 @@ jobs:
       matrix:
         config: [
           px4_fmu-v5_default,
-          tests, # includes px4_sitl
+          px4_sitl_default,
+          #tests, # includes px4_sitl
           ]
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
There's an intermittent crash when running these tests on Github Actions MacOS infrastructure (10.15). 

https://github.com/PX4/Firmware/issues/15225