### PR TITLE
Orbit yaw behaviours addition

### DIFF
--- a/src/lib/flight_tasks/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/lib/flight_tasks/tasks/Orbit/FlightTaskOrbit.cpp
@@ -73,6 +73,9 @@ bool FlightTaskOrbit::applyCommandParameters(const vehicle_command_s &command)
 		_yaw_behaviour = command.param3;
 	}
 
+	// save current yaw estimate for ORBIT_YAW_BEHAVIOUR_HOLD_INITIAL_HEADING
+	_initial_heading = _yaw;
+
 	// TODO: apply x,y / z independently in geo library
 	// commanded center coordinates
 	// if(PX4_ISFINITE(command.param5) && PX4_ISFINITE(command.param6)) {
@@ -153,7 +156,6 @@ bool FlightTaskOrbit::activate(vehicle_local_position_setpoint_s last_setpoint)
 	_v =  1.f;
 	_center = Vector2f(_position);
 	_center(0) -= _r;
-
 	_initial_heading = _yaw;
 
 	// need a valid position and velocity

--- a/src/lib/flight_tasks/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/lib/flight_tasks/tasks/Orbit/FlightTaskOrbit.cpp
@@ -245,15 +245,8 @@ void FlightTaskOrbit::generate_circle_yaw_setpoints(const Vector2f &center_to_po
 		break;
 
 	case orbit_status_s::ORBIT_YAW_BEHAVIOUR_HOLD_FRONT_TANGENT_TO_CIRCLE:
-		if (_r > 0) {
-			_yaw_setpoint = atan2f(center_to_position(1), center_to_position(0)) + M_PI_F / 2.f;
-
-		} else {
-			_yaw_setpoint = atan2f(center_to_position(1), center_to_position(0)) - M_PI_F / 2.f;
-		}
-
+		_yaw_setpoint = wrap_pi(atan2f(center_to_position(1), center_to_position(0)) + (sign(_v) * M_PI_F / 2.f));
 		_yawspeed_setpoint = _v / _r;
-
 		break;
 
 	case orbit_status_s::ORBIT_YAW_BEHAVIOUR_RC_CONTROLLED:
@@ -262,7 +255,7 @@ void FlightTaskOrbit::generate_circle_yaw_setpoints(const Vector2f &center_to_po
 
 	case orbit_status_s::ORBIT_YAW_BEHAVIOUR_HOLD_FRONT_TO_CIRCLE_CENTER:
 	default:
-		_yaw_setpoint = atan2f(center_to_position(1), center_to_position(0)) + M_PI_F;
+		_yaw_setpoint = wrap_pi(atan2f(center_to_position(1), center_to_position(0)) + M_PI_F);
 		// yawspeed feed-forward because we know the necessary angular rate
 		_yawspeed_setpoint = _v / _r;
 		break;

--- a/src/lib/flight_tasks/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/lib/flight_tasks/tasks/Orbit/FlightTaskOrbit.cpp
@@ -179,11 +179,10 @@ bool FlightTaskOrbit::update()
 	setRadius(r);
 	setVelocity(v);
 
-	Vector2f center_to_position = Vector2f(_position) - _center;
-	Vector2f start_to_circle = (_r - center_to_position.norm()) * center_to_position.unit_or_zero();
+	const Vector2f center_to_position = Vector2f(_position) - _center;
 
 	if (_in_circle_approach) {
-		generate_circle_approach_setpoints(start_to_circle);
+		generate_circle_approach_setpoints(center_to_position);
 
 	} else {
 		generate_circle_setpoints(center_to_position);
@@ -196,13 +195,13 @@ bool FlightTaskOrbit::update()
 	return ret;
 }
 
-void FlightTaskOrbit::generate_circle_approach_setpoints(Vector2f start_to_circle)
+void FlightTaskOrbit::generate_circle_approach_setpoints(const Vector2f &center_to_position)
 {
-
 	if (_circle_approach_line.isEndReached()) {
 		// calculate target point on circle and plan a line trajectory
-		Vector2f closest_circle_point = Vector2f(_position) + start_to_circle;
-		Vector3f target = Vector3f(closest_circle_point(0), closest_circle_point(1), _position(2));
+		const Vector2f start_to_circle = (_r - center_to_position.norm()) * center_to_position.unit_or_zero();
+		const Vector2f closest_circle_point = Vector2f(_position) + start_to_circle;
+		const Vector3f target = Vector3f(closest_circle_point(0), closest_circle_point(1), _position(2));
 		_circle_approach_line.setLineFromTo(_position, target);
 		_circle_approach_line.setSpeed(_param_mpc_xy_cruise.get());
 		_yaw_setpoint = atan2f(start_to_circle(1), start_to_circle(0));
@@ -213,7 +212,7 @@ void FlightTaskOrbit::generate_circle_approach_setpoints(Vector2f start_to_circl
 	_in_circle_approach = !_circle_approach_line.isEndReached();
 }
 
-void FlightTaskOrbit::generate_circle_setpoints(Vector2f center_to_position)
+void FlightTaskOrbit::generate_circle_setpoints(const Vector2f &center_to_position)
 {
 	// xy velocity to go around in a circle
 	Vector2f velocity_xy(-center_to_position(1), center_to_position(0));
@@ -228,7 +227,7 @@ void FlightTaskOrbit::generate_circle_setpoints(Vector2f center_to_position)
 	_acceleration_setpoint.xy() = -center_to_position.unit_or_zero() * _v * _v / _r;
 }
 
-void FlightTaskOrbit::generate_circle_yaw_setpoints(Vector2f center_to_position)
+void FlightTaskOrbit::generate_circle_yaw_setpoints(const Vector2f &center_to_position)
 {
 	switch (_yaw_behaviour) {
 	case orbit_status_s::ORBIT_YAW_BEHAVIOUR_HOLD_INITIAL_HEADING:

--- a/src/lib/flight_tasks/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/lib/flight_tasks/tasks/Orbit/FlightTaskOrbit.cpp
@@ -256,8 +256,7 @@ void FlightTaskOrbit::generate_circle_yaw_setpoints(Vector2f center_to_position)
 		break;
 
 	case orbit_status_s::ORBIT_YAW_BEHAVIOUR_RC_CONTROLLED:
-		_yaw_setpoint = NAN;
-		_yawspeed_setpoint = _sticks.getPositionExpo()(3);
+		// inherit setpoint from altitude flight task
 		break;
 
 	case orbit_status_s::ORBIT_YAW_BEHAVIOUR_HOLD_FRONT_TO_CIRCLE_CENTER:

--- a/src/lib/flight_tasks/tasks/Orbit/FlightTaskOrbit.hpp
+++ b/src/lib/flight_tasks/tasks/Orbit/FlightTaskOrbit.hpp
@@ -88,11 +88,12 @@ protected:
 	bool setVelocity(const float v);
 
 private:
-	void generate_circle_approach_setpoints(matrix::Vector2f
-						start_to_circle); /**< generates setpoints to smoothly reach the closest point on the circle when starting from far away */
-	void generate_circle_setpoints(matrix::Vector2f center_to_position); /**< generates xy setpoints to orbit the vehicle */
-	void generate_circle_yaw_setpoints(matrix::Vector2f
-					   center_to_position); /**< generates yaw setpoints to control the vehicle's heading */
+	/** generates setpoints to smoothly reach the closest point on the circle when starting from far away */
+	void generate_circle_approach_setpoints(matrix::Vector2f &center_to_position);
+	/** generates xy setpoints to make the vehicle orbit */
+	void generate_circle_setpoints(matrix::Vector2f &center_to_position);
+	/** generates yaw setpoints to control the vehicle's heading */
+	void generate_circle_yaw_setpoints(matrix::Vector2f &center_to_position);
 
 	float _r = 0.f; /**< radius with which to orbit the target */
 	float _v = 0.f; /**< clockwise tangential velocity for orbiting in m/s */
@@ -107,8 +108,8 @@ private:
 	const float _velocity_max = 10.f;
 	const float _acceleration_max = 2.f;
 
-	int _yaw_behaviour =
-		orbit_status_s::ORBIT_YAW_BEHAVIOUR_HOLD_FRONT_TO_CIRCLE_CENTER; /**<  yaw behaviour during the orbit flight according to MAVLink's ORBIT_YAW_BEHAVIOUR enum */
+	/** yaw behaviour during the orbit flight according to MAVLink's ORBIT_YAW_BEHAVIOUR enum */
+	int _yaw_behaviour = orbit_status_s::ORBIT_YAW_BEHAVIOUR_HOLD_FRONT_TO_CIRCLE_CENTER;
 	float _initial_heading = 0.f; /**< the heading of the drone when the orbit command was issued */
 
 	uORB::Publication<orbit_status_s> _orbit_status_pub{ORB_ID(orbit_status)};

--- a/src/lib/flight_tasks/tasks/Orbit/FlightTaskOrbit.hpp
+++ b/src/lib/flight_tasks/tasks/Orbit/FlightTaskOrbit.hpp
@@ -89,11 +89,11 @@ protected:
 
 private:
 	/** generates setpoints to smoothly reach the closest point on the circle when starting from far away */
-	void generate_circle_approach_setpoints(matrix::Vector2f &center_to_position);
+	void generate_circle_approach_setpoints(const matrix::Vector2f &center_to_position);
 	/** generates xy setpoints to make the vehicle orbit */
-	void generate_circle_setpoints(matrix::Vector2f &center_to_position);
+	void generate_circle_setpoints(const matrix::Vector2f &center_to_position);
 	/** generates yaw setpoints to control the vehicle's heading */
-	void generate_circle_yaw_setpoints(matrix::Vector2f &center_to_position);
+	void generate_circle_yaw_setpoints(const matrix::Vector2f &center_to_position);
 
 	float _r = 0.f; /**< radius with which to orbit the target */
 	float _v = 0.f; /**< clockwise tangential velocity for orbiting in m/s */


### PR DESCRIPTION
**Describe problem solved by this pull request**
Like discussed in https://github.com/PX4/Firmware/pull/13426#issuecomment-657430405 I had some open suggestions. FYI @dayjaby

**Describe your solution**
> - If there is a line break in the Doxygen comment anyways we can put it before the declaration.
> - FlightTaskManualAltitude which orbit is inheriting from is already generating yaw setpoints from RC. I know this is confusing and the goal is to move this stuff into libraries such that you can just write "I want the yaw generation from RC" instead of silently inheriting.
> - Your way of calculating `start_to_circle` is much nicer 👍  I just moved it back into the local scope such that it's only calculated when used. Unrelated I also added some const qualifiers and switched the parameter structs to pass by reference.
> - As a suggestion, I set the initial heading for every new command that arrives which is probably what https://github.com/PX4/Firmware/pull/13426#discussion_r348539982 wanted to address. It's up to discussion. I thought if you ran any other yaw behavior first and then command the `HOLD_INITIAL_HEADING` it should hold what was there at the moment and not when orbit was first commanded. If `HOLD_INITIAL_HEADING` was already used then it should stay very close to the same yaw.
> - I simplified the `HOLD_FRONT_TANGENT_TO_CIRCLE` yaw setpoint generation using the `sign()` function and made it depend on the sign of the velocity and not the radius since inside the task for technical reasons the radius is always positive but the velocity changes sign for the opposite rotation direction.

**Test data / coverage**
I did SITL test default yaw behavior, tangential and rc based modes by overriding the param3 of what QGC sends internally and didn't see any issues.
