### PR TITLE
Fixed problem with gyroscope not reading temperature

### DIFF
--- a/src/drivers/imu/bosch/bmi055/BMI055_Gyroscope.hpp
+++ b/src/drivers/imu/bosch/bmi055/BMI055_Gyroscope.hpp
@@ -96,6 +96,8 @@ private:
 	bool FIFORead(const hrt_abstime &timestamp_sample, uint8_t samples);
 	void FIFOReset();
 
+	void UpdateTemperature();
+
 	PX4Gyroscope _px4_gyro;
 
 	perf_counter_t _bad_register_perf{perf_alloc(PC_COUNT, MODULE_NAME"_gyro: bad register")};

--- a/src/drivers/imu/bosch/bmi055/Bosch_BMI055_Gyroscope_Registers.hpp
+++ b/src/drivers/imu/bosch/bmi055/Bosch_BMI055_Gyroscope_Registers.hpp
@@ -54,6 +54,8 @@ static constexpr uint8_t chip_id = 0x0F;
 enum class Register : uint8_t {
 	CHIP_ID        = 0x00,
 
+	GYRO_TEMP     = 0x08,
+
 	FIFO_STATUS    = 0x0E,
 	RANGE          = 0x0F,
 


### PR DESCRIPTION
The issue is https://github.com/PX4/Firmware/issues/15582.
I add some code to solve it.
![d1a071e94d581a75cf5be8ee2ea4c1a](https://user-images.githubusercontent.com/69180601/91534626-69c83d80-e944-11ea-81c0-f4e7d82be63c.png)
![7a057e7b6ce5b999ab4f6157ee7d0eb](https://user-images.githubusercontent.com/69180601/91534630-6b920100-e944-11ea-9ae9-50161a4fb78c.png)
![208685becbeb5bc6eeb571766983825](https://user-images.githubusercontent.com/69180601/91534636-6df45b00-e944-11ea-913a-8a7a093582bf.png)
![f2294d8d212ca0afc1ceadcf14ca003](https://user-images.githubusercontent.com/69180601/91534645-7187e200-e944-11ea-94e4-ff9fa31d93bf.png)
