### PR TITLE
camera triggering fix (PWM) + triggering on 78

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -406,15 +406,22 @@ else
 
 	if param greater TRIG_MODE 0
 	then
-		# We ONLY support trigger on pins 5 and 6 when simultanously using AUX for actuator output.
+		# We ONLY support trigger on pins 5+6 or 7+8 when simultanously using AUX for actuator output.
 		if param compare TRIG_PINS 56
 		then
 			# clear pins 5 and 6
 			set FMU_MODE pwm4
 			set AUX_MODE pwm4
 		else
-			set FMU_MODE none
-			set AUX_MODE none
+			if param compare TRIG_PINS 78
+			then
+				# clear pins 7 and 8
+				set FMU_MODE pwm6
+				set AUX_MODE pwm6
+			else
+				set FMU_MODE none
+				set AUX_MODE none
+			fi
 		fi
 
 		camera_trigger start

--- a/boards/av/x-v1/src/board_config.h
+++ b/boards/av/x-v1/src/board_config.h
@@ -103,6 +103,8 @@
 #define DIRECT_PWM_OUTPUT_CHANNELS  9
 #define DIRECT_INPUT_TIMER_CHANNELS  9
 
+#define BOARD_CAPTURE_GPIO /* PD14 */  (GPIO_INPUT|GPIO_FLOAT|GPIO_EXTI|GPIO_PORTD|GPIO_PIN14)
+
 /* High-resolution timer */
 #define HRT_TIMER		     5  /* use timer5 for the HRT */
 #define HRT_TIMER_CHANNEL    1  /* use capture/compare channel 3 */

--- a/boards/px4/fmu-v5x/src/board_config.h
+++ b/boards/px4/fmu-v5x/src/board_config.h
@@ -297,7 +297,8 @@
 /* Input Capture Channels. */
 #define INPUT_CAP1_TIMER                  5
 #define INPUT_CAP1_CHANNEL     /* T5C4 */ 4
-#define GPIO_INPUT_CAP1        /*  PI0 */ GPIO_TIM5_CH4_IN
+#define GPIO_INPUT_CAP1        /*  PI0 */ GPIO_TIM5_CH4IN
+#define BOARD_CAPTURE_GPIO /* PI0 */  (GPIO_INPUT|GPIO_FLOAT|GPIO_EXTI|GPIO_PORTI|GPIO_PIN0)
 
 /* PWM input driver. Use FMU AUX5 pins attached to timer4 channel 2 */
 #define PWMIN_TIMER                       4

--- a/src/drivers/camera_capture/camera_capture.cpp
+++ b/src/drivers/camera_capture/camera_capture.cpp
@@ -209,7 +209,15 @@ CameraCapture::Run()
 void
 CameraCapture::set_capture_control(bool enabled)
 {
-#if !defined CONFIG_ARCH_BOARD_AV_X_V1
+// a board can define BOARD_CAPTURE_GPIO to use a separate capture pin
+#if defined(BOARD_CAPTURE_GPIO)
+
+	px4_arch_gpiosetevent(BOARD_CAPTURE_GPIO, true, false, true, &CameraCapture::gpio_interrupt_routine, this);
+	_capture_enabled = enabled;
+	_gpio_capture = true;
+	reset_statistics(false);
+
+#else
 
 	int fd = ::open(PX4FMU_DEVICE_PATH, O_RDWR);
 
@@ -264,17 +272,8 @@ CameraCapture::set_capture_control(bool enabled)
 		goto err_out;
 	}
 
-#else
-
-	px4_arch_gpiosetevent(GPIO_TRIG_AVX, true, false, true, &CameraCapture::gpio_interrupt_routine, this);
-	_capture_enabled = enabled;
-	_gpio_capture = true;
-
-#endif
-
 	reset_statistics(false);
 
-#if !defined CONFIG_ARCH_BOARD_AV_X_V1
 err_out:
 	::close(fd);
 #endif
@@ -326,7 +325,14 @@ CameraCapture::status()
 {
 	PX4_INFO("Capture enabled : %s", _capture_enabled ? "YES" : "NO");
 	PX4_INFO("Frame sequence : %u", _capture_seq);
-	PX4_INFO("Last trigger timestamp : %" PRIu64 "", _last_trig_time);
+
+	if (_last_trig_time != 0) {
+		PX4_INFO("Last trigger timestamp : %" PRIu64 " (%i ms ago)", _last_trig_time,
+			 (int)(hrt_elapsed_time(&_last_trig_time) / 1000));
+
+	} else {
+		PX4_INFO("No trigger yet");
+	}
 
 	if (_camera_capture_mode != 0) {
 		PX4_INFO("Last exposure time : %0.2f ms", double(_last_exposure_time) / 1000.0);

--- a/src/drivers/camera_capture/camera_capture.hpp
+++ b/src/drivers/camera_capture/camera_capture.hpp
@@ -57,9 +57,6 @@
 
 #define PX4FMU_DEVICE_PATH	"/dev/px4fmu"
 
-// For AV-X board
-#define GPIO_TRIG_AVX /* PD14 */  (GPIO_INPUT|GPIO_FLOAT|GPIO_EXTI|GPIO_PORTD|GPIO_PIN14)
-
 
 class CameraCapture : public px4::ScheduledWorkItem
 {
@@ -141,7 +138,7 @@ private:
 	// Signal capture callback
 	void			capture_callback(uint32_t chan_index, hrt_abstime edge_time, uint32_t edge_state, uint32_t overflow);
 
-	// GPIO interrupt routine (for AV_X board)
+	// GPIO interrupt routine
 	static int		gpio_interrupt_routine(int irq, void *context, void *arg);
 
 	// Signal capture publish

--- a/src/drivers/camera_trigger/interfaces/src/gpio.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/gpio.cpp
@@ -25,7 +25,7 @@ void CameraInterfaceGPIO::setup()
 	for (unsigned i = 0, t = 0; i < arraySize(_pins); i++) {
 
 		// Pin range is from 0 to num_gpios - 1
-		if (_pins[i] >= 0 && t < (int)arraySize(_triggers) && _pins[i] < num_gpios) {
+		if (_pins[i] >= 0 && t < (int)arraySize(_triggers)) {
 			uint32_t gpio = io_timer_channel_get_gpio_output(_pins[i]);
 			_triggers[t++] = gpio;
 			px4_arch_configgpio(gpio);

--- a/src/drivers/dshot/dshot.cpp
+++ b/src/drivers/dshot/dshot.cpp
@@ -403,7 +403,7 @@ DShotOutput::set_mode(Mode mode)
 		/* default output rates */
 		_output_mask = 0x1f;
 		_outputs_initialized = false;
-		_num_outputs = 4;
+		_num_outputs = 5;
 
 		break;
 

--- a/src/drivers/pwm_out/PWMOut.cpp
+++ b/src/drivers/pwm_out/PWMOut.cpp
@@ -213,7 +213,7 @@ int PWMOut::set_mode(Mode mode)
 		_pwm_alt_rate_channels = 0;
 		_pwm_mask = 0x1f;
 		_pwm_initialized = false;
-		_num_outputs = 4;
+		_num_outputs = 5;
 
 		break;
 

--- a/src/drivers/pwm_out/PWMOut.cpp
+++ b/src/drivers/pwm_out/PWMOut.cpp
@@ -558,7 +558,7 @@ bool PWMOut::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
 
 	/* output to the servos */
 	if (_pwm_initialized) {
-		for (size_t i = 0; i < num_outputs; i++) {
+		for (size_t i = 0; i < math::min(_num_outputs, num_outputs); i++) {
 			up_pwm_servo_set(i, outputs[i]);
 		}
 	}


### PR DESCRIPTION
- Fixes camera triggering via PWM (1. commit)
- v5x: use board-specific camera capture pin PI0
- TRIG_PINS: allow triggering on 78 while still using the lower 6 pins for pwm

The whole camera trigger/capture pins config will need a bigger overhaul if we want to have more configurability. For now this should do though.

Replaces #10857