### PR TITLE
NXP FMUK66 - Fix VDD_3V3_SENSORS_EN polarity

### DIFF
--- a/boards/nxp/fmuk66-v3/src/board_config.h
+++ b/boards/nxp/fmuk66-v3/src/board_config.h
@@ -308,7 +308,7 @@ __END_DECLS
 #define VDD_ETH_EN(on_true)                px4_arch_gpiowrite(nGPIO_ETHERNET_P_EN, !(on_true))
 // Do not have #define VDD_5V_PERIPH_EN(on_true)          px4_arch_gpiowrite(GPIO_nVDD_5V_PERIPH_EN, !(on_true))
 // Do not have #define VDD_5V_HIPOWER_EN(on_true)         px4_arch_gpiowrite(GPIO_nVDD_5V_HIPOWER_EN, !(on_true))
-#define VDD_3V3_SENSORS_EN(on_true)        px4_arch_gpiowrite(GPIO_SENSOR_P_EN, !(on_true))
+#define VDD_3V3_SENSORS_EN(on_true)        px4_arch_gpiowrite(GPIO_SENSOR_P_EN, (on_true))
 #define VDD_3V3_SPEKTRUM_POWER_EN(on_true) px4_arch_gpiowrite(GPIO_SPEKTRUM_P_EN, !(on_true))
 #define READ_VDD_3V3_SPEKTRUM_POWER_EN()   px4_arch_gpioread(GPIO_SPEKTRUM_P_EN)
 // Do not have #define VDD_5V_RC_EN(on_true)              px4_arch_gpiowrite(GPIO_VDD_5V_RC_EN, (on_true))


### PR DESCRIPTION
@PetervdPerk-NXP reported that he had difficulty calibrating the sensors on a new NXP FMUK66 board (Rev. D). After further investigation he only measured about 2.6V on the 3V3_S domain on the NXP FMUK66. I measured a similar voltage level. It may or may not be the cause of the sensor calibration problems, but it's clear that something is not right here.

After studying the schematics and board init code, it seems that up until the Rev. B (not supported anymore) there was a PMOS that enabled the 3V3_S domain. Since Rev. C this voltage is coming from a dedicated low noise LDO. The enable signal is not connected to a PMOS anymore, but to the enable pin of the new LDO. The macro that is used to control the GPIO pin to enable the 3V3_S was never changed, though.

The schematics for different revisions are listed here: https://nxp.gitbook.io/hovergames/rddrone-fmuk66/schematics

This fix simply inverts the polarity for the particular GPIO pin. It will now be set to high when the macro is called. This pulls the enable pin on the LDO high. You can validate that it works by measuring the voltage at TP32. It should be about 2.5-2.6V without this fix. I am still not sure where this voltage is coming from, though.

@davids5 could you validate this?


FYI @igalloway @dk7xe - this one stayed under the radar for a LONG time. It's a miracle that there were no major problems for the participants of the first HoverGames challenge...
