### PR TITLE
FlightTask Auto: use yaw setpoint from Navigator if aligning for transition in VTOL_takeoff

### DIFF
--- a/src/lib/flight_tasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/flight_tasks/tasks/Auto/FlightTaskAuto.cpp
@@ -277,10 +277,12 @@ bool FlightTaskAuto::_evaluateTriplets()
 		_yaw_setpoint = NAN;
 
 	} else {
-		if (_type != WaypointType::takeoff
+		if ((_type != WaypointType::takeoff || _sub_triplet_setpoint.get().current.disable_weather_vane)
 		    && _sub_triplet_setpoint.get().current.yaw_valid) {
 			// Use the yaw computed in Navigator except during takeoff because
-			// Navigator is not handling the yaw reset properly
+			// Navigator is not handling the yaw reset properly.
+			// But: use if from Navigator during takeoff if disable_weather_vane is true,
+			// because we're then aligning to the transition waypoint.
 			// TODO: fix in navigator
 			_yaw_setpoint = _sub_triplet_setpoint.get().current.yaw;
 


### PR DESCRIPTION
Fixes https://github.com/PX4/Firmware/issues/15409, which was introduced by https://github.com/PX4/Firmware/pull/15358. 

It's certainly not the cleanest solution, but I guess it serves as a quick fix, as we already have the disable_weather_vane flag read in the FlightTask for a very similar purpose (to enable the aligning with the transition wp, weather vane needs to be switched off).
Maybe renaming the flag from "disable_weather_vane" to "enable_navigator_yaw_control" / "enforce_navigator_yaw_setpoint" makes it a bit cleaner. Or I guess even better it would be to have the alignment logic inside the flight task, and not Navigator. 