### PR TITLE
bosch/bmi055: fix accel temperature reading

### DIFF
--- a/src/drivers/imu/bosch/bmi055/BMI055_Accelerometer.cpp
+++ b/src/drivers/imu/bosch/bmi055/BMI055_Accelerometer.cpp
@@ -455,7 +455,8 @@ void BMI055_Accelerometer::FIFOReset()
 void BMI055_Accelerometer::UpdateTemperature()
 {
 	// The slope of the temperature sensor is 0.5K/LSB, its center temperature is 23°C [(ACC 0x08) temp = 0x00].
-	float temperature = RegisterRead(Register::ACCD_TEMP) * 0.5f + 23.f;
+	// The register contains the current chip temperature represented in two’s complement format.
+	float temperature = static_cast<int8_t>(RegisterRead(Register::ACCD_TEMP)) * 0.5f + 23.f;
 
 	if (PX4_ISFINITE(temperature)) {
 		_px4_accel.set_temperature(temperature);


### PR DESCRIPTION
 - single register output is in 2's complement

I might have caught this earlier if I didn't live in Florida (temp<7:0>=0x00 corresponds to a temperature of 23°C). 

![Screenshot from 2020-08-28 10-00-39](https://user-images.githubusercontent.com/84712/91575267-5b166200-e915-11ea-87cc-3a9e1c8a6fe1.png)

@NicolasM0 can you give this a try?