### PR TITLE
Fix CUAV CAN_PMU power display as 0%, unable to unlock

### DIFF
--- a/src/drivers/uavcan/sensors/battery.cpp
+++ b/src/drivers/uavcan/sensors/battery.cpp
@@ -35,6 +35,7 @@
 
 #include <lib/ecl/geo/geo.h>
 #include <px4_defines.h>
+#include <mathlib/mathlib.h>
 
 const char *const UavcanBatteryBridge::NAME = "battery";
 
@@ -99,6 +100,11 @@ UavcanBatteryBridge::battery_sub_cb(const uavcan::ReceivedDataStructure<uavcan::
 	// battery.max_cell_voltage_delta = msg.;
 
 	// battery.is_powering_off = msg.;
+
+	if (strstr((char *)&msg.model_name, "cuav_can_pmu")) {
+		float cell_voltage = (battery.voltage_v) / __param_bat_n_cells.get();
+		battery.remaining = math::gradual(cell_voltage, __param_bat_v_empty.get(), __param_bat_v_charged.get(), 0.f, 1.f);
+	}
 
 	determineWarning(battery.remaining);
 	battery.warning = _warning;

--- a/src/drivers/uavcan/sensors/battery.hpp
+++ b/src/drivers/uavcan/sensors/battery.hpp
@@ -70,7 +70,10 @@ private:
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::BAT_LOW_THR>) _param_bat_low_thr,
 		(ParamFloat<px4::params::BAT_CRIT_THR>) _param_bat_crit_thr,
-		(ParamFloat<px4::params::BAT_EMERGEN_THR>) _param_bat_emergen_thr
+		(ParamFloat<px4::params::BAT_EMERGEN_THR>) _param_bat_emergen_thr,
+		(ParamInt<px4::params::BAT1_N_CELLS>) __param_bat_n_cells,
+		(ParamFloat<px4::params::BAT1_V_EMPTY>) __param_bat_v_empty,
+		(ParamFloat<px4::params::BAT1_V_CHARGED>) __param_bat_v_charged
 	)
 
 	float _discharged_mah = 0.f;


### PR DESCRIPTION
Since CAN PMU is not a smart battery, it cannot provide an accurate percentage of remaining power