### PR TITLE
rc_loss_alarm: remove unimplemented declaration

### DIFF
--- a/src/modules/events/rc_loss_alarm.h
+++ b/src/modules/events/rc_loss_alarm.h
@@ -57,12 +57,6 @@ public:
 	void process();
 
 private:
-	/**
-	 * check for topic updates
-	 * @return true if one or more topics got updated
-	 */
-	bool check_for_updates();
-
 	/** Publish tune control to sound alarm */
 	void play_tune();
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
While looking into how the events module works, I found an unimplemented method declaration.

**Additional context**
That method was originally used and got removed in https://github.com/PX4/Firmware/commit/dc05ceaad2d3786d1c4929dbe867c044fbffe1dd#diff-70b849148026420261dae206d4aa2c6fL60