### PR TITLE
wq:attitude_ctrl increase stack (again)

### DIFF
--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
@@ -65,7 +65,7 @@ static constexpr wq_config_t I2C3{"wq:I2C3", 1472, -11};
 static constexpr wq_config_t I2C4{"wq:I2C4", 1472, -12};
 
 // PX4 att/pos controllers, highest priority after sensors.
-static constexpr wq_config_t attitude_ctrl{"wq:attitude_ctrl", 1656, -13};
+static constexpr wq_config_t attitude_ctrl{"wq:attitude_ctrl", 1672, -13};
 static constexpr wq_config_t nav_and_controllers{"wq:nav_and_controllers", 7200, -14};
 
 static constexpr wq_config_t hp_default{"wq:hp_default", 1900, -15};


### PR DESCRIPTION
``` Console
WARN  [load_mon] wq:attitude_ctrl low on stack! (284 bytes left)
```