### PR TITLE
remove unnecessary stderr msg when checking ldconfig

### DIFF
--- a/msg/tools/generate_microRTPS_bridge.py
+++ b/msg/tools/generate_microRTPS_bridge.py
@@ -261,7 +261,7 @@ else:
 
 # get FastRTPS version
 fastrtps_version = subprocess.check_output(
-    "ldconfig -v | grep libfastrtps", shell=True).decode("utf-8").strip().split('so.')[-1]
+    "ldconfig -v 2>/dev/null | grep libfastrtps", shell=True).decode("utf-8").strip().split('so.')[-1]
 
 # get ROS 2 version, if exists
 ros2_distro = ''


### PR DESCRIPTION
Hi,

When compiling firmware with rtps, I found unnecessary messages by ldconfig in my case
This problem happens in px4_ros_com.

please check it.

```
[769/778] Generating RTPS topic bridge
openjdk version "1.8.0_242"
OpenJDK Runtime Environment (build 1.8.0_242-8u242-b08-0ubuntu3~18.04-b08)
OpenJDK 64-Bit Server VM (build 25.242-b08, mixed mode)
/sbin/ldconfig.real: Can't stat /usr/local/lib/i386-linux-gnu: No such file or directory
/sbin/ldconfig.real: Can't stat /usr/local/lib/i686-linux-gnu: No such file or directory
/sbin/ldconfig.real: Can't stat /lib/i686-linux-gnu: No such file or directory
/sbin/ldconfig.real: Can't stat /usr/lib/i686-linux-gnu: No such file or directory
/sbin/ldconfig.real: Can't stat /usr/local/lib/x86_64-linux-gnu: No such file or directory
/sbin/ldconfig.real: Path `/lib/x86_64-linux-gnu' given more than once
/sbin/ldconfig.real: Path `/usr/lib/x86_64-linux-gnu' given more than once
/sbin/ldconfig.real: /lib/i386-linux-gnu/ld-2.27.so is the dynamic linker, ignoring
...

```
