### PR TITLE
Orbit approach fixes

### DIFF
--- a/src/lib/flight_tasks/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/lib/flight_tasks/tasks/Orbit/FlightTaskOrbit.cpp
@@ -127,6 +127,10 @@ bool FlightTaskOrbit::setRadius(float r)
 		_v = sign(_v) * sqrtf(_acceleration_max * r);
 	}
 
+	if (fabs(_r - r) > FLT_EPSILON) {
+		_circle_approach_line.reset();
+	}
+
 	_r = r;
 	return true;
 }

--- a/src/lib/flight_tasks/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/lib/flight_tasks/tasks/Orbit/FlightTaskOrbit.cpp
@@ -94,6 +94,7 @@ bool FlightTaskOrbit::applyCommandParameters(const vehicle_command_s &command)
 
 	// perpendicularly approach the orbit circle again when new parameters get commanded
 	_in_circle_approach = true;
+	_circle_approach_line.reset();
 
 	return ret;
 }

--- a/src/lib/flight_tasks/tasks/Utility/StraightLine.cpp
+++ b/src/lib/flight_tasks/tasks/Utility/StraightLine.cpp
@@ -76,7 +76,7 @@ void StraightLine::generateSetpoints(matrix::Vector3f &position_setpoint, matrix
 
 	// check if we plan to go against the line direction which indicates we reached the goal
 	if (start_to_end * vehicle_to_end < 0) {
-		end_reached = true;
+		_end_reached = true;
 	}
 }
 
@@ -85,6 +85,6 @@ void StraightLine::setLineFromTo(const Vector3f &start, const Vector3f &end)
 	if (PX4_ISFINITE(start.norm_squared()) && PX4_ISFINITE(end.norm_squared())) {
 		_start = start;
 		_end = end;
-		end_reached = false;
+		_end_reached = false;
 	}
 }

--- a/src/lib/flight_tasks/tasks/Utility/StraightLine.hpp
+++ b/src/lib/flight_tasks/tasks/Utility/StraightLine.hpp
@@ -66,7 +66,9 @@ public:
 	 *
 	 * @return false when on the way from start to end, true when end was reached
 	 */
-	bool isEndReached() { return end_reached; }
+	bool isEndReached() const { return _end_reached; }
+
+	void reset() { _end_reached = true; }
 
 private:
 	const matrix::Vector3f &_position; /**< vehicle position (dependency injection) */
@@ -75,5 +77,5 @@ private:
 	matrix::Vector3f _end; /**< End point of the straight line */
 	float _speed = 1.f; /**< desired speed between accelerating and decelerating */
 
-	bool end_reached = true; /**< Flag to lock further movement when end is reached */
+	bool _end_reached = true; /**< Flag to lock further movement when end is reached */
 };


### PR DESCRIPTION
**Describe problem solved by this pull request**
Credits got to @RomanBapst for finding all of these issues and helping me to fix them:
1. sending a new orbit command during approach lead to finishing the old approach and jumping to the new circle
1. changing the radius during approach lead to approaching to the old radius and jumping to the new one
1. the way setpoint output was not wrapped and could exceed the range
it showed in the log but still executed fine since sin() and cos() work properly also outside of [-pi, pi]

**Describe your solution**
1. reset the approach when a new orbit is commanded
1. reset the approach when the radius is changed
1. wrap the yaw setpoint before it's sent out

**Test data / coverage**
I SITL tested.
