### PR TITLE
sensors: VehicleIMU improve scheduling

### DIFF
--- a/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
@@ -385,7 +385,7 @@ void VehicleIMU::UpdateIntegratorConfiguration()
 					  _accel_calibration.device_id(), _gyro_calibration.device_id(), accel_integral_samples, gyro_integral_samples,
 					  (double)_accel_interval.update_interval, (double)_gyro_interval.update_interval, n);
 
-				return;
+				break;
 			}
 		}
 	}

--- a/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
@@ -122,7 +122,8 @@ private:
 	perf_counter_t _gyro_generation_gap_perf{perf_alloc(PC_COUNT, MODULE_NAME": gyro data gap")};
 
 	DEFINE_PARAMETERS(
-		(ParamInt<px4::params::IMU_INTEG_RATE>) _param_imu_integ_rate
+		(ParamInt<px4::params::IMU_INTEG_RATE>) _param_imu_integ_rate,
+		(ParamInt<px4::params::IMU_GYRO_RATEMAX>) _param_imu_gyro_ratemax
 	)
 };
 

--- a/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
@@ -106,6 +106,9 @@ private:
 	unsigned _accel_last_generation{0};
 	unsigned _gyro_last_generation{0};
 
+	unsigned _accel_consecutive_generation_gap{0};
+	unsigned _gyro_consecutive_generation_gap{0};
+
 	matrix::Vector3f _delta_angle_prev{0.f, 0.f, 0.f};	// delta angle from the previous IMU measurement
 	matrix::Vector3f _delta_velocity_prev{0.f, 0.f, 0.f};	// delta velocity from the previous IMU measurement
 
@@ -113,7 +116,6 @@ private:
 
 	uint8_t _delta_velocity_clipping{0};
 
-	bool _intervals_update{true};
 	bool _intervals_configured{false};
 
 	perf_counter_t _accel_update_perf{perf_alloc(PC_INTERVAL, MODULE_NAME": accel update interval")};

--- a/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
@@ -105,9 +105,7 @@ private:
 
 	unsigned _accel_last_generation{0};
 	unsigned _gyro_last_generation{0};
-
-	unsigned _accel_consecutive_generation_gap{0};
-	unsigned _gyro_consecutive_generation_gap{0};
+	unsigned _consecutive_data_gap{0};
 
 	matrix::Vector3f _delta_angle_prev{0.f, 0.f, 0.f};	// delta angle from the previous IMU measurement
 	matrix::Vector3f _delta_velocity_prev{0.f, 0.f, 0.f};	// delta velocity from the previous IMU measurement

--- a/src/modules/sensors/vehicle_imu/imu_parameters.c
+++ b/src/modules/sensors/vehicle_imu/imu_parameters.c
@@ -39,6 +39,9 @@
 *
 * @min 100
 * @max 1000
+* @value 100 100 Hz
+* @value 200 200 Hz
+* @value 400 400 Hz
 * @unit Hz
 * @reboot_required true
 * @group Sensors


### PR DESCRIPTION
 - schedule on interval multiple of sensor_gyro publications without increasing the configured integration rate
 - run VehicleIMU WorkItem faster (but still on integer multiples of sensor_gyro) to meet `IMU_INTEG_RATE` rather than raise the integration rate
 - constrain IMU_INTEG_RATE to [100, IMU_GYRO_RATEMAX] (100 Hz is the minimum for ekf2)
 - skip publication interval tracking if gaps in copying sensor_gyro/sensor_accel


In particular this improves the higher rate cases (eg IMU_GYRO_RATEMAX 2-4 kHz). Previously `IMU_INTEG_RATE` would be shifted from 200 Hz -> 250 Hz due to the current sensor_accel/sensor_gyro queue depth (somewhat arbitrary 8). Now in this situation VehicleIMU will still maintain the configured 200 Hz IMU_INTEG_RATE, but instead run twice as fast (400 Hz) to not miss any data.