### PR TITLE
Tko ramp: fix takeoff issue with large tko ramp time

### DIFF
--- a/src/lib/flight_tasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
+++ b/src/lib/flight_tasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
@@ -326,6 +326,11 @@ void FlightTaskAutoLineSmoothVel::_updateTrajConstraints()
 		if (_type == WaypointType::takeoff &&  _dist_to_ground < _param_mpc_land_alt1.get()) {
 			z_vel_constraint = _param_mpc_tko_speed.get();
 			z_accel_constraint = math::min(z_accel_constraint, _param_mpc_tko_speed.get() / _param_mpc_tko_ramp_t.get());
+
+			// Keep the altitude setpoint at the current altitude
+			// to avoid having it going down into the ground during
+			// the initial ramp as the velocity does not start at 0
+			_trajectory[2].setCurrentPosition(_position(2));
 		}
 
 		_trajectory[2].setMaxVel(z_vel_constraint);


### PR DESCRIPTION
fixes https://github.com/PX4/Firmware/issues/15408

Because the velocity starts with a positive value (down) to ramp-up slowly the motors, the position setpoint (integral) was going down into the ground, canceling the input of the velocity controller during the early takeoff phase.
Instead of a smooth ramp, the behavior was a delay followed by a quick takeoff or a land detection.
Setting the current altitude setpoint with the current altitude during this phase avoids the canceling effect and creates a takeoff purely velocity-based.

SITL (jMavSim) results:
`MPC_TKO_RAMP_T = 5s` for both tests.

Before, the trajectory_setpoint.z was going down during the early takeoff phase, delaying the thrust ramp:
![Screen Capture_select-area_20200807140839](https://user-images.githubusercontent.com/14822839/89645274-b8d90080-d8b9-11ea-90e0-eaad97f088df.png)


Now, the thrust ramps properly since the beginning of the velocity ramp:
![Screen Capture_select-area_20200807140857](https://user-images.githubusercontent.com/14822839/89645279-baa2c400-d8b9-11ea-815e-0d52fb2ec9fb.png)

@ThomasRigi Could you please test this?
@julianoes This was also probably a reason why we sometimes had a land detection during takeoff