### PR TITLE
start replacing sensor_combined usage (multi-EKF preparation)

### DIFF
--- a/src/drivers/telemetry/frsky_telemetry/frsky_data.cpp
+++ b/src/drivers/telemetry/frsky_telemetry/frsky_data.cpp
@@ -53,7 +53,7 @@
 
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/battery_status.h>
-#include <uORB/topics/sensor_combined.h>
+#include <uORB/topics/vehicle_acceleration.h>
 #include <uORB/topics/vehicle_air_data.h>
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_global_position.h>
@@ -67,7 +67,7 @@
 struct frsky_subscription_data_s {
 
 	uORB::SubscriptionData<battery_status_s> battery_status_sub{ORB_ID(battery_status)};
-	uORB::SubscriptionData<sensor_combined_s> sensor_combined_sub{ORB_ID(sensor_combined)};
+	uORB::SubscriptionData<vehicle_acceleration_s> vehicle_acceleration_sub{ORB_ID(vehicle_acceleration)};
 	uORB::SubscriptionData<vehicle_air_data_s> vehicle_air_data_sub{ORB_ID(vehicle_air_data)};
 	uORB::SubscriptionData<vehicle_local_position_s> vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
 	uORB::SubscriptionData<vehicle_global_position_s> vehicle_global_position_sub{ORB_ID(vehicle_global_position)};
@@ -149,7 +149,7 @@ static void frsky_send_data(int uart, uint8_t id, int16_t data)
 void frsky_update_topics()
 {
 	subscription_data->battery_status_sub.update();
-	subscription_data->sensor_combined_sub.update();
+	subscription_data->vehicle_acceleration_sub.update();
 	subscription_data->vehicle_air_data_sub.update();
 	subscription_data->vehicle_local_position_sub.update();
 	subscription_data->vehicle_global_position_sub.update();
@@ -164,10 +164,10 @@ void frsky_update_topics()
 void frsky_send_frame1(int uart)
 {
 	/* send formatted frame */
-	const sensor_combined_s &sensor_combined = subscription_data->sensor_combined_sub.get();
-	frsky_send_data(uart, FRSKY_ID_ACCEL_X, roundf(sensor_combined.accelerometer_m_s2[0] * 1000.0f));
-	frsky_send_data(uart, FRSKY_ID_ACCEL_Y, roundf(sensor_combined.accelerometer_m_s2[1] * 1000.0f));
-	frsky_send_data(uart, FRSKY_ID_ACCEL_Z, roundf(sensor_combined.accelerometer_m_s2[2] * 1000.0f));
+	const vehicle_acceleration_s &vehicle_acceleration = subscription_data->vehicle_acceleration_sub.get();
+	frsky_send_data(uart, FRSKY_ID_ACCEL_X, roundf(vehicle_acceleration.xyz[0] * 1000.0f));
+	frsky_send_data(uart, FRSKY_ID_ACCEL_Y, roundf(vehicle_acceleration.xyz[1] * 1000.0f));
+	frsky_send_data(uart, FRSKY_ID_ACCEL_Z, roundf(vehicle_acceleration.xyz[2] * 1000.0f));
 
 	const vehicle_air_data_s &air_data = subscription_data->vehicle_air_data_sub.get();
 	frsky_send_data(uart, FRSKY_ID_BARO_ALT_BP, air_data.baro_alt_meter);

--- a/src/drivers/telemetry/frsky_telemetry/sPort_data.cpp
+++ b/src/drivers/telemetry/frsky_telemetry/sPort_data.cpp
@@ -53,7 +53,7 @@
 
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/battery_status.h>
-#include <uORB/topics/sensor_combined.h>
+#include <uORB/topics/vehicle_acceleration.h>
 #include <uORB/topics/vehicle_air_data.h>
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_local_position.h>
@@ -66,7 +66,7 @@
 
 struct s_port_subscription_data_s {
 	uORB::SubscriptionData<battery_status_s> battery_status_sub{ORB_ID(battery_status)};
-	uORB::SubscriptionData<sensor_combined_s> sensor_combined_sub{ORB_ID(sensor_combined)};
+	uORB::SubscriptionData<vehicle_acceleration_s> vehicle_acceleration_sub{ORB_ID(vehicle_acceleration)};
 	uORB::SubscriptionData<vehicle_air_data_s> vehicle_air_data_sub{ORB_ID(vehicle_air_data)};
 	uORB::SubscriptionData<vehicle_global_position_s> vehicle_global_position_sub{ORB_ID(vehicle_global_position)};
 	uORB::SubscriptionData<vehicle_gps_position_s> vehicle_gps_position_sub{ORB_ID(vehicle_gps_position)};
@@ -102,7 +102,7 @@ void sPort_deinit()
 void sPort_update_topics()
 {
 	s_port_subscription_data->battery_status_sub.update();
-	s_port_subscription_data->sensor_combined_sub.update();
+	s_port_subscription_data->vehicle_acceleration_sub.update();
 	s_port_subscription_data->vehicle_air_data_sub.update();
 	s_port_subscription_data->vehicle_global_position_sub.update();
 	s_port_subscription_data->vehicle_gps_position_sub.update();

--- a/src/examples/px4_simple_app/px4_simple_app.c
+++ b/src/examples/px4_simple_app/px4_simple_app.c
@@ -48,7 +48,7 @@
 #include <math.h>
 
 #include <uORB/uORB.h>
-#include <uORB/topics/sensor_combined.h>
+#include <uORB/topics/vehicle_acceleration.h>
 #include <uORB/topics/vehicle_attitude.h>
 
 __EXPORT int px4_simple_app_main(int argc, char *argv[]);
@@ -57,8 +57,8 @@ int px4_simple_app_main(int argc, char *argv[])
 {
 	PX4_INFO("Hello Sky!");
 
-	/* subscribe to sensor_combined topic */
-	int sensor_sub_fd = orb_subscribe(ORB_ID(sensor_combined));
+	/* subscribe to vehicle_acceleration topic */
+	int sensor_sub_fd = orb_subscribe(ORB_ID(vehicle_acceleration));
 	/* limit the update rate to 5 Hz */
 	orb_set_interval(sensor_sub_fd, 200);
 
@@ -99,20 +99,20 @@ int px4_simple_app_main(int argc, char *argv[])
 
 			if (fds[0].revents & POLLIN) {
 				/* obtained data for the first file descriptor */
-				struct sensor_combined_s raw;
+				struct vehicle_acceleration_s accel;
 				/* copy sensors raw data into local buffer */
-				orb_copy(ORB_ID(sensor_combined), sensor_sub_fd, &raw);
+				orb_copy(ORB_ID(vehicle_acceleration), sensor_sub_fd, &accel);
 				PX4_INFO("Accelerometer:\t%8.4f\t%8.4f\t%8.4f",
-					 (double)raw.accelerometer_m_s2[0],
-					 (double)raw.accelerometer_m_s2[1],
-					 (double)raw.accelerometer_m_s2[2]);
+					 (double)accel.xyz[0],
+					 (double)accel.xyz[1],
+					 (double)accel.xyz[2]);
 
 				/* set att and publish this information for other apps
 				 the following does not have any meaning, it's just an example
 				*/
-				att.q[0] = raw.accelerometer_m_s2[0];
-				att.q[1] = raw.accelerometer_m_s2[1];
-				att.q[2] = raw.accelerometer_m_s2[2];
+				att.q[0] = accel.xyz[0];
+				att.q[1] = accel.xyz[1];
+				att.q[2] = accel.xyz[2];
 
 				orb_publish(ORB_ID(vehicle_attitude), att_pub, &att);
 			}

--- a/src/examples/uuv_example_app/uuv_example_app.cpp
+++ b/src/examples/uuv_example_app/uuv_example_app.cpp
@@ -62,7 +62,7 @@
 
 // Include uORB and the required topics for this app
 #include <uORB/uORB.h>
-#include <uORB/topics/sensor_combined.h>                // this topics hold the acceleration data
+#include <uORB/topics/vehicle_acceleration.h>                // this topics hold the acceleration data
 #include <uORB/topics/actuator_controls.h>              // this topic gives the actuators control input
 #include <uORB/topics/vehicle_attitude.h>                  // this topic holds the orientation of the hippocampus
 
@@ -72,8 +72,8 @@ int uuv_example_app_main(int argc, char *argv[])
 {
 	PX4_INFO("auv_hippocampus_example_app has been started!");
 
-	/* subscribe to sensor_combined topic */
-	int sensor_sub_fd = orb_subscribe(ORB_ID(sensor_combined));
+	/* subscribe to vehicle_acceleration topic */
+	int sensor_sub_fd = orb_subscribe(ORB_ID(vehicle_acceleration));
 	/* limit the update rate to 5 Hz */
 	orb_set_interval(sensor_sub_fd, 200);
 
@@ -118,17 +118,17 @@ int uuv_example_app_main(int argc, char *argv[])
 
 			if (fds[0].revents & POLLIN) {
 				/* obtained data for the first file descriptor */
-				struct sensor_combined_s raw_sensor;
+				vehicle_acceleration_s sensor{};
 				/* copy sensors raw data into local buffer */
-				orb_copy(ORB_ID(sensor_combined), sensor_sub_fd, &raw_sensor);
+				orb_copy(ORB_ID(vehicle_acceleration), sensor_sub_fd, &sensor);
 				// printing the sensor data into the terminal
 				PX4_INFO("Acc:\t%8.4f\t%8.4f\t%8.4f",
-					 (double)raw_sensor.accelerometer_m_s2[0],
-					 (double)raw_sensor.accelerometer_m_s2[1],
-					 (double)raw_sensor.accelerometer_m_s2[2]);
+					 (double)sensor.xyz[0],
+					 (double)sensor.xyz[1],
+					 (double)sensor.xyz[2]);
 
 				/* obtained data for the third file descriptor */
-				struct vehicle_attitude_s raw_ctrl_state;
+				vehicle_attitude_s raw_ctrl_state{};
 				/* copy sensors raw data into local buffer */
 				orb_copy(ORB_ID(vehicle_attitude), vehicle_attitude_sub_fd, &raw_ctrl_state);
 

--- a/src/modules/commander/calibration_routines.cpp
+++ b/src/modules/commander/calibration_routines.cpp
@@ -52,7 +52,7 @@
 
 #include <uORB/Publication.hpp>
 #include <uORB/SubscriptionBlocking.hpp>
-#include <uORB/topics/sensor_combined.h>
+#include <uORB/topics/vehicle_acceleration.h>
 #include <uORB/topics/vehicle_command.h>
 #include <uORB/topics/vehicle_command_ack.h>
 
@@ -345,12 +345,12 @@ enum detect_orientation_return detect_orientation(orb_advert_t *mavlink_log_pub,
 	unsigned poll_errcount = 0;
 
 	// Setup subscriptions to onboard accel sensor
-	uORB::SubscriptionBlocking<sensor_combined_s> sensor_sub{ORB_ID(sensor_combined)};
+	uORB::SubscriptionBlocking<vehicle_acceleration_s> vehicle_acceleration_sub{ORB_ID(vehicle_acceleration)};
 
 	while (true) {
-		sensor_combined_s sensor;
+		vehicle_acceleration_s accel;
 
-		if (sensor_sub.updateBlocking(sensor, 100000)) {
+		if (vehicle_acceleration_sub.updateBlocking(accel, 100000)) {
 			t = hrt_absolute_time();
 			float dt = (t - t_prev) / 1000000.0f;
 			t_prev = t;
@@ -358,7 +358,7 @@ enum detect_orientation_return detect_orientation(orb_advert_t *mavlink_log_pub,
 
 			for (unsigned i = 0; i < ndim; i++) {
 
-				float di = sensor.accelerometer_m_s2[i];
+				float di = accel.xyz[i];
 
 				float d = di - accel_ema[i];
 				accel_ema[i] += d * w;

--- a/src/modules/commander/gyro_calibration.cpp
+++ b/src/modules/commander/gyro_calibration.cpp
@@ -55,7 +55,6 @@
 #include <lib/systemlib/mavlink_log.h>
 #include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionBlocking.hpp>
-#include <uORB/topics/sensor_combined.h>
 #include <uORB/topics/sensor_correction.h>
 #include <uORB/topics/sensor_gyro.h>
 

--- a/src/modules/commander/rc_calibration.cpp
+++ b/src/modules/commander/rc_calibration.cpp
@@ -44,7 +44,6 @@
 #include "commander_helper.h"
 
 #include <uORB/Subscription.hpp>
-#include <uORB/topics/sensor_combined.h>
 #include <uORB/topics/manual_control_setpoint.h>
 #include <systemlib/mavlink_log.h>
 #include <parameters/param.h>

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -86,6 +86,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("tecs_status", 200);
 	add_topic("test_motor", 500);
 	add_topic("trajectory_setpoint", 200);
+	add_topic("vehicle_acceleration", 50);
 	add_topic("vehicle_air_data", 200);
 	add_topic("vehicle_angular_velocity", 20);
 	add_topic("vehicle_attitude", 50);

--- a/src/modules/muorb/adsp/px4muorb.cpp
+++ b/src/modules/muorb/adsp/px4muorb.cpp
@@ -38,7 +38,6 @@
 #include <px4_platform_common/tasks.h>
 #include <px4_platform_common/posix.h>
 #include <dspal_platform.h>
-#include "uORB/topics/sensor_combined.h"
 #include "uORB.h"
 #include <parameters/param.h>
 #include <px4_platform_common/shmem.h>

--- a/src/modules/rover_pos_control/RoverPositionControl.cpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.cpp
@@ -357,7 +357,6 @@ RoverPositionControl::run()
 	_att_sp_sub = orb_subscribe(ORB_ID(vehicle_attitude_setpoint));
 
 	_vehicle_attitude_sub = orb_subscribe(ORB_ID(vehicle_attitude));
-	_sensor_combined_sub = orb_subscribe(ORB_ID(sensor_combined));
 
 	/* rate limit control mode updates to 5Hz */
 	orb_set_interval(_control_mode_sub, 200);
@@ -369,19 +368,17 @@ RoverPositionControl::run()
 	parameters_update(true);
 
 	/* wakeup source(s) */
-	px4_pollfd_struct_t fds[5];
+	px4_pollfd_struct_t fds[4] {};
 
 	/* Setup of loop */
 	fds[0].fd = _global_pos_sub;
 	fds[0].events = POLLIN;
 	fds[1].fd = _manual_control_setpoint_sub;
 	fds[1].events = POLLIN;
-	fds[2].fd = _sensor_combined_sub;
+	fds[2].fd = _vehicle_attitude_sub; // Poll attitude
 	fds[2].events = POLLIN;
-	fds[3].fd = _vehicle_attitude_sub; // Poll attitude
+	fds[3].fd = _local_pos_sub; // Added local position as source of position
 	fds[3].events = POLLIN;
-	fds[4].fd = _local_pos_sub;  // Added local position as source of position
-	fds[4].events = POLLIN;
 
 	while (!should_exit()) {
 
@@ -407,7 +404,7 @@ RoverPositionControl::run()
 		bool manual_mode = _control_mode.flag_control_manual_enabled;
 
 		/* only run controller if position changed */
-		if (fds[0].revents & POLLIN || fds[4].revents & POLLIN) {
+		if (fds[0].revents & POLLIN || fds[3].revents & POLLIN) {
 			perf_begin(_loop_perf);
 
 			/* load local copies */
@@ -476,7 +473,7 @@ RoverPositionControl::run()
 			perf_end(_loop_perf);
 		}
 
-		if (fds[3].revents & POLLIN) {
+		if (fds[2].revents & POLLIN) {
 
 			vehicle_attitude_poll();
 
@@ -505,24 +502,6 @@ RoverPositionControl::run()
 				_act_controls.control[actuator_controls_s::INDEX_THROTTLE] = _manual_control_setpoint.z;
 			}
 		}
-
-		if (fds[2].revents & POLLIN) {
-
-			orb_copy(ORB_ID(sensor_combined), _sensor_combined_sub, &_sensor_combined);
-
-			//orb_copy(ORB_ID(vehicle_attitude), _vehicle_attitude_sub, &_vehicle_att);
-			_act_controls.timestamp = hrt_absolute_time();
-
-			/* Only publish if any of the proper modes are enabled */
-			if (_control_mode.flag_control_velocity_enabled ||
-			    _control_mode.flag_control_attitude_enabled ||
-			    _control_mode.flag_control_position_enabled ||
-			    manual_mode) {
-				/* publish the actuator controls */
-				_actuator_controls_pub.publish(_act_controls);
-			}
-		}
-
 	}
 
 	orb_unsubscribe(_control_mode_sub);
@@ -531,9 +510,6 @@ RoverPositionControl::run()
 	orb_unsubscribe(_manual_control_setpoint_sub);
 	orb_unsubscribe(_pos_sp_triplet_sub);
 	orb_unsubscribe(_vehicle_attitude_sub);
-	orb_unsubscribe(_sensor_combined_sub);
-
-	warnx("exiting.\n");
 }
 
 int RoverPositionControl::task_spawn(int argc, char *argv[])

--- a/src/modules/rover_pos_control/RoverPositionControl.hpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.hpp
@@ -61,7 +61,6 @@
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/position_controller_status.h>
 #include <uORB/topics/position_setpoint_triplet.h>
-#include <uORB/topics/sensor_combined.h>
 #include <uORB/topics/vehicle_acceleration.h>
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/vehicle_attitude_setpoint.h>
@@ -110,7 +109,6 @@ private:
 	int		_pos_sp_triplet_sub{-1};
 	int		_att_sp_sub{-1};
 	int		_vehicle_attitude_sub{-1};
-	int		_sensor_combined_sub{-1};
 
 	uORB::Subscription	_parameter_update_sub{ORB_ID(parameter_update)};
 
@@ -122,7 +120,6 @@ private:
 	vehicle_local_position_s		_local_pos{};			/**< global vehicle position */
 	actuator_controls_s				_act_controls{};		/**< direct control of actuators */
 	vehicle_attitude_s				_vehicle_att{};
-	sensor_combined_s				_sensor_combined{};
 
 	SubscriptionData<vehicle_acceleration_s>		_vehicle_acceleration_sub{ORB_ID(vehicle_acceleration)};
 


### PR DESCRIPTION
In multi-EKF we have a `sensor_combined` (now `vehicle_imu`) for every EKF instance. Most remaining `sensor_combined` usage in the code base can be easily replaced by `vehicle_acceleration` or `sensor_selection` + `vehicle_imu`.

https://github.com/PX4/Firmware/pull/14650