### PR TITLE
Move XML injection to the group level

### DIFF
--- a/src/lib/parameters/px4params/injectxmlparams.py
+++ b/src/lib/parameters/px4params/injectxmlparams.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# Injects params from XML file into a param_group
+#
+
+from __future__ import print_function
+from px4params import srcscanner, srcparser, xmlout, markdownout
+from .srcparser import ParameterGroup, Parameter
+
+import xml.etree.ElementTree as ET
+import sys
+
+
+class XMLInject():
+    def __init__(self, injected_xml_filename):
+        self.groups=[]
+
+        valid_parameter_attributes = set(["category", "default", "name", "type", "volatile"])
+        valid_field_tags = set(["board","short_desc", "long_desc", "min", "max", "unit", "decimal", "increment", "reboot_required"])
+        valid_other_top_level_tags = set(["group","values"])
+
+        importtree = ET.parse(injected_xml_filename)
+        injectgroups = importtree.getroot().findall("group")
+        not_handled_parameter_tags=set()
+        not_handled_parameter_attributes=set()
+        for igroup in injectgroups:
+            group_name=igroup.get('name')
+            imported_group = ParameterGroup(group_name)
+            for iparam in igroup:
+                param_name=iparam.get('name')
+                param_type=iparam.get('type')
+                new_param= Parameter(param_name, param_type)
+                #get other param info stored as attributes
+                for param_attrib in iparam.attrib:
+                    if param_attrib not in valid_parameter_attributes:
+                        not_handled_parameter_attributes.add(param_attrib)
+                    elif param_attrib == 'category':
+                        new_param.SetCategory(iparam.get('category'))
+                    elif param_attrib == 'default':
+                        new_param.default = iparam.get('default')
+                    elif param_attrib == 'volatile':
+                        new_param.SetVolatile()
+
+
+                #get param info stored as child tags
+                for child in iparam:
+                    if child.tag in valid_field_tags:
+                        new_param.SetField(child.tag, child.text)
+                    elif child.tag == 'values':
+                        for value in child:
+                            new_param.SetEnumValue(value.get('code'), value.text)
+                    elif child.tag == 'bitmask':
+                        for bit in child:
+                            new_param.SetBitmaskBit(bit.get('index'), bit.text)
+                    else:
+                        not_handled_parameter_tags.add(child.tag)                      
+            
+                imported_group.AddParameter(new_param)
+            self.groups.append(imported_group)
+
+                    
+        if not_handled_parameter_tags or not_handled_parameter_attributes:
+            print("WARNING: Injected file parameter has unhandled child tags: %s" % not_handled_parameter_tags)
+            print("WARNING: Injected file parameter has unhandled attributes: %s" % not_handled_parameter_attributes)
+
+        
+
+    def injected(self):
+        return self.groups

--- a/src/lib/parameters/px4params/injectxmlparams.py
+++ b/src/lib/parameters/px4params/injectxmlparams.py
@@ -25,6 +25,9 @@ class XMLInject():
         for igroup in injectgroups:
             group_name=igroup.get('name')
             imported_group = ParameterGroup(group_name)
+            no_code_generation=igroup.get('no_code_generation')
+            if no_code_generation:
+                imported_group.no_code_generation=no_code_generation
             for iparam in igroup:
                 param_name=iparam.get('name')
                 param_type=iparam.get('type')

--- a/src/lib/parameters/px4params/srcparser.py
+++ b/src/lib/parameters/px4params/srcparser.py
@@ -11,6 +11,7 @@ class ParameterGroup(object):
     """
     def __init__(self, name):
         self.name = name
+        self.no_code_generation = False #for injected parameters
         self.params = []
 
     def AddParameter(self, param):

--- a/src/lib/parameters/px4params/xmlout.py
+++ b/src/lib/parameters/px4params/xmlout.py
@@ -18,7 +18,7 @@ def indent(elem, level=0):
 
 class XMLOutput():
 
-    def __init__(self, groups, board, inject_xml_file_name):
+    def __init__(self, groups, board):
         xml_parameters = ET.Element("parameters")
         xml_version = ET.SubElement(xml_parameters, "version")
         xml_version.text = "3"
@@ -26,10 +26,6 @@ class XMLOutput():
         xml_version.text = "1"
         xml_version = ET.SubElement(xml_parameters, "parameter_version_minor")
         xml_version.text = "15"
-        importtree = ET.parse(inject_xml_file_name)
-        injectgroups = importtree.getroot().findall("group")
-        for igroup in injectgroups:
-            xml_parameters.append(igroup)
         last_param_name = ""
         board_specific_param_set = False
         for group in groups:

--- a/src/lib/parameters/px4params/xmlout.py
+++ b/src/lib/parameters/px4params/xmlout.py
@@ -31,6 +31,8 @@ class XMLOutput():
         for group in groups:
             xml_group = ET.SubElement(xml_parameters, "group")
             xml_group.attrib["name"] = group.GetName()
+            if group.no_code_generation:
+                xml_group.attrib["no_code_generation"] = group.no_code_generation
             for param in group.GetParams():
                 if (last_param_name == param.GetName() and not board_specific_param_set) or last_param_name != param.GetName():
                     xml_param = ET.SubElement(xml_group, "parameter")

--- a/src/lib/parameters/px_process_params.py
+++ b/src/lib/parameters/px_process_params.py
@@ -47,7 +47,7 @@ from __future__ import print_function
 import sys
 import os
 import argparse
-from px4params import srcscanner, srcparser, xmlout, markdownout
+from px4params import srcscanner, srcparser, injectxmlparams, xmlout, markdownout
 
 import re
 import json
@@ -118,6 +118,12 @@ def main():
     if len(param_groups) == 0:
         print("Warning: no parameters found")
 
+
+    #inject parameters at front of set
+    cur_dir = os.path.dirname(os.path.realpath(__file__))
+    groups_to_inject = injectxmlparams.XMLInject(os.path.join(cur_dir, args.inject_xml)).injected()
+    param_groups=groups_to_inject+param_groups
+
     override_dict = json.loads(args.overrides)
     if len(override_dict.keys()) > 0:
         for group in param_groups:
@@ -132,9 +138,7 @@ def main():
     if args.xml:
         if args.verbose:
             print("Creating XML file " + args.xml)
-        cur_dir = os.path.dirname(os.path.realpath(__file__))
-        out = xmlout.XMLOutput(param_groups, args.board,
-                               os.path.join(cur_dir, args.inject_xml))
+        out = xmlout.XMLOutput(param_groups, args.board)
         out.Save(args.xml)
 
     # Output to Markdown/HTML tables


### PR DESCRIPTION
Param metadata is generated from source param definitions. The xmloutput parser also prefixes the generated parameter.xml file with additional "injected XML" that it pulls in from a local file. The problem with this is that this injected XML is not included in the generated markdown output, and would also need to be  pulled into the [json parameter output](https://github.com/PX4/Firmware/pull/15389) and any future output formats.

What this change does is import the injected XML into parameter groups and prepend these to the parameter group list before it is passed to the output generators. With this change the groups in the XML are added for any new output.

I have tested this and the output is the almost identical to the original XML. 
- Generated output is better in that output field order of injected content matches all other fields.
- No fields are missing
- The only thing missing is the new output is the group attribute `no_code_generation` - which is not in the "official" output - see `<group name="UAVCAN Motor Parameters" no_code_generation="true">`

The injected params are a subset of the original XML, so does not test all possible input. I therefore ran this to round trip the generated XML- it works for all that XML too. 

Note however that it has the same limitations as the original parser - It does not check for duplication of groups/params in injected content. IMO not worth the effort. 
