### PR TITLE
uORB: remove lost message count per DeviceNode

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2144,9 +2144,14 @@ Commander::run()
 		/* handle commands last, as the system needs to be updated to handle them */
 		if (_cmd_sub.updated()) {
 			/* got command */
+			const unsigned last_generation = _cmd_sub.get_last_generation();
 			vehicle_command_s cmd;
 
 			if (_cmd_sub.copy(&cmd)) {
+				if (_cmd_sub.get_last_generation() != last_generation + 1) {
+					PX4_ERR("vehicle_command lost, generation %d -> %d", last_generation, _cmd_sub.get_last_generation());
+				}
+
 				if (handle_command(&status, cmd, &armed, _command_ack_pub)) {
 					_status_changed = true;
 				}

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2271,9 +2271,17 @@ Mavlink::task_main(int argc, char *argv[])
 			}
 		}
 
+
+		// vehicle_command
+		const unsigned last_generation = cmd_sub.get_last_generation();
 		vehicle_command_s vehicle_cmd;
 
 		if (cmd_sub.update(&vehicle_cmd)) {
+
+			if (cmd_sub.get_last_generation() != last_generation + 1) {
+				PX4_ERR("vehicle_command lost, generation %d -> %d", last_generation, cmd_sub.get_last_generation());
+			}
+
 			if ((vehicle_cmd.command == vehicle_command_s::VEHICLE_CMD_CONTROL_HIGH_LATENCY) &&
 			    (_mode == MAVLINK_MODE_IRIDIUM)) {
 				if (vehicle_cmd.param1 > 0.5f) {

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -217,8 +217,13 @@ Navigator::run()
 		_home_pos_sub.update(&_home_pos);
 
 		if (_vehicle_command_sub.updated()) {
+			const unsigned last_generation = _vehicle_command_sub.get_last_generation();
 			vehicle_command_s cmd{};
 			_vehicle_command_sub.copy(&cmd);
+
+			if (_vehicle_command_sub.get_last_generation() != last_generation + 1) {
+				PX4_ERR("vehicle_command lost, generation %d -> %d", last_generation, _vehicle_command_sub.get_last_generation());
+			}
 
 			if (cmd.command == vehicle_command_s::VEHICLE_CMD_DO_GO_AROUND) {
 

--- a/src/modules/uORB/uORBDeviceMaster.hpp
+++ b/src/modules/uORB/uORBDeviceMaster.hpp
@@ -78,9 +78,8 @@ public:
 
 	/**
 	 * Print statistics for each existing topic.
-	 * @param reset if true, reset statistics afterwards
 	 */
-	void printStatistics(bool reset);
+	void printStatistics();
 
 	/**
 	 * Continuously print statistics, like the unix top command for processes.
@@ -98,9 +97,7 @@ private:
 
 	struct DeviceNodeStatisticsData {
 		DeviceNode *node;
-		uint32_t last_lost_msg_count;
 		unsigned int last_pub_msg_count;
-		uint32_t lost_msg_delta;
 		unsigned int pub_msg_delta;
 		DeviceNodeStatisticsData *next = nullptr;
 	};
@@ -119,8 +116,6 @@ private:
 
 	List<uORB::DeviceNode *> _node_list;
 	AtomicBitset<ORB_TOPICS_COUNT> _node_exists[ORB_MULTI_MAX_INSTANCES];
-
-	hrt_abstime       _last_statistics_output;
 
 	px4_sem_t	_lock; /**< lock to protect access to all class members (also for derived classes) */
 

--- a/src/modules/uORB/uORBDeviceNode.hpp
+++ b/src/modules/uORB/uORBDeviceNode.hpp
@@ -176,17 +176,15 @@ public:
 	int update_queue_size(unsigned int queue_size);
 
 	/**
-	 * Print statistics (nr of lost messages)
-	 * @param reset if true, reset statistics afterwards
-	 * @return true if printed something, false otherwise (if no lost messages)
+	 * Print statistics
+	 * @param max_topic_length max topic name length for printing
+	 * @return true if printed something, false otherwise
 	 */
-	bool print_statistics(bool reset);
+	bool print_statistics(int max_topic_length);
 
 	uint8_t get_queue_size() const { return _queue_size; }
 
 	int8_t subscriber_count() const { return _subscriber_count; }
-
-	uint32_t lost_message_count() const { return _lost_messages; }
 
 	unsigned published_message_count() const { return _generation.load(); }
 
@@ -239,7 +237,7 @@ private:
 	 * @return bool
 	 *   Returns true if the data was copied.
 	 */
-	bool copy_locked(void *dst, unsigned &generation);
+	bool copy_locked(void *dst, unsigned &generation) const;
 
 	struct UpdateIntervalData {
 		uint64_t last_update{0}; /**< time at which the last update was provided, used when update_interval is nonzero */
@@ -258,10 +256,6 @@ private:
 	uint8_t     *_data{nullptr};   /**< allocated object buffer */
 	px4::atomic<unsigned>  _generation{0};  /**< object generation count */
 	List<uORB::SubscriptionCallback *>	_callbacks;
-
-	// statistics
-	uint32_t _lost_messages = 0; /**< nr of lost messages for all subscribers. If two subscribers lose the same
-					message, it is counted as two. */
 
 	ORB_PRIO _priority;  /**< priority of the topic */
 	const uint8_t _instance; /**< orb multi instance identifier */

--- a/src/modules/uORB/uORBMain.cpp
+++ b/src/modules/uORB/uORBMain.cpp
@@ -128,7 +128,7 @@ uorb_main(int argc, char *argv[])
 	 */
 	if (!strcmp(argv[1], "status")) {
 		if (g_dev != nullptr) {
-			g_dev->printStatistics(true);
+			g_dev->printStatistics();
 
 		} else {
 			PX4_INFO("uorb is not running");


### PR DESCRIPTION
Tracking the number of lost messages per uORB publication (uORB::DeviceNode) isn't generally useful because there are too many cases where it's perfectly acceptable for a subscription to only capture a subset of the updates. For the cases where it does matter we now have mechanisms for each subscription to track gaps (see sensors/vehicle_imu or logger message_gaps).

Removing `lost_messages` from each `uORB::DeviceNode` saves a little ram (and a tiny amount of cpu), makes `uorb top` a bit less confusing, and frees up `uorb status` to be used for a better overall status output. 



``` Console
nsh> uorb status
TOPIC NAME                     INST #SUB #Q SIZE PRIO PATH
log_message                       0    0  2  136   75 /obj/log_message0
parameter_update                  0   22  1   16   75 /obj/parameter_update0
tune_control                      0    1  3   24   75 /obj/tune_control0
safety                            0    2  1   16   75 /obj/safety0
input_rc                          0    4  1   72   75 /obj/input_rc0
sensor_mag                        0    3  1   48   75 /obj/sensor_mag0
adc_report                        0    1  1   96   75 /obj/adc_report0
system_power                      0    2  1   24   75 /obj/system_power0
sensor_accel                      0    4  8   48  100 /obj/sensor_accel0
sensor_gyro                       0    4  8   40  100 /obj/sensor_gyro0
sensor_baro                       0    2  1   32   75 /obj/sensor_baro0
sensor_accel                      1    3  8   48  100 /obj/sensor_accel1
sensor_gyro                       1    3  8   40  100 /obj/sensor_gyro1
sensor_baro                       1    2  1   32   75 /obj/sensor_baro1
sensor_gyro_fifo                  0    0  1  224  100 /obj/sensor_gyro_fifo0
sensor_accel_fifo                 0    0  1  224  100 /obj/sensor_accel_fifo0
sensor_mag                        1    3  1   48  125 /obj/sensor_mag1
sensor_selection                  0    6  1   24   75 /obj/sensor_selection0
vehicle_imu                       0    3  1   56   75 /obj/vehicle_imu0
battery_status                    0    6  1  112   75 /obj/battery_status0
battery_status                    1    6  1  112   75 /obj/battery_status1
led_control                       0    1  4   16   75 /obj/led_control0
vehicle_command_ack               0    3  1   24   75 /obj/vehicle_command_ack0
vehicle_control_mode              0    8  1   32   75 /obj/vehicle_control_mode0
vehicle_status                    0   17  1   56   75 /obj/vehicle_status0
actuator_armed                    0    6  1   24   75 /obj/actuator_armed0
commander_state                   0    1  1   16   75 /obj/commander_state0
vehicle_status_flags              0    1  1   40   75 /obj/vehicle_status_flags0
sensor_gyro_fifo                  1    0  1  224  100 /obj/sensor_gyro_fifo1
sensor_accel_fifo                 1    0  1  224  100 /obj/sensor_accel_fifo1
vehicle_command                   0   10  1   56   75 /obj/vehicle_command0
vehicle_angular_acceleration      0    1  1   32   75 /obj/vehicle_angular_acceleration0
vehicle_acceleration              0    1  1   32   75 /obj/vehicle_acceleration0
vehicle_angular_velocity          0    5  1   32   75 /obj/vehicle_angular_velocity0
vehicle_imu_status                0    4  1   56   75 /obj/vehicle_imu_status0
vehicle_imu                       1    3  1   56   75 /obj/vehicle_imu1
vehicle_imu_status                1    4  1   56   75 /obj/vehicle_imu_status1
sensor_combined                   0    3  1   48   75 /obj/sensor_combined0
sensor_preflight                  0    1  1   24   75 /obj/sensor_preflight0
vehicle_magnetometer              0    3  1   24   75 /obj/vehicle_magnetometer0
test_motor                        0    2  4   24   75 /obj/test_motor0
vehicle_air_data                  0    8  1   40   75 /obj/vehicle_air_data0
actuator_outputs                  0    3  1   80   75 /obj/actuator_outputs0
multirotor_motor_limits           0    2  1   16   75 /obj/multirotor_motor_limits0
actuator_controls_0               0    6  1   48   75 /obj/actuator_controls_00
ekf2_timestamps                   0    0  1   24   75 /obj/ekf2_timestamps0
landing_gear                      0    0  1   16   75 /obj/landing_gear0
rate_ctrl_status                  0    1  1   24   75 /obj/rate_ctrl_status0
vehicle_attitude                  0    7  1   48   75 /obj/vehicle_attitude0
vehicle_local_position_setpoint   0    3  1   80   75 /obj/vehicle_local_position_setpoint0
vehicle_local_position            0   11  1  152   75 /obj/vehicle_local_position0
cpuload                           0    4  1   16   75 /obj/cpuload0
task_stack_info                   0    0  2   40   75 /obj/task_stack_info0
position_setpoint_triplet         0    3  1  344   75 /obj/position_setpoint_triplet0
telemetry_status                  0    2  3   48   75 /obj/telemetry_status0
vehicle_land_detected             0    9  1   24   75 /obj/vehicle_land_detected0
estimator_sensor_bias             0    4  1   56   75 /obj/estimator_sensor_bias0
estimator_status                  0    4  1  288   75 /obj/estimator_status0
estimator_innovations             0    1  1  144   75 /obj/estimator_innovations0
estimator_innovation_variances    0    1  1  144   75 /obj/estimator_innovation_variances0
estimator_innovation_test_ratios  0    1  1  144   75 /obj/estimator_innovation_test_ratios0
vehicle_odometry                  0    1  1  256   75 /obj/vehicle_odometry0
vehicle_attitude_setpoint         0    4  1   64   75 /obj/vehicle_attitude_setpoint0
vehicle_rates_setpoint            0    4  1   32   75 /obj/vehicle_rates_setpoint0
```

