### PR TITLE
Enable reseting specific parameters to default from shell

### DIFF
--- a/.ci/Jenkinsfile-hardware
+++ b/.ci/Jenkinsfile-hardware
@@ -993,7 +993,7 @@ void cleanupFTDI() {
 
   // wipe parameters
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "mtd erase"'
-  sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param reset"'
+  sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param reset_all"'
 
   // disable buzzer and cleanup storage
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set CBRK_BUZZER 782097"'
@@ -1020,7 +1020,7 @@ void cleanupSEGGER() {
 
   // wipe parameters
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-SEGGER_*` --cmd "mtd erase"'
-  sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-SEGGER_*` --cmd "param reset"'
+  sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-SEGGER_*` --cmd "param reset_all"'
 
   // disable buzzer and cleanup storage
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-SEGGER_*` --cmd "param set CBRK_BUZZER 782097"'

--- a/ROMFS/cannode/init.d/rcS
+++ b/ROMFS/cannode/init.d/rcS
@@ -51,7 +51,7 @@ fi
 param select $PARAM_FILE
 if ! param load
 then
-	param reset
+	param reset_all
 fi
 
 #

--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -101,7 +101,7 @@ then
 	set AUTOCNF yes
 
 	# Wipe out params except RC*, flight modes, total flight time, accel cal, gyro cal, next flight UUID
-	param reset_nostart RC* COM_FLTMODE* LND_FLIGHT_T_* TC_* CAL_ACC* CAL_GYRO* COM_FLIGHT_UUID
+	param reset_all SYS_AUTOSTART SYS_AUTOCONFIG RC* COM_FLTMODE* LND_FLIGHT_T_* TC_* CAL_ACC* CAL_GYRO* COM_FLIGHT_UUID
 fi
 
 # multi-instance setup

--- a/ROMFS/px4fmu_common/init.d/airframes/4250_teal
+++ b/ROMFS/px4fmu_common/init.d/airframes/4250_teal
@@ -31,7 +31,7 @@ set PWM_OUT 1234
 if [ $AUTOCNF = yes ]
 then
 	# First thing, reset all params to default... EXCEPT THIS LIST
-	param reset_nostart RC* COM_FLTMODE* LND_FLIGHT_T_* TC_* CAL_ACC* CAL_GYRO* CAL_MAG* SENS_BOARD* EKF2_MAGBIAS*
+	param reset_all SYS_AUTOSTART SYS_AUTOCONFIG RC* COM_FLTMODE* LND_FLIGHT_T_* TC_* CAL_ACC* CAL_GYRO* CAL_MAG* SENS_BOARD* EKF2_MAGBIAS*
 
 	# battery
 	param set BAT_CAPACITY 2750

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -169,7 +169,7 @@ else
 	param select $PARAM_FILE
 	if ! param load
 	then
-		param reset
+		param reset_all
 	fi
 
 	#

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -180,7 +180,7 @@ else
 		if param compare SYS_AUTOCONFIG 1
 		then
 			# Wipe out params except RC*, flight modes, total flight time, accel cal, gyro cal, next flight UUID
-			param reset_nostart RC* COM_FLTMODE* LND_FLIGHT_T_* TC_* CAL_ACC* CAL_GYRO* COM_FLIGHT_UUID
+			param reset_all SYS_AUTOSTART SYS_AUTOCONFIG RC* COM_FLTMODE* LND_FLIGHT_T_* TC_* CAL_ACC* CAL_GYRO* COM_FLIGHT_UUID
 		fi
 
 		set AUTOCNF yes

--- a/src/lib/parameters/param.h
+++ b/src/lib/parameters/param.h
@@ -279,6 +279,16 @@ __EXPORT void		param_reset_all(void);
 __EXPORT void		param_reset_excludes(const char *excludes[], int num_excludes);
 
 /**
+ * Reset only specific parameters to their default values.
+ *
+ * This function also releases the storage used by struct parameters.
+ *
+ * @param resets Array of param names to reset. Use a wildcard at the end to reset parameters with a certain prefix.
+ * @param num_resets The number of passed reset conditions in the resets array.
+ */
+__EXPORT void		param_reset_specific(const char *resets[], int num_resets);
+
+/**
  * Export changed parameters to a file.
  * Note: this method requires a large amount of stack size!
  *

--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -881,8 +881,33 @@ param_reset_excludes(const char *excludes[], int num_excludes)
 			param_reset(param);
 		}
 	}
+}
 
-	_param_notify_changes();
+void
+param_reset_specific(const char *resets[], int num_resets)
+{
+	param_t	param;
+
+	for (param = 0; handle_in_range(param); param++) {
+		const char *name = param_name(param);
+		bool reset = false;
+
+		for (int index = 0; index < num_resets; index++) {
+			int len = strlen(resets[index]);
+
+			if ((resets[index][len - 1] == '*'
+			     && strncmp(name, resets[index], len - 1) == 0)
+			    || strcmp(name, resets[index]) == 0) {
+
+				reset = true;
+				break;
+			}
+		}
+
+		if (reset) {
+			param_reset(param);
+		}
+	}
 }
 
 int

--- a/src/systemcmds/param/param.cpp
+++ b/src/systemcmds/param/param.cpp
@@ -95,7 +95,6 @@ static int	do_compare(const char *name, char *vals[], unsigned comparisons, enum
 static int 	do_reset_all(const char *excludes[], int num_excludes);
 static int 	do_reset_specific(const char *resets[], int num_resets);
 static int 	do_touch(const char *params[], int num_params);
-static int	do_reset_nostart(const char *excludes[], int num_excludes);
 static int	do_find(const char *name);
 
 static void print_usage()
@@ -165,9 +164,6 @@ $ reboot
 	PRINT_MODULE_USAGE_COMMAND_DESCR("reset", "Reset only specified params to default");
 	PRINT_MODULE_USAGE_ARG("<param1> [<param2>]", "Parameter names to reset (wildcard at end allowed)", true);
 	PRINT_MODULE_USAGE_COMMAND_DESCR("reset_all", "Reset all params to default");
-	PRINT_MODULE_USAGE_ARG("<exclude1> [<exclude2>]", "Do not reset matching params (wildcard at end allowed)", true);
-	PRINT_MODULE_USAGE_COMMAND_DESCR("reset_nostart",
-					 "Reset params to default, but keep SYS_AUTOSTART and SYS_AUTOCONFIG");
 	PRINT_MODULE_USAGE_ARG("<exclude1> [<exclude2>]", "Do not reset matching params (wildcard at end allowed)", true);
 
 	PRINT_MODULE_USAGE_COMMAND_DESCR("index", "Show param for a given index");
@@ -328,15 +324,6 @@ param_main(int argc, char *argv[])
 			} else {
 				PX4_ERR("not enough arguments.");
 				return 1;
-			}
-		}
-
-		if (!strcmp(argv[1], "reset_nostart")) {
-			if (argc >= 3) {
-				return do_reset_nostart((const char **) &argv[2], argc - 2);
-
-			} else {
-				return do_reset_nostart(nullptr, 0);
 			}
 		}
 
@@ -834,27 +821,5 @@ do_touch(const char *params[], int num_params)
 			PX4_ERR("param %s not found", params[i]);
 		}
 	}
-	return 0;
-}
-
-static int
-do_reset_nostart(const char *excludes[], int num_excludes)
-{
-	int32_t autostart;
-	int32_t autoconfig;
-
-	(void)param_get(param_find("SYS_AUTOSTART"), &autostart);
-	(void)param_get(param_find("SYS_AUTOCONFIG"), &autoconfig);
-
-	if (num_excludes > 0) {
-		param_reset_excludes(excludes, num_excludes);
-
-	} else {
-		param_reset_all();
-	}
-
-	(void)param_set(param_find("SYS_AUTOSTART"), &autostart);
-	(void)param_set(param_find("SYS_AUTOCONFIG"), &autoconfig);
-
 	return 0;
 }


### PR DESCRIPTION
**Describe problem solved by this pull request**
There is currently no way to reset just one parameter to the default from shell/startup script.

This problem is bugging me for a long time:
You have an airframe that defines a ton of parameters some are defaults (for whatever reason), some not. Some need to be non-default because they are custom e.g. to enable a new non-default feature. Once the PX4 default is improved the airframe that ever had it custom needs to hardcode the default values and follow any upstream change to that part of the configuration from there on because otherwise existing vehicles don't get updated and are in an undefined state. Were they ever completely reset? Do they still have the old custom parameter?

After seeing `param show BAT_V_EMPTY` and `param set BAT_V_EMPTY 1` I expect `param reset BAT_V_EMPTY` to reset that parameter to its default value. I even did exactly that the first time, what could possibly go wrong.

**Describe your solution**
- `param reset {parameter name}` resets only that specific parameter with the possibility to specify multiple and the * wildcard.
- `param reset_all` resets all parameters with the possibility to have excludes and * wildcards.
- `param reset_nostart` is removed and all calls replaced with `param reset_all SYS_AUTOSTART SYS_AUTOCONFIG`

**Test data / coverage**
I SITL tested this. The only thing I found could be useful is result output e.g. following parameters were reset. There is no output like with all `param reset` before.
