### PR TITLE
wq:attitude_ctrl: small stack increase to silence warning

### DIFF
--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019-2020 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -65,7 +65,7 @@ static constexpr wq_config_t I2C3{"wq:I2C3", 1472, -11};
 static constexpr wq_config_t I2C4{"wq:I2C4", 1472, -12};
 
 // PX4 att/pos controllers, highest priority after sensors.
-static constexpr wq_config_t attitude_ctrl{"wq:attitude_ctrl", 1632, -13};
+static constexpr wq_config_t attitude_ctrl{"wq:attitude_ctrl", 1640, -13};
 static constexpr wq_config_t nav_and_controllers{"wq:nav_and_controllers", 7200, -14};
 
 static constexpr wq_config_t hp_default{"wq:hp_default", 1900, -15};


### PR DESCRIPTION
``` Console
WARN  [load_mon] wq:attitude_ctrl low on stack! (292 bytes left)
WARN  [load_mon] wq:attitude_ctrl low on stack! (292 bytes left)
WARN  [load_mon] wq:attitude_ctrl low on stack! (292 bytes left)
WARN  [load_mon] wq:attitude_ctrl low on stack! (292 bytes left)
WARN  [load_mon] wq:attitude_ctrl low on stack! (292 bytes left)
WARN  [load_mon] wq:attitude_ctrl low on stack! (292 bytes left)
WARN  [load_mon] wq:attitude_ctrl low on stack! (292 bytes left)
```