### PR TITLE
minor thread/task priority adjustments

### DIFF
--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019-2020 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -48,7 +48,7 @@ struct wq_config_t {
 
 namespace wq_configurations
 {
-static constexpr wq_config_t rate_ctrl{"wq:rate_ctrl", 1664, 0}; // PX4 inner loop highest priority
+// SCHED_PRIORITY_MAX left open
 
 static constexpr wq_config_t SPI0{"wq:SPI0", 2336, -1};
 static constexpr wq_config_t SPI1{"wq:SPI1", 2336, -2};
@@ -58,30 +58,33 @@ static constexpr wq_config_t SPI4{"wq:SPI4", 2336, -5};
 static constexpr wq_config_t SPI5{"wq:SPI5", 2336, -6};
 static constexpr wq_config_t SPI6{"wq:SPI6", 2336, -7};
 
-static constexpr wq_config_t I2C0{"wq:I2C0", 1472, -8};
-static constexpr wq_config_t I2C1{"wq:I2C1", 1472, -9};
-static constexpr wq_config_t I2C2{"wq:I2C2", 1472, -10};
-static constexpr wq_config_t I2C3{"wq:I2C3", 1472, -11};
-static constexpr wq_config_t I2C4{"wq:I2C4", 1472, -12};
+// PX4 inner loop highest priority after SPI (typically the primary IMU)
+static constexpr wq_config_t rate_ctrl{"wq:rate_ctrl", 1664, -8};
+
+static constexpr wq_config_t I2C0{"wq:I2C0", 1472, -9};
+static constexpr wq_config_t I2C1{"wq:I2C1", 1472, -10};
+static constexpr wq_config_t I2C2{"wq:I2C2", 1472, -11};
+static constexpr wq_config_t I2C3{"wq:I2C3", 1472, -12};
+static constexpr wq_config_t I2C4{"wq:I2C4", 1472, -13};
 
 // PX4 att/pos controllers, highest priority after sensors.
-static constexpr wq_config_t attitude_ctrl{"wq:attitude_ctrl", 1632, -13};
-static constexpr wq_config_t nav_and_controllers{"wq:nav_and_controllers", 7200, -14};
+static constexpr wq_config_t attitude_ctrl{"wq:attitude_ctrl", 1632, -14};
+static constexpr wq_config_t nav_and_controllers{"wq:nav_and_controllers", 7200, -15};
 
-static constexpr wq_config_t hp_default{"wq:hp_default", 1900, -15};
+static constexpr wq_config_t hp_default{"wq:hp_default", 1900, -16};
 
-static constexpr wq_config_t uavcan{"wq:uavcan", 3000, -16};
+static constexpr wq_config_t uavcan{"wq:uavcan", 3000, -17};
 
-static constexpr wq_config_t UART0{"wq:UART0", 1400, -17};
-static constexpr wq_config_t UART1{"wq:UART1", 1400, -18};
-static constexpr wq_config_t UART2{"wq:UART2", 1400, -19};
-static constexpr wq_config_t UART3{"wq:UART3", 1400, -20};
-static constexpr wq_config_t UART4{"wq:UART4", 1400, -21};
-static constexpr wq_config_t UART5{"wq:UART5", 1400, -22};
-static constexpr wq_config_t UART6{"wq:UART6", 1400, -23};
-static constexpr wq_config_t UART7{"wq:UART7", 1400, -24};
-static constexpr wq_config_t UART8{"wq:UART8", 1400, -25};
-static constexpr wq_config_t UART_UNKNOWN{"wq:UART_UNKNOWN", 1400, -26};
+static constexpr wq_config_t UART0{"wq:UART0", 1400, -18};
+static constexpr wq_config_t UART1{"wq:UART1", 1400, -19};
+static constexpr wq_config_t UART2{"wq:UART2", 1400, -20};
+static constexpr wq_config_t UART3{"wq:UART3", 1400, -21};
+static constexpr wq_config_t UART4{"wq:UART4", 1400, -22};
+static constexpr wq_config_t UART5{"wq:UART5", 1400, -23};
+static constexpr wq_config_t UART6{"wq:UART6", 1400, -24};
+static constexpr wq_config_t UART7{"wq:UART7", 1400, -25};
+static constexpr wq_config_t UART8{"wq:UART8", 1400, -26};
+static constexpr wq_config_t UART_UNKNOWN{"wq:UART_UNKNOWN", 1400, -27};
 
 static constexpr wq_config_t lp_default{"wq:lp_default", 1700, -50};
 

--- a/platforms/common/include/px4_platform_common/tasks.h
+++ b/platforms/common/include/px4_platform_common/tasks.h
@@ -100,35 +100,28 @@ typedef struct {
 #error "No target OS defined"
 #endif
 
-// PX4 work queue starting high priority
-#define PX4_WQ_HP_BASE (SCHED_PRIORITY_MAX - 15)
-
-// Fast drivers - they need to run as quickly as possible to minimize control
-// latency.
-#define SCHED_PRIORITY_FAST_DRIVER		(SCHED_PRIORITY_MAX - 0)
+// keep in sync with wq_configurations (platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp)
+#define PX4_WQ_RATE_CONTROL     (SCHED_PRIORITY_MAX - 8)
+#define PX4_WQ_ATTITUDE_CONTROL (SCHED_PRIORITY_MAX - 14)
+#define PX4_WQ_POSITION_CONTROL (SCHED_PRIORITY_MAX - 15)
+#define PX4_WQ_HP_BASE          (SCHED_PRIORITY_MAX - 16)
+#define PX4_WQ_UART_MAX         (SCHED_PRIORITY_MAX - 18)
 
 // Actuator outputs should run as soon as the rate controller publishes
 // the actuator controls topic
-#define SCHED_PRIORITY_ACTUATOR_OUTPUTS		(PX4_WQ_HP_BASE - 3)
+#define SCHED_PRIORITY_ACTUATOR_OUTPUTS		(PX4_WQ_RATE_CONTROL)
 
 // Attitude controllers typically are in a blocking wait on driver data
 // they should be the first to run on an update, using the current sensor
 // data and the *previous* attitude reference from the position controller
 // which typically runs at a slower rate
-#define SCHED_PRIORITY_ATTITUDE_CONTROL		(PX4_WQ_HP_BASE - 4)
-
-// Estimators should run after the attitude controller but before anything
-// else in the system. They wait on sensor data which is either coming
-// from the sensor hub or from a driver. Keeping this class at a higher
-// priority ensures that the estimator runs first if it can, but will
-// wait for the sensor hub if its data is coming from it.
-#define SCHED_PRIORITY_ESTIMATOR		(PX4_WQ_HP_BASE - 5)
+#define SCHED_PRIORITY_ATTITUDE_CONTROL		(PX4_WQ_ATTITUDE_CONTROL)
 
 // Position controllers typically are in a blocking wait on estimator data
 // so when new sensor data is available they will run last. Keeping them
 // on a high priority ensures that they are the first process to be run
 // when the estimator updates.
-#define SCHED_PRIORITY_POSITION_CONTROL		(PX4_WQ_HP_BASE - 7)
+#define SCHED_PRIORITY_POSITION_CONTROL		(PX4_WQ_POSITION_CONTROL)
 
 // The log capture (which stores log data into RAM) should run faster
 // than other components, but should not run before the control pipeline
@@ -136,13 +129,11 @@ typedef struct {
 
 // Slow drivers should run at a rate where they do not impact the overall
 // system execution
-#define SCHED_PRIORITY_SLOW_DRIVER		(PX4_WQ_HP_BASE - 35)
+#define SCHED_PRIORITY_SLOW_DRIVER		(PX4_WQ_UART_MAX + 1)
 
 // The navigation system needs to execute regularly but has no realtime needs
 #define SCHED_PRIORITY_NAVIGATION		(SCHED_PRIORITY_DEFAULT + 5)
 //      SCHED_PRIORITY_DEFAULT
-#define SCHED_PRIORITY_LOG_WRITER		(SCHED_PRIORITY_DEFAULT - 10)
-#define SCHED_PRIORITY_PARAMS			(SCHED_PRIORITY_DEFAULT - 15)
 //      SCHED_PRIORITY_IDLE
 
 typedef int (*px4_main_t)(int argc, char *argv[]);

--- a/src/drivers/linux_pwm_out/linux_pwm_out.cpp
+++ b/src/drivers/linux_pwm_out/linux_pwm_out.cpp
@@ -465,7 +465,7 @@ void start()
 	/* start the task */
 	_task_handle = px4_task_spawn_cmd("pwm_out_main",
 					  SCHED_DEFAULT,
-					  SCHED_PRIORITY_MAX,
+					  SCHED_PRIORITY_ACTUATOR_OUTPUTS,
 					  1500,
 					  (px4_main_t)&task_main_trampoline,
 					  nullptr);

--- a/src/drivers/mkblctrl/mkblctrl.cpp
+++ b/src/drivers/mkblctrl/mkblctrl.cpp
@@ -305,7 +305,7 @@ MK::init(unsigned motors)
 	/* start the IO interface task */
 	_task = px4_task_spawn_cmd("mkblctrl",
 				   SCHED_DEFAULT,
-				   SCHED_PRIORITY_MAX - 20,
+				   SCHED_PRIORITY_ACTUATOR_OUTPUTS,
 				   1500,
 				   (main_t)&MK::task_main_trampoline,
 				   nullptr);

--- a/src/drivers/roboclaw/roboclaw_main.cpp
+++ b/src/drivers/roboclaw/roboclaw_main.cpp
@@ -148,7 +148,7 @@ int roboclaw_main(int argc, char *argv[])
 		RoboClaw::taskShouldExit = false;
 		deamon_task = px4_task_spawn_cmd("roboclaw",
 						 SCHED_DEFAULT,
-						 SCHED_PRIORITY_MAX - 10,
+						 SCHED_PRIORITY_ACTUATOR_OUTPUTS,
 						 2000,
 						 roboclaw_thread_main,
 						 (char *const *)argv);

--- a/src/drivers/snapdragon_pwm_out/snapdragon_pwm_out.cpp
+++ b/src/drivers/snapdragon_pwm_out/snapdragon_pwm_out.cpp
@@ -485,7 +485,7 @@ void start()
 	/* start the task */
 	_task_handle = px4_task_spawn_cmd("snapdragon_pwm_out_main",
 					  SCHED_DEFAULT,
-					  SCHED_PRIORITY_MAX,
+					  SCHED_PRIORITY_ACTUATOR_OUTPUTS,
 					  1500,
 					  (px4_main_t)&task_main_trampoline,
 					  nullptr);

--- a/src/examples/fixedwing_control/main.cpp
+++ b/src/examples/fixedwing_control/main.cpp
@@ -465,7 +465,7 @@ int ex_fixedwing_control_main(int argc, char *argv[])
 		thread_should_exit = false;
 		deamon_task = px4_task_spawn_cmd("ex_fixedwing_control",
 						 SCHED_DEFAULT,
-						 SCHED_PRIORITY_MAX - 20,
+						 SCHED_PRIORITY_ATTITUDE_CONTROL,
 						 2048,
 						 fixedwing_control_thread_main,
 						 (argv) ? (char *const *)&argv[2] : (char *const *)nullptr);

--- a/src/examples/hello/hello_start.cpp
+++ b/src/examples/hello/hello_start.cpp
@@ -69,7 +69,7 @@ int hello_main(int argc, char *argv[])
 
 		daemon_task = px4_task_spawn_cmd("hello",
 						 SCHED_DEFAULT,
-						 SCHED_PRIORITY_MAX - 5,
+						 SCHED_PRIORITY_DEFAULT,
 						 2000,
 						 PX4_MAIN,
 						 (argv) ? (char *const *)&argv[2] : (char *const *)nullptr);

--- a/src/examples/matlab_csv_serial/matlab_csv_serial.c
+++ b/src/examples/matlab_csv_serial/matlab_csv_serial.c
@@ -102,7 +102,7 @@ int matlab_csv_serial_main(int argc, char *argv[])
 		thread_should_exit = false;
 		daemon_task = px4_task_spawn_cmd("matlab_csv_serial",
 						 SCHED_DEFAULT,
-						 SCHED_PRIORITY_MAX - 5,
+						 SCHED_PRIORITY_DEFAULT,
 						 2000,
 						 matlab_csv_serial_thread_main,
 						 (argv) ? (char *const *)&argv[2] : (char *const *)NULL);

--- a/src/examples/rover_steering_control/main.cpp
+++ b/src/examples/rover_steering_control/main.cpp
@@ -419,7 +419,7 @@ int rover_steering_control_main(int argc, char *argv[])
 		thread_should_exit = false;
 		deamon_task = px4_task_spawn_cmd("rover_steering_control",
 						 SCHED_DEFAULT,
-						 SCHED_PRIORITY_MAX - 20,
+						 SCHED_PRIORITY_ATTITUDE_CONTROL,
 						 2048,
 						 rover_steering_control_thread_main,
 						 (argv) ? (char *const *)&argv[2] : (char *const *)nullptr);

--- a/src/systemcmds/top/CMakeLists.txt
+++ b/src/systemcmds/top/CMakeLists.txt
@@ -34,7 +34,7 @@ px4_add_module(
 	MODULE systemcmds__top
 	MAIN top
 	PRIORITY
-		"SCHED_PRIORITY_MAX - 16" # max priority below high priority WQ threads
+		"SCHED_PRIORITY_MAX - 17" # max priority below high priority WQ threads
 	SRCS
 		top.c
 	DEPENDS


### PR DESCRIPTION
The goal here is to ensure consistent scheduling of the IMUs, immune to things like parameter update. Initially with the PX4 work queue the rate control (inner loop) thread was the highest priority to ensure it runs immediately when the primary gyro publishes.

With nearly all the sensor processing removed from the bus thread (now handled downstream in sensors) the actual cpu time spent in a driver is minimal (~10-20us) and overall it's slightly faster to let them always run to completion and avoid additional high rate context switching. 

So overall there is a small increase in control latency (and potential jitter), but I consider it negligible. 

 - SPI threads become highest priority to ensure consistent scheduling
 - run inner loop after SPI (for primary IMU)
 - adjust remaining task priorities to be consistent with PX4 work queue



