### PR TITLE
vtol_att_control: limit excessive scheduling

### DIFF
--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -51,6 +51,7 @@
 #include <uORB/Publication.hpp>
 
 using namespace matrix;
+using namespace time_literals;
 
 VtolAttitudeControl::VtolAttitudeControl() :
 	WorkItem(MODULE_NAME, px4::wq_configurations::rate_ctrl),
@@ -341,6 +342,19 @@ VtolAttitudeControl::Run()
 		exit_and_cleanup();
 		return;
 	}
+
+	const hrt_abstime now = hrt_absolute_time();
+
+#if !defined(ENABLE_LOCKSTEP_SCHEDULER)
+
+	// prevent excessive scheduling (> 500 Hz)
+	if (now - _last_run_timestamp < 2_ms) {
+		return;
+	}
+
+#endif // !ENABLE_LOCKSTEP_SCHEDULER
+
+	_last_run_timestamp = now;
 
 	if (!_initialized) {
 		parameters_update();  // initialize parameter cache

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -213,6 +213,8 @@ private:
 		param_t mpc_land_alt2;
 	} _params_handles{};
 
+	hrt_abstime _last_run_timestamp{0};
+
 	/* for multicopters it is usual to have a non-zero idle speed of the engines
 	 * for fixed wings we want to have an idle speed of zero since we do not want
 	 * to waste energy when gliding. */


### PR DESCRIPTION
This is to prevent `vtol_att_control` running at absurdly high rates (kilohertz) from every single actuator controls publication from both the multicopter and fixed wing controllers. I don't really like this solution, but it works for now until there are larger VTOL architectural changes in place.

It's not really an issue if `IMU_GYRO_RATEMAX` is set appropriately for these platforms, but currently it's still possible to slip through with the defaults intended for a small multicopter.