### PR TITLE
FlightTaskOrbit: correct acceleration feed-forward

### DIFF
--- a/src/lib/flight_tasks/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/lib/flight_tasks/tasks/Orbit/FlightTaskOrbit.cpp
@@ -223,9 +223,9 @@ void FlightTaskOrbit::generate_circle_setpoints(Vector2f center_to_position)
 	// xy velocity adjustment to stay on the radius distance
 	velocity_xy += (_r - center_to_position.norm()) * center_to_position.unit_or_zero();
 
-	_velocity_setpoint(0) = velocity_xy(0);
-	_velocity_setpoint(1) = velocity_xy(1);
 	_position_setpoint(0) = _position_setpoint(1) = NAN;
+	_velocity_setpoint.xy() = velocity_xy;
+	_acceleration_setpoint.xy() = -center_to_position.unit_or_zero() * _v * _v / _r;
 }
 
 void FlightTaskOrbit::generate_circle_yaw_setpoints(Vector2f center_to_position)


### PR DESCRIPTION
**Describe problem solved by this pull request**
The acceleration setpoint gets implicitly inherited from the altitude flight task since #14212. This feed-forward adds an unwanted acceleration when the right stick is deflected.

**Describe your solution**
Instead of the wrong acceleration setpoint I command the expected centripetal acceleration when flying in a circle as feed-forward for better orbit tracking. This is only possible since #14212.

**Test data / coverage**
I SITL tested and the direction and amplitude of the acceleration are exactly like expected.
It also leads to better tracking already with the default orbit radius and a bit increased speed like can be seen in the screenshots below.
Before (malicious feed-forward setpoint removed):
![orbit_without_acc](https://user-images.githubusercontent.com/4668506/87344050-0f1e8200-c54e-11ea-9375-c7873ce282fd.png)
After (adding centripetal acceleration feed-forward):
![orbit_with_acc](https://user-images.githubusercontent.com/4668506/87344110-265d6f80-c54e-11ea-9111-eb0bd169d205.png)
