### PR TITLE
Add the function of getting metadata to the message structure of uORB

### DIFF
--- a/msg/templates/uorb/msg.h.em
+++ b/msg/templates/uorb/msg.h.em
@@ -82,6 +82,11 @@ for field in spec.parsed_fields():
             print('#include <uORB/topics/%s.h>'%(name))
 }@
 
+/* register this as object request broker structure */
+@[for multi_topic in topics]@
+ORB_DECLARE(@multi_topic);
+@[end for]
+
 @# Constants c style
 #ifndef __cplusplus
 @[for constant in spec.constants]@
@@ -125,14 +130,13 @@ for constant in spec.constants:
         raise Exception("Type {0} not supported, add to to template file!".format(type_name))
 
     print('\tstatic constexpr %s %s = %s;'%(type_px4, constant.name, int(constant.val)))
+
+print('\tstatic inline const constexpr orb_metadata &get_metadata() {')
+print('\t\treturn *ORB_ID(%s);'%(topic_name))
+print('\t}')
 }
 #endif
 };
-
-/* register this as object request broker structure */
-@[for multi_topic in topics]@
-ORB_DECLARE(@multi_topic);
-@[end for]
 
 #ifdef __cplusplus
 void print_message(const @uorb_struct& message);

--- a/src/modules/uORB/Publication.hpp
+++ b/src/modules/uORB/Publication.hpp
@@ -90,7 +90,7 @@ public:
 	 * @param meta The uORB metadata (usually from the ORB_ID() macro) for the topic.
 	 */
 	Publication(ORB_ID id) : PublicationBase(id) {}
-	Publication(const orb_metadata *meta) : PublicationBase(static_cast<ORB_ID>(meta->o_id)) {}
+	Publication(const orb_metadata *meta = &T::get_metadata()) : PublicationBase(static_cast<ORB_ID>(meta->o_id)) {}
 
 	bool advertise()
 	{
@@ -128,7 +128,7 @@ public:
 	 * @param meta The uORB metadata (usually from the ORB_ID() macro) for the topic.
 	 */
 	PublicationData(ORB_ID id) : Publication<T>(id) {}
-	PublicationData(const orb_metadata *meta) : Publication<T>(meta) {}
+	PublicationData(const orb_metadata *meta = &T::get_metadata()) : Publication<T>(meta) {}
 
 	T	&get() { return _data; }
 	void	set(const T &data) { _data = data; }

--- a/src/modules/uORB/PublicationMulti.hpp
+++ b/src/modules/uORB/PublicationMulti.hpp
@@ -64,7 +64,7 @@ public:
 		PublicationBase(id)
 	{}
 
-	PublicationMulti(const orb_metadata *meta) :
+	PublicationMulti(const orb_metadata *meta = &T::get_metadata()) :
 		PublicationBase(static_cast<ORB_ID>(meta->o_id))
 	{}
 
@@ -105,7 +105,7 @@ public:
 	 * @param meta The uORB metadata (usually from the ORB_ID() macro) for the topic.
 	 */
 	PublicationMultiData(ORB_ID id) : PublicationMulti<T>(id) {}
-	PublicationMultiData(const orb_metadata *meta) : PublicationMulti<T>(meta) {}
+	PublicationMultiData(const orb_metadata *meta = &T::get_metadata()) : PublicationMulti<T>(meta) {}
 
 	T	&get() { return _data; }
 	void	set(const T &data) { _data = data; }

--- a/src/modules/uORB/Subscription.hpp
+++ b/src/modules/uORB/Subscription.hpp
@@ -169,7 +169,7 @@ public:
 	 * @param meta The uORB metadata (usually from the ORB_ID() macro) for the topic.
 	 * @param instance The instance for multi sub.
 	 */
-	SubscriptionData(const orb_metadata *meta, uint8_t instance = 0) :
+	SubscriptionData(const orb_metadata *meta = &T::get_metadata(), uint8_t instance = 0) :
 		Subscription(meta, instance)
 	{
 		copy(&_data);

--- a/src/modules/uORB/SubscriptionBlocking.hpp
+++ b/src/modules/uORB/SubscriptionBlocking.hpp
@@ -53,7 +53,7 @@ public:
 	 * @param interval_us The requested maximum update interval in microseconds.
 	 * @param instance The instance for multi sub.
 	 */
-	SubscriptionBlocking(const orb_metadata *meta, uint32_t interval_us = 0, uint8_t instance = 0) :
+	SubscriptionBlocking(const orb_metadata *meta = &T::get_metadata(), uint32_t interval_us = 0, uint8_t instance = 0) :
 		SubscriptionCallback(meta, interval_us, instance)
 	{
 		// pthread_mutexattr_init


### PR DESCRIPTION
This modification simplifies the construction of the C++ uORB ``Publication``/``Subscription`` class.
The static constant expression function of ``get_metadata()`` is added to the generated uORB message.
Use T::get_metadata() in ``Publication``/``Subscription`` class to easily get metadata.

A few suggestions:
1. Using this method can make ``orb_metadata`` in the uORB publish and subscribe related classes can all define constant reference types, reduce memory usage(maybe 1~2KB?), and reduce code inspection.

2. There is an inconsistency between the template type and the real message type in the current source code (vtol related code), so I did not replace all of them without authorization.

3. ``ORB_ID enum`` is a very redundant design, and it has the same name as ``ORB_ID()`` macro, you can quickly manage it in ``DeviceMaster``, but it should not be used externally, it can be replaced by this commit.

If this pull request passes, you can use the following regular expressions to replace all constructs:
Search:
``Publication(.*<(.*)_s>.*)\{(\s*ORB_ID\(\2\)[^,}]*,?\s?)+(.*\})``
Replace:
``Publication$1{$4``
It can complete most replacements.