### PR TITLE
uORB::DeviceNode replace SubscriptionData with uORB::SubscriptionInterval

### DIFF
--- a/src/lib/flight_tasks/tasks/Offboard/FlightTaskOffboard.cpp
+++ b/src/lib/flight_tasks/tasks/Offboard/FlightTaskOffboard.cpp
@@ -45,11 +45,6 @@ bool FlightTaskOffboard::updateInitialize()
 {
 	bool ret = FlightTask::updateInitialize();
 
-	_sub_triplet_setpoint.update();
-
-	// require a valid triplet
-	ret = ret && _sub_triplet_setpoint.get().current.valid;
-
 	// require valid position / velocity in xy
 	return ret && PX4_ISFINITE(_position(0))
 	       && PX4_ISFINITE(_position(1))
@@ -72,6 +67,8 @@ bool FlightTaskOffboard::update()
 
 	// reset setpoint for every loop
 	_resetSetpoints();
+
+	_sub_triplet_setpoint.update();
 
 	if (!_sub_triplet_setpoint.get().current.valid) {
 		_setDefaultConstraints();

--- a/src/modules/uORB/Subscription.cpp
+++ b/src/modules/uORB/Subscription.cpp
@@ -65,16 +65,10 @@ bool Subscription::subscribe()
 				_node = node;
 				_node->add_internal_subscriber();
 
-				// If there were any previous publications, allow the subscriber to read them
 				const unsigned curr_gen = _node->published_message_count();
-				const uint8_t q_size = _node->get_queue_size();
 
-				if (q_size < curr_gen) {
-					_last_generation = curr_gen - q_size;
-
-				} else {
-					_last_generation = 0;
-				}
+				// If there were any previous publications allow the subscriber to read them
+				_last_generation = curr_gen - math::min((unsigned)_node->get_queue_size(), curr_gen);
 
 				return true;
 			}

--- a/src/modules/uORB/Subscription.hpp
+++ b/src/modules/uORB/Subscription.hpp
@@ -68,6 +68,7 @@ public:
 		_orb_id(id),
 		_instance(instance)
 	{
+		subscribe();
 	}
 
 	/**
@@ -80,6 +81,7 @@ public:
 		_orb_id((meta == nullptr) ? ORB_ID::INVALID : static_cast<ORB_ID>(meta->o_id)),
 		_instance(instance)
 	{
+		subscribe();
 	}
 
 	~Subscription()
@@ -111,19 +113,19 @@ public:
 	/**
 	 * Check if there is a new update.
 	 * */
-	bool updated() { return advertised() ? (_node->published_message_count() != _last_generation) : false; }
+	bool updated() { return advertised() && (_node->published_message_count() != _last_generation); }
 
 	/**
 	 * Update the struct
 	 * @param dst The uORB message struct we are updating.
 	 */
-	bool update(void *dst) { return updated() ? copy(dst) : false; }
+	bool update(void *dst) { return updated() && _node->copy(dst, _last_generation); }
 
 	/**
 	 * Copy the struct
 	 * @param dst The uORB message struct we are updating.
 	 */
-	bool copy(void *dst) { return advertised() ? _node->copy(dst, _last_generation) : false; }
+	bool copy(void *dst) { return advertised() && _node->copy(dst, _last_generation); }
 
 	uint8_t  get_instance() const { return _instance; }
 	unsigned get_last_generation() const { return _last_generation; }

--- a/src/modules/uORB/uORBDeviceNode.hpp
+++ b/src/modules/uORB/uORBDeviceNode.hpp
@@ -229,31 +229,6 @@ protected:
 
 private:
 
-	/**
-	 * Copies data and the corresponding generation
-	 * from a node to the buffer provided. Caller handles locking.
-	 *
-	 * @param dst
-	 *   The buffer into which the data is copied.
-	 * @param generation
-	 *   The generation that was copied.
-	 * @return bool
-	 *   Returns true if the data was copied.
-	 */
-	bool copy_locked(void *dst, unsigned &generation) const;
-
-	struct UpdateIntervalData {
-		uint64_t last_update{0}; /**< time at which the last update was provided, used when update_interval is nonzero */
-		unsigned interval{0}; /**< if nonzero minimum interval between updates */
-	};
-
-	struct SubscriberData {
-		~SubscriberData() { if (update_interval) { delete (update_interval); } }
-
-		unsigned generation{0}; /**< last generation the subscriber has seen */
-		UpdateIntervalData *update_interval{nullptr}; /**< if null, no update interval */
-	};
-
 	const orb_metadata *_meta; /**< object metadata information */
 
 	uint8_t     *_data{nullptr};   /**< allocated object buffer */
@@ -265,15 +240,4 @@ private:
 	bool _advertised{false};  /**< has ever been advertised (not necessarily published data yet) */
 	uint8_t _queue_size; /**< maximum number of elements in the queue */
 	int8_t _subscriber_count{0};
-
-	/**
-	 * Check whether a topic appears updated to a subscriber.
-	 *
-	 * Lock must already be held when calling this.
-	 *
-	 * @param sd    The subscriber for whom to check.
-	 * @return    True if the topic should appear updated to the subscriber
-	 */
-	bool      appears_updated(cdev::file_t *filp);
-
 };


### PR DESCRIPTION
This finally brings "new" uORB Subscriptions full circle with file descriptor based subscriptions (orb_subscribe/px4_open), unifying `uORB::Subscription` as the internal data structure of a subscription in all cases.

 - orb_subscribe/orb_unsubscribe are now equivalent to `uORB::SubscriptionInterval` construction/destruction
   - previously we had slightly different logic and lazy subscribing (first update) in `uORB::Subscription`
 - update checks or modifying a subscription interval are now identical code paths

The downside is that each old style orb subscription is slightly more expensive (a few extra fields per Subscription), but there's so little remaining usage it's not worth worrying about (real numbers coming).