### PR TITLE
[CI/CD] Feature: deploy microRTPS agent to a separate respository

### DIFF
--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -70,6 +70,20 @@ jobs:
         ls -ls *
       # TODO: deploy graph_px4_sitl.json to S3 px4-travis:Firmware/master/
 
+  micrortps_agent:
+    runs-on: ubuntu-latest
+    container: px4io/px4-dev-base-bionic:2020-04-01
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        token: ${{ secrets.ACCESS_TOKEN }}
+
+    - name: microRTPS agent
+      run: |
+        make px4_sitl_rtps
+        git clone https://github.com/PX4/micrortps_agent.git
+        cp -R build/px4_sitl_rtps/src/modules/micrortps_bridge/micrortps_agent/* micrortps_agent
+
   ROS_msgs:
     runs-on: ubuntu-latest
     container: px4io/px4-dev-base-bionic:2020-04-01

--- a/msg/templates/urtps/microRTPS_agent_CMakeLists.txt.em
+++ b/msg/templates/urtps/microRTPS_agent_CMakeLists.txt.em
@@ -50,6 +50,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
     endif()
 endif()
 
-file(GLOB MICRORTPS_AGENT_SOURCES *.cpp *.h)
+file(GLOB MICRORTPS_AGENT_SOURCES src/*.cpp src/*.h)
 add_executable(micrortps_agent ${MICRORTPS_AGENT_SOURCES})
 target_link_libraries(micrortps_agent fastrtps fastcdr)

--- a/msg/tools/generate_microRTPS_bridge.py
+++ b/msg/tools/generate_microRTPS_bridge.py
@@ -264,10 +264,10 @@ else:
 # get ROS 2 version, if exists
 ros2_distro = ''
 ros_version = os.environ.get('ROS_VERSION')
-if ros_version == '2' :
+if ros_version == '2':
     if args.ros2_distro != '':
         ros2_distro = args.ros2_distro
-    else :
+    else:
         ros2_distro = os.environ.get('ROS_DISTRO')
 
 # get FastRTPS version
@@ -414,7 +414,7 @@ def generate_agent(out_dir):
     px_generate_uorb_topic_files.generate_uRTPS_general(classifier.msgs_to_send, classifier.alias_msgs_to_send, classifier.msgs_to_receive, classifier.alias_msgs_to_receive, msg_dir, out_dir,
                                                         urtps_templates_dir, package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtps_version, ros2_distro, uRTPS_AGENT_TOPICS_SRC_TEMPL_FILE)
     if cmakelists:
-        px_generate_uorb_topic_files.generate_uRTPS_general(classifier.msgs_to_send, classifier.alias_msgs_to_send, classifier.msgs_to_receive, classifier.alias_msgs_to_receive, msg_dir, out_dir,
+        px_generate_uorb_topic_files.generate_uRTPS_general(classifier.msgs_to_send, classifier.alias_msgs_to_send, classifier.msgs_to_receive, classifier.alias_msgs_to_receive, msg_dir, os.path.dirname(out_dir),
                                                             urtps_templates_dir, package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, fastrtps_version, ros2_distro, uRTPS_AGENT_CMAKELISTS_TEMPL_FILE)
 
     # Final steps to install agent
@@ -450,10 +450,10 @@ def generate_agent(out_dir):
     cp_wildcard(os.path.join(urtps_templates_dir,
                              "microRTPS_transport.*"), agent_out_dir)
     if cmakelists:
-        os.rename(os.path.join(out_dir, "microRTPS_agent_CMakeLists.txt"),
-                  os.path.join(out_dir, "CMakeLists.txt"))
+        os.rename(os.path.join(os.path.dirname(out_dir), "microRTPS_agent_CMakeLists.txt"),
+                  os.path.join(os.path.dirname(out_dir), "CMakeLists.txt"))
     if (mkdir_build):
-        mkdir_p(os.path.join(out_dir, "build"))
+        mkdir_p(os.path.join(os.path.dirname(out_dir), "build"))
     os.chdir(prev_cwd_path)
     return 0
 

--- a/src/modules/micrortps_bridge/micrortps_client/CMakeLists.txt
+++ b/src/modules/micrortps_bridge/micrortps_client/CMakeLists.txt
@@ -81,7 +81,7 @@ if (NOT "${config_rtps_send_topics}" STREQUAL "" OR NOT "${config_rtps_receive_t
 			--urtps-templates-dir templates/urtps
 			--agent-outdir ${micrortps_bridge_path}/micrortps_agent/src
 			--client-outdir ${micrortps_bridge_path}/micrortps_client
-			--idl-dir ../micrortps_agent/idl
+			--idl-dir ${micrortps_bridge_path}/micrortps_agent/idl
 			>micrortps_bridge.log >/dev/null
 		DEPENDS ${send_topic_files} ${receive_topic_files}
 		COMMENT "Generating RTPS topic bridge"

--- a/src/modules/micrortps_bridge/micrortps_client/CMakeLists.txt
+++ b/src/modules/micrortps_bridge/micrortps_client/CMakeLists.txt
@@ -32,6 +32,7 @@
 ############################################################################
 
 set(msg_out_path ${CMAKE_CURRENT_BINARY_DIR})
+get_filename_component(micrortps_bridge_path ${msg_out_path} PATH)
 
 if (NOT "${config_rtps_send_topics}" STREQUAL "" OR NOT "${config_rtps_receive_topics}" STREQUAL "")
 
@@ -54,19 +55,19 @@ if (NOT "${config_rtps_send_topics}" STREQUAL "" OR NOT "${config_rtps_receive_t
 	endif()
 
 	foreach(topic ${config_rtps_send_topics})
-		list(APPEND topic_bridge_files_out ${msg_out_path}/micrortps_agent/${topic}_Publisher.cpp)
-		list(APPEND topic_bridge_files_out ${msg_out_path}/micrortps_agent/${topic}_Publisher.h)
+		list(APPEND topic_bridge_files_out ${micrortps_bridge_path}/micrortps_agent/${topic}_Publisher.cpp)
+		list(APPEND topic_bridge_files_out ${micrortps_bridge_path}/micrortps_agent/${topic}_Publisher.h)
 	endforeach()
 
 	foreach(topic ${config_rtps_receive_topics})
-		list(APPEND topic_bridge_files_out ${msg_out_path}/micrortps_agent/${topic}_Subscriber.cpp)
-		list(APPEND topic_bridge_files_out ${msg_out_path}/micrortps_agent/${topic}_Subscriber.h)
+		list(APPEND topic_bridge_files_out ${micrortps_bridge_path}/micrortps_agent/${topic}_Subscriber.cpp)
+		list(APPEND topic_bridge_files_out ${micrortps_bridge_path}/micrortps_agent/${topic}_Subscriber.h)
 	endforeach()
 
 	list(APPEND topic_bridge_files_out
-		${msg_out_path}/micrortps_client/microRTPS_client.cpp
-		${msg_out_path}/micrortps_client/microRTPS_transport.cpp
-		${msg_out_path}/micrortps_client/microRTPS_transport.h
+		${micrortps_bridge_path}/micrortps_client/microRTPS_client.cpp
+		${micrortps_bridge_path}/micrortps_client/microRTPS_transport.cpp
+		${micrortps_bridge_path}/micrortps_client/microRTPS_transport.h
 		)
 
 	add_custom_command(OUTPUT ${topic_bridge_files_out}
@@ -78,9 +79,9 @@ if (NOT "${config_rtps_send_topics}" STREQUAL "" OR NOT "${config_rtps_receive_t
 			--topic-msg-dir ${PX4_SOURCE_DIR}/msg
 			--uorb-templates-dir templates/uorb_microcdr
 			--urtps-templates-dir templates/urtps
-			--agent-outdir ${CMAKE_CURRENT_BINARY_DIR}/micrortps_agent
-			--client-outdir ${CMAKE_CURRENT_BINARY_DIR}/micrortps_client
-			--idl-dir ${CMAKE_CURRENT_BINARY_DIR}/micrortps_agent/idl
+			--agent-outdir ${micrortps_bridge_path}/micrortps_agent/src
+			--client-outdir ${micrortps_bridge_path}/micrortps_client
+			--idl-dir ../micrortps_agent/idl
 			>micrortps_bridge.log >/dev/null
 		DEPENDS ${send_topic_files} ${receive_topic_files}
 		COMMENT "Generating RTPS topic bridge"
@@ -93,11 +94,11 @@ if (NOT "${config_rtps_send_topics}" STREQUAL "" OR NOT "${config_rtps_receive_t
 		STACK_MAIN 4096
 		INCLUDES
 			${CMAKE_CURRENT_SOURCE_DIR}
-			${CMAKE_CURRENT_BINARY_DIR}/micrortps_client
+			${micrortps_bridge_path}/micrortps_client
 		SRCS
 			microRTPS_client_main.cpp
-			${msg_out_path}/micrortps_client/microRTPS_client.cpp
-			${msg_out_path}/micrortps_client/microRTPS_transport.cpp
+			${micrortps_bridge_path}/micrortps_client/microRTPS_client.cpp
+			${micrortps_bridge_path}/micrortps_client/microRTPS_transport.cpp
 		MODULE_CONFIG
 			module.yaml
 		DEPENDS


### PR DESCRIPTION
**Describe problem solved by this pull request**
To deploy the microRTPS agent in any system, it's currently required that one builds the `_rtps` target and then `cd` inside the `build` folder of the Firmware to get to the source files of the agent and then build it manually. Since the overall bridge was already validated, it made sense to automate the deployment of the different parts of the bridge (excluding the client, since it composes a PX4 Firmware module).

**Describe your solution**
1. Split the microRTPS agent and client destination directories, so one can handle them properly after the CMake build.
2. Add a deploy stage for the microRTPS bridge source code (including the PX4 generated IDL files for convenience) to the https://github.com/PX4/micrortps_agent repo.
