### PR TITLE
uavcan: add rangefinder sensor

### DIFF
--- a/src/drivers/uavcan/CMakeLists.txt
+++ b/src/drivers/uavcan/CMakeLists.txt
@@ -134,6 +134,7 @@ px4_add_module(
 		sensors/flow.cpp
 		sensors/gnss.cpp
 		sensors/mag.cpp
+		sensors/rangefinder.cpp
 
 	DEPENDS
 		px4_uavcan_dsdlc

--- a/src/drivers/uavcan/sensors/rangefinder.cpp
+++ b/src/drivers/uavcan/sensors/rangefinder.cpp
@@ -1,0 +1,79 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2014, 2015 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @author Dmitry Ponomarev <ponomarevda96@gmail.com>
+ */
+
+#include "rangefinder.hpp"
+
+const char *const UavcanRangefinderBridge::NAME = "range_finder";
+
+#define UAVCAN_RANGEFINDER_BASE_DEVICE_PATH "/dev/uavcan/range_finder"
+#define SF_LW20_C_MIN_DISTANCE 0.01
+#define SF_LW20_C_MAX_DISTANCE 100.0
+
+UavcanRangefinderBridge::UavcanRangefinderBridge(uavcan::INode &node) :
+	UavcanCDevSensorBridgeBase("uavcan_rangefinder", "/dev/uavcan/range_finder", RANGE_FINDER_BASE_DEVICE_PATH, ORB_ID(distance_sensor)),
+	_sub_measurement_data(node),
+	_px4_rangefinder(DRV_DIST_DEVTYPE_SF1XX, ORB_PRIO_DEFAULT)
+{}
+
+int UavcanRangefinderBridge::init()
+{
+	int res = device::CDev::init();
+
+	if (res < 0) {
+		return res;
+	}
+
+	res = _sub_measurement_data.start(RangefinderCbBinder(this, &UavcanRangefinderBridge::measurement_sub_cb));
+
+	if (res < 0) {
+		DEVICE_LOG("failed to start uavcan rangefinder sub: %d", res);
+		return res;
+	}
+
+	return 0;
+}
+
+
+void
+UavcanRangefinderBridge::measurement_sub_cb(const
+		uavcan::ReceivedDataStructure<uavcan::equipment::range_sensor::Measurement> &msg)
+{
+	_px4_rangefinder.set_min_distance(SF_LW20_C_MIN_DISTANCE);
+	_px4_rangefinder.set_max_distance(SF_LW20_C_MAX_DISTANCE);
+
+	_px4_rangefinder.update(hrt_absolute_time(), msg.range);
+}

--- a/src/drivers/uavcan/sensors/rangefinder.hpp
+++ b/src/drivers/uavcan/sensors/rangefinder.hpp
@@ -1,0 +1,67 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2014, 2015 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @author Dmitry Ponomarev <ponomarevda96@gmail.com>
+ */
+
+#pragma once
+
+#include "sensor_bridge.hpp"
+#include <uavcan/equipment/range_sensor/Measurement.hpp>
+#include <lib/drivers/rangefinder/PX4Rangefinder.hpp>
+
+class UavcanRangefinderBridge : public UavcanCDevSensorBridgeBase
+{
+public:
+	static const char *const NAME;
+
+	UavcanRangefinderBridge(uavcan::INode &node);
+
+	const char *get_name() const override { return NAME; }
+
+	int init() override;
+
+private:
+
+	void measurement_sub_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::range_sensor::Measurement> &msg);
+
+	typedef uavcan::MethodBinder < UavcanRangefinderBridge *,
+		void (UavcanRangefinderBridge::*)
+		(const uavcan::ReceivedDataStructure<uavcan::equipment::range_sensor::Measurement> &) >
+		RangefinderCbBinder;
+
+	uavcan::Subscriber<uavcan::equipment::range_sensor::Measurement, RangefinderCbBinder> _sub_measurement_data;
+	PX4Rangefinder	_px4_rangefinder;
+
+};

--- a/src/drivers/uavcan/sensors/sensor_bridge.cpp
+++ b/src/drivers/uavcan/sensors/sensor_bridge.cpp
@@ -45,6 +45,7 @@
 #include "gnss.hpp"
 #include "flow.hpp"
 #include "mag.hpp"
+#include "rangefinder.hpp"
 
 /*
  * IUavcanSensorBridge
@@ -58,6 +59,7 @@ void IUavcanSensorBridge::make_all(uavcan::INode &node, List<IUavcanSensorBridge
 	list.add(new UavcanBatteryBridge(node));
 	list.add(new UavcanAirspeedBridge(node));
 	list.add(new UavcanDifferentialPressureBridge(node));
+	list.add(new UavcanRangefinderBridge(node));
 }
 
 /*


### PR DESCRIPTION
Current version PX4 supports distance sensors only using I2C.
I added support of this type of sensors to uavcan.

I added `uavcan/rangefinder` module like other sensors (for example baro) looking at current implementation of I2C distance sensors. So, I use `PX4Rangefinder` to publish data to uorb.

To test module I was measuring data from [rangefinder LightWare LW20](https://ardupilot.org/copter/docs/common-lightware-lw20-lidar.html) using my own device and was publising it to [CUAV V5+ autopilot](https://docs.px4.io/master/en/flight_controller/cuav_v5_plus.html) through CAN bus. It looks like it works well.

The only thing I'm worrying about is that now the minimal and maximum distances are hard coded. Uavcan message [have not got these info](https://legacy.uavcan.org/Specification/7._List_of_standard_data_types/#uavcanequipmentrange_sensor). So, should I use some param to define them?

The screens with working distance sensor are below. Sensor exists in output of `uavcan status` and we can see his measurements in `mavlink inspector`.

![image](https://user-images.githubusercontent.com/36133264/90230653-8af83c80-de22-11ea-85f5-b3154ba8f937.png)

![image](https://user-images.githubusercontent.com/36133264/90229853-46b86c80-de21-11ea-8527-8d50ae33825a.png)
