### PR TITLE
Rename of the DF Robot Rover Airframe

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/50004_nxpcup_car_dfrobot_gpx
+++ b/ROMFS/px4fmu_common/init.d/airframes/50004_nxpcup_car_dfrobot_gpx
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# @name DF Robot GPX:Asurada
+# @name NXP Cup car: DF Robot GPX
 
 #
 # @type Rover

--- a/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
@@ -147,7 +147,7 @@ px4_add_romfs_files(
 	50001_axialracing_ax10
 	50002_traxxas_stampede_2wd
 	50003_aion_robotics_r1_rover
-	50004_dfrobot_gpx_asurada
+	50004_nxpcup_car_dfrobot_gpx
 
 	# [60000, 61000] (Unmanned) Underwater Robots
 	60000_uuv_generic


### PR DESCRIPTION
**Describe problem solved by this pull request**
The "DF Robot Asurada: GPX Aiframe" is renamed to "NXP Cup car: DF Robot GPX". This was made to give a clear understanding of the purpose of this airframe. This rover is mainly used for the NXP Cup.

**Describe your solution**
Renaming of the 50004_dfrobot_gpx_asurada to 50004_nxpcup_car_dfrobot_gpx.

**Describe possible alternatives**
If this solution is not okay, a new airframe with same parameters but other name can be considered.
