### PR TITLE
fix thermal calibration if a sensor does not have temperature sensor

### DIFF
--- a/src/modules/temperature_compensation/TemperatureCompensationModule.cpp
+++ b/src/modules/temperature_compensation/TemperatureCompensationModule.cpp
@@ -67,7 +67,7 @@ void TemperatureCompensationModule::parameters_update()
 			int temp = _temperature_compensation.set_sensor_id_gyro(report.device_id, uorb_index);
 
 			if (temp < 0) {
-				PX4_ERR("%s init: failed to find device ID %u for instance %i", "gyro", report.device_id, uorb_index);
+				PX4_INFO("No temperature calibration available for gyro %i (device id %u)", uorb_index, report.device_id);
 				_corrections.gyro_device_ids[uorb_index] = 0;
 
 			} else {
@@ -84,8 +84,7 @@ void TemperatureCompensationModule::parameters_update()
 			int temp = _temperature_compensation.set_sensor_id_accel(report.device_id, uorb_index);
 
 			if (temp < 0) {
-				PX4_ERR("%s init: failed to find device ID %u for instance %i", "accel", report.device_id, uorb_index);
-
+				PX4_INFO("No temperature calibration available for accel %i (device id %u)", uorb_index, report.device_id);
 				_corrections.accel_device_ids[uorb_index] = 0;
 
 			} else {
@@ -102,7 +101,7 @@ void TemperatureCompensationModule::parameters_update()
 			int temp = _temperature_compensation.set_sensor_id_baro(report.device_id, uorb_index);
 
 			if (temp < 0) {
-				PX4_ERR("%s init: failed to find device ID %u for instance %i", "baro", report.device_id, uorb_index);
+				PX4_INFO("No temperature calibration available for baro %i (device id %u)", uorb_index, report.device_id);
 				_corrections.baro_device_ids[uorb_index] = 0;
 
 			} else {

--- a/src/modules/temperature_compensation/temperature_calibration/accel.cpp
+++ b/src/modules/temperature_compensation/temperature_calibration/accel.cpp
@@ -87,6 +87,13 @@ int TemperatureCalibrationAccel::update_sensor_instance(PerSensorData &data, int
 		return 0;
 	}
 
+	if (PX4_ISFINITE(accel_data.temperature)) {
+		data.has_valid_temperature = true;
+
+	} else {
+		return 0;
+	}
+
 	data.device_id = accel_data.device_id;
 
 	data.sensor_sample_filt[0] = accel_data.x;
@@ -167,6 +174,14 @@ int TemperatureCalibrationAccel::finish()
 
 int TemperatureCalibrationAccel::finish_sensor_instance(PerSensorData &data, int sensor_index)
 {
+	if (!data.has_valid_temperature) {
+		PX4_WARN("Result Accel %d does not have a valid temperature sensor", sensor_index);
+
+		uint32_t param = 0;
+		set_parameter("TC_A%d_ID", sensor_index, &param);
+		return 0;
+	}
+
 	if (!data.hot_soaked || data.tempcal_complete) {
 		return 0;
 	}

--- a/src/modules/temperature_compensation/temperature_calibration/baro.cpp
+++ b/src/modules/temperature_compensation/temperature_calibration/baro.cpp
@@ -87,6 +87,13 @@ int TemperatureCalibrationBaro::update_sensor_instance(PerSensorData &data, int 
 		return 0;
 	}
 
+	if (PX4_ISFINITE(baro_data.temperature)) {
+		data.has_valid_temperature = true;
+
+	} else {
+		return 0;
+	}
+
 	data.device_id = baro_data.device_id;
 
 	data.sensor_sample_filt[0] = 100.0f * baro_data.pressure; // convert from hPA to Pa
@@ -163,6 +170,14 @@ int TemperatureCalibrationBaro::finish()
 
 int TemperatureCalibrationBaro::finish_sensor_instance(PerSensorData &data, int sensor_index)
 {
+	if (!data.has_valid_temperature) {
+		PX4_WARN("Result baro %d does not have a valid temperature sensor", sensor_index);
+
+		uint32_t param = 0;
+		set_parameter("TC_B%d_ID", sensor_index, &param);
+		return 0;
+	}
+
 	if (!data.hot_soaked || data.tempcal_complete) {
 		return 0;
 	}

--- a/src/modules/temperature_compensation/temperature_calibration/common.h
+++ b/src/modules/temperature_compensation/temperature_calibration/common.h
@@ -146,6 +146,10 @@ public:
 			float min_diff = _min_temperature_rise;
 
 			for (unsigned uorb_index = 0; uorb_index < _num_sensor_instances; uorb_index++) {
+				if (!_data[uorb_index].has_valid_temperature) {
+					return 110;
+				}
+
 				float cur_diff = _data[uorb_index].high_temp - _data[uorb_index].low_temp;
 
 				if (cur_diff < min_diff) {
@@ -171,6 +175,7 @@ protected:
 		/// verified and the starting temperature set
 		bool hot_soaked = false; ///< true when the sensor has achieved the specified temperature increase
 		bool tempcal_complete = false; ///< true when the calibration has been completed
+		bool has_valid_temperature = false; ///< true if this sensor has temperature sensor
 		float low_temp = 0.f; ///< low temperature recorded at start of calibration (deg C)
 		float high_temp = 0.f; ///< highest temperature recorded during calibration (deg C)
 		float ref_temp = 0.f; /**< calibration reference temperature, nominally in the middle of the

--- a/src/modules/temperature_compensation/temperature_calibration/gyro.cpp
+++ b/src/modules/temperature_compensation/temperature_calibration/gyro.cpp
@@ -74,6 +74,13 @@ int TemperatureCalibrationGyro::update_sensor_instance(PerSensorData &data, int 
 		return 0;
 	}
 
+	if (PX4_ISFINITE(gyro_data.temperature)) {
+		data.has_valid_temperature = true;
+
+	} else {
+		return 0;
+	}
+
 	data.device_id = gyro_data.device_id;
 
 	data.sensor_sample_filt[0] = gyro_data.x;
@@ -154,6 +161,15 @@ int TemperatureCalibrationGyro::finish()
 
 int TemperatureCalibrationGyro::finish_sensor_instance(PerSensorData &data, int sensor_index)
 {
+	if (!data.has_valid_temperature) {
+		PX4_WARN("Result Gyro %d does not have a valid temperature sensor", sensor_index);
+		data.tempcal_complete = true;
+
+		uint32_t param = 0;
+		set_parameter("TC_G%d_ID", sensor_index, &param);
+		return 0;
+	}
+
 	if (!data.hot_soaked || data.tempcal_complete) {
 		return 0;
 	}


### PR DESCRIPTION
**Describe problem solved by this pull request**
If a sensor does not have temperature measurement, the onboard thermal calibration of other sensors will never finish.

This PR also change the message displayed as an error by thermal compensation module if a sensor does not have a thermal compensation. It is now the normal use case for some autopilots (eg: CUAV V5+).

**Describe your solution**
Sensors with no temperature measure are skipped.
The compensation not found error is now displayed as an info.

**Test data / coverage**
Tested on V5+ with no temperature data on gyro 2

**Additional context**
related to :
https://github.com/PX4/Firmware/pull/15644
https://github.com/PX4/Firmware/issues/15582
