### PR TITLE
cm8jl65: avoid flooding console with errors if errno is EAGAIN

### DIFF
--- a/src/drivers/distance_sensor/cm8jl65/CM8JL65.cpp
+++ b/src/drivers/distance_sensor/cm8jl65/CM8JL65.cpp
@@ -166,8 +166,12 @@ CM8JL65::collect()
 			index--;
 		}
 
+	} else if (bytes_read == -1 && errno == EAGAIN) {
+		return -EAGAIN;
+
 	} else {
-		PX4_INFO("read error: %d", bytes_read);
+
+		PX4_ERR("read error: %i, errno: %i", bytes_read, errno);
 		perf_count(_comms_errors);
 		perf_end(_sample_perf);
 		return PX4_ERROR;


### PR DESCRIPTION
This avoids infinitely spamming `PX4_ERR("read error: %i, errno: %i", bytes_read, errno);`  if the driver is running but no distance sensor is connected.

**Test data / coverage**
Tested with real hardware

