### PR TITLE
commander: fix takeoff and land CI test

### DIFF
--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -532,8 +532,8 @@ bool set_nav_state(vehicle_status_s *status, actuator_armed_s *armed, commander_
 
 			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_datalink);
 
-		} else if (rc_lost && !data_link_loss_act_configured && is_armed) {
-			/* go into failsafe if RC is lost and datalink loss is not set up and rc loss is not DISABLED */
+		} else if (rc_lost && !data_link_loss_act_configured && status->data_link_lost && is_armed) {
+			/* go into failsafe if RC is lost and datalink is lost and datalink loss is not set up */
 			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_rc);
 
 			set_link_loss_nav_state(status, armed, status_flags, internal_state, rc_loss_act);


### PR DESCRIPTION
This fixes the takeoff and land CI test where we do a takeoff and land without RC connected.

In my opinion it does not make sense to go into RC lost failsafe if a datalink is still available.
Of course, this can be dangerous if someone has a companion computer connected which gets detected as "data link" but actually has no connection to the ground station.

This is required for the takeoff and land SITL test after https://github.com/PX4/Firmware/pull/15316.