### PR TITLE
mavsdk_tests: load all os environment variables for gazebo client

### DIFF
--- a/test/mavsdk_tests/process_helper.py
+++ b/test/mavsdk_tests/process_helper.py
@@ -238,10 +238,8 @@ class GzclientRunner(Runner):
         super().__init__(log_dir, model, case, verbose)
         self.name = "gzclient"
         self.cwd = workspace_dir
-        self.env = {"PATH": os.environ['PATH'],
-                    "HOME": os.environ['HOME'],
-                    "GAZEBO_MODEL_PATH":
-                    workspace_dir + "/Tools/sitl_gazebo/models"}
+        self.env = dict(os.environ, **{
+            "GAZEBO_MODEL_PATH": workspace_dir + "/Tools/sitl_gazebo/models"})
         self.add_to_env_if_set("DISPLAY")
         self.cmd = "gzclient"
         self.args = ["--verbose"]


### PR DESCRIPTION
**Describe problem solved by this pull request**
OpenGL options set in the environment like https://github.com/PX4/Firmware/blob/405cb5038d88723bce33b8644ce640798140d053/Tools/setup/ubuntu.sh#L210 are ignored when running `mavsdk_tests` with the `--gui` option to have the gazebo client show what's going on.

**Describe your solution**
Followed https://stackoverflow.com/questions/2231227/python-subprocess-popen-with-a-modified-environment and https://code.tutsplus.com/tutorials/how-to-merge-two-python-dictionaries--cms-26230 to append the local environment to the global one overwriting duplicates.

**Describe possible alternatives**
This could in principle be done for all these invokes, not sure about the potential (dis)advantages.

**Test data / coverage**
`test/mavsdk_tests/mavsdk_test_runner.py test/mavsdk_tests/configs/sitl.json --speed-factor 1 --verbose --case "Takeoff and Land" --model iris --gui` shows the gazebo GUI where the test is executed.

**Additional context**
Thanks a lot to @julianoes for his introduction to the testing system and help in finding the problem!
