### PR TITLE
logger: disable estimator replay logging by default

### DIFF
--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -64,11 +64,11 @@ void LoggedTopics::add_default_topics()
 	add_topic("estimator_status", 200);
 	add_topic("home_position");
 	add_topic("hover_thrust_estimate", 100);
-	add_topic("input_rc", 200);
+	add_topic("input_rc", 500);
 	add_topic("manual_control_setpoint", 200);
 	add_topic("mission");
 	add_topic("mission_result");
-	add_topic("offboard_control_mode", 1000);
+	add_topic("offboard_control_mode", 100);
 	add_topic("position_controller_status", 500);
 	add_topic("position_setpoint_triplet", 200);
 	add_topic("px4io_status");
@@ -76,8 +76,8 @@ void LoggedTopics::add_default_topics()
 	add_topic("rate_ctrl_status", 200);
 	add_topic("rpm", 500);
 	add_topic("safety");
-	add_topic("sensor_combined", 100);
-	add_topic("sensor_correction", 1000);
+	add_topic("sensor_combined");
+	add_topic("sensor_correction");
 	add_topic("sensor_preflight", 200);
 	add_topic("sensor_selection");
 	add_topic("system_power", 500);

--- a/src/modules/logger/params.c
+++ b/src/modules/logger/params.c
@@ -141,7 +141,7 @@ PARAM_DEFINE_INT32(SDLOG_MISSION, 0);
  * @reboot_required true
  * @group SD Logging
  */
-PARAM_DEFINE_INT32(SDLOG_PROFILE, 3);
+PARAM_DEFINE_INT32(SDLOG_PROFILE, 1);
 
 /**
  * Maximum number of log directories to keep


### PR DESCRIPTION
 - unnecessarily wearing out cheap sd cards that come with most flight controllers
     - default cards often stop functioning entirely within months of operating on the test rack (logging for ~5 minutes at a time 5-20 times/day)
 - default ekf2 replay really needs logging from boot anyway (@priseborough)
 - some people actually use USB and Mavlink FTP to transfer log files

### Master
 - nominal logging rate `~32 KiB/s` (~115 MiB/hour)

### PR
 - nominal logging rate `~15 KiB/s` (~54 MiB/hour)


As a follow up I would look at further optimizing the default logging rate.