### PR TITLE
batterry_status: fix checking default a_per_v

### DIFF
--- a/src/modules/battery_status/analog_battery.cpp
+++ b/src/modules/battery_status/analog_battery.cpp
@@ -116,7 +116,7 @@ AnalogBattery::updateParams()
 		}
 	}
 
-	if (_analog_params.a_per_v <= 0.0f) {
+	if (_analog_params.a_per_v < 0.0f) {
 		/* apply scaling according to defaults if set to default */
 
 		_analog_params.a_per_v = BOARD_BATTERY1_A_PER_V;


### PR DESCRIPTION
Without this patch if value of BAT1_A_PER_V parameter is zero and board doesn't support current measurment, that is BOARD_BATTERY1_A_PER_V define is not used (0 by default), batterry_status module will always write this parameter to mtd on each boot and on any paramer update.

Description for BAT1_A_PER_V already says that a value of -1 means to use the board default, so no big deal here.

Besides efficiency it looks like it can be very dangerous to write anything to mtd on boot for systems with unstable and bouncing power on turning on (especially without bootloader). I've got parameters corruptions several times - cluster of mtd get erased but wasn't written due to bouncing power off.