### PR TITLE
Update json param field names

### DIFF
--- a/src/lib/parameters/px4params/jsonout.py
+++ b/src/lib/parameters/px4params/jsonout.py
@@ -22,8 +22,8 @@ class JsonOutput():
         #xml_version.text = "15"
 
         schema_map = {
-                        "short_desc": "shortDescription",
-			"long_desc": "longDescription",
+                        "short_desc": "shortDesc",
+			"long_desc": "longDesc",
 			"unit": "units",
 			"decimal": "decimalPlaces",
 			"min": "min",
@@ -42,7 +42,7 @@ class JsonOutput():
                 if (last_param_name == param.GetName() and not board_specific_param_set) or last_param_name != param.GetName():
                     curr_param=dict()
                     curr_param['name'] = param.GetName()
-                    curr_param['defaultValue'] = param.GetDefault()
+                    curr_param['default'] = param.GetDefault()
                     curr_param['type'] = param.GetType().capitalize()
                     if not curr_param['type'] in allowed_types:
                         print("Error: %s type not supported: curr_param['type']" % (curr_param['name'],curr_param['type']) )


### PR DESCRIPTION
Json param field names [changed in MAVLink](https://github.com/mavlink/mavlink/pull/1431) to longDesc, shortDesc, default (for consistency and size reasons).

@bkueng Do we standardise our units? The units accepted by QGC/MAVLink under discussion here: https://github.com/mavlink/mavlink/pull/1431/files#r464716317
The reason I ask is that the UAVCAN ones are inconsistent with the PX4 ones - e.g. Hertz, etc - see https://gist.github.com/hamishwillee/3779fcfb6bd368b1cd9fd3f84cbcb5b6

Should they be the same? If so, you OK with me moving the inject code before the validator, then fixing up the injected XML - OR, should I tidy up the output as expected by MAVLink once this stabilises?