### PR TITLE
Correctly set the FW_ARSP_MODE parameter value

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/1042_tiltrotor
+++ b/ROMFS/px4fmu_common/init.d-posix/1042_tiltrotor
@@ -9,7 +9,7 @@ sh /etc/init.d/rc.vtol_defaults
 
 if [ $AUTOCNF = yes ]
 then
-	param set FW_ARSP_MODE 2
+	param set FW_ARSP_MODE 1
 	param set FW_AIRSPD_MAX 25
 	param set FW_AIRSPD_MIN 14
 	param set FW_AIRSPD_TRIM 16

--- a/ROMFS/px4fmu_common/init.d/airframes/13012_convergence
+++ b/ROMFS/px4fmu_common/init.d/airframes/13012_convergence
@@ -26,7 +26,7 @@ if [ $AUTOCNF = yes ]
 then
 	param set CBRK_AIRSPD_CHK 162128
 
-	param set FW_ARSP_MODE 2
+	param set FW_ARSP_MODE 1
 
 	param set FW_L1_PERIOD 17
 	param set FW_MAN_R_MAX 50

--- a/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
@@ -34,7 +34,7 @@ then
 	param set EKF2_GPS_P_GATE 10
 	param set EKF2_GPS_V_GATE 10
 
-	param set FW_ARSP_MODE 2
+	param set FW_ARSP_MODE 1
 	param set FW_L1_PERIOD 25
 	param set FW_PR_FF 0.7
 	param set FW_PR_I 0.18


### PR DESCRIPTION
```
/**
 * Airspeed mode
 *
 * For small wings or VTOL without airspeed sensor this parameter can be used to
 * enable flying without an airspeed reading
 *
 * @value 0 Normal (use airspeed if available)
 * @value 1 Airspeed disabled
 * @group FW Attitude Control
 */
PARAM_DEFINE_INT32(FW_ARSP_MODE, 0);
```
not have value 2

By the way, I think the functions of these two parameters are similar　`CBRK_AIRSPD_CHK`   `FW_ARSP_MODE`

Can we just keep `CBRK_AIRSPD_CHK`? Use `CBRK_AIRSPD_CHK` instead of `FW_ARSP_MODE`

FYI @sfuhrer 
