### PR TITLE
telemetry status updates

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -125,6 +125,7 @@ set(msg_files
 	system_power.msg
 	task_stack_info.msg
 	tecs_status.msg
+	telemetry_heartbeat.msg
 	telemetry_status.msg
 	test_motor.msg
 	timesync.msg

--- a/msg/telemetry_heartbeat.msg
+++ b/msg/telemetry_heartbeat.msg
@@ -1,0 +1,51 @@
+uint64 timestamp          # time since system start (microseconds)
+
+
+# COMPONENT (fill in as needed)
+uint8 COMP_ID_ALL                      = 0
+uint8 COMP_ID_AUTOPILOT1               = 1
+uint8 COMP_ID_TELEMETRY_RADIO          = 68
+uint8 COMP_ID_CAMERA                   = 100
+uint8 COMP_ID_GIMBAL                   = 154
+uint8 COMP_ID_LOG                      = 155
+uint8 COMP_ID_ADSB                     = 156
+uint8 COMP_ID_OSD                      = 157
+uint8 COMP_ID_PERIPHERAL               = 158
+uint8 COMP_ID_FLARM                    = 160
+uint8 COMP_ID_MISSIONPLANNER           = 190
+uint8 COMP_ID_OBSTACLE_AVOIDANCE       = 196
+uint8 COMP_ID_VISUAL_INERTIAL_ODOMETRY = 197
+uint8 COMP_ID_PAIRING_MANAGER          = 198
+uint8 COMP_ID_UDP_BRIDGE               = 240
+uint8 COMP_ID_UART_BRIDGE              = 241
+uint8 COMP_ID_TUNNEL_NODE              = 242
+
+uint8 system_id           # system id of the remote system (Mavlink header sys_id)
+uint8 component_id        # component id of the remote system (Mavlink header comp_id)
+
+
+# TYPE (fill in as needed)
+uint8 TYPE_GENERIC                     = 0
+uint8 TYPE_ANTENNA_TRACKER             = 5
+uint8 TYPE_GCS                         = 6
+uint8 TYPE_ONBOARD_CONTROLLER          = 18
+uint8 TYPE_GIMBAL                      = 26
+uint8 TYPE_ADSB                        = 27
+uint8 TYPE_CAMERA                      = 30
+uint8 TYPE_CHARGING_STATION            = 31
+
+uint8 type
+
+
+# STATE
+uint8 STATE_UNINIT                     = 0
+uint8 STATE_BOOT                       = 1
+uint8 STATE_CALIBRATING                = 2
+uint8 STATE_STANDBY                    = 3
+uint8 STATE_ACTIVE                     = 4
+uint8 STATE_CRITICAL                   = 5
+uint8 STATE_EMERGENCY                  = 6
+uint8 STATE_POWEROFF                   = 7
+uint8 STATE_FLIGHT_TERMINATION         = 8
+
+uint8 state

--- a/msg/telemetry_status.msg
+++ b/msg/telemetry_status.msg
@@ -4,36 +4,9 @@ uint8 LINK_TYPE_WIRE = 2
 uint8 LINK_TYPE_USB = 3
 uint8 LINK_TYPE_IRIDIUM	= 4
 
-# MAV_COMPONENT (fill in as needed)
-uint8 COMPONENT_ID_ALL		= 0
-uint8 COMPONENT_ID_AUTOPILOT1	= 1
-uint8 COMPONENT_ID_CAMERA	= 100
-uint8 COMPONENT_ID_OBSTACLE_AVOIDANCE = 196
-
-# MAV_TYPE (fill in as needed)
-uint8 MAV_TYPE_GENERIC = 0
-uint8 MAV_TYPE_GCS = 6
-uint8 MAV_TYPE_ONBOARD_CONTROLLER = 18
-
-# MAV_STATE
-uint8 MAV_STATE_UNINIT = 0
-uint8 MAV_STATE_BOOT = 1
-uint8 MAV_STATE_CALIBRATING = 2
-uint8 MAV_STATE_STANDBY = 3
-uint8 MAV_STATE_ACTIVE = 4
-uint8 MAV_STATE_CRITICAL = 5
-uint8 MAV_STATE_EMERGENCY = 6
-uint8 MAV_STATE_POWEROFF = 7
-uint8 MAV_STATE_FLIGHT_TERMINATION = 8
-
 uint64 timestamp			# time since system start (microseconds)
 
-uint64 heartbeat_time			# Time of last received heartbeat from remote system
-
-uint8 remote_system_id			# system id of the remote system (Mavlink header sys_id)
-uint8 remote_component_id		# component id of the remote system (Mavlink header comp_id)
-uint8 remote_type			# remote system status flag (Mavlink MAV_TYPE)
-uint8 remote_system_status		# remote system status flag (Mavlink MAV_STATE)
+telemetry_heartbeat[4] heartbeats
 
 uint8 type				#  type of the radio hardware (LINK_TYPE_*)
 
@@ -54,5 +27,3 @@ float32 rate_rx
 
 float32 rate_tx
 float32 rate_txerr
-
-uint8 ORB_QUEUE_LENGTH = 3

--- a/msg/tools/uorb_rtps_message_ids.yaml
+++ b/msg/tools/uorb_rtps_message_ids.yaml
@@ -295,6 +295,8 @@ rtps:
     id: 131
   - msg: yaw_estimator_status
     id: 132
+  - msg: telemetry_heartbeat
+    id: 133
   ########## multi topics: begin ##########
   - msg: actuator_controls_0
     id: 150

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -320,7 +320,7 @@ private:
 	bool		_onboard_controller_lost{false};
 	bool		_avoidance_system_lost{false};
 	bool		_avoidance_system_status_change{false};
-	uint8_t		_datalink_last_status_avoidance_system{telemetry_status_s::MAV_STATE_UNINIT};
+	uint8_t		_datalink_last_status_avoidance_system{telemetry_heartbeat_s::STATE_UNINIT};
 
 	hrt_abstime	_high_latency_datalink_heartbeat{0};
 	hrt_abstime	_high_latency_datalink_lost{0};
@@ -406,7 +406,7 @@ private:
 	uORB::Subscription					_manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
 	uORB::Subscription					_subsys_sub{ORB_ID(subsystem_info)};
 	uORB::Subscription					_system_power_sub{ORB_ID(system_power)};
-	uORB::Subscription					_telemetry_status_sub{ORB_ID(telemetry_status)};
+	uORB::Subscription					_telemetry_status_sub[ORB_MULTI_MAX_INSTANCES] {{ORB_ID(telemetry_status), 0}, {ORB_ID(telemetry_status), 1}, {ORB_ID(telemetry_status), 2}, {ORB_ID(telemetry_status), 3}};
 	uORB::Subscription					_vehicle_acceleration_sub{ORB_ID(vehicle_acceleration)};
 	uORB::Subscription					_vtol_vehicle_status_sub{ORB_ID(vtol_vehicle_status)};
 

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2472,7 +2472,6 @@ Mavlink::task_main(int argc, char *argv[])
 				_tstatus.rate_tx = _bytes_tx / dt;
 				_tstatus.rate_txerr = _bytes_txerr / dt;
 				_tstatus.rate_rx = _bytes_rx / dt;
-				_tstatus_updated = true;
 
 				_bytes_tx = 0;
 				_bytes_txerr = 0;
@@ -2485,7 +2484,6 @@ Mavlink::task_main(int argc, char *argv[])
 		// publish status at 1 Hz, or sooner if HEARTBEAT has updated
 		if ((hrt_elapsed_time(&_tstatus.timestamp) >= 1_s) || _tstatus_updated) {
 			publish_telemetry_status();
-			_tstatus_updated = false;
 		}
 
 		perf_end(_loop_perf);
@@ -2618,6 +2616,7 @@ void Mavlink::publish_telemetry_status()
 	lock_telemetry_status();
 	_tstatus.timestamp = hrt_absolute_time();
 	_telem_status_pub.publish(_tstatus);
+	_tstatus_updated = false;
 	unlock_telemetry_status();
 }
 

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -71,7 +71,7 @@
 #include <px4_platform_common/posix.h>
 #include <systemlib/mavlink_log.h>
 #include <systemlib/uthash/utlist.h>
-#include <uORB/Publication.hpp>
+#include <uORB/PublicationMulti.hpp>
 #include <uORB/topics/mavlink_log.h>
 #include <uORB/topics/mission_result.h>
 #include <uORB/topics/radio_status.h>
@@ -258,7 +258,7 @@ public:
 
 	bool			get_forwarding_on() { return _forwarding_on; }
 
-	bool			is_connected() { return (hrt_elapsed_time(&_tstatus.heartbeat_time) < 3_s); }
+	bool			is_connected();
 
 #if defined(MAVLINK_UDP)
 	static Mavlink 		*get_instance_for_network_port(unsigned long port);
@@ -431,6 +431,9 @@ public:
 	 * Get the receive status of this MAVLink link
 	 */
 	telemetry_status_s	&get_telemetry_status() { return _tstatus; }
+	void                    lock_telemetry_status() { pthread_mutex_lock(&_telemetry_status_mutex); }
+	void                    unlock_telemetry_status() { pthread_mutex_unlock(&_telemetry_status_mutex); }
+	void                    telemetry_status_updated() { _tstatus_updated = true; }
 
 	void			set_telemetry_status_type(uint8_t type) { _tstatus.type = type; }
 
@@ -530,7 +533,7 @@ private:
 
 	orb_advert_t		_mavlink_log_pub{nullptr};
 
-	uORB::PublicationQueued<telemetry_status_s>	_telem_status_pub{ORB_ID(telemetry_status)};
+	uORB::PublicationMulti<telemetry_status_s> _telem_status_pub{ORB_ID(telemetry_status)};
 
 	bool			_task_running{true};
 	static bool		_boot_complete;
@@ -632,6 +635,7 @@ private:
 
 	radio_status_s		_rstatus {};
 	telemetry_status_s	_tstatus {};
+	bool                    _tstatus_updated{false};
 
 	ping_statistics_s	_ping_stats {};
 
@@ -646,6 +650,7 @@ private:
 
 	pthread_mutex_t		_message_buffer_mutex {};
 	pthread_mutex_t		_send_mutex {};
+	pthread_mutex_t		_telemetry_status_mutex {};
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::MAV_SYS_ID>) _param_mav_sys_id,

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2053,7 +2053,7 @@ MavlinkReceiver::handle_message_heartbeat(mavlink_message_t *msg)
 
 		const bool same_system = (msg->sysid == mavlink_system.sysid);
 
-		if (same_system || (!same_system && (hb.type == MAV_TYPE_GCS))) {
+		if (same_system || hb.type == MAV_TYPE_GCS) {
 
 			telemetry_status_s &tstatus = _mavlink->get_telemetry_status();
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2086,14 +2086,15 @@ MavlinkReceiver::handle_message_heartbeat(mavlink_message_t *msg)
 
 			if (heartbeat_slot_found) {
 				_mavlink->lock_telemetry_status();
+
 				tstatus.heartbeats[heartbeat_slot].timestamp = now;
 				tstatus.heartbeats[heartbeat_slot].system_id = msg->sysid;
 				tstatus.heartbeats[heartbeat_slot].component_id = msg->compid;
 				tstatus.heartbeats[heartbeat_slot].type = hb.type;
 				tstatus.heartbeats[heartbeat_slot].state = hb.system_status;
-				_mavlink->unlock_telemetry_status();
 
 				_mavlink->telemetry_status_updated();
+				_mavlink->unlock_telemetry_status();
 
 			} else {
 				PX4_ERR("no telemetry heartbeat slots available");

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2045,25 +2045,60 @@ MavlinkReceiver::handle_message_heartbeat(mavlink_message_t *msg)
 {
 	/* telemetry status supported only on first TELEMETRY_STATUS_ORB_ID_NUM mavlink channels */
 	if (_mavlink->get_channel() < (mavlink_channel_t)ORB_MULTI_MAX_INSTANCES) {
+
+		const hrt_abstime now = hrt_absolute_time();
+
 		mavlink_heartbeat_t hb;
 		mavlink_msg_heartbeat_decode(msg, &hb);
 
-		/* Accept only heartbeats from GCS or ONBOARD Controller, skip heartbeats from other vehicles */
-		if ((msg->sysid != mavlink_system.sysid && hb.type == MAV_TYPE_GCS) || (msg->sysid == mavlink_system.sysid
-				&& hb.type == MAV_TYPE_ONBOARD_CONTROLLER)) {
+		const bool same_system = (msg->sysid == mavlink_system.sysid);
+
+		if (same_system || (!same_system && (hb.type == MAV_TYPE_GCS))) {
 
 			telemetry_status_s &tstatus = _mavlink->get_telemetry_status();
 
-			/* set heartbeat time and topic time and publish -
-			 * the telem status also gets updated on telemetry events
-			 */
-			tstatus.heartbeat_time = hrt_absolute_time();
-			tstatus.remote_system_id = msg->sysid;
-			tstatus.remote_component_id = msg->compid;
-			tstatus.remote_type = hb.type;
-			tstatus.remote_system_status = hb.system_status;
-		}
+			bool heartbeat_slot_found = false;
+			int heartbeat_slot = 0;
 
+			// find existing HEARTBEAT slot
+			for (size_t i = 0; i < (sizeof(tstatus.heartbeats) / sizeof(tstatus.heartbeats[0])); i++) {
+				if ((tstatus.heartbeats[i].system_id == msg->sysid)
+				    && (tstatus.heartbeats[i].component_id == msg->compid)
+				    && (tstatus.heartbeats[i].type == hb.type)) {
+
+					// found matching heartbeat slot
+					heartbeat_slot = i;
+					heartbeat_slot_found = true;
+					break;
+				}
+			}
+
+			// otherwise use first available slot
+			if (!heartbeat_slot_found) {
+				for (size_t i = 0; i < (sizeof(tstatus.heartbeats) / sizeof(tstatus.heartbeats[0])); i++) {
+					if ((tstatus.heartbeats[i].system_id == 0) && (tstatus.heartbeats[i].timestamp == 0)) {
+						heartbeat_slot = i;
+						heartbeat_slot_found = true;
+						break;
+					}
+				}
+			}
+
+			if (heartbeat_slot_found) {
+				_mavlink->lock_telemetry_status();
+				tstatus.heartbeats[heartbeat_slot].timestamp = now;
+				tstatus.heartbeats[heartbeat_slot].system_id = msg->sysid;
+				tstatus.heartbeats[heartbeat_slot].component_id = msg->compid;
+				tstatus.heartbeats[heartbeat_slot].type = hb.type;
+				tstatus.heartbeats[heartbeat_slot].state = hb.system_status;
+				_mavlink->unlock_telemetry_status();
+
+				_mavlink->telemetry_status_updated();
+
+			} else {
+				PX4_ERR("no telemetry heartbeat slots available");
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
 - one telemetry_status publication per mavlink instance
 - each telemetry_status has an array of unique HEARTBEATS


This is useful to monitor what's going on with other mavlink components that are part of the same system (gimbals, etc). It's also more convenient for review to have a telemetry status per mavlink instance rather than mixing them on the same publication instance.