### PR TITLE
fixed erroneous task_spawn

### DIFF
--- a/src/modules/uuv_att_control/uuv_att_control.hpp
+++ b/src/modules/uuv_att_control/uuv_att_control.hpp
@@ -95,9 +95,6 @@ public:
 	/** @see ModuleBase */
 	static int task_spawn(int argc, char *argv[]);
 
-	/** @see ModuleBase */
-	static UUVAttitudeControl *instantiate(int argc, char *argv[]);
-
 	static int custom_command(int argc, char *argv[]);
 
 	/** @see ModuleBase */


### PR DESCRIPTION
**Describe problem solved by this pull request**
The uuv_att_control module did not spawn its task correctly. The problem was mentioned in [Slack](https://px4.slack.com/archives/C0V533X4N/p1599672383139200?thread_ts=1599672135.137400&cid=C0V533X4N). This request should fix it (also `perf_begin` and `perf_end` were placed oddly and are repositioned)