### PR TITLE
i2c: use board-specific bus numbering for '-X -b <bus>' CLI

### DIFF
--- a/Tools/px4moduledoc/srcparser.py
+++ b/Tools/px4moduledoc/srcparser.py
@@ -134,7 +134,7 @@ class ModuleDocumentation(object):
             self._handle_usage_param_flag(['\'S\'', "\"External SPI bus(es)\"", 'true'])
 
         self._handle_usage_param_int(['\'b\'', '-1', '0', '16',
-            "\"bus (board-specific internal (default=all) or n-th external (default=1))\"", 'true'])
+            "\"board-specific bus (default=all) (external SPI: n-th bus (default=1))\"", 'true'])
 
         if self._is_bool_true(args[1]):
             self._handle_usage_param_int(['\'c\'', '1', '1', '10',

--- a/boards/cubepilot/cubeorange/init/rc.board_sensors
+++ b/boards/cubepilot/cubeorange/init/rc.board_sensors
@@ -14,4 +14,4 @@ icm20602 -s -b 4 -R 12 start
 icm20948 -s -b 4 -R 10 -M start
 
 # standard Here/Here2 connected to GPS1
-ak09916 -X -b 2 -R 6 start # external AK09916 (Here2) is rotated 270 degrees yaw
+ak09916 -X -b 1 -R 6 start # external AK09916 (Here2) is rotated 270 degrees yaw

--- a/boards/cubepilot/cubeyellow/init/rc.board_sensors
+++ b/boards/cubepilot/cubeyellow/init/rc.board_sensors
@@ -14,4 +14,4 @@ icm20602 -s -b 4 -R 12 start
 icm20948 -s -b 4 -R 10 -M start
 
 # standard Here/Here2 connected to GPS1
-ak09916 -X -b 2 -R 6 start # external AK09916 (Here2) is rotated 270 degrees yaw
+ak09916 -X -b 1 -R 6 start # external AK09916 (Here2) is rotated 270 degrees yaw

--- a/boards/holybro/pix32v5/init/rc.board_sensors
+++ b/boards/holybro/pix32v5/init/rc.board_sensors
@@ -22,4 +22,4 @@ ist8310 -I -R 10 start
 ms5611 -s start
 
 # External compass on GPS1/I2C1 (the 3rd external bus): standard Holybro GPS/compass puck (with lights, safety button, and buzzer)
-ist8310 -X -b 3 -R 10 start
+ist8310 -X -b 1 -R 10 start

--- a/boards/px4/fmu-v5/init/rc.board_sensors
+++ b/boards/px4/fmu-v5/init/rc.board_sensors
@@ -22,4 +22,4 @@ ms5611 -s start
 ist8310 -I -R 10 start
 
 # External compass on GPS1/I2C1 (the 3rd external bus): standard Holybro Pixhawk 4 or CUAV V5 GPS/compass puck (with lights, safety button, and buzzer)
-ist8310 -X -b 3 -R 10 start
+ist8310 -X -b 1 -R 10 start

--- a/platforms/common/i2c.cpp
+++ b/platforms/common/i2c.cpp
@@ -73,7 +73,7 @@ bool I2CBusIterator::next()
 			if (px4_i2c_bus_external(bus_data)) {
 				++_external_bus_counter;
 
-				if (_bus == _external_bus_counter || _bus == -1) {
+				if (_bus == bus_data.bus || _bus == -1) {
 					return true;
 				}
 			}

--- a/platforms/common/i2c_spi_buses.cpp
+++ b/platforms/common/i2c_spi_buses.cpp
@@ -504,14 +504,8 @@ int I2CSPIDriverBase::module_start(const BusCLIArguments &cli, BusInstanceIterat
 		// print some info that we are running
 		switch (iterator.busType()) {
 		case BOARD_I2C_BUS:
-			PX4_INFO_RAW("%s #%i on I2C bus %d", instance->ItemName(), runtime_instance, iterator.bus());
-
-			if (iterator.external()) {
-				PX4_INFO_RAW(" (external, equal to '-b %i')\n", iterator.externalBusIndex());
-
-			} else {
-				PX4_INFO_RAW("\n");
-			}
+			PX4_INFO_RAW("%s #%i on I2C bus %d%s\n", instance->ItemName(), runtime_instance, iterator.bus(),
+				     iterator.external() ? " (external)" : "");
 
 			break;
 

--- a/platforms/common/module.cpp
+++ b/platforms/common/module.cpp
@@ -102,7 +102,7 @@ void PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(bool i2c_support, bool spi_support
 		PRINT_MODULE_USAGE_PARAM_FLAG('S', "External SPI bus", true);
 	}
 
-	PRINT_MODULE_USAGE_PARAM_INT('b', -1, 0, 16, "bus (board-specific internal (default=all) or n-th external (default=1))",
+	PRINT_MODULE_USAGE_PARAM_INT('b', -1, 0, 16, "board-specific bus (default=all) (external SPI: n-th bus (default=1))",
 				     true);
 
 	if (spi_support) {


### PR DESCRIPTION
As boards don't have their external buses labeled consistently, it was not useful to use an abstraction.