### PR TITLE
imu/bosch/bmi055: remove interrupt latch

### DIFF
--- a/src/drivers/imu/bosch/bmi055/BMI055_Accelerometer.hpp
+++ b/src/drivers/imu/bosch/bmi055/BMI055_Accelerometer.hpp
@@ -111,7 +111,7 @@ private:
 	uint8_t _fifo_accel_samples{static_cast<uint8_t>(_fifo_empty_interval_us / (1000000 / ACCEL_RATE))};
 
 	uint8_t _checked_register{0};
-	static constexpr uint8_t size_register_cfg{8};
+	static constexpr uint8_t size_register_cfg{7};
 	register_config_t _register_cfg[size_register_cfg] {
 		// Register                    | Set bits, Clear bits
 		{ Register::PMU_RANGE,         PMU_RANGE_BIT::range_16g, Bit1 | Bit0},
@@ -119,7 +119,6 @@ private:
 		{ Register::INT_EN_1,          INT_EN_1_BIT::int_fwm_en, 0},
 		{ Register::INT_MAP_1,         INT_MAP_1_BIT::int1_fwm, 0},
 		{ Register::INT_OUT_CTRL,      0, INT_OUT_CTRL_BIT::int1_od | INT_OUT_CTRL_BIT::int1_lvl},
-		{ Register::INT_RST_LATCH,     INT_RST_LATCH_BIT::temporary_250us, 0},
 		{ Register::FIFO_CONFIG_0,     0, 0 }, // fifo_water_mark_level_trigger_retain<5:0>
 		{ Register::FIFO_CONFIG_1,     FIFO_CONFIG_1_BIT::fifo_mode, 0},
 	};

--- a/src/drivers/imu/bosch/bmi055/BMI055_Gyroscope.hpp
+++ b/src/drivers/imu/bosch/bmi055/BMI055_Gyroscope.hpp
@@ -109,7 +109,7 @@ private:
 	uint8_t _fifo_gyro_samples{static_cast<uint8_t>(_fifo_empty_interval_us / (1000000 / GYRO_RATE))};
 
 	uint8_t _checked_register{0};
-	static constexpr uint8_t size_register_cfg{9};
+	static constexpr uint8_t size_register_cfg{8};
 	register_config_t _register_cfg[size_register_cfg] {
 		// Register                    | Set bits, Clear bits
 		{ Register::RANGE,             RANGE_BIT::gyro_range_2000_dps, 0 },
@@ -118,7 +118,6 @@ private:
 		{ Register::INT_EN_1,          0, INT_EN_1_BIT::int1_od | INT_EN_1_BIT::int1_lvl },
 		{ Register::INT_MAP_1,         INT_MAP_1_BIT::int1_fifo, 0 },
 		{ Register::FIFO_WM_ENABLE,    FIFO_WM_ENABLE_BIT::fifo_wm_enable, 0 },
-		{ Register::INT_RST_LATCH,     INT_RST_LATCH_BIT::temporary_250us, 0 },
 		{ Register::FIFO_CONFIG_0,     0, FIFO_CONFIG_0_BIT::tag }, // fifo_water_mark_level_trigger_retain<6:0>
 		{ Register::FIFO_CONFIG_1,     FIFO_CONFIG_1_BIT::fifo_mode, 0 },
 	};

--- a/src/drivers/imu/bosch/bmi055/Bosch_BMI055_Accelerometer_Registers.hpp
+++ b/src/drivers/imu/bosch/bmi055/Bosch_BMI055_Accelerometer_Registers.hpp
@@ -69,7 +69,6 @@ enum class Register : uint8_t {
 	INT_MAP_1     = 0x1A,
 
 	INT_OUT_CTRL  = 0x20,
-	INT_RST_LATCH = 0x21,
 
 	FIFO_CONFIG_0 = 0x30,
 
@@ -126,12 +125,6 @@ enum INT_MAP_1_BIT : uint8_t {
 enum INT_OUT_CTRL_BIT : uint8_t {
 	int1_od  = Bit1,
 	int1_lvl = Bit0,
-};
-
-// INT_RST_LATCH
-enum INT_RST_LATCH_BIT : uint8_t {
-	// latch_int<3:0>
-	temporary_250us = Bit3 | Bit0, // 1001b -> temporary, 250 us
 };
 
 // FIFO_CONFIG_1

--- a/src/drivers/imu/bosch/bmi055/Bosch_BMI055_Gyroscope_Registers.hpp
+++ b/src/drivers/imu/bosch/bmi055/Bosch_BMI055_Gyroscope_Registers.hpp
@@ -66,8 +66,6 @@ enum class Register : uint8_t {
 
 	FIFO_WM_ENABLE = 0x1E,
 
-	INT_RST_LATCH  = 0x21,
-
 	FIFO_CONFIG_0  = 0x3D,
 	FIFO_CONFIG_1  = 0x3E,
 	FIFO_DATA      = 0x3F,
@@ -114,12 +112,6 @@ enum INT_MAP_1_BIT : uint8_t {
 // FIFO_WM_ENABLE
 enum FIFO_WM_ENABLE_BIT : uint8_t {
 	fifo_wm_enable  = Bit7,
-};
-
-// INT_RST_LATCH
-enum INT_RST_LATCH_BIT : uint8_t {
-	// latch_int<3:0>
-	temporary_250us = Bit3 | Bit0, // 1001b -> temporary, 250 us
 };
 
 // FIFO_CONFIG_0


### PR DESCRIPTION
 - the latch would actually cause more problems if the backup schedule hit
 - this reduces the number of cycles where the FIFO is actually empty at max rate (when there's only 1 sample in the FIFO expected)

### Master (after only a minute, but the FIFO empty count continues to increase gradually)
``` Console
nsh> bmi055 status
INFO  [SPI_I2C] Running on SPI Bus 1
INFO  [bmi055] FIFO empty interval: 500 us (2000.000 Hz)
bmi055_accel: transfer: 127017 events, 1760627us elapsed, 13.86us avg, min 13us max 32us 1.587us rms
bmi055_accel: bad register: 0 events
bmi055_accel: bad transfer: 0 events
bmi055_accel: FIFO empty: 10 events
bmi055_accel: FIFO overflow: 0 events
bmi055_accel: FIFO reset: 1 events
bmi055_accel: DRDY interval: 127047 events, 495.98us avg, min 171us max 1505us 27.462us rms
INFO  [SPI_I2C] Running on SPI Bus 1
INFO  [bmi055] FIFO empty interval: 500 us (2000.000 Hz)
bmi055_gyro: transfer: 125880 events, 1746083us elapsed, 13.87us avg, min 13us max 33us 1.579us rms
bmi055_gyro: bad register: 0 events
bmi055_gyro: bad transfer: 0 events
bmi055_gyro: FIFO empty: 0 events
bmi055_gyro: FIFO overflow: 0 events
bmi055_gyro: FIFO reset: 1 events
bmi055_gyro: DRDY interval: 125920 events, 500.84us avg, min 145us max 1051us 52.025us rms

```


### PR
``` Console

nsh> bmi055 status
INFO  [SPI_I2C] Running on SPI Bus 1
INFO  [bmi055] FIFO empty interval: 500 us (2000.000 Hz)
bmi055_accel: transfer: 7864 events, 108004us elapsed, 13.73us avg, min 13us max 30us 1.475us rms
bmi055_accel: bad register: 0 events
bmi055_accel: bad transfer: 0 events
bmi055_accel: FIFO empty: 0 events
bmi055_accel: FIFO overflow: 0 events
bmi055_accel: FIFO reset: 1 events
bmi055_accel: DRDY interval: 7891 events, 495.97us avg, min 174us max 1508us 32.082us rms
INFO  [SPI_I2C] Running on SPI Bus 1
INFO  [bmi055] FIFO empty interval: 500 us (2000.000 Hz)
bmi055_gyro: transfer: 7869 events, 108879us elapsed, 13.84us avg, min 13us max 31us 1.545us rms
bmi055_gyro: bad register: 0 events
bmi055_gyro: bad transfer: 0 events
bmi055_gyro: FIFO empty: 0 events
bmi055_gyro: FIFO overflow: 0 events
bmi055_gyro: FIFO reset: 1 events
bmi055_gyro: DRDY interval: 7894 events, 500.89us avg, min 152us max 961us 51.294us rms


```

As previously noted, the BMI055 timing isn't as stable as other sensors.
