### PR TITLE
FlightTaskAuto: fix yaw reset issue during takeoff

### DIFF
--- a/src/lib/flight_tasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/flight_tasks/tasks/Auto/FlightTaskAuto.cpp
@@ -277,7 +277,11 @@ bool FlightTaskAuto::_evaluateTriplets()
 		_yaw_setpoint = NAN;
 
 	} else {
-		if (_sub_triplet_setpoint.get().current.yaw_valid) {
+		if (_type != WaypointType::takeoff
+		    && _sub_triplet_setpoint.get().current.yaw_valid) {
+			// Use the yaw computed in Navigator except during takeoff because
+			// Navigator is not handling the yaw reset properly
+			// TODO: fix in navigator
 			_yaw_setpoint = _sub_triplet_setpoint.get().current.yaw;
 
 		} else {


### PR DESCRIPTION
During takeoff, Navigator is sending a constant yaw value.
However, there is always a reset at 1.5m of the yaw estimate in EKF2 that is not handled by Navigator that produces a glitch in the rate controller. Given that in FlightTask, the yaw is already computed and properly corrected in case of an estimator reset event, we just ignore the yaw value sent by navigator during takeoff.

Before:
![yaw_reset_bug](https://user-images.githubusercontent.com/14822839/87761638-17a6df00-c812-11ea-8c3f-000a7cc3701e.png)

With this PR:
![yaw_reset_fix](https://user-images.githubusercontent.com/14822839/87761642-183f7580-c812-11ea-892d-299d836097ee.png)
