### PR TITLE
SPRacing H7 extreme - OSD enabled

### DIFF
--- a/boards/spracing/h7extreme/init/rc.board_extras
+++ b/boards/spracing/h7extreme/init/rc.board_extras
@@ -5,7 +5,7 @@
 
 if ! param compare OSD_ATXXXX_CFG 0
 then
-	atxxxx start
+	atxxxx start -s
 fi
 
 


### PR DESCRIPTION
This is a simple configuration change that enables OSD. I can confirm that OSD works on this board.