### PR TITLE
logger: by default, log the onboard_computer_status topic

### DIFF
--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -69,6 +69,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("mission");
 	add_topic("mission_result");
 	add_topic("offboard_control_mode", 100);
+	add_topic("onboard_computer_status", 10);
 	add_topic("position_controller_status", 500);
 	add_topic("position_setpoint_triplet", 200);
 	add_topic("px4io_status");
@@ -199,7 +200,6 @@ void LoggedTopics::add_vision_and_avoidance_topics()
 {
 	add_topic("collision_constraints");
 	add_topic("obstacle_distance_fused");
-	add_topic("onboard_computer_status", 200);
 	add_topic("vehicle_mocap_odometry", 30);
 	add_topic("vehicle_trajectory_waypoint", 200);
 	add_topic("vehicle_trajectory_waypoint_desired", 200);


### PR DESCRIPTION
**Describe problem solved by this pull request**
Currently it is required to set the `VISION_AND_AVOIDANCE` bit in the `SDLOG_PROFILE` parameter of PX4 to log performance metrics coming from the mission computer, which doesn't make much sense since this is not specific to a profile like that, even though it does require a connection to a companion/mission computer.

**Describe your solution**
Log the `onboard_computer_status` topic by default. Set to 10 Hz, but can be even lower.
