### PR TITLE
mavlink_ftp: close inactive session

### DIFF
--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -51,6 +51,7 @@
 #include <v2.0/standard/mavlink.h>
 #endif
 
+using namespace time_literals;
 
 constexpr const char MavlinkFTP::_root_dir[];
 
@@ -960,7 +961,7 @@ void MavlinkFTP::send(const hrt_abstime t)
 
 	if (_work_buffer1 || _work_buffer2) {
 		// free the work buffers if they are not used for a while
-		if (hrt_elapsed_time(&_last_work_buffer_access) > 2000000) {
+		if (hrt_elapsed_time(&_last_work_buffer_access) > 2_s) {
 			if (_work_buffer1) {
 				delete[] _work_buffer1;
 				_work_buffer1 = nullptr;
@@ -970,6 +971,16 @@ void MavlinkFTP::send(const hrt_abstime t)
 				delete[] _work_buffer2;
 				_work_buffer2 = nullptr;
 			}
+		}
+
+	} else if (_session_info.fd != -1) {
+		// close session without activity
+		if (hrt_elapsed_time(&_last_work_buffer_access) > 10_s) {
+			::close(_session_info.fd);
+			_session_info.fd = -1;
+			_session_info.stream_download = false;
+			_last_reply_valid = false;
+			PX4_WARN("Session was closed without activity");
 		}
 	}
 


### PR DESCRIPTION
10s inactivity timeout to close session (can be corrected to more suitable timeout).

Without this patch if GCS is disconnected during ftp session, vehicle get stuck with not closed session and GCS will not be able to open new session (FTP: Open failed - out of sessions) until vehicle reboot. Another option is for GCS to send kCmdResetSessions before open any new session, but I suppose it is not right solution (but can be implemented in common).

I'm working with custom GCS, I didn't check this with QGC and don't know will it pass ftp checks.