### PR TITLE
land_detector: MC remove relaxed throttle threshold

### DIFF
--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -186,8 +186,8 @@ bool MulticopterLandDetector::_get_ground_contact_state()
 	}
 
 
-	// low thrust: 30% of throttle range between min and hover, relaxed to 60% if hover thrust estimate available
-	const float thr_pct_hover = _hover_thrust_estimate_valid ? 0.6f : 0.3f;
+	// low thrust: 30% of throttle range between min and hover
+	const float thr_pct_hover = 0.3f;
 	const float sys_low_throttle = _params.minThrottle + (_params.hoverThrottle - _params.minThrottle) * thr_pct_hover;
 	bool ground_contact = (_actuator_controls_throttle <= sys_low_throttle);
 


### PR DESCRIPTION
There are intermittent MAVSDK mission test failures due to land detector false ground contact.

For example this mission.
https://logs.px4.io/plot_app?log=70226385-5b90-4310-91ca-8fe2be3e7948

<img width="1466" alt="Screen Shot 2020-08-17 at 7 57 29 PM" src="https://user-images.githubusercontent.com/84712/90455368-e563f800-e0c3-11ea-9859-c1ffb9661a74.png">

Debatably I think we could blame the somewhat unrealistic gazebo iris model with apparently ~20% hover and MPC_THR_MIN at 12%.

<img width="1468" alt="Screen Shot 2020-08-17 at 7 58 16 PM" src="https://user-images.githubusercontent.com/84712/90455437-0f1d1f00-e0c4-11ea-8a77-3682f820fe3b.png">

As a precaution (and SITL test failure workaround) I'm going to remove the land detector ground contact optimization that tightens the throttle threshold if the hover thrust estimate is valid.

Could we also take a closer look at making these models more realistic?