### PR TITLE
Commander: update home position yaw in case of EKF yaw reset

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1238,6 +1238,31 @@ Commander::set_home_position_alt_only()
 }
 
 void
+Commander::updateHomePositionYaw(float yaw)
+{
+	home_position_s home = _home_pub.get();
+
+	home.yaw = yaw;
+	home.timestamp = hrt_absolute_time();
+
+	_home_pub.update(home);
+}
+
+void
+Commander::checkEkfResetCounters()
+{
+	if (_attitude_sub.get().quat_reset_counter != _quat_reset_counter) {
+		const float delta_psi = matrix::Eulerf(matrix::Quatf(_attitude_sub.get().delta_q_reset)).psi();
+
+		if (!_home_pub.get().manual_home) {
+			updateHomePositionYaw(matrix::wrap_pi(_home_pub.get().yaw + delta_psi));
+		}
+
+		_quat_reset_counter = _attitude_sub.get().quat_reset_counter;
+	}
+}
+
+void
 Commander::run()
 {
 	bool sensor_fail_tune_played = false;
@@ -2253,6 +2278,8 @@ Commander::run()
 
 		/* Get current timestamp */
 		const hrt_abstime now = hrt_absolute_time();
+
+		checkEkfResetCounters();
 
 		// automatically set or update home position
 		if (!_home_pub.get().manual_home) {
@@ -4029,6 +4056,7 @@ void Commander::estimator_check()
 
 	_local_position_sub.update();
 	_global_position_sub.update();
+	_attitude_sub.update();
 
 	const vehicle_local_position_s &lpos = _local_position_sub.get();
 	const vehicle_global_position_s &gpos = _global_position_sub.get();

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -155,6 +155,8 @@ private:
 
 	bool set_home_position();
 	bool set_home_position_alt_only();
+	void updateHomePositionYaw(float yaw);
+	void checkEkfResetCounters();
 
 	void update_control_mode();
 
@@ -360,6 +362,7 @@ private:
 	hrt_abstime	_timestamp_engine_healthy{0}; ///< absolute time when engine was healty
 
 	uint32_t	_counter{0};
+	uint8_t		_quat_reset_counter{0};
 
 	bool		_status_changed{true};
 	bool		_arm_tune_played{false};
@@ -420,6 +423,7 @@ private:
 	uORB::SubscriptionData<offboard_control_mode_s>		_offboard_control_mode_sub{ORB_ID(offboard_control_mode)};
 	uORB::SubscriptionData<vehicle_global_position_s>	_global_position_sub{ORB_ID(vehicle_global_position)};
 	uORB::SubscriptionData<vehicle_local_position_s>	_local_position_sub{ORB_ID(vehicle_local_position)};
+	uORB::SubscriptionData<vehicle_attitude_s>		_attitude_sub{ORB_ID(vehicle_attitude)};
 
 	// Publications
 	uORB::Publication<actuator_armed_s>			_armed_pub{ORB_ID(actuator_armed)};


### PR DESCRIPTION
Fixing the following issue:
A drone taking off with a true heading "psi" but measuring "psi+delta" and correcting its bias in air would land (RTL) with a heading "psi+delta" instead of "psi".

This makes sure the drone lands in the correct orientation during RTL even if the initial yaw at takeoff was wrong by updating the home position "yaw" at every ekf yaw reset.

Tested in SITL with mag data artificially biased (yaw 180deg) on ground.
Before, the drone would land in the wrong direction (see yaw changes before landing):
![2020-08-07_17-37-18_01_plot](https://user-images.githubusercontent.com/14822839/89662725-c9e33b00-d8d4-11ea-8c03-ace6dfabba69.png)

With this PR, the drone takes-off and lands in the same orientation:
![2020-08-07_17-39-34_01_plot](https://user-images.githubusercontent.com/14822839/89662856-fb5c0680-d8d4-11ea-9b06-40a5f78ee98f.png)