### PR TITLE
Ignore optical flow samples with too large integration time spans.

### DIFF
--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -1061,7 +1061,8 @@ void Ekf2::Run()
 				flow.time_us = optical_flow.timestamp;
 
 				if (PX4_ISFINITE(optical_flow.pixel_flow_y_integral) &&
-				    PX4_ISFINITE(optical_flow.pixel_flow_x_integral)) {
+				    PX4_ISFINITE(optical_flow.pixel_flow_x_integral) &&
+				    flow.dt < 1) {
 
 					_ekf.setOpticalFlowData(flow);
 				}


### PR DESCRIPTION
Fixes #14165. Probably also fixes PX4/Flow#102

Within ekf2, optical flow messages (amongst others) are fused to the state estimates. It might occur that optical flow sensors report unreliable and unrealistic spikes. In that case, the state estimator went crazy so far and just ignored optical flow values from that moment on.

The common thread for all these spikes seems to be a too high integration time span (can be as high as the data type upper limit). Therefore, this fix adds a simple logic that ignores unrealistically high integration time spans. As a threshold, 1 second was chosen. This way, the EKF doesn't go crazy and keeps incorporating optical flow values.

Reported-by: Dominik Natter <dominik.natter@gmail.com>

