### PR TITLE
Failure detector improvements

### DIFF
--- a/src/modules/commander/Arming/PreFlightCheck/checks/failureDetectorCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/failureDetectorCheck.cpp
@@ -45,30 +45,25 @@ bool PreFlightCheck::failureDetectorCheck(orb_advert_t *mavlink_log_pub, const v
 
 	if (status.failure_detector_status != vehicle_status_s::FAILURE_NONE) {
 		if (report_fail) {
-			// in case an error is forgotten to get handled here the user at least gets a less specific message
-			const char *message = "Unspecified";
-
 			if (status.failure_detector_status & vehicle_status_s::FAILURE_ROLL) {
-				message = "Roll";
+				mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Roll failure detected");
 			}
 
 			if (status.failure_detector_status & vehicle_status_s::FAILURE_PITCH) {
-				message = "Pitch";
+				mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Pitch failure detected");
 			}
 
 			if (status.failure_detector_status & vehicle_status_s::FAILURE_ALT) {
-				message = "Altitude";
+				mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Altitude failure detected");
 			}
 
 			if (status.failure_detector_status & vehicle_status_s::FAILURE_EXT) {
-				message = "Parachute";
+				mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Parachute failure detected");
 			}
 
 			if (status.failure_detector_status & vehicle_status_s::FAILURE_ARM_ESC) {
-				message = "ESC";
+				mavlink_log_critical(mavlink_log_pub, "Preflight Fail: ESC failure detected");
 			}
-
-			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: %s failure detected", message);
 		}
 
 		return false;

--- a/src/modules/commander/Arming/PreFlightCheck/checks/failureDetectorCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/failureDetectorCheck.cpp
@@ -45,17 +45,30 @@ bool PreFlightCheck::failureDetectorCheck(orb_advert_t *mavlink_log_pub, const v
 
 	if (status.failure_detector_status != vehicle_status_s::FAILURE_NONE) {
 		if (report_fail) {
+			// in case an error is forgotten to get handled here the user at least gets a less specific message
+			const char *message = "Unspecified";
+
 			if (status.failure_detector_status & vehicle_status_s::FAILURE_ROLL) {
-				mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Roll failure detected");
+				message = "Roll";
 			}
 
 			if (status.failure_detector_status & vehicle_status_s::FAILURE_PITCH) {
-				mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Pitch failure detected");
+				message = "Pitch";
 			}
 
 			if (status.failure_detector_status & vehicle_status_s::FAILURE_ALT) {
-				mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Altitude failure detected");
+				message = "Altitude";
 			}
+
+			if (status.failure_detector_status & vehicle_status_s::FAILURE_EXT) {
+				message = "Parachute";
+			}
+
+			if (status.failure_detector_status & vehicle_status_s::FAILURE_ARM_ESC) {
+				message = "ESC";
+			}
+
+			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: %s failure detected", message);
 		}
 
 		return false;

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2234,23 +2234,15 @@ Commander::run()
 		}
 
 		/* Check for failure detector status */
-		const bool failure_detector_updated = _failure_detector.update(status);
-
-		if (failure_detector_updated) {
-
+		if (_failure_detector.update(status)) {
 			const uint8_t failure_status = _failure_detector.getStatus();
 
 			if (failure_status != status.failure_detector_status) {
 				status.failure_detector_status = failure_status;
 				_status_changed = true;
 			}
-		}
 
-		if (armed.armed &&
-		    failure_detector_updated) {
-
-			if (_failure_detector.isFailure()) {
-
+			if (armed.armed && _failure_detector.isFailure()) {
 				const hrt_abstime time_at_arm = armed.armed_time_ms * 1000;
 
 				if (hrt_elapsed_time(&time_at_arm) < 500_ms) {

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2245,7 +2245,6 @@ Commander::run()
 					// 500ms is the PWM spoolup time. Within this timeframe controllers are not affecting actuator_outputs
 					if (hrt_elapsed_time(&time_at_arm) < 500_ms) {
 						arm_disarm(false, true, &mavlink_log_pub, arm_disarm_reason_t::FAILURE_DETECTOR);
-						_status_changed = true;
 						mavlink_log_critical(&mavlink_log_pub, "ESCs did not respond to arm request");
 					}
 				}
@@ -2258,7 +2257,6 @@ Commander::run()
 						// This handles the case where something fails during the early takeoff phase
 						armed.lockdown = true;
 						_lockdown_triggered = true;
-						_status_changed = true;
 						mavlink_log_emergency(&mavlink_log_pub, "Critical failure detected: lockdown");
 
 					} else if (!status_flags.circuit_breaker_flight_termination_disabled &&
@@ -2266,7 +2264,6 @@ Commander::run()
 
 						armed.force_failsafe = true;
 						_flight_termination_triggered = true;
-						_status_changed = true;
 						mavlink_log_emergency(&mavlink_log_pub, "Critical failure detected: terminate flight");
 						set_tune_override(TONE_PARACHUTE_RELEASE_TUNE);
 					}

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2235,12 +2235,8 @@ Commander::run()
 
 		/* Check for failure detector status */
 		if (_failure_detector.update(status)) {
-			const uint8_t failure_status = _failure_detector.getStatus();
-
-			if (failure_status != status.failure_detector_status) {
-				status.failure_detector_status = failure_status;
-				_status_changed = true;
-			}
+			status.failure_detector_status = _failure_detector.getStatus();
+			_status_changed = true;
 
 			if (armed.armed && _failure_detector.isFailure()) {
 				const hrt_abstime time_at_arm = armed.armed_time_ms * 1000;

--- a/src/modules/commander/failure_detector/FailureDetector.cpp
+++ b/src/modules/commander/failure_detector/FailureDetector.cpp
@@ -78,7 +78,7 @@ FailureDetector::update(const vehicle_status_s &vehicle_status)
 		updated |= resetAttitudeStatus();
 	}
 
-	if (_sub_esc_status.updated()) {
+	if (_esc_status_sub.updated()) {
 
 		if (_param_escs_en.get()) {
 			updated |= updateEscsStatus(vehicle_status);
@@ -115,7 +115,7 @@ FailureDetector::updateAttitudeStatus()
 	bool updated(false);
 	vehicle_attitude_s attitude;
 
-	if (_sub_vehicule_attitude.update(&attitude)) {
+	if (_vehicule_attitude_sub.update(&attitude)) {
 
 		const matrix::Eulerf euler(matrix::Quatf(attitude.q));
 		const float roll(euler.phi());
@@ -160,7 +160,7 @@ FailureDetector::updateExternalAtsStatus()
 	pwm_input_s pwm_input;
 	bool updated(false);
 
-	if (_sub_pwm_input.update(&pwm_input)) {
+	if (_pwm_input_sub.update(&pwm_input)) {
 
 		uint32_t pulse_width = pwm_input.pulse_width;
 		bool ats_trigger_status = (pulse_width >= (uint32_t)_param_fd_ext_ats_trig.get()) && (pulse_width < 3_ms);
@@ -192,10 +192,9 @@ FailureDetector::updateEscsStatus(const vehicle_status_s &vehicle_status)
 	if (vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED) {
 
 		esc_status_s esc_status{};
-		_sub_esc_status.copy(&esc_status);
+		_esc_status_sub.copy(&esc_status);
 
 		int all_escs_armed = (1 << esc_status.esc_count) - 1;
-
 
 		_esc_failure_hysteresis.set_hysteresis_time_from(false, 300_ms);
 		_esc_failure_hysteresis.set_state_and_update(all_escs_armed != esc_status.esc_armed_flags, time_now);

--- a/src/modules/commander/failure_detector/FailureDetector.cpp
+++ b/src/modules/commander/failure_detector/FailureDetector.cpp
@@ -47,15 +47,6 @@ FailureDetector::FailureDetector(ModuleParams *parent) :
 {
 }
 
-void FailureDetector::resetAttitudeStatus()
-{
-	int attitude_fields_bitmask = _status & (FAILURE_ROLL | FAILURE_PITCH | FAILURE_ALT | FAILURE_EXT);
-
-	if (attitude_fields_bitmask > FAILURE_NONE) {
-		_status &= ~attitude_fields_bitmask;
-	}
-}
-
 bool FailureDetector::update(const vehicle_status_s &vehicle_status)
 {
 	uint8_t previous_status = _status;
@@ -68,7 +59,7 @@ bool FailureDetector::update(const vehicle_status_s &vehicle_status)
 		}
 
 	} else {
-		resetAttitudeStatus();
+		_status &= ~(FAILURE_ROLL | FAILURE_PITCH | FAILURE_ALT | FAILURE_EXT);
 	}
 
 	if (_esc_status_sub.updated()) {

--- a/src/modules/commander/failure_detector/FailureDetector.cpp
+++ b/src/modules/commander/failure_detector/FailureDetector.cpp
@@ -177,16 +177,13 @@ void FailureDetector::updateEscsStatus(const vehicle_status_s &vehicle_status)
 		_esc_failure_hysteresis.set_hysteresis_time_from(false, 300_ms);
 		_esc_failure_hysteresis.set_state_and_update(all_escs_armed != esc_status.esc_armed_flags, time_now);
 
-		if (_esc_failure_hysteresis.get_state() && !(_status & FAILURE_ARM_ESCS)) {
+		if (_esc_failure_hysteresis.get_state()) {
 			_status |= FAILURE_ARM_ESCS;
 		}
 
 	} else {
 		// reset ESC bitfield
 		_esc_failure_hysteresis.set_state_and_update(false, time_now);
-
-		if (_status & FAILURE_ARM_ESCS) {
-			_status &= ~FAILURE_ARM_ESCS;
-		}
+		_status &= ~FAILURE_ARM_ESCS;
 	}
 }

--- a/src/modules/commander/failure_detector/FailureDetector.hpp
+++ b/src/modules/commander/failure_detector/FailureDetector.hpp
@@ -77,7 +77,6 @@ public:
 	uint8_t getStatus() const { return _status; }
 
 private:
-	void resetAttitudeStatus();
 	bool isAttitudeStabilized(const vehicle_status_s &vehicle_status);
 	void updateAttitudeStatus();
 	void updateExternalAtsStatus();

--- a/src/modules/commander/failure_detector/FailureDetector.hpp
+++ b/src/modules/commander/failure_detector/FailureDetector.hpp
@@ -79,11 +79,11 @@ public:
 	bool isFailure() const { return _status != FAILURE_NONE; }
 
 private:
-	bool resetAttitudeStatus();
+	void resetAttitudeStatus();
 	bool isAttitudeStabilized(const vehicle_status_s &vehicle_status);
-	bool updateAttitudeStatus();
-	bool updateExternalAtsStatus();
-	bool updateEscsStatus(const vehicle_status_s &vehicle_status);
+	void updateAttitudeStatus();
+	void updateExternalAtsStatus();
+	void updateEscsStatus(const vehicle_status_s &vehicle_status);
 
 	uint8_t _status{FAILURE_NONE};
 

--- a/src/modules/commander/failure_detector/FailureDetector.hpp
+++ b/src/modules/commander/failure_detector/FailureDetector.hpp
@@ -74,9 +74,7 @@ public:
 	FailureDetector(ModuleParams *parent);
 
 	bool update(const vehicle_status_s &vehicle_status);
-
 	uint8_t getStatus() const { return _status; }
-	bool isFailure() const { return _status != FAILURE_NONE; }
 
 private:
 	void resetAttitudeStatus();

--- a/src/modules/commander/failure_detector/FailureDetector.hpp
+++ b/src/modules/commander/failure_detector/FailureDetector.hpp
@@ -79,6 +79,22 @@ public:
 	bool isFailure() const { return _status != FAILURE_NONE; }
 
 private:
+	bool resetAttitudeStatus();
+	bool isAttitudeStabilized(const vehicle_status_s &vehicle_status);
+	bool updateAttitudeStatus();
+	bool updateExternalAtsStatus();
+	bool updateEscsStatus(const vehicle_status_s &vehicle_status);
+
+	uint8_t _status{FAILURE_NONE};
+
+	systemlib::Hysteresis _roll_failure_hysteresis{false};
+	systemlib::Hysteresis _pitch_failure_hysteresis{false};
+	systemlib::Hysteresis _ext_ats_failure_hysteresis{false};
+	systemlib::Hysteresis _esc_failure_hysteresis{false};
+
+	uORB::Subscription _vehicule_attitude_sub{ORB_ID(vehicle_attitude)};
+	uORB::Subscription _esc_status_sub{ORB_ID(esc_status)};
+	uORB::Subscription _pwm_input_sub{ORB_ID(pwm_input)};
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::FD_FAIL_P>) _param_fd_fail_p,
@@ -88,25 +104,5 @@ private:
 		(ParamBool<px4::params::FD_EXT_ATS_EN>) _param_fd_ext_ats_en,
 		(ParamInt<px4::params::FD_EXT_ATS_TRIG>) _param_fd_ext_ats_trig,
 		(ParamInt<px4::params::FD_ESCS_EN>) _param_escs_en
-
 	)
-
-	// Subscriptions
-	uORB::Subscription _sub_vehicule_attitude{ORB_ID(vehicle_attitude)};
-	uORB::Subscription _sub_esc_status{ORB_ID(esc_status)};
-	uORB::Subscription _sub_pwm_input{ORB_ID(pwm_input)};
-
-
-	uint8_t _status{FAILURE_NONE};
-
-	systemlib::Hysteresis _roll_failure_hysteresis{false};
-	systemlib::Hysteresis _pitch_failure_hysteresis{false};
-	systemlib::Hysteresis _ext_ats_failure_hysteresis{false};
-	systemlib::Hysteresis _esc_failure_hysteresis{false};
-
-	bool resetAttitudeStatus();
-	bool isAttitudeStabilized(const vehicle_status_s &vehicle_status);
-	bool updateAttitudeStatus();
-	bool updateExternalAtsStatus();
-	bool updateEscsStatus(const vehicle_status_s &vehicle_status);
 };


### PR DESCRIPTION
**Describe problem solved by this pull request**
I found:
1. Commander contained two very similar conditions to process failure detector output
1.  Failure detector used different naming conventions
1. Failure detector contained extensive logic to keep track of the state getting updated or not. This can be done by just comparing the one-byte state before and after.
1.  Failure detector reactions to attitude tracking checks are not independent of reactions to ESC checks

**Test data / coverage**
No tests done.