### PR TITLE
fw_pos_control_l1: if using air data (baro) copy every iteration

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1756,7 +1756,7 @@ FixedwingPositionControl::tecs_update_pitch_throttle(float alt_sp, float airspee
 	if (_param_fw_thr_alt_scl.get() > FLT_EPSILON) {
 		vehicle_air_data_s air_data;
 
-		if (_vehicle_air_data_sub.update(&air_data)) {
+		if (_vehicle_air_data_sub.copy(&air_data)) {
 			if (PX4_ISFINITE(air_data.baro_pressure_pa) && PX4_ISFINITE(_param_fw_thr_alt_scl.get())) {
 				// scale throttle as a function of sqrt(p0/p) (~ EAS -> TAS at low speeds and altitudes ignoring temperature)
 				const float eas2tas = sqrtf(CONSTANTS_STD_PRESSURE_PA / air_data.baro_pressure_pa);


### PR DESCRIPTION
Quick followup to https://github.com/PX4/Firmware/pull/15309.

 - vehicle_air_data won't have an update every iteration and these adjusted throttle values aren't stored


This only would have worked in the past because the vast majority of systems were using the ms5611 barometer with a publication rate somewhere around 100 Hz.
