### PR TITLE
setup scripts: install dmidecode before using it

### DIFF
--- a/Tools/setup/arch.sh
+++ b/Tools/setup/arch.sh
@@ -131,6 +131,7 @@ if [[ $INSTALL_SIM == "true" ]]; then
 
 		# PX4 gazebo simulation dependencies
 		sudo pacman -S --noconfirm --needed \
+			dmidecode \
 			eigen3 \
 			hdf5 \
 			opencv \

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -196,6 +196,7 @@ if [[ $INSTALL_SIM == "true" ]]; then
 	sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
 	wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
 	sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
+		dmidecode \
 		gazebo9 \
 		gstreamer1.0-plugins-bad \
 		gstreamer1.0-plugins-base \


### PR DESCRIPTION
**Describe problem solved by this pull request**
On normal desktop distributions dmidecode is preinstalled and I was assuming it's part of the core tools. Thanks to a hint https://github.com/PX4/Firmware/pull/15241#issuecomment-659395458 I found out it's not and am installing the package before using it.

**Test data / coverage**
I checked the package to be available and already installed on my systems on Manjaro and Ubuntu 20.04.
