### PR TITLE
load_mon: slightly longer cpu average (300 -> 500 ms)

### DIFF
--- a/src/modules/load_mon/LoadMon.cpp
+++ b/src/modules/load_mon/LoadMon.cpp
@@ -79,7 +79,7 @@ int LoadMon::task_spawn(int argc, char *argv[])
 
 void LoadMon::start()
 {
-	ScheduleOnInterval(300_ms);
+	ScheduleOnInterval(500_ms); // 2 Hz
 }
 
 void LoadMon::Run()


### PR DESCRIPTION
Along with other fixes I recently changed the `load_mon` interval from 1000 ms to 300 ms (1 Hz -> 3.33 Hz) with the intention of capturing more cpu load detail in the logs.

Now that we have data from an actual flight I think we're just seeing more distracting noise possibly from load_mon itself being somewhat erratically scheduled in the low priority work queue.

![Screenshot from 2020-07-28 10-06-02](https://user-images.githubusercontent.com/84712/88676381-fc618c80-d0b9-11ea-9d7a-293a018d6a2c.png)

This PR decreases the rate to get a slightly longer cpuload average. 

To really improve this in the future I'd likely move the load calculation so that it's not dependent on work queue scheduling for timing and possibly track multiple averages (somewhat like a linux load average).
