### PR TITLE
microRTPS: small tweaks

### DIFF
--- a/msg/templates/urtps/microRTPS_agent.cpp.em
+++ b/msg/templates/urtps/microRTPS_agent.cpp.em
@@ -90,9 +90,6 @@ Transport_node *transport_node = nullptr;
 RtpsTopics topics;
 uint32_t total_sent = 0, sent = 0;
 
-// Init timesync
-std::shared_ptr<TimeSync> timeSync = std::make_shared<TimeSync>();
-
 struct options {
     enum class eTransports
     {
@@ -174,7 +171,6 @@ void signal_handler(int signum)
    printf("\033[1;33m[   micrortps_agent   ]\tInterrupt signal (%d) received.\033[0m\n", signum);
    running = 0;
    transport_node->close();
-   timeSync->stop();
 }
 
 @[if recv_topics]@
@@ -271,6 +267,9 @@ int main(int argc, char** argv)
     std::chrono::time_point<std::chrono::steady_clock> start, end;
 @[end if]@
 
+    // Init timesync
+    std::shared_ptr<TimeSync> timeSync = std::make_shared<TimeSync>(_options.verbose_debug);
+
     topics.set_timesync(timeSync);
 
 @[if recv_topics]@
@@ -319,6 +318,7 @@ int main(int argc, char** argv)
     delete transport_node;
     transport_node = nullptr;
 
+    timeSync->stop();
     timeSync->reset();
 
     return 0;

--- a/msg/templates/urtps/microRTPS_timesync.h.em
+++ b/msg/templates/urtps/microRTPS_timesync.h.em
@@ -109,7 +109,7 @@ using TimesyncPublisher = timesync_Publisher;
 
 class TimeSync {
 public:
-	TimeSync();
+	TimeSync(bool debug);
 	virtual ~TimeSync();
 
 	/**
@@ -195,6 +195,8 @@ private:
 	int32_t _request_reset_counter;
 	uint8_t _last_msg_seq;
 	uint8_t _last_remote_msg_seq;
+
+	bool _debug;
 
 @[if ros2_distro]@
 	Timesync_Publisher _timesync_pub;

--- a/msg/tools/uorb_rtps_message_ids.yaml
+++ b/msg/tools/uorb_rtps_message_ids.yaml
@@ -7,27 +7,20 @@ rtps:
     id: 3
   - msg: adc_report
     id: 4
-    send: true
   - msg: airspeed
     id: 5
-    send: true
   - msg: battery_status
     id: 6
-    send: true
   - msg: camera_capture
     id: 7
-    receive: true
   - msg: camera_trigger
     id: 8
-    receive: true
   - msg: collision_report
     id: 9
-    receive: true
   - msg: commander_state
     id: 10
   - msg: cpuload
     id: 11
-    send: true
   - msg: debug_array
     id: 12
     receive: true
@@ -44,7 +37,6 @@ rtps:
     id: 16
   - msg: distance_sensor
     id: 17
-    send: true
   - msg: estimator_innovations
     id: 18
   - msg: ekf2_timestamps
@@ -59,7 +51,6 @@ rtps:
     id: 23
   - msg: estimator_status
     id: 24
-    send: true
   - msg: follow_target
     id: 25
   - msg: geofence_result
@@ -70,12 +61,10 @@ rtps:
     id: 28
   - msg: home_position
     id: 29
-    send: true
   - msg: input_rc
     id: 30
   - msg: iridiumsbd_status
     id: 31
-    send: true
   - msg: irlock_report
     id: 32
   - msg: landing_target_innovations
@@ -100,7 +89,6 @@ rtps:
     id: 42
   - msg: obstacle_distance
     id: 43
-    receive: true
   - msg: offboard_control_mode
     id: 44
   - msg: optical_flow
@@ -130,7 +118,6 @@ rtps:
     id: 55
   - msg: radio_status
     id: 56
-    send: true
   - msg: rate_ctrl_status
     id: 57
   - msg: rc_channels
@@ -146,7 +133,6 @@ rtps:
     id: 62
   - msg: sensor_baro
     id: 63
-    send: true
   - msg: estimator_sensor_bias
     id: 64
   - msg: sensor_combined
@@ -162,7 +148,6 @@ rtps:
     id: 69
   - msg: sensor_selection
     id: 70
-    send: true
   - msg: px4io_status
     id: 71
   - msg: subsystem_info
@@ -200,7 +185,6 @@ rtps:
     id: 86
   - msg: vehicle_attitude
     id: 87
-    send: true
   - msg: vehicle_attitude_setpoint
     id: 88
   - msg: vehicle_command
@@ -239,10 +223,8 @@ rtps:
     receive: true
   - msg: vtol_vehicle_status
     id: 105
-    send: true
   - msg: wind_estimate
     id: 106
-    send: true
   - msg: collision_constraints
     id: 107
     send: true


### PR DESCRIPTION
In the process of leveraging the [agent_protocol_splitter](https://github.com/Auterion/agent_protocol_splitter), some problems were found on the transport code that resulted on unneeded dropouts of certain msgs. This PR:

1. Solves a small (big) bug on the parsing of the packets when a packet is found to have a CRC error;
2. Adds verbosity control to the timesync functionality;
3. Reduce the number of RTPS streams (a lot didn't make sense to expose on the mission computer).

