### PR TITLE
sdp3x: remove reset during init

### DIFF
--- a/src/drivers/differential_pressure/sdp3x/SDP3X.cpp
+++ b/src/drivers/differential_pressure/sdp3x/SDP3X.cpp
@@ -66,23 +66,6 @@ int SDP3X::write_command(uint16_t command)
 bool
 SDP3X::init_sdp3x()
 {
-	if (get_device_address() == I2C_ADDRESS_1_SDP3X) { // since we are broadcasting, only do it for the first device address
-		// reset on broadcast
-		uint16_t prev_addr = get_device_address();
-		set_device_address(SDP3X_RESET_ADDR);
-		uint8_t reset_cmd = SDP3X_RESET_CMD;
-		int ret = transfer(&reset_cmd, 1, nullptr, 0);
-		set_device_address(prev_addr);
-
-		if (ret != PX4_OK) {
-			perf_count(_comms_errors);
-			return false;
-		}
-
-		// wait until sensor is ready
-		px4_usleep(20000);
-	}
-
 	return configure() == 0;
 }
 


### PR DESCRIPTION
It is not playing nice with other devices on the same bus.
In particular with the FreeFly RTK GPS: once the reset is sent, the whole bus is blocked and becomes unusable (this does not happen with the Pixhawk 4 GPS for example though).