### PR TITLE
cdev: remove unnecessary virtuals and increase opt level

### DIFF
--- a/src/lib/cdev/CDev.hpp
+++ b/src/lib/cdev/CDev.hpp
@@ -159,7 +159,7 @@ public:
 	 *			it is being torn down.
 	 * @return		OK on success, or -errno otherwise.
 	 */
-	virtual int	poll(file_t *filep, px4_pollfd_struct_t *fds, bool setup);
+	int	poll(file_t *filep, px4_pollfd_struct_t *fds, bool setup);
 
 	/**
 	 * Get the device name.
@@ -197,7 +197,7 @@ protected:
 	 *
 	 * @param events	The new event(s) being announced.
 	 */
-	virtual void	poll_notify(px4_pollevent_t events);
+	void	poll_notify(px4_pollevent_t events);
 
 	/**
 	 * Internal implementation of poll_notify.
@@ -240,7 +240,7 @@ protected:
 	 * @param class_devname   Device class name
 	 * @return class_instamce Class instance created, or -errno on failure
 	 */
-	virtual int register_class_devname(const char *class_devname);
+	int register_class_devname(const char *class_devname);
 
 	/**
 	 * Register a class device name, automatically adding device
@@ -250,7 +250,7 @@ protected:
 	 * @param class_instance  Device class instance from register_class_devname()
 	 * @return		  OK on success, -errno otherwise
 	 */
-	virtual int unregister_class_devname(const char *class_devname, unsigned class_instance);
+	int unregister_class_devname(const char *class_devname, unsigned class_instance);
 
 	/**
 	 * Take the driver lock.

--- a/src/lib/cdev/CMakeLists.txt
+++ b/src/lib/cdev/CMakeLists.txt
@@ -35,17 +35,21 @@ set(SRCS_PLATFORM)
 if (${PX4_PLATFORM} STREQUAL "nuttx")
 	list(APPEND SRCS_PLATFORM
 		nuttx/cdev_platform.cpp
+		nuttx/cdev_platform.hpp
 	)
 else()
 	list(APPEND SRCS_PLATFORM
 		posix/cdev_platform.cpp
+		posix/cdev_platform.hpp
 	)
 endif()
 
 px4_add_library(cdev
 	CDev.cpp
+	CDev.hpp
 	${SRCS_PLATFORM}
-	)
+)
+target_compile_options(cdev PRIVATE ${MAX_CUSTOM_OPT_LEVEL})
 
 if(PX4_TESTING)
 	add_subdirectory(test)


### PR DESCRIPTION
 - poll, poll_notify, register_class_devname, unregister_class_devname aren't virtual
 - increase max optimization level on platforms that aren't flash constrained (MAX_CUSTOM_OPT_LEVEL)

Saves a little flash.

``` Console
    VM SIZE    
 -------------- 
   +24%     +88    cdev::CDev::poll(file*, pollfd*, bool)
   +35%     +22    cdev::CDev::open(file*)
   +83%     +20    cdev::cdev_ioctl(file*, int, unsigned long)
   +83%     +20    cdev::cdev_read(file*, char*, unsigned int)
   +83%     +20    cdev::cdev_seek(file*, int, int)
   +83%     +20    cdev::cdev_write(file*, char const*, unsigned int)
  +0.0%     +12    [section .text]
   +20%     +12    cdev::CDev::close(file*)
   +18%     +12    cdev::CDev::poll_notify(unsigned char)
   +22%      +8    cdev::CDev::CDev(char const*)
   +11%      +4    cdev::CDev::init()
  +5.0%      +4    cdev::CDev::register_class_devname(char const*)
  +0.1%      +4    listener_generated(char*, int, int, int)
  [ = ]       0    FakeMagnetometer::print_usage(char const*)
  [ = ]       0    GPS::initializeCommunicationDump()
  [ = ]       0    PX4IO::print_status(bool)
  [ = ]       0    [Unmapped]
  [ = ]       0    [section .debug_abbrev]
  [ = ]       0    [section .debug_aranges]
  [ = ]       0    [section .debug_frame]
  [ = ]       0    [section .debug_info]
  [ = ]       0    [section .debug_line]
  [ = ]       0    [section .debug_loc]
  [ = ]       0    [section .debug_ranges]
  [ = ]       0    [section .debug_str]
  [ = ]       0    [section .symtab]
  [ = ]       0    cdev::CDev::unregister_driver_and_memory()
  [ = ]       0    int listener_print_topic<onboard_computer_status_s>(orb_metadata const* const&, int)
  [ = ]       0    int listener_print_topic<vehicle_trajectory_waypoint_s>(orb_metadata const* const&, int)
  -4.3%      -2    CDevNode::write(file*, char const*, unsigned int)
  -4.8%      -4    DShotOutput::init()
  -1.9%      -4    PX4FLOW::init()
 -16.7%      -4    cdev::cdev_poll(file*, pollfd*, bool)
  -2.6%      -8    UavcanCDevSensorBridgeBase::publish(int, void const*)
  -8.7%     -16    vtable for ADIS16448
  -8.5%     -16    vtable for ADIS16477
  -8.5%     -16    vtable for ADIS16497
  -8.7%     -16    vtable for AK09916
  -8.7%     -16    vtable for AK8963
 -11.8%     -16    vtable for Airspeed
  -8.5%     -16    vtable for BMI055
  -8.5%     -16    vtable for BMM150
  -8.2%     -16    vtable for BMP280_I2C
  -8.2%     -16    vtable for BMP280_SPI
  -8.2%     -16    vtable for BMP388_I2C
  -8.2%     -16    vtable for BMP388_SPI
  -8.5%     -16    vtable for BlinkM
  -8.3%     -16    vtable for Bosch::BMI055::Accelerometer::BMI055_Accelerometer
  -8.3%     -16    vtable for Bosch::BMI055::Gyroscope::BMI055_Gyroscope
 -21.1%     -16    vtable for CDevNode
  -8.9%     -16    vtable for DShotOutput
  -8.5%     -16    vtable for ETSAirspeed
 -12.5%     -16    vtable for HMC5883_I2C
 -12.5%     -16    vtable for HMC5883_SPI
  -8.5%     -16    vtable for ICM20602
  -8.5%     -16    vtable for ICM20689
  -7.7%     -16    vtable for INA226
  -8.7%     -16    vtable for IRLOCK
  -8.5%     -16    vtable for IST8308
  -8.7%     -16    vtable for IST8310
 -21.1%     -16    vtable for IridiumSBD
 -21.1%     -16    vtable for LED
 -12.5%     -16    vtable for LIS2MDL_I2C
 -12.5%     -16    vtable for LIS2MDL_SPI
 -12.5%     -16    vtable for LIS3MDL_I2C
 -12.5%     -16    vtable for LIS3MDL_SPI
 -12.5%     -16    vtable for LPS22HB_I2C
 -12.5%     -16    vtable for LPS22HB_SPI
  -8.7%     -16    vtable for LSM303AGR
  -8.5%     -16    vtable for LidarLiteI2C
  -7.4%     -16    vtable for MB12XX
  -8.5%     -16    vtable for MEASAirspeed
 -11.8%     -16    vtable for MK
  -8.5%     -16    vtable for MS5525
 -12.5%     -16    vtable for MS5611_I2C
 -12.5%     -16    vtable for MS5611_SPI
  -7.5%     -16    vtable for MappyDot
  -8.7%     -16    vtable for PAW3902
  -8.5%     -16    vtable for PCA9685
  -7.5%     -16    vtable for PCF8583
  -8.7%     -16    vtable for PMW3901
  -9.3%     -16    vtable for PWMOut
  -9.3%     -16    vtable for PWMSim
 -21.1%     -16    vtable for PX4Barometer
  -8.7%     -16    vtable for PX4FLOW
 -20.0%     -16    vtable for PX4IO
 -21.1%     -16    vtable for PX4Magnetometer
 -12.5%     -16    vtable for QMC5883_I2C
  -8.7%     -16    vtable for RGBLED
  -8.9%     -16    vtable for RGBLED_NPC5623C
 -12.5%     -16    vtable for RM3100_I2C
 -12.5%     -16    vtable for RM3100_SPI
  -8.5%     -16    vtable for SDP3X
  -8.7%     -16    vtable for SF1XX
 -12.5%     -16    vtable for SMBus
  -8.7%     -16    vtable for SRF02
 -11.8%     -16    vtable for TAP_ESC
  -8.7%     -16    vtable for TERARANGER
 -15.4%     -16    vtable for ToneAlarm
 -10.0%     -16    vtable for UavcanAirspeedBridge
 -10.0%     -16    vtable for UavcanBarometerBridge
  -8.5%     -16    vtable for UavcanBatteryBridge
 -10.0%     -16    vtable for UavcanCDevSensorBridgeBase
  -9.8%     -16    vtable for UavcanDifferentialPressureBridge
 -10.0%     -16    vtable for UavcanFlowBridge
 -10.0%     -16    vtable for UavcanGnssBridge
  -9.8%     -16    vtable for UavcanMagnetometerBridge
 -12.5%     -16    vtable for UavcanNode
  -8.7%     -16    vtable for VL53L0X
 -21.1%     -16    vtable for cdev::CDev
 -12.9%     -16    vtable for device::CDev
 -12.5%     -16    vtable for device::I2C
 -12.5%     -16    vtable for device::SPI
 -12.5%     -16    vtable for dps310::DPS310_I2C
 -12.5%     -16    vtable for dps310::DPS310_SPI
 -12.5%     -16    vtable for lps33hw::LPS33HW_I2C
 -12.5%     -16    vtable for lps33hw::LPS33HW_SPI
  -8.9%     -16    vtable for px4::bst::BST
 -21.1%     -16    vtable for uORB::DeviceNode
  -0.1% -1.11Ki    TOTAL
```