### PR TITLE
parameters: delete unused PARAM_TYPE_STRUCT

### DIFF
--- a/src/lib/parameters/flashparams/flashparams.cpp
+++ b/src/lib/parameters/flashparams/flashparams.cpp
@@ -110,7 +110,6 @@ param_export_internal(bool only_unsaved)
 		/* append the appropriate BSON type object */
 
 		switch (param_type(s->param)) {
-
 		case PARAM_TYPE_INT32:
 			i = s->val.i;
 
@@ -125,18 +124,6 @@ param_export_internal(bool only_unsaved)
 			f = s->val.f;
 
 			if (bson_encoder_append_double(&encoder, param_name(s->param), f)) {
-				debug("BSON append failed for '%s'", param_name(s->param));
-				goto out;
-			}
-
-			break;
-
-		case PARAM_TYPE_STRUCT ... PARAM_TYPE_STRUCT_MAX:
-			if (bson_encoder_append_binary(&encoder,
-						       param_name(s->param),
-						       BSON_BIN_BINARY,
-						       param_size(s->param),
-						       param_get_value_ptr_external(s->param))) {
 				debug("BSON append failed for '%s'", param_name(s->param));
 				goto out;
 			}

--- a/src/lib/parameters/param.h
+++ b/src/lib/parameters/param.h
@@ -57,16 +57,12 @@ __BEGIN_DECLS
 /**
  * Parameter types.
  */
-#define PARAM_TYPE_INT32		0
-#define PARAM_TYPE_FLOAT		1
-#define PARAM_TYPE_STRUCT		100
-#define PARAM_TYPE_STRUCT_MAX	(16384 + PARAM_TYPE_STRUCT)
-#define PARAM_TYPE_UNKNOWN		(0xffff)
+#define PARAM_TYPE_UNKNOWN		0
+#define PARAM_TYPE_INT32		1
+#define PARAM_TYPE_FLOAT		2
 
-typedef uint16_t param_type_t;
+typedef uint8_t param_type_t;
 
-
-#ifdef __PX4_NUTTX // on NuttX use 16 bits to save RAM
 /**
  * Parameter handle.
  *
@@ -85,29 +81,6 @@ typedef uint16_t	param_t;
  * Magic handle for hash check param
  */
 #define PARAM_HASH      ((uint16_t)INT16_MAX)
-
-#else // on other platforms use 32 bits for better performance
-
-/**
- * Parameter handle.
- *
- * Parameters are represented by parameter handles, which can
- * be obtained by looking up parameters. They are an offset into a global
- * constant parameter array.
- */
-typedef uint32_t	param_t;
-
-/**
- * Handle returned when a parameter cannot be found.
- */
-#define PARAM_INVALID	((uint32_t)0xffffffff)
-
-/**
- * Magic handle for hash check param
- */
-#define PARAM_HASH      ((uint32_t)INT32_MAX)
-
-#endif /* __PX4_NUTTX */
 
 
 /**

--- a/src/lib/parameters/parameters_shmem.cpp
+++ b/src/lib/parameters/parameters_shmem.cpp
@@ -541,16 +541,10 @@ size_t
 param_size(param_t param)
 {
 	if (handle_in_range(param)) {
-
 		switch (param_type(param)) {
-
 		case PARAM_TYPE_INT32:
 		case PARAM_TYPE_FLOAT:
 			return 4;
-
-		case PARAM_TYPE_STRUCT ... PARAM_TYPE_STRUCT_MAX:
-			/* decode structure size from type value */
-			return param_type(param) - PARAM_TYPE_STRUCT;
 
 		default:
 			return 0;
@@ -588,14 +582,7 @@ param_get_value_ptr(param_t param)
 			v = &param_info_base[param].val;
 		}
 
-		if (param_type(param) >= PARAM_TYPE_STRUCT &&
-		    param_type(param) <= PARAM_TYPE_STRUCT_MAX) {
-
-			result = v->p;
-
-		} else {
-			result = v;
-		}
+		result = v;
 	}
 
 	return result;
@@ -761,7 +748,6 @@ param_set_internal(param_t param, const void *val, bool mark_saved, bool notify_
 
 		/* update the changed value */
 		switch (param_type(param)) {
-
 		case PARAM_TYPE_INT32:
 			params_changed = params_changed || s->val.i != *(int32_t *)val;
 			s->val.i = *(int32_t *)val;
@@ -770,27 +756,6 @@ param_set_internal(param_t param, const void *val, bool mark_saved, bool notify_
 		case PARAM_TYPE_FLOAT:
 			params_changed = params_changed || fabsf(s->val.f - * (float *)val) > FLT_EPSILON;
 			s->val.f = *(float *)val;
-			break;
-
-		case PARAM_TYPE_STRUCT ... PARAM_TYPE_STRUCT_MAX:
-			if (s->val.p == nullptr) {
-				size_t psize = param_size(param);
-
-				if (psize > 0) {
-					s->val.p = malloc(psize);
-
-				} else {
-					s->val.p = nullptr;
-				}
-
-				if (s->val.p == nullptr) {
-					PX4_ERR("failed to allocate parameter storage");
-					goto out;
-				}
-			}
-
-			memcpy(s->val.p, val, param_size(param));
-			params_changed = true;
 			break;
 
 		default:
@@ -1193,22 +1158,6 @@ param_export(int fd, bool only_unsaved)
 				PX4_DEBUG("exporting: %s (%d) size: %d val: %.3f", name, s->param, size, (double)f);
 
 				if (bson_encoder_append_double(&encoder, name, f)) {
-					PX4_ERR("BSON append failed for '%s'", name);
-					goto out;
-				}
-			}
-			break;
-
-		case PARAM_TYPE_STRUCT ... PARAM_TYPE_STRUCT_MAX: {
-				const void *value_ptr = param_get_value_ptr(s->param);
-
-				/* lock as short as possible */
-				if (bson_encoder_append_binary(&encoder,
-							       name,
-							       BSON_BIN_BINARY,
-							       size,
-							       value_ptr)) {
-
 					PX4_ERR("BSON append failed for '%s'", name);
 					goto out;
 				}

--- a/src/systemcmds/param/param.cpp
+++ b/src/systemcmds/param/param.cpp
@@ -638,10 +638,6 @@ do_show_print(void *arg, param_t param)
 
 		break;
 
-	case PARAM_TYPE_STRUCT ... PARAM_TYPE_STRUCT_MAX:
-		PARAM_PRINT("<struct type %d size %zu>\n", 0 + param_type(param), param_size(param));
-		return;
-
 	default:
 		PARAM_PRINT("<unknown type %d>\n", 0 + param_type(param));
 		return;


### PR DESCRIPTION
PARAM_TYPE_STRUCT was never really used and potentially gets in the way of newer parameter system development.