### PR TITLE
Jenkins: temporarily disable MC safe landing SITL test

### DIFF
--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -42,13 +42,13 @@ pipeline {
               vehicle: "iris_obs_avoid",
               run_script: "rostest_avoidance_run.sh"
             ],
-            [
-              name: "MC_safe_landing",
-              test: "mavros_posix_test_safe_landing.test",
-              mission: "MC_safe_landing",
-              vehicle: "iris_obs_avoid",
-              run_script: "rostest_avoidance_run.sh"
-            ],
+            // [
+            //   name: "MC_safe_landing",
+            //   test: "mavros_posix_test_safe_landing.test",
+            //   mission: "MC_safe_landing",
+            //   vehicle: "iris_obs_avoid",
+            //   run_script: "rostest_avoidance_run.sh"
+            // ],
 
           ]
 


### PR DESCRIPTION
The MC safe landing SITL test continues to fail intermittently so I'm disabling it for now.

 - http://ci.px4.io:8080/blue/organizations/jenkins/PX4_misc%2FFirmware-SITL_tests/detail/PR-15687/3/pipeline
 - http://ci.px4.io:8080/blue/organizations/jenkins/PX4_misc%2FFirmware-SITL_tests/detail/master/2925/pipeline
 
FYI @Jaeyoung-Lim @mrivi 

I can dig up more examples if it would help.