### PR TITLE
STM32H7 CAN: fix uninitialized pending variable

### DIFF
--- a/src/drivers/uavcan/uavcan_drivers/stm32h7/driver/include/uavcan_stm32h7/can.hpp
+++ b/src/drivers/uavcan/uavcan_drivers/stm32h7/driver/include/uavcan_stm32h7/can.hpp
@@ -99,8 +99,8 @@ class CanIface : public uavcan::ICanIface, uavcan::Noncopyable
 		bool abort_on_error;
 
 		TxItem()
-			: /*pending(false)
-			,*/ loopback(false)
+			: pending(false)
+			, loopback(false)
 			, abort_on_error(false)
 		{ }
 	};


### PR DESCRIPTION
STM32H7 CAN: fix uninitialized pending variable
