### PR TITLE
VTOL: Use correct pwm output device & reset quadchute states

### DIFF
--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -222,6 +222,12 @@ bool VtolType::can_transition_on_ground()
 void VtolType::check_quadchute_condition()
 {
 
+	if (!_tecs_running) {
+		// reset the filtered height rate and heigh rate setpoint if TECS is not running
+		_ra_hrate = 0.0f;
+		_ra_hrate_sp = 0.0f;
+	}
+
 	if (_v_control_mode->flag_armed && !_land_detected->landed) {
 		Eulerf euler = Quatf(_v_att->q);
 

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -81,7 +81,8 @@ VtolType::VtolType(VtolAttitudeControl *att_controller) :
 
 bool VtolType::init()
 {
-	const char *dev = PWM_OUTPUT0_DEVICE_PATH;
+	const char *dev = _params->vt_mc_on_fmu ? PWM_OUTPUT1_DEVICE_PATH : PWM_OUTPUT0_DEVICE_PATH;
+
 	int fd = px4_open(dev, 0);
 
 	if (fd < 0) {


### PR DESCRIPTION
1) The VtolType::init() method was not using the correct pwm output device if motors were attached to the FMU.

2) The filter states used in quadchute were not reset to reset in case TECS was not running.

Still awaiting testing results for 1)
