### PR TITLE
PAW3902: align mode change logic with the spec

### DIFF
--- a/src/drivers/optical_flow/paw3902/PAW3902.hpp
+++ b/src/drivers/optical_flow/paw3902/PAW3902.hpp
@@ -119,5 +119,9 @@ private:
 	int		_flow_sum_y{0};
 
 	Mode		_mode{Mode::LowLight};
+	uint8_t 	_bright_to_low_counter{0};
+	uint8_t 	_low_to_superlow_counter{0};
+	uint8_t 	_low_to_bright_counter{0};
+	uint8_t 	_superlow_to_low_counter{0};
 
 };


### PR DESCRIPTION
1. The spec specifies that the mode change condition should be met for 10
   consecutive frames before changing to the next mode.
2. The spec (and comment) says that "PAW3902JF should not operate with Shutter < 0x01F4 in Mode 2" -
   however the if condition checked the reverse condition

Signed-off-by: Koby Aizer <koby.aizer@tg-17.com>