### PR TITLE
PreFlightchecks: remove duplicated VTOL mode prearm check

### DIFF
--- a/src/modules/commander/Arming/PreFlightCheck/checks/manualControlCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/manualControlCheck.cpp
@@ -74,13 +74,6 @@ bool PreFlightCheck::manualControlCheck(orb_advert_t *mavlink_log_pub, const boo
 			}
 		}
 
-		if (manual_control_setpoint.transition_switch == manual_control_setpoint_s::SWITCH_POS_ON) {
-			success = false;
-
-			if (report_fail) {
-				mavlink_log_critical(mavlink_log_pub, "Failure: VTOL transition switch engaged");
-			}
-		}
 	}
 
 	return success;


### PR DESCRIPTION
This removes the check for the current position of the VTOL switch, as arming is already prevented if in transition mode,
plus also if VTOL and in fixed-wing mode (unless CBRK_VTOL_ARMING is set). That is more general than the check for the RC switch only, and I don't see a problem by removing it.

https://github.com/PX4/Firmware/blob/38fa913fedf49b65d24502182d5af601d41e891b/src/modules/commander/Arming/PreFlightCheck/checks/preArmCheck.cpp#L156


Fixes https://github.com/PX4/Firmware/issues/15212.

