### PR TITLE
magnetometer drivers remove register read error message

### DIFF
--- a/src/drivers/magnetometer/lis2mdl/lis2mdl.cpp
+++ b/src/drivers/magnetometer/lis2mdl/lis2mdl.cpp
@@ -102,7 +102,6 @@ LIS2MDL::measure()
 	if (ret != OK) {
 		perf_end(_sample_perf);
 		perf_count(_comms_errors);
-		PX4_WARN("Register read error.");
 		return ret;
 	}
 

--- a/src/drivers/magnetometer/lis3mdl/lis3mdl.cpp
+++ b/src/drivers/magnetometer/lis3mdl/lis3mdl.cpp
@@ -113,7 +113,6 @@ int LIS3MDL::collect()
 	if (ret != OK) {
 		perf_end(_sample_perf);
 		perf_count(_comms_errors);
-		PX4_WARN("Register read error.");
 		return ret;
 	}
 

--- a/src/drivers/magnetometer/rm3100/rm3100.cpp
+++ b/src/drivers/magnetometer/rm3100/rm3100.cpp
@@ -151,7 +151,6 @@ int RM3100::collect()
 	if (ret != OK) {
 		perf_end(_sample_perf);
 		perf_count(_comms_errors);
-		PX4_WARN("Register read error.");
 		return ret;
 	}
 


### PR DESCRIPTION
Similar to https://github.com/PX4/Firmware/pull/15525, we really need to be conservative with any error messages that have the potential to flood the console and even drag other parts of the system down. 

``` Console
WARN  [lis3mdl] Register read error.
WARN  [lis3mdl] Register read error.
WARN  [lis3mdl] Register read error.
WARN  [lis3mdl] Register read error.
WARN  [lis3mdl] Register read error.
```