### PR TITLE
land_detector: quick workaround for MC NAN setpoints

### DIFF
--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -79,11 +79,9 @@ private:
 	/** Get control mode dependent pilot throttle threshold with which we should quit landed state and take off. */
 	float _get_takeoff_throttle();
 
-	bool _has_low_thrust();
 	bool _has_minimal_thrust();
 	bool _has_altitude_lock();
 	bool _has_position_lock();
-	bool _is_climb_rate_enabled();
 
 	/** Time in us that landing conditions have to hold before triggering a land. */
 	static constexpr hrt_abstime LAND_DETECTOR_TRIGGER_TIME_US = 300_ms;


### PR DESCRIPTION
This is a quick fix for one of the issues found in the process of fixing other MC land detector issues.

When the multicopter position controller sees `ground_contact` the setpoint reset (NANs) is briefly published on `vehicle_local_position_setpoint`. This can force the multicopter land detector `_in_descend` state immediately back to false which interrupts ground_contact if not currently in low thrust.

https://github.com/PX4/Firmware/blob/7354e3989335dfb38cc41216182f48fe84d165c7/src/modules/mc_pos_control/mc_pos_control_main.cpp#L644-L654