### PR TITLE
NuttX sched notes add C linkage to fix arm-none-eabi-gcc 9

### DIFF
--- a/platforms/nuttx/src/px4/common/cpuload.cpp
+++ b/platforms/nuttx/src/px4/common/cpuload.cpp
@@ -45,20 +45,11 @@
 
 #include <drivers/drv_hrt.h>
 
-#include <sys/time.h>
-
 #if defined(__PX4_NUTTX) && defined(CONFIG_SCHED_INSTRUMENTATION)
-
+__BEGIN_DECLS
 # include <nuttx/sched_note.h>
 
-void sched_note_suspend(FAR struct tcb_s *tcb);
-void sched_note_resume(FAR struct tcb_s *tcb);
-
-__EXPORT void sched_note_switch(FAR struct tcb_s *pFromTcb, FAR struct tcb_s *pToTcb);
-
 __EXPORT struct system_load_s system_load;
-
-extern FAR struct tcb_s *sched_gettcb(pid_t pid);
 
 static px4::atomic_int cpuload_monitor_all_count{0};
 
@@ -200,5 +191,5 @@ void sched_note_resume(FAR struct tcb_s *tcb)
 		}
 	}
 }
-
+__END_DECLS
 #endif // PX4_NUTTX && CONFIG_SCHED_INSTRUMENTATION


### PR DESCRIPTION
For some reason the NuttX scheduling note linkage is broken with the updated arm-none-eabi toolchain (on MacOS at least).

``` Console
/usr/local/Cellar/gcc-arm-none-eabi/20200630/bin/../lib/gcc/arm-none-eabi/9.3.1/../../../../arm-none-eabi/bin/ld: NuttX/nuttx/sched/libsched.a(nx_start.o): in function `nx_start':
/Users/dagar/git/Firmware/build/px4_fmu-v5_default/NuttX/nuttx/sched/init/nx_start.c:756: undefined reference to `sched_note_start'
/usr/local/Cellar/gcc-arm-none-eabi/20200630/bin/../lib/gcc/arm-none-eabi/9.3.1/../../../../arm-none-eabi/bin/ld: NuttX/nuttx/sched/libsched.a(task_activate.o): in function `task_activate':
/Users/dagar/git/Firmware/build/px4_fmu-v5_default/NuttX/nuttx/sched/task/task_activate.c:82: undefined reference to `sched_note_stop'
/usr/local/Cellar/gcc-arm-none-eabi/20200630/bin/../lib/gcc/arm-none-eabi/9.3.1/../../../../arm-none-eabi/bin/ld: /Users/dagar/git/Firmware/build/px4_fmu-v5_default/NuttX/nuttx/sched/task/task_activate.c:89: undefined reference to `sched_note_start'
/usr/local/Cellar/gcc-arm-none-eabi/20200630/bin/../lib/gcc/arm-none-eabi/9.3.1/../../../../arm-none-eabi/bin/ld: NuttX/nuttx/sched/libsched.a(sched_suspendscheduler.o): in function `sched_suspend_scheduler':
/Users/dagar/git/Firmware/build/px4_fmu-v5_default/NuttX/nuttx/sched/sched/sched_suspendscheduler.c:92: undefined reference to `sched_note_suspend'
/usr/local/Cellar/gcc-arm-none-eabi/20200630/bin/../lib/gcc/arm-none-eabi/9.3.1/../../../../arm-none-eabi/bin/ld: NuttX/nuttx/sched/libsched.a(sched_resumescheduler.o): in function `sched_resume_scheduler':
/Users/dagar/git/Firmware/build/px4_fmu-v5_default/NuttX/nuttx/sched/sched/sched_resumescheduler.c:104: undefined reference to `sched_note_resume'
/usr/local/Cellar/gcc-arm-none-eabi/20200630/bin/../lib/gcc/arm-none-eabi/9.3.1/../../../../arm-none-eabi/bin/ld: NuttX/nuttx/sched/libsched.a(task_terminate.o): in function `nxtask_terminate':
/Users/dagar/git/Firmware/build/px4_fmu-v5_default/NuttX/nuttx/sched/task/task_terminate.c:196: undefined reference to `sched_note_stop'
collect2: error: ld returned 1 exit status
%
ninja: build stopped: subcommand failed.
make: *** [px4_fmu-v5_default] Error 1
```