### PR TITLE
drivers/pwm_out: limit scheduling to primary actuator controls groups if used

### DIFF
--- a/src/drivers/pwm_out/PWMOut.hpp
+++ b/src/drivers/pwm_out/PWMOut.hpp
@@ -161,6 +161,8 @@ private:
 
 	Mode		_mode{MODE_NONE};
 
+	uint32_t	_backup_schedule_interval_us{1_s};
+
 	unsigned	_pwm_default_rate{50};
 	unsigned	_pwm_alt_rate{50};
 	uint32_t	_pwm_alt_rate_channels{0};

--- a/src/lib/mixer_module/mixer_module.hpp
+++ b/src/lib/mixer_module/mixer_module.hpp
@@ -124,9 +124,10 @@ public:
 	 * Check for subscription updates (e.g. after a mixer is loaded).
 	 * Call this at the very end of Run() if allow_wq_switch
 	 * @param allow_wq_switch if true
+	 * @param limit_callbacks_to_primary set to only register callbacks for primary actuator controls (if used)
 	 * @return true if subscriptions got changed
 	 */
-	bool updateSubscriptions(bool allow_wq_switch);
+	bool updateSubscriptions(bool allow_wq_switch, bool limit_callbacks_to_primary = false);
 
 	/**
 	 * unregister uORB subscription callbacks


### PR DESCRIPTION
When a passthrough or gimbal mixer is loaded in addition to the primary mixer the output module will be schedule to run on both controller updates (new actuator_controls_0 publications) as well as new RC data (actuator_controls_3). This can be problematic for things like OneShot ESCs that don't seem to like very tight back to back updates.

This limits scheduling of the output module (pwm_out) to primarily run on updates to the primary actuator control groups (0 & 1) if in use. Additionally there's a backup should groups 0 & 1 stop publishing for some reason.

 - fixes OneShot in certain configurations https://github.com/PX4/Firmware/issues/15043

