### PR TITLE
Jenkins: replace 'python' with '.' to run the uORB to ROS conversion Python scritpt

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -292,12 +292,12 @@ pipeline {
             withCredentials([usernamePassword(credentialsId: 'px4buildbot_github_personal_token', passwordVariable: 'GIT_PASS', usernameVariable: 'GIT_USER')]) {
               sh("git clone https://${GIT_USER}:${GIT_PASS}@github.com/PX4/px4_msgs.git")
               // 'master' branch
-              sh('python msg/tools/uorb_to_ros_msgs.py msg/ px4_msgs/msg/')
+              sh('./msg/tools/uorb_to_ros_msgs.py msg/ px4_msgs/msg/')
               sh('cd px4_msgs; git status; git add .; git commit -a -m "Update message definitions `date`" || true')
               sh('cd px4_msgs; git push origin master || true')
               // 'ros1' branch
               sh('cd px4_msgs; git checkout ros1')
-              sh('python msg/tools/uorb_to_ros_msgs.py msg/ px4_msgs/msg/')
+              sh('./msg/tools/uorb_to_ros_msgs.py msg/ px4_msgs/msg/')
               sh('cd px4_msgs; git status; git add .; git commit -a -m "Update message definitions `date`" || true')
               sh('cd px4_msgs; git push origin ros1 || true')
               sh('rm -rf px4_msgs')


### PR DESCRIPTION
Fixes the problem reported in http://ci.px4.io:8080/blue/organizations/jenkins/PX4%2FFirmware/detail/master/2936/pipeline/221.
