### PR TITLE
uORB: print individual bits of fields

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -235,6 +235,7 @@ add_custom_command(OUTPUT ${uorb_headers}
 		templates/uorb/msg.h.em
 		templates/uorb/uORBTopics.hpp.em
 		tools/px_generate_uorb_topic_files.py
+		tools/px_generate_uorb_topic_helper.py
 	COMMENT "Generating uORB topic headers"
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 	VERBATIM
@@ -257,6 +258,7 @@ add_custom_command(OUTPUT ${uorb_sources}
 		templates/uorb/msg.cpp.em
 		templates/uorb/uORBTopics.cpp.em
 		tools/px_generate_uorb_topic_files.py
+		tools/px_generate_uorb_topic_helper.py
 	COMMENT "Generating uORB topic sources"
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 	VERBATIM

--- a/msg/tools/px_generate_uorb_topic_helper.py
+++ b/msg/tools/px_generate_uorb_topic_helper.py
@@ -317,11 +317,15 @@ def print_field(field):
         print("char baro_device_id_buffer[80];")
         print("device::Device::device_id_print_buffer(baro_device_id_buffer, sizeof(baro_device_id_buffer), message.baro_device_id);")
         print("PX4_INFO_RAW(\"\\tbaro_device_id: %d (%s) \\n\", message.baro_device_id, baro_device_id_buffer);")
+    elif ("flags" in field.name or "bits" in field.name) and "uint" in field.type:
+        # print bits of fixed width unsigned integers (uint8, uint16, uint32) if name contains flags or bits
+        print("PX4_INFO_RAW(\"\\t" + field.name + ": " + c_type + " (0b\", " + field_name + ");")
+        print("\tfor (int i = (sizeof(" + field_name + ") * 8) - 1; i >= 0; i--) { PX4_INFO_RAW(\"%u%s\", " + field_name + " >> i & 1, ((unsigned)i < (sizeof(" + field_name + ") * 8) - 1 && i % 4 == 0 && i > 0) ? \"'\" : \"\"); }")
+        print("\tPX4_INFO_RAW(\")\\n\");")
     elif is_array and 'char' in field.type:
         print(("PX4_INFO_RAW(\"\\t" + field.name + ": \\\"%." + str(array_length) + "s\\\" \\n\", message." + field.name + ");"))
     else:
-        print(("PX4_INFO_RAW(\"\\t" + field.name + ": " +
-              c_type + "\\n\", " + field_name + ");"))
+        print(("PX4_INFO_RAW(\"\\t" + field.name + ": " + c_type + "\\n\", " + field_name + ");"))
 
 
 def print_field_def(field):


### PR DESCRIPTION
 - applies to messages with names containing "flags" or "bits" and unsigned fixed width integer type (uint8, uint16, uint32)


### Examples

``` Console
nsh> listener estimator_status

TOPIC: estimator_status
 estimator_status_s
        timestamp: 63865011  (0.004478 seconds ago)
        states: [0.0499, 0.0007, -0.0241, 0.9984, -0.2369, 0.2916, 0.0396, -0.1543, 0.2069, 0.1159, 0.0000, 0.0000, -0.0001, 0.0000, 0.0000, -0.0001, 0.4105, -0.1005, 0.8565, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000]
        vibe: [0.0000, 0.0000, 0.0003]
        covariances: [0.0002, 0.0000, 0.0000, 0.0000, 0.0483, 0.0482, 0.0427, 0.0809, 0.0808, 0.2147, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000]
        output_tracking_error: [0.0076, 0.0209, 0.0196]
        control_mode_flags: 67109395 (0b0000'0100'0000'0000'0000'0010'0001'0011)
        pos_horiz_accuracy: 0.4022
        pos_vert_accuracy: 0.4634
        mag_test_ratio: 0.0600
        vel_test_ratio: 0.0000
        pos_test_ratio: 0.0038
        hgt_test_ratio: 0.0038
        tas_test_ratio: 0.0000
        hagl_test_ratio: 0.0000
        beta_test_ratio: 0.0000
        time_slip: -0.0105
        gps_check_fail_flags: 0 (0b0000'0000'0000'0000)
        filter_fault_flags: 0 (0b0000'0000'0000'0000)
        innovation_check_flags: 0 (0b0000'0000'0000'0000)
        solution_status_flags: 229 (0b0000'0000'1110'0101)
        n_states: 24
        pre_flt_fail_innov_heading: False
        pre_flt_fail_innov_vel_horiz: False
        pre_flt_fail_innov_vel_vert: False
        pre_flt_fail_innov_height: False
        pre_flt_fail_mag_field_disturbed: False
        health_flags: 0 (0b0000'0000)
        timeout_flags: 0 (0b0000'0000)

nsh> listener multirotor_motor_limits

TOPIC: multirotor_motor_limits
 multirotor_motor_limits_s
        timestamp: 130735043  (0.011383 seconds ago)
        saturation_status_flags: 1533 (0b0000'0101'1111'1101)
```