### PR TITLE
[WIP] cuav/nora: Enable UAVCAN

### DIFF
--- a/boards/cuav/nora/default.cmake
+++ b/boards/cuav/nora/default.cmake
@@ -9,7 +9,7 @@ px4_add_board(
 	ROMFSROOT px4fmu_common
 	BUILD_BOOTLOADER
 	TESTING
-#	UAVCAN_INTERFACES 2  - No H7 or FD can support in UAVCAN
+	UAVCAN_INTERFACES 2
 	SERIAL_PORTS
 		GPS1:/dev/ttyS0
 		TEL1:/dev/ttyS1
@@ -53,7 +53,7 @@ px4_add_board(
 		telemetry # all available telemetry drivers
 		test_ppm
 		tone_alarm
-#		uavcan - No H7 or FD can support in UAVCAN yet
+		uavcan
 	MODULES
 		airspeed_selector
 		attitude_estimator_q


### PR DESCRIPTION
**Describe problem solved by this pull request**
Saw in the config that UAVCAN is not supported. As of today, I would say that support has been added in the meantime and the switch can be turned on here. The target, which has stm32h7, too, and got UAVCAN enabled, is `hex/cube-orange`.

**Describe your solution**
Uncommenting code to enable it.

**Describe possible alternatives**
Don't think you want to see any other solution than this.

**Test data / coverage**
Not tested on hardware. Needs feedback from manufacturer or user.

**Additional context**
\- nope -

Relates to:
https://github.com/PX4/Firmware/pull/14967
