### PR TITLE
some gps driver cleanup

### DIFF
--- a/platforms/common/include/px4_platform_common/module.h
+++ b/platforms/common/include/px4_platform_common/module.h
@@ -239,10 +239,12 @@ public:
 
 				do {
 					unlock_module();
-					px4_usleep(20000); // 20 ms
+					px4_usleep(10000); // 10 ms
 					lock_module();
 
-					if (++i > 100 && _task_id != -1) { // wait at most 2 sec
+					if (++i > 500 && _task_id != -1) { // wait at most 5 sec
+						PX4_ERR("timeout, forcing stop");
+
 						if (_task_id != task_id_is_work_queue) {
 							px4_task_delete(_task_id);
 						}

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -294,18 +294,10 @@ GPS::~GPS()
 		} while (_secondary_instance && i < 100);
 	}
 
-	if (_sat_info) {
-		delete (_sat_info);
-	}
-
-	if (_dump_to_device) {
-		delete (_dump_to_device);
-	}
-
-	if (_dump_from_device) {
-		delete (_dump_from_device);
-	}
-
+	delete _sat_info;
+	delete _dump_to_device;
+	delete _dump_from_device;
+	delete _helper;
 }
 
 int GPS::callback(GPSCallbackType type, void *data1, int data2, void *user)


### PR DESCRIPTION
- use px4::atomic instead of volatile
- fix memory leak on module exit (delete _helper)
-  increase max timeout for stopping modules from 2s to 5s. The gps module might take up to 4s to stop (if stopped during module configuration). I've seen hardfaults when stopped in the wrong moment.