### PR TITLE
NuttX based bootloader:Track QGC change in sequencing

### DIFF
--- a/platforms/nuttx/src/bootloader/bl.c
+++ b/platforms/nuttx/src/bootloader/bl.c
@@ -588,7 +588,7 @@ bootloader(unsigned timeout)
 				goto cmd_bad;
 			}
 
-			bl_state = STATE_PROTO_GET_SYNC;
+			SET_BL_STATE(STATE_PROTO_GET_SYNC);
 			break;
 
 		// get device info


### PR DESCRIPTION
   It appear that QGC is not resyncing between operation.
   This was causing the bl_state to be reset to STATE_PROTO_GET_SYNC
   and loosing the state of (STATE_PROTO_GET_SYNC|STATE_PROTO_GET_DEVICE)

@CUAVcaijie @DonLakeFlyer 