### PR TITLE
sdp3x: improve robustness, try to reconfigure on transfer error

### DIFF
--- a/src/drivers/differential_pressure/sdp3x/SDP3X.hpp
+++ b/src/drivers/differential_pressure/sdp3x/SDP3X.hpp
@@ -69,9 +69,11 @@
 class SDP3X : public Airspeed, public I2CSPIDriver<SDP3X>
 {
 public:
-	SDP3X(I2CSPIBusOption bus_option, const int bus, int bus_frequency, int address = I2C_ADDRESS_1_SDP3X) :
+	SDP3X(I2CSPIBusOption bus_option, const int bus, int bus_frequency, int address = I2C_ADDRESS_1_SDP3X,
+	      bool keep_retrying = false) :
 		Airspeed(bus, bus_frequency, address, CONVERSION_INTERVAL),
-		I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus, address)
+		I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus, address),
+		_keep_retrying{keep_retrying}
 	{
 	}
 
@@ -88,6 +90,7 @@ private:
 	int	measure() override { return 0; }
 	int	collect() override;
 	int	probe() override;
+	int	configure();
 
 	math::LowPassFilter2p _filter{SPD3X_MEAS_RATE, SDP3X_MEAS_DRIVER_FILTER_FREQ};
 
@@ -104,4 +107,6 @@ private:
 	int write_command(uint16_t command);
 
 	uint16_t _scale{0};
+	const bool _keep_retrying;
+	bool _require_initialization{true};
 };

--- a/src/drivers/differential_pressure/sdp3x/SDP3X.hpp
+++ b/src/drivers/differential_pressure/sdp3x/SDP3X.hpp
@@ -85,12 +85,20 @@ public:
 
 	void	RunImpl();
 
+	void start();
+
 private:
+	enum class State {
+		RequireConfig,
+		Configuring,
+		Running
+	};
 
 	int	measure() override { return 0; }
 	int	collect() override;
 	int	probe() override;
 	int	configure();
+	int	read_scale();
 
 	math::LowPassFilter2p _filter{SPD3X_MEAS_RATE, SDP3X_MEAS_DRIVER_FILTER_FREQ};
 
@@ -108,5 +116,5 @@ private:
 
 	uint16_t _scale{0};
 	const bool _keep_retrying;
-	bool _require_initialization{true};
+	State _state{State::RequireConfig};
 };

--- a/src/drivers/differential_pressure/sdp3x/SDP3X_main.cpp
+++ b/src/drivers/differential_pressure/sdp3x/SDP3X_main.cpp
@@ -51,7 +51,7 @@ I2CSPIDriverBase *SDP3X::instantiate(const BusCLIArguments &cli, const BusInstan
 		return nullptr;
 	}
 
-	instance->ScheduleNow();
+	instance->start();
 	return instance;
 }
 

--- a/src/drivers/differential_pressure/sdp3x/SDP3X_main.cpp
+++ b/src/drivers/differential_pressure/sdp3x/SDP3X_main.cpp
@@ -38,7 +38,8 @@ extern "C" __EXPORT int sdp3x_airspeed_main(int argc, char *argv[]);
 I2CSPIDriverBase *SDP3X::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
 				     int runtime_instance)
 {
-	SDP3X *instance = new SDP3X(iterator.configuredBusOption(), iterator.bus(), cli.bus_frequency, cli.i2c_address);
+	SDP3X *instance = new SDP3X(iterator.configuredBusOption(), iterator.bus(), cli.bus_frequency, cli.i2c_address,
+				    cli.custom1 == 1);
 
 	if (instance == nullptr) {
 		PX4_ERR("alloc failed");
@@ -63,18 +64,28 @@ SDP3X::print_usage()
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(true, false);
 	PRINT_MODULE_USAGE_PARAMS_I2C_ADDRESS(0x21);
+	PRINT_MODULE_USAGE_PARAM_FLAG('k', "if initialization (probing) fails, keep retrying periodically", true);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
 int
 sdp3x_airspeed_main(int argc, char *argv[])
 {
+	int ch;
 	using ThisDriver = SDP3X;
 	BusCLIArguments cli{true, false};
 	cli.default_i2c_frequency = 100000;
 	cli.i2c_address = I2C_ADDRESS_1_SDP3X;
 
-	const char *verb = cli.parseDefaultArguments(argc, argv);
+	while ((ch = cli.getopt(argc, argv, "k")) != EOF) {
+		switch (ch) {
+		case 'k': // keep retrying
+			cli.custom1 = 1;
+			break;
+		}
+	}
+
+	const char *verb = cli.optarg();
 
 	if (!verb) {
 		ThisDriver::print_usage();


### PR DESCRIPTION
- reconfigure on transfer error (allows recovery from sensor reconnect)
- add State to avoid usleep
- add `-k` option to keep running and retrying even if no sensor present (we have a system that might boot w/o sensor attached).