### PR TITLE
Generate param metadata as MAVLink-compatible JSON component info

### DIFF
--- a/cmake/metadata.cmake
+++ b/cmake/metadata.cmake
@@ -55,11 +55,18 @@ add_custom_target(metadata_parameters
 		--src-path `find ${PX4_SOURCE_DIR}/src -maxdepth 4 -type d`
 		--inject-xml ${PX4_SOURCE_DIR}/src/lib/parameters/parameters_injected.xml
 		--markdown ${PX4_BINARY_DIR}/docs/parameters.md
+
+	COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/src/lib/parameters/px_process_params.py
+		--src-path `find ${PX4_SOURCE_DIR}/src -maxdepth 4 -type d`
+		--inject-xml ${PX4_SOURCE_DIR}/src/lib/parameters/parameters_injected.xml
+		--json ${PX4_BINARY_DIR}/docs/parameters.json
+
 	COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/src/lib/parameters/px_process_params.py
 		--src-path `find ${PX4_SOURCE_DIR}/src -maxdepth 4 -type d`
 		--inject-xml ${PX4_SOURCE_DIR}/src/lib/parameters/parameters_injected.xml
 		--xml ${PX4_BINARY_DIR}/docs/parameters.xml
-	COMMENT "Generating full parameter metadata (markdown and xml)"
+
+	COMMENT "Generating full parameter metadata (markdown, xml, and json)"
 	USES_TERMINAL
 )
 

--- a/src/lib/parameters/CMakeLists.txt
+++ b/src/lib/parameters/CMakeLists.txt
@@ -114,6 +114,7 @@ add_custom_command(OUTPUT ${parameters_json}
 	COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/px_process_params.py
 		--src-path ${module_list} ${generated_params_dir}
 		--json ${parameters_json}
+		--compress
 		--inject-xml ${CMAKE_CURRENT_SOURCE_DIR}/parameters_injected.xml
 		--overrides ${PARAM_DEFAULT_OVERRIDES}
 		--board ${PX4_BOARD}

--- a/src/lib/parameters/CMakeLists.txt
+++ b/src/lib/parameters/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2017 - 2020 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -109,12 +109,36 @@ add_custom_command(OUTPUT ${parameters_xml}
 )
 add_custom_target(parameters_xml DEPENDS ${parameters_xml})
 
+set(parameters_json ${PX4_BINARY_DIR}/parameters.json)
+add_custom_command(OUTPUT ${parameters_json}
+	COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/px_process_params.py
+		--src-path ${module_list} ${generated_params_dir}
+		--json ${parameters_json}
+		--inject-xml ${CMAKE_CURRENT_SOURCE_DIR}/parameters_injected.xml
+		--overrides ${PARAM_DEFAULT_OVERRIDES}
+		--board ${PX4_BOARD}
+		#--verbose
+	DEPENDS
+		${param_src_files}
+		${generated_serial_params_file}
+		parameters_injected.xml
+		px4params/srcparser.py
+		px4params/srcscanner.py
+		px4params/xmlout.py
+		px4params/jsonout.py
+		px_process_params.py
+		parameters_injected.xml
+	COMMENT "Generating parameters.json"
+)
+add_custom_target(parameters_json DEPENDS ${parameters_json})
+
 # generate px4_parameters.c and px4_parameters{,_public}.h
 add_custom_command(OUTPUT px4_parameters.c px4_parameters.h px4_parameters_public.h
 	COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/px_generate_params.py
 		--xml ${parameters_xml} --dest ${CMAKE_CURRENT_BINARY_DIR}
 	DEPENDS
 		${PX4_BINARY_DIR}/parameters.xml
+		${PX4_BINARY_DIR}/parameters.json
 		px_generate_params.py
 		templates/px4_parameters.c.jinja
 		templates/px4_parameters.h.jinja

--- a/src/lib/parameters/CMakeLists.txt
+++ b/src/lib/parameters/CMakeLists.txt
@@ -87,32 +87,12 @@ add_custom_command(OUTPUT ${generated_serial_params_file}
 )
 
 set(parameters_xml ${PX4_BINARY_DIR}/parameters.xml)
+set(parameters_json ${PX4_BINARY_DIR}/parameters.json)
 file(GLOB_RECURSE param_src_files ${PX4_SOURCE_DIR}/src/*params.c)
-add_custom_command(OUTPUT ${parameters_xml}
+add_custom_command(OUTPUT ${parameters_xml} ${parameters_json}
 	COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/px_process_params.py
 		--src-path ${module_list} ${generated_params_dir}
 		--xml ${parameters_xml}
-		--inject-xml ${CMAKE_CURRENT_SOURCE_DIR}/parameters_injected.xml
-		--overrides ${PARAM_DEFAULT_OVERRIDES}
-		--board ${PX4_BOARD}
-		#--verbose
-	DEPENDS
-		${param_src_files}
-		${generated_serial_params_file}
-		parameters_injected.xml
-		px4params/srcparser.py
-		px4params/srcscanner.py
-		px4params/xmlout.py
-		px_process_params.py
-		parameters_injected.xml
-	COMMENT "Generating parameters.xml"
-)
-add_custom_target(parameters_xml DEPENDS ${parameters_xml})
-
-set(parameters_json ${PX4_BINARY_DIR}/parameters.json)
-add_custom_command(OUTPUT ${parameters_json}
-	COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/px_process_params.py
-		--src-path ${module_list} ${generated_params_dir}
 		--json ${parameters_json}
 		--compress
 		--inject-xml ${CMAKE_CURRENT_SOURCE_DIR}/parameters_injected.xml
@@ -125,13 +105,13 @@ add_custom_command(OUTPUT ${parameters_json}
 		parameters_injected.xml
 		px4params/srcparser.py
 		px4params/srcscanner.py
-		px4params/xmlout.py
 		px4params/jsonout.py
+		px4params/xmlout.py
 		px_process_params.py
 		parameters_injected.xml
-	COMMENT "Generating parameters.json"
+	COMMENT "Generating parameters.xml"
 )
-add_custom_target(parameters_json DEPENDS ${parameters_json})
+add_custom_target(parameters_xml DEPENDS ${parameters_xml})
 
 # generate px4_parameters.c and px4_parameters{,_public}.h
 add_custom_command(OUTPUT px4_parameters.c px4_parameters.h px4_parameters_public.h
@@ -139,7 +119,6 @@ add_custom_command(OUTPUT px4_parameters.c px4_parameters.h px4_parameters_publi
 		--xml ${parameters_xml} --dest ${CMAKE_CURRENT_BINARY_DIR}
 	DEPENDS
 		${PX4_BINARY_DIR}/parameters.xml
-		${PX4_BINARY_DIR}/parameters.json
 		px_generate_params.py
 		templates/px4_parameters.c.jinja
 		templates/px4_parameters.h.jinja

--- a/src/lib/parameters/px4params/jsonout.py
+++ b/src/lib/parameters/px4params/jsonout.py
@@ -9,7 +9,7 @@ class JsonOutput():
     def __init__(self, groups, board, inject_xml_file_name):
         all_json=dict()
         all_json['version']=1
-        all_json['uid']=1
+        all_json['uid']=1  #COMPONENT_INFORMATION.comp_metadata_type
         all_json['scope']="Firmware"
         all_params=[]
         all_json['parameters']=all_params
@@ -22,21 +22,17 @@ class JsonOutput():
         #xml_version = ET.SubElement(xml_parameters, "parameter_version_minor")
         #xml_version.text = "15"
 
-        #importtree = ET.parse(inject_xml_file_name)
-        #injectgroups = importtree.getroot().findall("group")
-        #for igroup in injectgroups:
-        #    xml_parameters.append(igroup)
-
         schema_map = {
                         "short_desc": "shortDescription",
 			"long_desc": "longDescription",
 			"unit": "units",
 			"decimal": "decimalPlaces",
-			"min": "minValue",
-			"max": "maxValue",
+			"min": "min",
+			"max": "max",
 			"increment": "increment",
 			"reboot_required": "rebootRequired"
 			}
+        allowed_types = { "Uint8", "Int8", "Uint16", "Int16", "Uint32", "Int32", "Float"}
 
         last_param_name = ""
         board_specific_param_set = False
@@ -49,6 +45,10 @@ class JsonOutput():
                     curr_param['name'] = param.GetName()
                     curr_param['defaultValue'] = param.GetDefault()
                     curr_param['type'] = param.GetType().capitalize()
+                    if not curr_param['type'] in allowed_types:
+                        print("Error: %s type not supported: curr_param['type']" % (curr_param['name'],curr_param['type']) )
+                        sys.Exit(1)
+
                     curr_param['group'] = group_name
                     if (param.GetCategory()):
                         curr_param['category'] = param.GetCategory()
@@ -102,47 +102,6 @@ class JsonOutput():
 
                 all_params.append(curr_param)
 
- 
-
-
-        '''
-        result = ""
-        all_json=dict()
-        all_json['version']=1
-        all_json['uid']=1
-        all_json['scope']="Firmware"
-        all_params=[]
-        all_json['parameters']=all_params
-        for group in groups:
-            #result += '## %s\n\n' % group.GetName()
-            group_name=group.GetName()
-            for param in group.GetParams():
-                curr_param=dict()
-                curr_param['name'] = param.GetName()
-                curr_param['type'] = param.GetType().capitalize()
-                curr_param['group'] = group_name
-                curr_param['category'] = param.GetCategory()
-                curr_param['shortDescription'] = param.GetFieldValue("short_desc")
-                curr_param['longDescription'] = param.GetFieldValue("long_desc")
-                curr_param['units'] = param.GetFieldValue("unit")
-                curr_param['defaultValue'] = param.GetDefault()
-
-                curr_param['decimalPlaces'] = param.GetFieldValue("decimal")
-                curr_param['minValue'] = param.GetFieldValue("min")
-                curr_param['maxValue'] = param.GetFieldValue("max")
-                curr_param['increment'] = param.GetFieldValue("increment")
-                curr_param['rebootRequired'] = param.GetFieldValue("reboot_required")
-                curr_param['volatile'] = param.GetVolatile()
-
-
-
-
-
-                all_params.append(curr_param)
-        '''
-
-
-        #Note clear if we need additionalProperties, required, and what to do if values not defined.
 
         #Json string output.
         self.output = json.dumps(all_json,indent=2)

--- a/src/lib/parameters/px4params/jsonout.py
+++ b/src/lib/parameters/px4params/jsonout.py
@@ -1,0 +1,63 @@
+from xml.sax.saxutils import escape
+import codecs
+import json
+
+
+class JsonOutput():
+    def __init__(self, groups):
+        result = ""
+        all_json=dict()
+        all_json['version']=1
+        all_json['uid']=1
+        all_json['scope']="Firmware"
+        all_params=[]
+        all_json['parameters']=all_params
+        for group in groups:
+            #result += '## %s\n\n' % group.GetName()
+            group_name=group.GetName()
+            for param in group.GetParams():
+                curr_param=dict()
+                curr_param['name'] = param.GetName()
+                curr_param['type'] = param.GetType().capitalize()
+                curr_param['group'] = group_name
+                curr_param['category'] = param.GetCategory()
+                curr_param['shortDescription'] = param.GetFieldValue("short_desc")
+                curr_param['longDescription'] = param.GetFieldValue("long_desc")
+                curr_param['units'] = param.GetFieldValue("unit")
+                curr_param['defaultValue'] = param.GetDefault()
+
+                curr_param['decimalPlaces'] = param.GetFieldValue("decimal")
+                curr_param['minValue'] = param.GetFieldValue("min")
+                curr_param['maxValue'] = param.GetFieldValue("max")
+                curr_param['increment'] = param.GetFieldValue("increment")
+                curr_param['rebootRequired'] = param.GetFieldValue("reboot_required")
+                curr_param['volatile'] = param.GetVolatile()
+
+                enum_codes=param.GetEnumCodes() or '' # Gets numerical values for parameter.
+                if enum_codes:
+                    enum_codes=sorted(enum_codes,key=float)
+                    codes_list=list()
+                    for item in enum_codes:
+                        code_dict=dict()
+                        code_dict['value']=item
+                        code_dict['description']=param.GetEnumValue(item)
+                        codes_list.append(code_dict)
+                    #only add this if values are defined.
+                    curr_param['values'] = codes_list
+
+
+
+                all_params.append(curr_param)
+
+
+        #Note clear if we need additionalProperties, required, and what to do if values not defined.
+
+        #Json string output.
+        self.output = json.dumps(all_json,indent=2)
+
+
+
+
+    def Save(self, filename):
+        with codecs.open(filename, 'w', 'utf-8') as f:
+            f.write(self.output)

--- a/src/lib/parameters/px4params/jsonout.py
+++ b/src/lib/parameters/px4params/jsonout.py
@@ -2,10 +2,110 @@ from xml.sax.saxutils import escape
 import codecs
 import json
 import gzip #to create .gz file of json
+import sys
 
 
 class JsonOutput():
-    def __init__(self, groups):
+    def __init__(self, groups, board, inject_xml_file_name):
+        all_json=dict()
+        all_json['version']=1
+        all_json['uid']=1
+        all_json['scope']="Firmware"
+        all_params=[]
+        all_json['parameters']=all_params
+
+        #xml_parameters = ET.Element("parameters")
+        #xml_version = ET.SubElement(xml_parameters, "version")
+        #xml_version.text = "3"
+        #xml_version = ET.SubElement(xml_parameters, "parameter_version_major")
+        #xml_version.text = "1"
+        #xml_version = ET.SubElement(xml_parameters, "parameter_version_minor")
+        #xml_version.text = "15"
+
+        #importtree = ET.parse(inject_xml_file_name)
+        #injectgroups = importtree.getroot().findall("group")
+        #for igroup in injectgroups:
+        #    xml_parameters.append(igroup)
+
+        schema_map = {
+                        "short_desc": "shortDescription",
+			"long_desc": "longDescription",
+			"unit": "units",
+			"decimal": "decimalPlaces",
+			"min": "minValue",
+			"max": "maxValue",
+			"increment": "increment",
+			"reboot_required": "rebootRequired"
+			}
+
+        last_param_name = ""
+        board_specific_param_set = False
+        for group in groups:
+            group_name=group.GetName()
+
+            for param in group.GetParams():
+                if (last_param_name == param.GetName() and not board_specific_param_set) or last_param_name != param.GetName():
+                    curr_param=dict()
+                    curr_param['name'] = param.GetName()
+                    curr_param['defaultValue'] = param.GetDefault()
+                    curr_param['type'] = param.GetType().capitalize()
+                    curr_param['group'] = group_name
+                    if (param.GetCategory()):
+                        curr_param['category'] = param.GetCategory()
+
+                    if (param.GetVolatile() == "true"):
+                        curr_param['volatile'] = param.GetVolatile()
+
+                    last_param_name = param.GetName()
+                    for code in param.GetFieldCodes():
+                        value = param.GetFieldValue(code)
+                        if code == "board":
+                            if value == board:
+                                board_specific_param_set = True
+                                # JSON schema has no field for board_specific schema. Ignore.
+                            else:
+                                #xml_group.remove(xml_param)
+                                continue
+                        else:
+                            #map PX4 param field names to schema names
+                           if code in schema_map:
+                               curr_param[schema_map[code]] = value
+                           else:
+                               print('ERROR: Field not in json schema: %s' % code)
+                               sys.exit(1)
+
+
+                if last_param_name != param.GetName():
+                    board_specific_param_set = False
+
+                enum_codes=param.GetEnumCodes() or '' # Gets numerical values for parameter.
+                if enum_codes:
+                    enum_codes=sorted(enum_codes,key=float)
+                    codes_list=list()
+                    for item in enum_codes:
+                        code_dict=dict()
+                        code_dict['value']=item
+                        code_dict['description']=param.GetEnumValue(item)
+                        codes_list.append(code_dict)
+                    curr_param['values'] = codes_list
+
+
+                if len(param.GetBitmaskList()) > 0:
+                    bitmasks_list=list()
+                    for index in param.GetBitmaskList():
+                        bitmask_dict=dict()
+                        bitmask_dict['index']=index
+                        bitmask_dict['description']=param.GetBitmaskBit(index)
+                        bitmasks_list.append(bitmask_dict)
+                    curr_param['bitmask'] = bitmasks_list
+
+
+                all_params.append(curr_param)
+
+ 
+
+
+        '''
         result = ""
         all_json=dict()
         all_json['version']=1
@@ -34,21 +134,12 @@ class JsonOutput():
                 curr_param['rebootRequired'] = param.GetFieldValue("reboot_required")
                 curr_param['volatile'] = param.GetVolatile()
 
-                enum_codes=param.GetEnumCodes() or '' # Gets numerical values for parameter.
-                if enum_codes:
-                    enum_codes=sorted(enum_codes,key=float)
-                    codes_list=list()
-                    for item in enum_codes:
-                        code_dict=dict()
-                        code_dict['value']=item
-                        code_dict['description']=param.GetEnumValue(item)
-                        codes_list.append(code_dict)
-                    #only add this if values are defined.
-                    curr_param['values'] = codes_list
+
 
 
 
                 all_params.append(curr_param)
+        '''
 
 
         #Note clear if we need additionalProperties, required, and what to do if values not defined.

--- a/src/lib/parameters/px4params/jsonout.py
+++ b/src/lib/parameters/px4params/jsonout.py
@@ -1,6 +1,7 @@
 from xml.sax.saxutils import escape
 import codecs
 import json
+import gzip #to create .gz file of json
 
 
 class JsonOutput():
@@ -60,4 +61,9 @@ class JsonOutput():
 
     def Save(self, filename):
         with codecs.open(filename, 'w', 'utf-8') as f:
+            f.write(self.output)
+
+        #create gz version
+        gz_filename=filename+'.gz'
+        with gzip.open(gz_filename, 'wt') as f:
             f.write(self.output)

--- a/src/lib/parameters/px4params/jsonout.py
+++ b/src/lib/parameters/px4params/jsonout.py
@@ -1,7 +1,6 @@
 from xml.sax.saxutils import escape
 import codecs
 import json
-import gzip #to create .gz file of json
 import sys
 
 
@@ -105,13 +104,6 @@ class JsonOutput():
 
         #Json string output.
         self.output = json.dumps(all_json,indent=2)
-
-
-    def SaveCompressed(self, filename):
-        #create gz compressed version
-        gz_filename=filename+'.gz'
-        with gzip.open(gz_filename, 'wt') as f:
-            f.write(self.output)
 
 
     def Save(self, filename):

--- a/src/lib/parameters/px4params/jsonout.py
+++ b/src/lib/parameters/px4params/jsonout.py
@@ -107,13 +107,14 @@ class JsonOutput():
         self.output = json.dumps(all_json,indent=2)
 
 
+    def SaveCompressed(self, filename):
+        #create gz compressed version
+        gz_filename=filename+'.gz'
+        with gzip.open(gz_filename, 'wt') as f:
+            f.write(self.output)
 
 
     def Save(self, filename):
         with codecs.open(filename, 'w', 'utf-8') as f:
             f.write(self.output)
 
-        #create gz version
-        gz_filename=filename+'.gz'
-        with gzip.open(gz_filename, 'wt') as f:
-            f.write(self.output)

--- a/src/lib/parameters/px_process_params.py
+++ b/src/lib/parameters/px_process_params.py
@@ -84,6 +84,12 @@ def main():
                         metavar="FILENAME",
                         help="Create Markdown file"
                              " (default FILENAME: parameters.md)")
+    parser.add_argument("-j", "--json",
+                        nargs='?',
+                        const="parameters.json",
+                        metavar="FILENAME",
+                        help="Create Json file"
+                             " (default FILENAME: parameters.json)")
     parser.add_argument('-v', '--verbose',
                         action='store_true',
                         help="verbose output")
@@ -95,7 +101,7 @@ def main():
     args = parser.parse_args()
 
     # Check for valid command
-    if not (args.xml or args.markdown):
+    if not (args.xml or args.markdown or args.json):
         print("Error: You need to specify at least one output method!\n")
         parser.print_usage()
         sys.exit(1)
@@ -148,6 +154,12 @@ def main():
             print("Creating markdown file " + args.markdown)
             out.Save(args.markdown)
 
+    # Output to JSON file
+    if args.json:
+        out = markdownout.MarkdownTablesOutput(param_groups)
+        if args.json:
+            print("Creating json file " + args.json)
+            out.Save(args.json)
     #print("All done!")
 
 

--- a/src/lib/parameters/px_process_params.py
+++ b/src/lib/parameters/px_process_params.py
@@ -33,7 +33,7 @@
 ############################################################################
 
 #
-# PX4 paramers processor (main executable file)
+# PX4 paramaters processor (main executable file)
 #
 # This tool scans the PX4 source code for declarations of tunable parameters
 # and outputs the list in various formats.
@@ -156,11 +156,12 @@ def main():
 
     # Output to JSON file
     if args.json:
-        out = jsonout.JsonOutput(param_groups)
-        if args.json:
-            print("Creating json file " + args.json)
-            out.Save(args.json)
-    #print("All done!")
+        if args.verbose:
+            print("Creating Json/Json.gz file " + args.json)
+        cur_dir = os.path.dirname(os.path.realpath(__file__))
+        out = jsonout.JsonOutput(param_groups, args.board,
+                               os.path.join(cur_dir, args.inject_xml))
+        out.Save(args.json)
 
 
 if __name__ == "__main__":

--- a/src/lib/parameters/px_process_params.py
+++ b/src/lib/parameters/px_process_params.py
@@ -47,7 +47,7 @@ from __future__ import print_function
 import sys
 import os
 import argparse
-from px4params import srcscanner, srcparser, injectxmlparams, xmlout, markdownout
+from px4params import srcscanner, srcparser, injectxmlparams, xmlout, markdownout, jsonout
 
 import re
 import json
@@ -156,7 +156,7 @@ def main():
 
     # Output to JSON file
     if args.json:
-        out = markdownout.MarkdownTablesOutput(param_groups)
+        out = jsonout.JsonOutput(param_groups)
         if args.json:
             print("Creating json file " + args.json)
             out.Save(args.json)

--- a/src/lib/parameters/px_process_params.py
+++ b/src/lib/parameters/px_process_params.py
@@ -93,6 +93,9 @@ def main():
     parser.add_argument('-v', '--verbose',
                         action='store_true',
                         help="verbose output")
+    parser.add_argument('-c', '--compress',
+                        action='store_true',
+                        help="compress parameter file (if supported by type)")
     parser.add_argument("-o", "--overrides",
                         default="{}",
                         metavar="OVERRIDES",
@@ -157,12 +160,16 @@ def main():
     # Output to JSON file
     if args.json:
         if args.verbose:
-            print("Creating Json/Json.gz file " + args.json)
+            print("Creating Json file " + args.json)
         cur_dir = os.path.dirname(os.path.realpath(__file__))
         out = jsonout.JsonOutput(param_groups, args.board,
                                os.path.join(cur_dir, args.inject_xml))
         out.Save(args.json)
-
+        if args.compress:
+            if args.verbose:
+                print("Save compressed Json file " + args.json)
+            out.SaveCompressed(args.json)
+            
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
MAVLink has defined a standardised way for a GCS to query a component's parameter metadata (in this case  autopilot) in [Using COMPONENT_INFORMATION to obtain vehicle metadata](https://github.com/mavlink/mavlink/issues/1346).

This does the first part of that work by automatically generating the parameter metadata in Json format.  The generated output for the FIRST version of this can be found here: https://gist.github.com/hamishwillee/3779fcfb6bd368b1cd9fd3f84cbcb5b6

The parser works, but is not ready for merging because the schema defined in https://github.com/mavlink/mavlink/issues/1346 is incomplete/incorrect with respect to the test code provided. 
Once schema is signed off by @DonLakeFlyer the output here can be validated/updated. Further modifications for changes should be fairly simple.

Some of the questions I have outstanding:
- Should every value be defined whether or not empty?
- Does this also apply to "values"? If values are not defined what should these look like?
- Note that min value and max value on test and schema mismatch.
- When is additionalProperties declared, and where?
- How is "required" used - is this a param property or a higher level property [unclear in schema].

@DonLakeFlyer I have not looked at the translation file - do you have test code for that/workable schema?

FYI @julianoes @dagar I was planning on leaving the next part of this project - the COMPONENT_INFORMATION implementation and working out how to include this file in the Firmware file system for someone else.

Also, does this need to include the param metadata for params that are defined as "injected"?