### PR TITLE
logger: record message gaps

### DIFF
--- a/msg/logger_status.msg
+++ b/msg/logger_status.msg
@@ -13,6 +13,7 @@ float32 total_written_kb       # total written to log in kiloBytes
 float32 write_rate_kb_s        # write rate in kiloBytes/s
 
 uint32 dropouts                # number of failed buffer writes due to buffer overflow
+uint32 message_gaps            # messages misssed
 
 uint32 buffer_used_bytes       # current buffer fill in Bytes
 uint32 buffer_size_bytes       # total buffer size in Bytes

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -68,14 +68,13 @@ namespace logger
 static constexpr uint8_t MSG_ID_INVALID = UINT8_MAX;
 
 struct LoggerSubscription : public uORB::SubscriptionInterval {
-
-	uint8_t msg_id{MSG_ID_INVALID};
-
 	LoggerSubscription() = default;
 
 	LoggerSubscription(ORB_ID id, uint32_t interval_ms = 0, uint8_t instance = 0) :
 		uORB::SubscriptionInterval(id, interval_ms * 1000, instance)
 	{}
+
+	uint8_t msg_id{MSG_ID_INVALID};
 };
 
 class Logger : public ModuleBase<Logger>, public ModuleParams
@@ -346,6 +345,8 @@ private:
 
 	hrt_abstime					_logger_status_last {0};
 	int						_lockstep_component{-1};
+
+	uint32_t					_message_gaps{0};
 
 	uORB::Subscription				_manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
 	uORB::Subscription				_vehicle_command_sub{ORB_ID(vehicle_command)};

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -57,7 +57,9 @@
 
 extern "C" __EXPORT int logger_main(int argc, char *argv[]);
 
-static constexpr hrt_abstime TRY_SUBSCRIBE_INTERVAL{1000 * 1000};	// interval in microseconds at which we try to subscribe to a topic
+using namespace time_literals;
+
+static constexpr hrt_abstime TRY_SUBSCRIBE_INTERVAL{20_ms};	// interval in microseconds at which we try to subscribe to a topic
 // if we haven't succeeded before
 
 namespace px4

--- a/src/modules/uORB/SubscriptionInterval.hpp
+++ b/src/modules/uORB/SubscriptionInterval.hpp
@@ -135,6 +135,7 @@ public:
 	bool		valid() const { return _subscription.valid(); }
 
 	uint8_t		get_instance() const { return _subscription.get_instance(); }
+	uint32_t        get_interval_us() const { return _interval_us; }
 	unsigned	get_last_generation() const { return _subscription.get_last_generation(); }
 	ORB_PRIO	get_priority() { return _subscription.get_priority(); }
 	orb_id_t	get_topic() const { return _subscription.get_topic(); }


### PR DESCRIPTION
This adds simple logging of gaps in uORB copies for full rate (no interval) messages. Currently it's possible to miss messages while still having no dropouts in the ulg.