### PR TITLE
Rephrase more errors and warnings

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1631,10 +1631,10 @@ Commander::run()
 
 			if (_auto_disarm_killed.get_state()) {
 				if (armed.manual_lockdown) {
-					arm_disarm(false, true, &mavlink_log_pub, "Kill-switch still engaged, disarming");
+					arm_disarm(false, true, &mavlink_log_pub, "Kill-switch still engaged");
 
 				} else {
-					arm_disarm(false, true, &mavlink_log_pub, "System in lockdown, disarming");
+					arm_disarm(false, true, &mavlink_log_pub, "System in lockdown");
 				}
 
 			}
@@ -2035,11 +2035,13 @@ Commander::run()
 			if (_manual_control_setpoint.kill_switch == manual_control_setpoint_s::SWITCH_POS_ON) {
 				/* set lockdown flag */
 				if (!armed.manual_lockdown) {
+					const char kill_switch_string[] = "Kill-switch engaged";
+
 					if (_land_detector.landed) {
-						mavlink_and_console_log_info(&mavlink_log_pub, "Manual kill-switch engaged");
+						mavlink_log_info(&mavlink_log_pub, kill_switch_string);
 
 					} else {
-						mavlink_log_critical(&mavlink_log_pub, "Manual kill-switch engaged");
+						mavlink_log_critical(&mavlink_log_pub, kill_switch_string);
 					}
 
 					_status_changed = true;
@@ -2048,7 +2050,7 @@ Commander::run()
 
 			} else if (_manual_control_setpoint.kill_switch == manual_control_setpoint_s::SWITCH_POS_OFF) {
 				if (armed.manual_lockdown) {
-					mavlink_and_console_log_info(&mavlink_log_pub, "Manual kill-switch disengaged");
+					mavlink_log_info(&mavlink_log_pub, "Kill-switch disengaged");
 					_status_changed = true;
 					armed.manual_lockdown = false;
 				}

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2035,7 +2035,13 @@ Commander::run()
 			if (_manual_control_setpoint.kill_switch == manual_control_setpoint_s::SWITCH_POS_ON) {
 				/* set lockdown flag */
 				if (!armed.manual_lockdown) {
-					mavlink_and_console_log_info(&mavlink_log_pub, "Manual kill-switch engaged");
+					if (_land_detector.landed) {
+						mavlink_and_console_log_info(&mavlink_log_pub, "Manual kill-switch engaged");
+
+					} else {
+						mavlink_log_critical(&mavlink_log_pub, "Manual kill-switch engaged");
+					}
+
 					_status_changed = true;
 					armed.manual_lockdown = true;
 				}

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2035,14 +2035,14 @@ Commander::run()
 			if (_manual_control_setpoint.kill_switch == manual_control_setpoint_s::SWITCH_POS_ON) {
 				/* set lockdown flag */
 				if (!armed.manual_lockdown) {
-					mavlink_log_emergency(&mavlink_log_pub, "Manual kill-switch engaged");
+					mavlink_and_console_log_info(&mavlink_log_pub, "Manual kill-switch engaged");
 					_status_changed = true;
 					armed.manual_lockdown = true;
 				}
 
 			} else if (_manual_control_setpoint.kill_switch == manual_control_setpoint_s::SWITCH_POS_OFF) {
 				if (armed.manual_lockdown) {
-					mavlink_log_emergency(&mavlink_log_pub, "Manual kill-switch disengaged");
+					mavlink_and_console_log_info(&mavlink_log_pub, "Manual kill-switch disengaged");
 					_status_changed = true;
 					armed.manual_lockdown = false;
 				}
@@ -3774,7 +3774,7 @@ void Commander::data_link_check()
 			status.data_link_lost = true;
 			status.data_link_lost_counter++;
 
-			mavlink_log_critical(&mavlink_log_pub, "Data link lost");
+			mavlink_log_critical(&mavlink_log_pub, "Connection to ground station lost");
 
 			_status_changed = true;
 		}
@@ -3785,7 +3785,7 @@ void Commander::data_link_check()
 	    && (hrt_elapsed_time(&_datalink_last_heartbeat_onboard_controller) > 5_s)
 	    && !_onboard_controller_lost) {
 
-		mavlink_log_critical(&mavlink_log_pub, "Onboard controller lost");
+		mavlink_log_critical(&mavlink_log_pub, "Connection to mission computer lost");
 		_onboard_controller_lost = true;
 		_status_changed = true;
 	}

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -49,7 +49,7 @@
 #include "state_machine_helper.h"
 #include "commander_helper.h"
 
-static constexpr const char reason_no_rc[] = "no RC";
+static constexpr const char reason_no_rc[] = "No manual control stick input";
 static constexpr const char reason_no_offboard[] = "no offboard";
 static constexpr const char reason_no_rc_and_no_offboard[] = "no RC and no offboard";
 static constexpr const char reason_no_local_position[] = "no local position";


### PR DESCRIPTION
**Describe problem solved by this pull request**
Porting @DanielePettenuzzo 's changes, credit goes to him.

**Describe your solution**
More error rephrasing. These are the ones done in this pr:

- change kill switch from error to info when the vehicle is not flying
- "Data link lost" --> "Connection to ground station lost"
- "Onboard controller lost" --> "Connection to mission computer lost"
- "Failsafe enabled: no RC" --> "Failsafe enabled: Manual control stick input unavailable"

**Test data / coverage**
How was it tested? What cases were covered? Logs uploaded to https://review.px4.io/ and screenshots of the important plot parts.

**Additional context**
**EDIT:** just found a related non-conflicting pr changing some messageing: https://github.com/PX4/Firmware/pull/14377
