### PR TITLE
FlightTasks: Stick library for auto land

### DIFF
--- a/src/lib/flight_tasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/flight_tasks/tasks/Auto/FlightTaskAuto.cpp
@@ -64,7 +64,6 @@ bool FlightTaskAuto::updateInitialize()
 	bool ret = FlightTask::updateInitialize();
 
 	_sub_home_position.update();
-	_sub_manual_control_setpoint.update();
 	_sub_vehicle_status.update();
 	_sub_triplet_setpoint.update();
 

--- a/src/lib/flight_tasks/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/lib/flight_tasks/tasks/Auto/FlightTaskAuto.hpp
@@ -108,7 +108,6 @@ protected:
 	WaypointType _type{WaypointType::idle}; /**< Type of current target triplet. */
 
 	uORB::SubscriptionData<home_position_s>			_sub_home_position{ORB_ID(home_position)};
-	uORB::SubscriptionData<manual_control_setpoint_s>	_sub_manual_control_setpoint{ORB_ID(manual_control_setpoint)};
 	uORB::SubscriptionData<vehicle_status_s>		_sub_vehicle_status{ORB_ID(vehicle_status)};
 
 	State _current_state{State::none};

--- a/src/lib/flight_tasks/tasks/AutoMapper/FlightTaskAutoMapper.cpp
+++ b/src/lib/flight_tasks/tasks/AutoMapper/FlightTaskAutoMapper.cpp
@@ -187,7 +187,7 @@ float FlightTaskAutoMapper::_getLandSpeed()
 	// user input assisted land speed
 	if (_param_mpc_land_rc_help.get()
 	    && (_dist_to_ground < _param_mpc_land_alt1.get())
-	    && _sticks.evaluateSticks(_time_stamp_current)) {
+	    && _sticks.checkAndSetStickInputs(_time_stamp_current)) {
 		// stick full up -1 -> stop, stick full down 1 -> double the speed
 		land_speed *= (1 + _sticks.getPositionExpo()(2));
 	}

--- a/src/lib/flight_tasks/tasks/AutoMapper/FlightTaskAutoMapper.cpp
+++ b/src/lib/flight_tasks/tasks/AutoMapper/FlightTaskAutoMapper.cpp
@@ -193,14 +193,7 @@ float FlightTaskAutoMapper::_getLandSpeed()
 		// user input assisted land speed
 		if (_param_mpc_land_rc_help.get()) {
 			_sticks.evaluateSticks(_time_stamp_current);
-			const float head_room = _constraints.speed_down - land_speed;
-
-			speed = land_speed + _sticks.getPositionExpo()(2) * head_room;
-
-			// Allow minimum assisted land speed to be half of parameter
-			if (speed < land_speed * 0.5f) {
-				speed = land_speed * 0.5f;
-			}
+			speed = land_speed + _sticks.getPositionExpo()(2) * land_speed;
 		}
 	}
 

--- a/src/lib/flight_tasks/tasks/AutoMapper/FlightTaskAutoMapper.hpp
+++ b/src/lib/flight_tasks/tasks/AutoMapper/FlightTaskAutoMapper.hpp
@@ -41,11 +41,12 @@
 #pragma once
 
 #include "FlightTaskAuto.hpp"
+#include "Sticks.hpp"
 
 class FlightTaskAutoMapper : public FlightTaskAuto
 {
 public:
-	FlightTaskAutoMapper() = default;
+	FlightTaskAutoMapper();
 	virtual ~FlightTaskAutoMapper() = default;
 	bool activate(vehicle_local_position_setpoint_s last_setpoint) override;
 	bool update() override;
@@ -76,7 +77,7 @@ protected:
 				       );
 
 private:
-
+	Sticks _sticks;
 	void _reset(); /**< Resets member variables to current vehicle state */
 	WaypointType _type_previous{WaypointType::idle}; /**< Previous type of current target triplet. */
 	bool _highEnoughForLandingGear(); /**< Checks if gears can be lowered. */

--- a/src/lib/flight_tasks/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
+++ b/src/lib/flight_tasks/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
@@ -50,8 +50,8 @@ bool FlightTaskManualAltitude::updateInitialize()
 {
 	bool ret = FlightTask::updateInitialize();
 
-	_sticks.evaluateSticks(_time_stamp_current);
-	_sticks.applyGearSwitch(_gear);
+	_sticks.checkAndSetStickInputs(_time_stamp_current);
+	_sticks.setGearAccordingToSwitch(_gear);
 
 	if (_sticks_data_required) {
 		ret = ret && _sticks.isAvailable();

--- a/src/lib/flight_tasks/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
+++ b/src/lib/flight_tasks/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
@@ -50,10 +50,11 @@ bool FlightTaskManualAltitude::updateInitialize()
 {
 	bool ret = FlightTask::updateInitialize();
 
-	const bool sticks_available = _sticks.evaluateSticks(_time_stamp_current, _gear);
+	_sticks.evaluateSticks(_time_stamp_current);
+	_sticks.applyGearSwitch(_gear);
 
 	if (_sticks_data_required) {
-		ret = ret && sticks_available;
+		ret = ret && _sticks.isAvailable();
 	}
 
 	// in addition to manual require valid position and velocity in D-direction and valid yaw

--- a/src/lib/flight_tasks/tasks/Utility/Sticks.cpp
+++ b/src/lib/flight_tasks/tasks/Utility/Sticks.cpp
@@ -43,7 +43,7 @@ Sticks::Sticks(ModuleParams *parent) :
 	ModuleParams(parent)
 {};
 
-void Sticks::evaluateSticks(hrt_abstime now)
+bool Sticks::evaluateSticks(hrt_abstime now)
 {
 	_sub_manual_control_setpoint.update();
 
@@ -80,6 +80,8 @@ void Sticks::evaluateSticks(hrt_abstime now)
 		_positions.zero();
 		_positions_expo.zero();
 	}
+
+	return _input_available;
 }
 
 void Sticks::applyGearSwitch(landing_gear_s &gear)

--- a/src/lib/flight_tasks/tasks/Utility/Sticks.cpp
+++ b/src/lib/flight_tasks/tasks/Utility/Sticks.cpp
@@ -43,7 +43,7 @@ Sticks::Sticks(ModuleParams *parent) :
 	ModuleParams(parent)
 {};
 
-bool Sticks::evaluateSticks(hrt_abstime now)
+bool Sticks::checkAndSetStickInputs(hrt_abstime now)
 {
 	_sub_manual_control_setpoint.update();
 
@@ -84,7 +84,7 @@ bool Sticks::evaluateSticks(hrt_abstime now)
 	return _input_available;
 }
 
-void Sticks::applyGearSwitch(landing_gear_s &gear)
+void Sticks::setGearAccordingToSwitch(landing_gear_s &gear)
 {
 	// Only switch the landing gear up if the user switched from gear down to gear up.
 	// If the user had the switch in the gear up position and took off ignore it

--- a/src/lib/flight_tasks/tasks/Utility/Sticks.cpp
+++ b/src/lib/flight_tasks/tasks/Utility/Sticks.cpp
@@ -43,7 +43,7 @@ Sticks::Sticks(ModuleParams *parent) :
 	ModuleParams(parent)
 {};
 
-bool Sticks::evaluateSticks(hrt_abstime now, landing_gear_s &gear)
+void Sticks::evaluateSticks(hrt_abstime now)
 {
 	_sub_manual_control_setpoint.update();
 
@@ -51,7 +51,6 @@ bool Sticks::evaluateSticks(hrt_abstime now, landing_gear_s &gear)
 
 	// Sticks are rescaled linearly and exponentially to [-1,1]
 	if ((now - _sub_manual_control_setpoint.get().timestamp) < rc_timeout) {
-
 		// Linear scale
 		_positions(0) = _sub_manual_control_setpoint.get().x; // NED x, pitch [-1,1]
 		_positions(1) = _sub_manual_control_setpoint.get().y; // NED y, roll [-1,1]
@@ -64,41 +63,46 @@ bool Sticks::evaluateSticks(hrt_abstime now, landing_gear_s &gear)
 		_positions_expo(2) = math::expo_deadzone(_positions(2), _param_mpc_z_man_expo.get(), _param_mpc_hold_dz.get());
 		_positions_expo(3) = math::expo_deadzone(_positions(3), _param_mpc_yaw_expo.get(), _param_mpc_hold_dz.get());
 
-		// Only switch the landing gear up if the user switched from gear down to gear up.
-		// If the user had the switch in the gear up position and took off ignore it
-		// until he toggles the switch to avoid retracting the gear immediately on takeoff.
-		int8_t gear_switch = _sub_manual_control_setpoint.get().gear_switch;
-
-		if (_gear_switch_old != gear_switch) {
-			applyGearSwitch(gear_switch, gear);
-		}
-
-		_gear_switch_old = gear_switch;
-
 		// valid stick inputs are required
 		const bool valid_sticks =  PX4_ISFINITE(_positions(0))
 					   && PX4_ISFINITE(_positions(1))
 					   && PX4_ISFINITE(_positions(2))
 					   && PX4_ISFINITE(_positions(3));
 
-		return valid_sticks;
+		_input_available = valid_sticks;
 
 	} else {
+		_input_available = false;
+	}
+
+	if (!_input_available) {
 		// Timeout: set all sticks to zero
 		_positions.zero();
 		_positions_expo.zero();
-		gear.landing_gear = landing_gear_s::GEAR_KEEP;
-		return false;
 	}
 }
 
-void Sticks::applyGearSwitch(uint8_t gear_switch, landing_gear_s &gear)
+void Sticks::applyGearSwitch(landing_gear_s &gear)
 {
-	if (gear_switch == manual_control_setpoint_s::SWITCH_POS_OFF) {
-		gear.landing_gear = landing_gear_s::GEAR_DOWN;
-	}
+	// Only switch the landing gear up if the user switched from gear down to gear up.
+	// If the user had the switch in the gear up position and took off ignore it
+	// until he toggles the switch to avoid retracting the gear immediately on takeoff.
+	if (!isAvailable()) {
+		gear.landing_gear = landing_gear_s::GEAR_KEEP;
 
-	if (gear_switch == manual_control_setpoint_s::SWITCH_POS_ON) {
-		gear.landing_gear = landing_gear_s::GEAR_UP;
+	} else {
+		const int8_t gear_switch = _sub_manual_control_setpoint.get().gear_switch;
+
+		if (_gear_switch_old != gear_switch) {
+			if (gear_switch == manual_control_setpoint_s::SWITCH_POS_OFF) {
+				gear.landing_gear = landing_gear_s::GEAR_DOWN;
+			}
+
+			if (gear_switch == manual_control_setpoint_s::SWITCH_POS_ON) {
+				gear.landing_gear = landing_gear_s::GEAR_UP;
+			}
+		}
+
+		_gear_switch_old = gear_switch;
 	}
 }

--- a/src/lib/flight_tasks/tasks/Utility/Sticks.hpp
+++ b/src/lib/flight_tasks/tasks/Utility/Sticks.hpp
@@ -53,7 +53,7 @@ public:
 	Sticks(ModuleParams *parent);
 	~Sticks() = default;
 
-	void evaluateSticks(hrt_abstime now); ///< checks and sets stick inputs
+	bool evaluateSticks(hrt_abstime now); ///< checks and sets stick inputs
 	void applyGearSwitch(landing_gear_s &gear); ///< Sets gears according to switch
 	bool isAvailable() { return _input_available; };
 	const matrix::Vector<float, 4> &getPosition() { return _positions; };

--- a/src/lib/flight_tasks/tasks/Utility/Sticks.hpp
+++ b/src/lib/flight_tasks/tasks/Utility/Sticks.hpp
@@ -53,11 +53,14 @@ public:
 	Sticks(ModuleParams *parent);
 	~Sticks() = default;
 
-	bool evaluateSticks(hrt_abstime now, landing_gear_s &gear); ///< checks and sets stick inputs
-	void applyGearSwitch(uint8_t gear_switch, landing_gear_s &gear); ///< Sets gears according to switch
+	void evaluateSticks(hrt_abstime now); ///< checks and sets stick inputs
+	void applyGearSwitch(landing_gear_s &gear); ///< Sets gears according to switch
+	bool isAvailable() { return _input_available; };
 	const matrix::Vector<float, 4> &getPosition() { return _positions; };
 	const matrix::Vector<float, 4> &getPositionExpo() { return _positions_expo; };
+
 private:
+	bool _input_available = false;
 	matrix::Vector<float, 4> _positions; ///< unmodified manual stick inputs
 	matrix::Vector<float, 4> _positions_expo; ///< modified manual sticks using expo function
 	int _gear_switch_old = manual_control_setpoint_s::SWITCH_POS_NONE; ///< old switch state

--- a/src/lib/flight_tasks/tasks/Utility/Sticks.hpp
+++ b/src/lib/flight_tasks/tasks/Utility/Sticks.hpp
@@ -53,8 +53,8 @@ public:
 	Sticks(ModuleParams *parent);
 	~Sticks() = default;
 
-	bool evaluateSticks(hrt_abstime now); ///< checks and sets stick inputs
-	void applyGearSwitch(landing_gear_s &gear); ///< Sets gears according to switch
+	bool checkAndSetStickInputs(hrt_abstime now);
+	void setGearAccordingToSwitch(landing_gear_s &gear);
 	bool isAvailable() { return _input_available; };
 	const matrix::Vector<float, 4> &getPosition() { return _positions; };
 	const matrix::Vector<float, 4> &getPositionExpo() { return _positions_expo; };

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -359,8 +359,11 @@ PARAM_DEFINE_FLOAT(MPC_LAND_VEL_XY, 10.0f);
 
 /**
  * Enable user assisted descent speed for autonomous land routine.
- * When enabled, descent speed will be equal to MPC_LAND_SPEED at half throttle,
- * MPC_Z_VEL_MAX_DN at zero throttle, and 0.5 * MPC_LAND_SPEED at full throttle.
+ *
+ * When enabled, descent speed will be:
+ * stick full up - 0
+ * stick centered - MPC_LAND_SPEED
+ * stick full down - 2 * MPC_LAND_SPEED
  *
  * @min 0
  * @max 1


### PR DESCRIPTION
**Describe problem solved by this pull request**
This is a follow-up to https://github.com/PX4/Firmware/pull/15324 but I didn't want to overload the original pr.
The auto task uses the sticks since https://github.com/PX4/Firmware/pull/12220/ to adjust the land speed during final descend. It did so in a `FlightTaskManual` independent way duplicating the functionality.

**Describe your solution**
- Now it can reuse the `Sticks` library from https://github.com/PX4/Firmware/pull/15324
- For the reusability of the things I copied into the `Sticks` library I had to untangle the landing gear logic since you don't want to override the landing gear automatically set by the land mode using your RC.
- As discussed with @jkflying the stick has a bit more authority to actual stop during slow down and not just slow down vertical movement.

**Describe possible alternatives**
A clear and concise description of alternative solutions or features you've considered.

**Test data / coverage**
I tested it in SITL but I did not have a landing gear in my tests so please review that logic thoroughly.