### PR TITLE
Straight line slowdown test

### DIFF
--- a/test/mavsdk_tests/autopilot_tester.cpp
+++ b/test/mavsdk_tests/autopilot_tester.cpp
@@ -37,6 +37,44 @@
 
 std::string connection_url {"udp://"};
 
+namespace
+{
+std::array<float, 3> get_local_mission_item(const Mission::MissionItem &item, const CoordinateTransformation &ct)
+{
+	using GlobalCoordinate = mavsdk::geometry::CoordinateTransformation::GlobalCoordinate;
+	GlobalCoordinate global;
+	global.latitude_deg = item.latitude_deg;
+	global.longitude_deg = item.longitude_deg;
+	auto local = ct.local_from_global(global);
+	return {static_cast<float>(local.north_m), static_cast<float>(local.east_m), -item.relative_altitude_m};
+}
+
+float point_to_line_distance(const std::array<float, 3> &point, const std::array<float, 3> &line_start,
+			     const std::array<float, 3> &line_end)
+{
+	// norm_dir = (line_end - line_start).normalize();
+	std::array<float, 3> dir { line_end[0] - line_start[0], line_end[1] - line_start[1], line_end[2] - line_start[2]};
+	float norm = std::sqrt(dir[0] * dir[0] + dir[1] * dir[1] + dir[2] * dir[2]);
+	std::array<float, 3> norm_dir {dir[0] / norm, dir[1] / norm, dir[2] / norm};
+
+	// dir_component = point - line_start
+	std::array<float, 3> dir_component {point[0] - line_start[0], point[1] - line_start[1], point[2] - line_start[2]};
+
+	// t = norm_dir.dot(dir_component);
+	float t = norm_dir[0] * dir_component[0] + norm_dir[1] * dir_component[1] + norm_dir[2] * dir_component[2];
+
+	// closest_on_line = line_start + t * norm_dir;
+	std::array<float, 3> closest_on_line { line_start[0] + t *norm_dir[0], line_start[1] + t *norm_dir[1], line_start[2] + t *norm_dir[2]};
+
+	// distance = (closest_on_line - point).norm();
+	std::array<float, 3> vec_to_line {closest_on_line[0] - point[0], closest_on_line[1] - point[1], closest_on_line[2] - point[2]};
+	float distance_to_trajectory = std::sqrt(vec_to_line[0] * vec_to_line[0] + vec_to_line[1] * vec_to_line[1] +
+				       vec_to_line[2] * vec_to_line[2]);
+	return distance_to_trajectory;
+}
+
+}
+
 void AutopilotTester::connect(const std::string uri)
 {
 	ConnectionResult ret = _mavsdk.add_any_connection(uri);
@@ -268,49 +306,21 @@ void AutopilotTester::check_tracks_mission(float corridor_radius_m)
 	std::vector<Mission::MissionItem> mission_items = mission.second.mission_items;
 	auto ct = get_coordinate_transformation();
 
-	auto get_local_mission_item = [mission_items, ct](int item_index) -> std::array<float, 3> {
-		using GlobalCoordinate = mavsdk::geometry::CoordinateTransformation::GlobalCoordinate;
-		auto item = mission_items[item_index];
-		GlobalCoordinate global;
-		global.latitude_deg = item.latitude_deg;
-		global.longitude_deg = item.longitude_deg;
-		auto local = ct.local_from_global(global);
-		std::array<float, 3> res = {static_cast<float>(local.north_m), static_cast<float>(local.east_m), -item.relative_altitude_m};
-
-		return res;
-	};
-
 	_telemetry->set_rate_position_velocity_ned(5);
-	_telemetry->subscribe_position_velocity_ned([get_local_mission_item, corridor_radius_m,
-				this](Telemetry::PositionVelocityNed position_velocity_ned) {
+	_telemetry->subscribe_position_velocity_ned([ct, mission_items, corridor_radius_m,
+	    this](Telemetry::PositionVelocityNed position_velocity_ned) {
 		auto progress = _mission->mission_progress();
 
 		if (progress.current > 0 && progress.current < progress.total) {
 			// Get shortest distance of current position to 3D line between previous and next waypoint
+
 			std::array<float, 3> current { position_velocity_ned.position.north_m,
 						       position_velocity_ned.position.east_m,
 						       position_velocity_ned.position.down_m };
-			std::array<float, 3> wp_prev = get_local_mission_item(progress.current - 1);
-			std::array<float, 3> wp_next = get_local_mission_item(progress.current);
+			std::array<float, 3> wp_prev = get_local_mission_item(mission_items[progress.current - 1], ct);
+			std::array<float, 3> wp_next = get_local_mission_item(mission_items[progress.current], ct);
 
-			// wp_dir_norm = (wp_next - wp_prev).normalize();
-			std::array<float, 3> wp_dir { wp_next[0] - wp_prev[0], wp_next[1] - wp_prev[1], wp_next[2] - wp_prev[2]};
-			float norm = std::sqrt(wp_dir[0] * wp_dir[0] + wp_dir[1] * wp_dir[1] + wp_dir[2] * wp_dir[2]);
-			std::array<float, 3> wp_dir_norm {wp_dir[0] / norm, wp_dir[1] / norm, wp_dir[2] / norm};
-
-			// travelled = current - wp_prev
-			std::array<float, 3> travelled {current[0] - wp_prev[0], current[1] - wp_prev[1], current[2] - wp_prev[2]};
-
-			// t = wp_dir_norm.dot(travelled);
-			float t = wp_dir_norm[0] * travelled[0] + wp_dir_norm[1] * travelled[1] + wp_dir_norm[2] * travelled[2];
-
-			// closest_on_line = wp_prev + t * wp_dir_norm;
-			std::array<float, 3> closest_on_line { wp_prev[0] + t *wp_dir_norm[0], wp_prev[1] + t *wp_dir_norm[1], wp_prev[2] + t *wp_dir_norm[2]};
-
-			// distance = (closest_on_line - current).norm();
-			std::array<float, 3> vec_to_line {closest_on_line[0] - current[0], closest_on_line[1] - current[1], closest_on_line[2] - current[2]};
-			float distance_to_trajectory = std::sqrt(vec_to_line[0] * vec_to_line[0] * vec_to_line[1] * vec_to_line[1] *
-						       vec_to_line[2] * vec_to_line[2]);
+			float distance_to_trajectory = point_to_line_distance(current, wp_prev, wp_next);
 
 			CHECK(distance_to_trajectory < corridor_radius_m);
 		}

--- a/test/mavsdk_tests/autopilot_tester.cpp
+++ b/test/mavsdk_tests/autopilot_tester.cpp
@@ -246,14 +246,16 @@ void AutopilotTester::offboard_goto(const Offboard::PositionNedYaw &target, floa
 	std::cout << "Target position reached" << std::endl;
 }
 
-void AutopilotTester::check_mission_item_speed_above(int item_index, float min_speed)
+void AutopilotTester::check_mission_item_speed_above(int item_index, float min_speed_m_s)
 {
-	_telemetry->subscribe_velocity_ned([item_index, min_speed, this](Telemetry::VelocityNed velocity) {
+
+	_telemetry->set_rate_velocity_ned(10);
+	_telemetry->subscribe_velocity_ned([item_index, min_speed_m_s, this](Telemetry::VelocityNed velocity) {
 		float horizontal = std::hypot(velocity.north_m_s, velocity.east_m_s);
 		auto progress = _mission->mission_progress();
 
 		if (progress.current == item_index) {
-			CHECK(horizontal > min_speed);
+			CHECK(horizontal > min_speed_m_s);
 		}
 	});
 }

--- a/test/mavsdk_tests/autopilot_tester.h
+++ b/test/mavsdk_tests/autopilot_tester.h
@@ -56,6 +56,7 @@ public:
 		double leg_length_m {20.0};
 		double relative_altitude_m {10.0};
 		bool rtl_at_end {false};
+		bool fly_through {false};
 	};
 
 	void connect(const std::string uri);
@@ -72,12 +73,14 @@ public:
 	void wait_until_disarmed(std::chrono::seconds timeout_duration = std::chrono::seconds(90));
 	void wait_until_hovering();
 	void prepare_square_mission(MissionOptions mission_options);
+	void prepare_straight_mission(MissionOptions mission_options);
 	void execute_mission();
 	void execute_rtl();
 	void offboard_goto(const Offboard::PositionNedYaw &target, float acceptance_radius_m = 0.3f,
 			   std::chrono::seconds timeout_duration = std::chrono::seconds(60));
 	void offboard_land();
 	void request_ground_truth();
+	void check_mission_item_speed_above(int item_index, float min_speed);
 
 
 private:

--- a/test/mavsdk_tests/autopilot_tester.h
+++ b/test/mavsdk_tests/autopilot_tester.h
@@ -81,6 +81,7 @@ public:
 	void offboard_land();
 	void request_ground_truth();
 	void check_mission_item_speed_above(int item_index, float min_speed);
+	void check_tracks_mission(float corridor_radius_m = 1.0f);
 
 
 private:

--- a/test/mavsdk_tests/autopilot_tester.h
+++ b/test/mavsdk_tests/autopilot_tester.h
@@ -80,7 +80,7 @@ public:
 			   std::chrono::seconds timeout_duration = std::chrono::seconds(60));
 	void offboard_land();
 	void request_ground_truth();
-	void check_mission_item_speed_above(int item_index, float min_speed);
+	void check_mission_item_speed_above(int item_index, float min_speed_m_s);
 	void check_tracks_mission(float corridor_radius_m = 1.0f);
 
 

--- a/test/mavsdk_tests/test_multicopter_mission.cpp
+++ b/test/mavsdk_tests/test_multicopter_mission.cpp
@@ -71,6 +71,7 @@ TEST_CASE("Fly square Multicopter Missions", "[multicopter][vtol]")
 		AutopilotTester::MissionOptions mission_options;
 		mission_options.rtl_at_end = false;
 		tester.prepare_square_mission(mission_options);
+		tester.check_tracks_mission(0.8f);
 		tester.arm();
 		tester.execute_mission();
 		tester.wait_until_hovering();
@@ -90,10 +91,10 @@ TEST_CASE("Fly straight Multicopter Mission", "[multicopter]")
 	mission_options.fly_through = true;
 	tester.prepare_straight_mission(mission_options);
 	tester.check_mission_item_speed_above(2, 4.5);
+	tester.check_tracks_mission(0.8f);
 	tester.arm();
 	tester.execute_mission();
 	tester.wait_until_hovering();
 	tester.execute_rtl();
 	tester.wait_until_disarmed();
-
 }

--- a/test/mavsdk_tests/test_multicopter_mission.cpp
+++ b/test/mavsdk_tests/test_multicopter_mission.cpp
@@ -91,7 +91,7 @@ TEST_CASE("Fly straight Multicopter Mission", "[multicopter]")
 	mission_options.fly_through = true;
 	tester.prepare_straight_mission(mission_options);
 	tester.check_mission_item_speed_above(2, 4.5);
-	tester.check_tracks_mission(0.8f);
+	tester.check_tracks_mission(0.9f);
 	tester.arm();
 	tester.execute_mission();
 	tester.wait_until_hovering();

--- a/test/mavsdk_tests/test_multicopter_mission.cpp
+++ b/test/mavsdk_tests/test_multicopter_mission.cpp
@@ -78,3 +78,22 @@ TEST_CASE("Fly square Multicopter Missions", "[multicopter][vtol]")
 		tester.wait_until_disarmed();
 	}
 }
+
+TEST_CASE("Fly straight Multicopter Mission", "[multicopter]")
+{
+	AutopilotTester tester;
+	tester.connect(connection_url);
+	tester.wait_until_ready();
+
+	AutopilotTester::MissionOptions mission_options;
+	mission_options.rtl_at_end = false;
+	mission_options.fly_through = true;
+	tester.prepare_straight_mission(mission_options);
+	tester.check_mission_item_speed_above(2, 4.5);
+	tester.arm();
+	tester.execute_mission();
+	tester.wait_until_hovering();
+	tester.execute_rtl();
+	tester.wait_until_disarmed();
+
+}


### PR DESCRIPTION
This doesn't change any behavior, just adds a SITL test to make sure the vehicle doesn't slow down when travelling straight through a waypoint.

It also adds 'corridor checks' to allow checking that the vehicle is tracking its mission path during a flight.