### PR TITLE
Tools: retry gz model if gzserver is not ready yet

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 
 set -e
 
@@ -106,10 +107,10 @@ elif [ "$program" == "gazebo" ] && [ ! -n "$no_sim" ]; then
 		fi
 		SIM_PID=$!
 
-		if gz model --spawn-file="${src_path}/Tools/sitl_gazebo/models/${model}/${model}.sdf" --model-name=${model} -x 1.01 -y 0.98 -z 0.83 2>&1 | grep "An instance of Gazebo is not running."; then
-			echo "Start of gzserver failed"
-			exit 1
-        fi
+		while gz model --verbose --spawn-file="${src_path}/Tools/sitl_gazebo/models/${model}/${model}.sdf" --model-name=${model} -x 1.01 -y 0.98 -z 0.83 2>&1 | grep -q "An instance of Gazebo is not running."; do
+			echo "gzserver not ready yet, trying again!"
+			sleep 1
+		done
 
 		if [[ -n "$HEADLESS" ]]; then
 			echo "not running gazebo gui"


### PR DESCRIPTION
This should prevent the race between gzserver and gz model and fix the integration tests which sometimes timeout because the model is not spawned correctly.

This patch also changes the shebang to what's generally recommended.