### PR TITLE
ekf2: move "using" keywords to cpp

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -33,6 +33,10 @@
 
 #include "EKF2.hpp"
 
+using namespace time_literals;
+
+using math::constrain;
+
 EKF2::EKF2(bool replay_mode):
 	ModuleParams(nullptr),
 	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::nav_and_controllers),
@@ -1961,7 +1965,7 @@ float EKF2::filter_altitude_ellipsoid(float amsl_hgt)
 		float dt = 1e-6f * static_cast<float>(_gps_state[0].time_usec - _gps_alttitude_ellipsoid_previous_timestamp[0]);
 		_gps_alttitude_ellipsoid_previous_timestamp[0] = _gps_state[0].time_usec;
 		float offset_rate_correction = 0.1f * (height_diff - _wgs84_hgt_offset);
-		_wgs84_hgt_offset += dt * math::constrain(offset_rate_correction, -0.1f, 0.1f);
+		_wgs84_hgt_offset += dt * constrain(offset_rate_correction, -0.1f, 0.1f);
 	}
 
 	return amsl_hgt + _wgs84_hgt_offset;

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -94,9 +94,6 @@
 #define GPS_MAX_RECEIVERS 2
 #define GPS_BLENDED_INSTANCE 2
 
-using math::constrain;
-using namespace time_literals;
-
 class EKF2 final : public ModuleBase<EKF2>, public ModuleParams, public px4::ScheduledWorkItem
 {
 public:


### PR DESCRIPTION
Found that while checking https://github.com/PX4/Firmware/pull/15657