### PR TITLE
mixer_module/tap_esc: fix usage of constrain() on input

### DIFF
--- a/src/drivers/tap_esc/tap_esc.cpp
+++ b/src/drivers/tap_esc/tap_esc.cpp
@@ -639,12 +639,7 @@ int TAP_ESC::control_callback(uint8_t control_group, uint8_t control_index, floa
 	input = _controls[control_group].control[control_index];
 
 	/* limit control input */
-	if (input > 1.0f) {
-		input = 1.0f;
-
-	} else if (input < -1.0f) {
-		input = -1.0f;
-	}
+	input = math::constrain(input, -1.f, 1.f);
 
 	/* throttle not arming - mark throttle input as invalid */
 	if (_armed.prearmed && !_armed.armed) {

--- a/src/lib/mixer_module/mixer_module.cpp
+++ b/src/lib/mixer_module/mixer_module.cpp
@@ -499,7 +499,7 @@ int MixingOutput::controlCallback(uintptr_t handle, uint8_t control_group, uint8
 	input = output->_controls[control_group].control[control_index];
 
 	/* limit control input */
-	math::constrain(input, -1.f, 1.f);
+	input = math::constrain(input, -1.f, 1.f);
 
 	/* motor spinup phase - lock throttle to zero */
 	if (output->_output_limit.state == OUTPUT_LIMIT_STATE_RAMP) {


### PR DESCRIPTION
**Describe problem solved by this pull request**
I changed the input constraint in #15349 but screwed up the usage because I was convinced it's püass by reference. I'll double check for sure next time.

**Describe your solution**
It's pass by value and the return value has to be assigned again like @bkueng pointed out in https://github.com/PX4/Firmware/pull/15349/files#r457096522 Thanks!!