### PR TITLE
Raname DJI Airframe name to Provent Large PWM_MIN for normal ESCs

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4010_dji_f330
+++ b/ROMFS/px4fmu_common/init.d/airframes/4010_dji_f330
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# @name DJI Flame Wheel F330
+# @name DJI F330 w/ DJI ESCs
 #
 # @type Quadrotor x
 # @class Copter

--- a/ROMFS/px4fmu_common/init.d/airframes/4011_dji_f450
+++ b/ROMFS/px4fmu_common/init.d/airframes/4011_dji_f450
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# @name DJI Flame Wheel F450
+# @name DJI F450 w/ DJI ESCs
 #
 # @type Quadrotor x
 # @class Copter


### PR DESCRIPTION
I saw too many users choose DJI Airframe for their normal ESCs, makes lots of trouble, even hit the ceiling.
So, this change could provent most of these situation.