### PR TITLE
logger: fix hardfault for invalid SDLOG_PROFILE setting

### DIFF
--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -373,7 +373,7 @@ bool LoggedTopics::initialize_logged_topics(SDLogProfileMask profile)
 		initialize_configured_topics(profile);
 	}
 
-	return true;
+	return _subscriptions.count > 0;
 }
 
 void LoggedTopics::initialize_configured_topics(SDLogProfileMask profile)

--- a/src/systemcmds/param/param.cpp
+++ b/src/systemcmds/param/param.cpp
@@ -137,7 +137,7 @@ $ reboot
 
 	PRINT_MODULE_USAGE_COMMAND_DESCR("show", "Show parameter values");
 	PRINT_MODULE_USAGE_PARAM_FLAG('a', "Show all parameters (not just used)", true);
-	PRINT_MODULE_USAGE_PARAM_FLAG('c', "Show only changed and used params", true);
+	PRINT_MODULE_USAGE_PARAM_FLAG('c', "Show only changed params (unused too)", true);
 	PRINT_MODULE_USAGE_PARAM_FLAG('q', "quiet mode, print only param value (name needs to be exact)", true);
 	PRINT_MODULE_USAGE_ARG("<filter>", "Filter by param name (wildcard at end allowed, eg. sys_*)", true);
 
@@ -457,7 +457,8 @@ static int
 do_show(const char *search_string, bool only_changed)
 {
 	PARAM_PRINT("Symbols: x = used, + = saved, * = unsaved\n");
-	param_foreach(do_show_print, (char *)search_string, only_changed, true);
+	// also show unused params if we show non-default values only
+	param_foreach(do_show_print, (char *)search_string, only_changed, !only_changed);
 	PARAM_PRINT("\n %u/%u parameters used.\n", param_count_used(), param_count());
 
 	return 0;


### PR DESCRIPTION
If some bits are set but no topic was added, _subscriptions was null but
later accessed.

During normal use this only happens when switching between different
firmware versions with different SDLOG_PROFILE definition (with custom
config).

Also:  param: also show unused params for 'param show -c' (I find this generally useful for debugging).