### PR TITLE
ROMFS: remove remaining RC_FLT_CUTOFF

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4016_holybro_px4vision
+++ b/ROMFS/px4fmu_common/init.d/airframes/4016_holybro_px4vision
@@ -109,7 +109,6 @@ then
 
 	# use oneshot motor output protocol
 	param set PWM_RATE 0
-	param set RC_FLT_CUTOFF 0
 
 	# RTL Parameters
 	param set RTL_DESCEND_ALT 5

--- a/ROMFS/px4fmu_common/init.d/airframes/4041_beta75x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4041_beta75x
@@ -53,8 +53,6 @@ then
 	param set MOT_ORDERING 1
 	param set DSHOT_CONFIG 600
 
-	param set RC_FLT_CUTOFF 0
-
 	param set SYS_HAS_BARO 0
 	param set SYS_HAS_MAG 0
 

--- a/ROMFS/px4fmu_common/init.d/airframes/4050_generic_250
+++ b/ROMFS/px4fmu_common/init.d/airframes/4050_generic_250
@@ -48,9 +48,6 @@ then
 	# enable high-rate logging profile (helps with tuning)
 	param set SDLOG_PROFILE 19
 
-	# disable RC filtering
-	param set RC_FLT_CUTOFF 0
-
 	param set IMU_DGYRO_CUTOFF 50
 	param set IMU_GYRO_CUTOFF 90
 

--- a/ROMFS/px4fmu_common/init.d/airframes/4052_holybro_qav250
+++ b/ROMFS/px4fmu_common/init.d/airframes/4052_holybro_qav250
@@ -54,7 +54,6 @@ then
 	param set PWM_MIN 1050
 
 	param set PWM_RATE 0
-	param set RC_FLT_CUTOFF 0
 	param set THR_MDL_FAC 0.3
 fi
 

--- a/ROMFS/px4fmu_common/init.d/airframes/4071_ifo
+++ b/ROMFS/px4fmu_common/init.d/airframes/4071_ifo
@@ -57,9 +57,6 @@ then
 	#param set MPC_MAN_TILT_MAX 35
 	#param set MPC_TILTMAX_AIR 20
 
-	# Disable RC filtering
-	param set RC_FLT_CUTOFF 0
-
 	# Filter settings
 	param set IMU_DGYRO_CUTOFF 90
 	param set IMU_GYRO_CUTOFF 100

--- a/ROMFS/px4fmu_common/init.d/airframes/4072_draco
+++ b/ROMFS/px4fmu_common/init.d/airframes/4072_draco
@@ -63,9 +63,6 @@ then
 	param set MPC_THR_CURVE 1
 	param set MPC_THR_HOVER 0.25
 
-	# Disable RC filtering
-	param set RC_FLT_CUTOFF 0
-
 	# Thrust curve (avoids the need for TPA)
 	param set THR_MDL_FAC 0.3
 

--- a/ROMFS/px4fmu_common/init.d/airframes/4073_ifo-s
+++ b/ROMFS/px4fmu_common/init.d/airframes/4073_ifo-s
@@ -54,9 +54,6 @@ then
 	#param set MPC_MAN_TILT_MAX 35
 	#param set MPC_TILTMAX_AIR 20
 
-	# Disable RC filtering
-	param set RC_FLT_CUTOFF 0
-
 	# Filter settings
 	param set IMU_GYRO_CUTOFF 100
 

--- a/ROMFS/px4fmu_common/init.d/airframes/6002_draco_r
+++ b/ROMFS/px4fmu_common/init.d/airframes/6002_draco_r
@@ -75,9 +75,6 @@ then
 	param set MPC_TKO_SPEED 1.5
 	param set MPC_VEL_MANUAL 5
 
-	# Disable RC filtering
-	param set RC_FLT_CUTOFF 0
-
 	# Filter settings
 	param set IMU_DGYRO_CUTOFF 90
 	param set IMU_GYRO_CUTOFF 100


### PR DESCRIPTION
**Describe problem solved by this pull request**
The parameter `RC_FLT_CUTOFF` was removed in #14896 and I forgot to remove it from all the configurations.

**Describe your solution**
The RC filter is gone because the different modes using RC have the option now to filter the setpoints to get a not "too agressive" reaction. So no need to set the parameter anymore.

**Additional context**
Thanks @bkueng for reminding me to take care of the orphan configurations in https://github.com/PX4/Firmware/pull/14896#issuecomment-633910892
