### PR TITLE
px4_fmu-v6x Fix BOARD_TYPE

### DIFF
--- a/boards/px4/fmu-v6x/src/hw_config.h
+++ b/boards/px4/fmu-v6x/src/hw_config.h
@@ -71,7 +71,7 @@
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,115200"
 #define BOOT_DELAY_ADDRESS             0x000001a0
-#define BOARD_TYPE                     139
+#define BOARD_TYPE                     53
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)
 #define BOARD_FLASH_SIZE               (_FLASH_KBYTES * 1024)


### PR DESCRIPTION
Was 139 (durandal) is 53 px4_fmu-v6x