### PR TITLE
Tools: abort SITL start if gzserver fails

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -105,8 +105,11 @@ elif [ "$program" == "gazebo" ] && [ ! -n "$no_sim" ]; then
 			fi
 		fi
 		SIM_PID=$!
-		gz model --spawn-file="${src_path}/Tools/sitl_gazebo/models/${model}/${model}.sdf" --model-name=${model} -x 1.01 -y 0.98 -z 0.83
 
+		if gz model --spawn-file="${src_path}/Tools/sitl_gazebo/models/${model}/${model}.sdf" --model-name=${model} -x 1.01 -y 0.98 -z 0.83 2>&1 | grep "An instance of Gazebo is not running."; then
+			echo "Start of gzserver failed"
+			exit 1
+        fi
 
 		if [[ -n "$HEADLESS" ]]; then
 			echo "not running gazebo gui"


### PR DESCRIPTION
Sometimes gzserver seems to not start or not start fast enough. In this case, instead of stalling forever, it would be nice to abort.

Closes #15398.