### PR TITLE
Compare RC override from center, not last sticks

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1884,12 +1884,9 @@ Commander::run()
 		if ((override_auto_mode || override_offboard_mode) && is_rotary_wing
 		    && !in_low_battery_failsafe && !_geofence_warning_action_on) {
 			// transition to previous state if sticks are touched
-			if ((_last_manual_control_setpoint.timestamp != _manual_control_setpoint.timestamp) &&
-			    ((fabsf(_manual_control_setpoint.x - _last_manual_control_setpoint.x) > _min_stick_change) ||
-			     (fabsf(_manual_control_setpoint.y - _last_manual_control_setpoint.y) > _min_stick_change) ||
-			     (fabsf(_manual_control_setpoint.z - _last_manual_control_setpoint.z) > _min_stick_change) ||
-			     (fabsf(_manual_control_setpoint.r - _last_manual_control_setpoint.r) > _min_stick_change))) {
-
+			if (hrt_elapsed_time(&_manual_control_setpoint.timestamp) < 1_s && // don't use uninitialized or old messages
+			    ((fabsf(_manual_control_setpoint.x) > _min_stick_change) ||
+			     (fabsf(_manual_control_setpoint.y) > _min_stick_change))) {
 				// revert to position control in any case
 				main_state_transition(status, commander_state_s::MAIN_STATE_POSCTL, status_flags, &_internal_state);
 				mavlink_log_info(&mavlink_log_pub, "Pilot took over control using sticks");

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -194,11 +194,11 @@ PARAM_DEFINE_FLOAT(COM_RC_LOSS_T, 0.5f);
  * @group Commander
  * @unit %
  * @min 5
- * @max 40
+ * @max 80
  * @decimal 0
  * @increment 0.05
  */
-PARAM_DEFINE_FLOAT(COM_RC_STICK_OV, 12.0f);
+PARAM_DEFINE_FLOAT(COM_RC_STICK_OV, 50.0f);
 
 /**
  * Home set horizontal threshold


### PR DESCRIPTION
**Describe problem solved by this pull request**
Before it was possible for the sticks to be _not_ centered when entering an auto mode which didn't have RC override enabled (eg. fixed-wing mission). When a scheduled change to a different auto mode which _did_ have RC override enabled happened, it would then cause the RC override to be activated unexpectedly.

This was seen specifically during VTOL back-transition, where it was very dangerous because the manual VTOL switch would still be in fixed wing mode, and would cause the vehicle to transition back to fixed wing.

**Describe your solution**
RC override is entered based on sticks not being centered, not based on sticks _moving_

**Describe possible alternatives**
Do some kind of messaging request for RC override instead, and check for timeouts. Lots of other very complicated mechanisms :man_shrugging: 

**Test data / coverage**
Tested in SITL to fix the desired case, and also that we don't have any regressions for RC override in other cases.
