### PR TITLE
SITL: enable ROMFS & metadata storage

### DIFF
--- a/ROMFS/CMakeLists.txt
+++ b/ROMFS/CMakeLists.txt
@@ -137,15 +137,6 @@ add_custom_command(
 # copy extras into ROMFS
 set(extras_dependencies)
 
-if(config_bl_file)
-	file(MAKE_DIRECTORY ${PX4_BINARY_DIR}/romfs_extras)
-	configure_file(${config_bl_file} ${PX4_BINARY_DIR}/romfs_extras COPYONLY)
-
-	list(APPEND extras_dependencies
-		${config_bl_file}
-		)
-endif()
-
 # copy px4io binary if configured
 if(config_io_board)
 	list(APPEND extras_dependencies
@@ -193,13 +184,24 @@ foreach(board_rc_file ${OPTIONAL_BOARD_RC})
 
 endforeach()
 
+list(APPEND extras_dependencies
+	${config_romfs_extra_dependencies}
+	)
+
+if (config_romfs_extra_files)
+	set(extras_copy_cmd COMMAND ${CMAKE_COMMAND} -E copy_if_different ${config_romfs_extra_files} ${romfs_gen_root_dir}/extras/)
+else()
+	set(extras_copy_cmd "")
+endif()
 add_custom_command(OUTPUT romfs_extras.stamp
 	COMMAND ${CMAKE_COMMAND} -E make_directory ${romfs_gen_root_dir}/extras/
 	COMMAND ${CMAKE_COMMAND} -E make_directory ${PX4_BINARY_DIR}/romfs_extras/
 	COMMAND ${CMAKE_COMMAND} -E copy_directory ${PX4_BINARY_DIR}/romfs_extras/ ${romfs_gen_root_dir}/extras/
+	${extras_copy_cmd}
 	COMMAND ${CMAKE_COMMAND} -E touch romfs_extras.stamp
 	DEPENDS
 		romfs_copy.stamp
+		${config_romfs_extra_files}
 		${extras_dependencies}
 	COMMENT "ROMFS: copying extras"
 	)

--- a/ROMFS/CMakeLists.txt
+++ b/ROMFS/CMakeLists.txt
@@ -34,7 +34,7 @@
 message(STATUS "ROMFS: ${config_romfs_root}")
 
 set(romfs_src_dir ${PX4_SOURCE_DIR}/ROMFS/${config_romfs_root})
-set(romfs_gen_root_dir ${PX4_BINARY_DIR}/genromfs)
+set(romfs_gen_root_dir ${PX4_BINARY_DIR}/etc)
 
 set_property(GLOBAL PROPERTY PX4_ROMFS_FILES)
 set_property(GLOBAL PROPERTY PX4_ROMFS_CMAKE_FILES)
@@ -81,21 +81,35 @@ file(GLOB jinja_templates ${PX4_SOURCE_DIR}/Tools/serial/*.jinja)
 if (px4_constrained_flash_build)
 	set(added_arguments --constrained-flash)
 endif()
+# create list of relative romfs file names
+set(romfs_copy_files_relative)
+foreach(romfs_file IN LISTS romfs_copy_files)
+	string(REPLACE "${romfs_src_dir}/" "" romfs_file_rel ${romfs_file})
+	list(APPEND romfs_copy_files_relative ${romfs_file_rel})
+endforeach()
+# copy the ROMFS files by creating a tar and extracting it to the build
+# directory (which preserves the directory structure)
+file(MAKE_DIRECTORY ${romfs_gen_root_dir})
+set(romfs_tar_file ${PX4_BINARY_DIR}/romfs_files.tar)
+add_custom_command(
+	OUTPUT ${romfs_tar_file}
+	COMMAND ${CMAKE_COMMAND} -E tar cf ${romfs_tar_file} ${romfs_copy_files_relative}
+	WORKING_DIRECTORY ${romfs_src_dir}
+	DEPENDS ${romfs_copy_files}
+	)
+add_custom_command(
+	OUTPUT ${romfs_gen_root_dir}/init.d/rcS
+	COMMAND ${CMAKE_COMMAND} -E tar xf ${romfs_tar_file}
+	WORKING_DIRECTORY ${romfs_gen_root_dir}
+	DEPENDS ${romfs_tar_file}
+	)
+
 add_custom_command(
 	OUTPUT
-		${romfs_gen_root_dir}/init.d/rcS
 		${romfs_gen_root_dir}/init.d/rc.serial
 		${romfs_gen_root_dir}/init.d/rc.autostart
 		${romfs_gen_root_dir}/init.d/rc.autostart.post
 		romfs_copy.stamp
-	COMMAND ${CMAKE_COMMAND} -E remove_directory ${romfs_gen_root_dir}
-	# TODO: we should only copy the files in ${romfs_copy_files}
-	COMMAND ${CMAKE_COMMAND} -E copy_directory ${romfs_src_dir} ${romfs_gen_root_dir}
-	COMMAND ${CMAKE_COMMAND} -E remove_directory ${romfs_gen_root_dir}/init.d-posix
-	COMMAND ${CMAKE_COMMAND} -E remove_directory ${romfs_gen_root_dir}/mixers-sitl
-	COMMAND ${CMAKE_COMMAND} -E remove ${romfs_gen_root_dir}/mixers/CMakeLists.txt
-	COMMAND ${CMAKE_COMMAND} -E remove ${romfs_gen_root_dir}/init.d/CMakeLists.txt
-	COMMAND ${CMAKE_COMMAND} -E remove ${romfs_gen_root_dir}/init.d/airframes/CMakeLists.txt
 	COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/Tools/px_process_airframes.py
 		--airframes-path ${romfs_gen_root_dir}/init.d
 		--start-script ${romfs_gen_root_dir}/init.d/rc.autostart
@@ -106,10 +120,10 @@ add_custom_command(
 		--config-files ${module_config_files} #--verbose
 	COMMAND ${CMAKE_COMMAND} -E touch romfs_copy.stamp
 	DEPENDS
+		${romfs_gen_root_dir}/init.d/rcS
 		${jinja_templates}
 		${module_config_files}
 		${romfs_cmake_files}
-		${romfs_copy_files}
 		${PX4_SOURCE_DIR}/Tools/px_process_airframes.py
 		${PX4_SOURCE_DIR}/Tools/px4airframes/markdownout.py
 		${PX4_SOURCE_DIR}/Tools/px4airframes/rcout.py
@@ -190,6 +204,13 @@ add_custom_command(OUTPUT romfs_extras.stamp
 	COMMENT "ROMFS: copying extras"
 	)
 
+add_custom_target(romfs_gen_files_target
+	DEPENDS
+		${romfs_gen_root_dir}/init.d/rcS
+		${romfs_gen_root_dir}/init.d/rc.serial
+		romfs_extras.stamp
+	)
+
 add_custom_command(
 	OUTPUT romfs_pruned.stamp
 	COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/Tools/px_romfs_pruner.py --folder ${romfs_gen_root_dir} --board ${PX4_BOARD}
@@ -220,7 +241,11 @@ if("${CONFIG_FS_CROMFS}" STREQUAL "y")
 		COMMENT "ROMFS: generating image"
 	)
 
-else()
+	add_library(romfs STATIC nsh_romfsimg.c)
+	add_dependencies(romfs prebuild_targets)
+	set_target_properties(romfs PROPERTIES LINKER_LANGUAGE C)
+
+elseif("${CONFIG_FS_ROMFS}" STREQUAL "y")
 	# create romfs.img
 	find_program(GENROMFS genromfs)
 	if(NOT GENROMFS)
@@ -255,12 +280,12 @@ else()
 		COMMAND ${SED} 's/unsigned/const unsigned/g' nsh_romfsimg.c > nsh_romfsimg.c.tmp && ${CMAKE_COMMAND} -E rename nsh_romfsimg.c.tmp nsh_romfsimg.c
 		DEPENDS romfs.img
 	)
+
+	add_library(romfs STATIC nsh_romfsimg.c)
+	add_dependencies(romfs prebuild_targets)
+	set_target_properties(romfs PROPERTIES LINKER_LANGUAGE C)
 endif()
 
-
-add_library(romfs STATIC nsh_romfsimg.c)
-add_dependencies(romfs prebuild_targets)
-set_target_properties(romfs PROPERTIES LINKER_LANGUAGE C)
 
 
 # shellcheck

--- a/ROMFS/px4fmu_common/init.d-posix/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2020 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,10 +31,43 @@
 #
 ############################################################################
 
-add_subdirectory(init.d)
-add_subdirectory(mixers)
-# TODO: make this configurable from the board config, or better combine
-if("${PX4_BOARD}" MATCHES "sitl")
-	add_subdirectory(mixers-sitl)
-	add_subdirectory(init.d-posix)
-endif()
+px4_add_romfs_files(
+	10016_iris
+	10020_if750a
+	10030_px4vision
+	1010_iris_opt_flow
+	1010_iris_opt_flow.post
+	1011_iris_irlock
+	1012_iris_rplidar
+	1013_iris_vision
+	1013_iris_vision.post
+	1014_solo
+	1015_iris_obs_avoid
+	1015_iris_obs_avoid.post
+	1016_iris_rtps
+	1016_iris_rtps.post
+	1017_iris_opt_flow_mockup
+	1018_iris_vision_velocity
+	1019_iris_dual_gps
+	1020_uuv_generic
+	1021_uuv_hippocampus
+	1030_plane
+	1031_plane_cam
+	1032_plane_catapult
+	1033_plane_lidar
+	1033_rascal
+	1034_rascal-electric
+	1040_standard_vtol
+	1041_tailsitter
+	1042_tiltrotor
+	1060_rover
+	1061_r1_rover
+	1062_tf-r1
+	1070_boat
+	17001_tf-g1
+	2507_cloudship
+	6011_typhoon_h480
+	6011_typhoon_h480.post
+	rc.replay
+	rcS
+)

--- a/ROMFS/px4fmu_common/init.d/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d/CMakeLists.txt
@@ -34,6 +34,8 @@
 add_subdirectory(airframes)
 
 px4_add_romfs_files(
+	rc.airship_apps
+	rc.airship_defaults
 	rc.fw_apps
 	rc.fw_defaults
 	rc.interface

--- a/ROMFS/px4fmu_common/init.d/airframes/13050_generic_vtol_octo
+++ b/ROMFS/px4fmu_common/init.d/airframes/13050_generic_vtol_octo
@@ -5,8 +5,6 @@
 # @type VTOL Octoplane
 # @class VTOL
 #
-# @maintainer
-#
 # @output MAIN1 motor 1
 # @output MAIN2 motor 2
 # @output MAIN3 motor 3
@@ -21,6 +19,7 @@
 # @output AUX4 Rudder
 # @output AUX5 Throttle
 #
+# @board px4_fmu-v2 exclude
 # @board intel_aerofc-v1 exclude
 # @board bitcraze_crazyflie exclude
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/2507_cloudship
+++ b/ROMFS/px4fmu_common/init.d/airframes/2507_cloudship
@@ -8,6 +8,11 @@
 # @output MAIN2 port thruster
 # @output MAIN3 thrust tilt
 # @output MAIN4 tail thruster
+#
+# @board px4_fmu-v2 exclude
+# @board intel_aerofc-v1 exclude
+# @board bitcraze_crazyflie exclude
+#
 
 sh /etc/init.d/rc.airship_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
@@ -46,6 +46,8 @@ px4_add_romfs_files(
 	2106_albatross
 	2200_mini_talon
 
+	2507_cloudship
+
 	# [3000, 3999] Flying wing"
 	3000_generic_wing
 	3030_io_camflyer
@@ -131,6 +133,8 @@ px4_add_romfs_files(
 	13010_claire
 	13012_convergence
 	13013_deltaquad
+	13014_vtol_babyshark
+	13050_generic_vtol_octo
 	13200_generic_vtol_tailsitter
 
 	# [14000, 14999] Tri Y
@@ -140,6 +144,8 @@ px4_add_romfs_files(
 	15001_coax_heli
 
 	16001_helicopter
+
+	17002_TF-AutoG2
 
 	24001_dodeca_cox
 

--- a/ROMFS/px4fmu_common/mixers-sitl/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/mixers-sitl/CMakeLists.txt
@@ -32,8 +32,11 @@
 ############################################################################
 
 px4_add_romfs_files(
+	autogyro_sitl.main.mix
+	boat_sitl.main.mix
 	delta_wing_sitl.main.mix
 	plane_sitl.main.mix
+	quad_x_vtol.main.mix
 	rover_ackermann_sitl.main.mix
 	rover_diff_sitl.main.mix
 	standard_vtol_sitl.main.mix

--- a/ROMFS/px4fmu_common/mixers/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/mixers/CMakeLists.txt
@@ -34,13 +34,16 @@
 px4_add_romfs_files(
 	AAERTWF.main.mix
 	AAVVTWFF.main.mix
+	AAVVTWFF_vtail.main.mix
 	AERT.main.mix
 	AETRFG.main.mix
+	babyshark.main.mix
 	blade130.main.mix
 	caipi.main.mix
 	CCPM.main.mix
 	claire.aux.mix
 	claire.main.mix
+	cloudship.main.mix
 	coax.main.mix
 	delta.main.mix
 	deltaquad.main.mix
@@ -69,20 +72,24 @@ px4_add_romfs_files(
 	quad_s250aq.main.mix
 	quad_+_vtol.main.mix
 	quad_w.main.mix
-	quad_x.main.mix
 	quad_x_cw.main.mix
+	quad_x.main.mix
 	quad_x_vtol.main.mix
-	stampede.main.mix
-	tri_y_yaw-.main.mix
-	tri_y_yaw+.main.mix
-	rover_generic.main.mix
 	rover_diff_and_servo.main.mix
+	rover_generic.main.mix
+	stampede.main.mix
+	standard_vtol_hitl.main.mix
+	TF-AutoG2.main.mix
+	tilt_quad.aux.mix
+	tilt_quad.main.mix
+	tri_y_yaw+.main.mix
+	tri_y_yaw-.main.mix
+	uuv_x.main.mix
 	Viper.main.mix
 	vtol_AAERT.aux.mix
 	vtol_AAVVT.aux.mix
 	vtol_convergence.main.mix
 	vtol_delta.aux.mix
+	vtol_tailsitter_duo.main.mix
 	wingwing.main.mix
-	TF-AutoG2.main.mix
-	uuv_x.main.mix
 )

--- a/Tools/gazebo_sitl_multiple_run.sh
+++ b/Tools/gazebo_sitl_multiple_run.sh
@@ -30,7 +30,7 @@ function spawn_model() {
 
 	pushd "$working_dir" &>/dev/null
 	echo "starting instance $n in $(pwd)"
-	../bin/px4 -i $n -d "$src_path/ROMFS/px4fmu_common" -w sitl_${MODEL}_${n} -s etc/init.d-posix/rcS >out.log 2>err.log &
+	../bin/px4 -i $n -d "$build_path/etc" -w sitl_${MODEL}_${n} -s etc/init.d-posix/rcS >out.log 2>err.log &
 	python3 ${src_path}/Tools/sitl_gazebo/scripts/xacro.py ${src_path}/Tools/sitl_gazebo/models/rotors_description/urdf/${MODEL}_base.xacro \
 		rotors_description_dir:=${src_path}/Tools/sitl_gazebo/models/rotors_description mavlink_udp_port:=$(($mavlink_udp_port+$N)) \
 		mavlink_tcp_port:=$(($mavlink_tcp_port+$N))  -o /tmp/${MODEL}_${N}.urdf

--- a/Tools/px_romfs_pruner.py
+++ b/Tools/px_romfs_pruner.py
@@ -83,6 +83,7 @@ def main():
 
             # only prune text files
             if ".zip" in file or ".bin" in file or ".swp" in file \
+                    or ".gz" in file or ".bz2" in file \
                     or ".data" in file or ".DS_Store" in file:
                 continue
 

--- a/Tools/sitl_multiple_run.sh
+++ b/Tools/sitl_multiple_run.sh
@@ -28,7 +28,7 @@ while [ $n -lt $sitl_num ]; do
 
 	pushd "$working_dir" &>/dev/null
 	echo "starting instance $n in $(pwd)"
-	../bin/px4 -i $n -d "$src_path/ROMFS/px4fmu_common" -s etc/init.d-posix/rcS >out.log 2>err.log &
+	../bin/px4 -i $n -d "$build_path/etc" -s etc/init.d-posix/rcS >out.log 2>err.log &
 	popd &>/dev/null
 
 	n=$(($n + 1))

--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -49,7 +49,7 @@ else
 	verbose=""
 fi
 
-if [ "$model" != none ]; then
+if [ "$program" == "jmavsim" ]; then
 	jmavsim_pid=`ps aux | grep java | grep "\-jar jmavsim_run.jar" | awk '{ print $2 }'`
 	if [ -n "$jmavsim_pid" ]; then
 		kill $jmavsim_pid
@@ -84,7 +84,7 @@ SIM_PID=0
 if [ "$program" == "jmavsim" ] && [ ! -n "$no_sim" ]; then
 	# Start Java simulator
 	"$src_path"/Tools/jmavsim_run.sh -r 250 -l &
-	SIM_PID=`echo $!`
+	SIM_PID=$!
 elif [ "$program" == "gazebo" ] && [ ! -n "$no_sim" ]; then
 	if [ -x "$(command -v gazebo)" ]; then
 		# Get the model name
@@ -134,7 +134,7 @@ elif [ "$program" == "gazebo" ] && [ ! -n "$no_sim" ]; then
 			# is putting it into the background we need to avoid it by backing off
 			sleep 3
 			nice -n 20 gzclient --verbose &
-			GUI_PID=`echo $!`
+			GUI_PID=$!
 		fi
 	else
 		echo "You need to have gazebo simulator installed!"
@@ -145,7 +145,7 @@ elif [ "$program" == "flightgear" ] && [ -z "$no_sim" ]; then
 	cd "${src_path}/Tools/flightgear_bridge/"
 	"${src_path}/Tools/flightgear_bridge/FG_run.py" "models/"${model}".json" 0
 	"${build_path}/build_flightgear_bridge/flightgear_bridge" 0 `./get_FGbridge_params.py "models/"${model}".json"` &
-	FG_BRIDGE_PID=`echo $!`
+	FG_BRIDGE_PID=$!
 fi
 
 pushd "$rootfs" >/dev/null

--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -156,7 +156,7 @@ set +e
 if [[ ${model} == test_* ]] || [[ ${model} == *_generated ]]; then
 	sitl_command="\"$sitl_bin\" $no_pxh \"$src_path\"/ROMFS/px4fmu_test -s \"${src_path}\"/posix-configs/SITL/init/test/${model} -t \"$src_path\"/test_data"
 else
-	sitl_command="\"$sitl_bin\" $no_pxh \"$src_path\"/ROMFS/px4fmu_common -s etc/init.d-posix/rcS -t \"$src_path\"/test_data"
+	sitl_command="\"$sitl_bin\" $no_pxh \"$build_path\"/etc -s etc/init.d-posix/rcS -t \"$src_path\"/test_data"
 fi
 
 echo SITL COMMAND: $sitl_command

--- a/boards/atlflight/eagle/cmake/upload.cmake
+++ b/boards/atlflight/eagle/cmake/upload.cmake
@@ -46,7 +46,7 @@ else()
 
 	add_custom_target(upload
 		COMMAND ${PX4_BOARD_DIR}/scripts/adb_upload.sh
-				${CMAKE_RUNTIME_OUTPUT_DIRECTORY} ${PX4_SOURCE_DIR}/posix-configs/eagle/flight/mainapp.config ${PX4_SOURCE_DIR}/ROMFS # source
+				${CMAKE_RUNTIME_OUTPUT_DIRECTORY} ${PX4_SOURCE_DIR}/posix-configs/eagle/flight/mainapp.config ${PX4_BINARY_DIR}/etc # source
 				/home/linaro # destination
 		DEPENDS px4 ${PX4_BOARD_DIR}/scripts/adb_upload.sh
 		COMMENT "uploading px4"

--- a/boards/atlflight/eagle/default.cmake
+++ b/boards/atlflight/eagle/default.cmake
@@ -41,6 +41,7 @@ px4_add_board(
 	LABEL default
 	#TESTING
 	TOOLCHAIN arm-linux-gnueabihf
+	ROMFSROOT px4fmu_common
 	DRIVERS
 		#barometer # all available barometer drivers
 		batt_smbus

--- a/boards/beaglebone/blue/cmake/upload.cmake
+++ b/boards/beaglebone/blue/cmake/upload.cmake
@@ -33,7 +33,7 @@
 
 add_custom_target(upload
 	COMMAND rsync -arh --progress
-			${CMAKE_RUNTIME_OUTPUT_DIRECTORY} ${PX4_SOURCE_DIR}/posix-configs/bbblue/*.config ${PX4_SOURCE_DIR}/ROMFS # source
+			${CMAKE_RUNTIME_OUTPUT_DIRECTORY} ${PX4_SOURCE_DIR}/posix-configs/bbblue/*.config ${PX4_BINARY_DIR}/etc # source
 			debian@beaglebone.lan:/home/debian/px4 # destination
 	DEPENDS px4
 	COMMENT "uploading px4"

--- a/boards/beaglebone/blue/default.cmake
+++ b/boards/beaglebone/blue/default.cmake
@@ -10,6 +10,7 @@ px4_add_board(
 	LABEL default
 	PLATFORM posix
 	ARCHITECTURE cortex-a8
+	ROMFSROOT px4fmu_common
 	TOOLCHAIN arm-linux-gnueabihf
 	TESTING
 	DRIVERS

--- a/boards/emlid/navio2/cmake/upload.cmake
+++ b/boards/emlid/navio2/cmake/upload.cmake
@@ -39,7 +39,7 @@ endif()
 
 add_custom_target(upload
 	COMMAND rsync -arh --progress
-			${CMAKE_RUNTIME_OUTPUT_DIRECTORY} ${PX4_SOURCE_DIR}/posix-configs/rpi/*.config ${PX4_SOURCE_DIR}/ROMFS # source
+			${CMAKE_RUNTIME_OUTPUT_DIRECTORY} ${PX4_SOURCE_DIR}/posix-configs/rpi/*.config ${PX4_BINARY_DIR}/etc # source
 			pi@${AUTOPILOT_HOST}:/home/pi/px4 # destination
 	DEPENDS px4
 	COMMENT "uploading px4"

--- a/boards/emlid/navio2/default.cmake
+++ b/boards/emlid/navio2/default.cmake
@@ -8,6 +8,7 @@ px4_add_board(
 	LABEL default
 	PLATFORM posix
 	ARCHITECTURE cortex-a53
+	ROMFSROOT px4fmu_common
 	TOOLCHAIN arm-linux-gnueabihf
 	TESTING
 	DRIVERS

--- a/boards/px4/raspberrypi/cmake/upload.cmake
+++ b/boards/px4/raspberrypi/cmake/upload.cmake
@@ -39,7 +39,7 @@ endif()
 
 add_custom_target(upload
 	COMMAND rsync -arh --progress
-			${CMAKE_RUNTIME_OUTPUT_DIRECTORY} ${PX4_SOURCE_DIR}/posix-configs/rpi/*.config ${PX4_SOURCE_DIR}/ROMFS # source
+			${CMAKE_RUNTIME_OUTPUT_DIRECTORY} ${PX4_SOURCE_DIR}/posix-configs/rpi/*.config ${PX4_BINARY_DIR}/etc # source
 			pi@${AUTOPILOT_HOST}:/home/pi/px4 # destination
 	DEPENDS px4
 	COMMENT "uploading px4"

--- a/boards/px4/raspberrypi/default.cmake
+++ b/boards/px4/raspberrypi/default.cmake
@@ -8,6 +8,7 @@ px4_add_board(
 	LABEL default
 	PLATFORM posix
 	ARCHITECTURE cortex-a53
+	ROMFSROOT px4fmu_common
 	TOOLCHAIN arm-linux-gnueabihf
 	TESTING
 	DRIVERS

--- a/boards/px4/sitl/default.cmake
+++ b/boards/px4/sitl/default.cmake
@@ -3,6 +3,7 @@ px4_add_board(
 	PLATFORM posix
 	VENDOR px4
 	MODEL sitl
+	ROMFSROOT px4fmu_common
 	LABEL default
 	TESTING
 	DRIVERS

--- a/boards/px4/sitl/default.cmake
+++ b/boards/px4/sitl/default.cmake
@@ -5,6 +5,7 @@ px4_add_board(
 	MODEL sitl
 	ROMFSROOT px4fmu_common
 	LABEL default
+	EMBEDDED_METADATA parameters
 	TESTING
 	DRIVERS
 		#barometer # all available barometer drivers

--- a/boards/px4/sitl/nolockstep.cmake
+++ b/boards/px4/sitl/nolockstep.cmake
@@ -3,6 +3,7 @@ px4_add_board(
 	PLATFORM posix
 	VENDOR px4
 	MODEL sitl
+	ROMFSROOT px4fmu_common
 	LABEL nolockstep
 	TESTING
 	DRIVERS

--- a/boards/px4/sitl/replay.cmake
+++ b/boards/px4/sitl/replay.cmake
@@ -3,6 +3,7 @@ px4_add_board(
 	PLATFORM posix
 	VENDOR px4
 	MODEL sitl
+	ROMFSROOT px4fmu_common
 	LABEL replay
 	MODULES
 		ekf2

--- a/boards/px4/sitl/rtps.cmake
+++ b/boards/px4/sitl/rtps.cmake
@@ -3,6 +3,7 @@ px4_add_board(
 	PLATFORM posix
 	VENDOR px4
 	MODEL sitl
+	ROMFSROOT px4fmu_common
 	LABEL rtps
 	TESTING
 	DRIVERS

--- a/boards/px4/sitl/test.cmake
+++ b/boards/px4/sitl/test.cmake
@@ -3,6 +3,7 @@ px4_add_board(
 	PLATFORM posix
 	VENDOR px4
 	MODEL sitl
+	ROMFSROOT px4fmu_common
 	LABEL test
 	TESTING
 	DRIVERS

--- a/cmake/px4_add_board.cmake
+++ b/cmake/px4_add_board.cmake
@@ -67,7 +67,7 @@
 #		LABEL			: optional label, set to default if not specified
 #		TOOLCHAIN		: cmake toolchain
 #		ARCHITECTURE		: name of the CPU CMake is building for (used by the toolchain)
-#		ROMFSROOT		: relative path to the ROMFS root directory (currently NuttX only)
+#		ROMFSROOT		: relative path to the ROMFS root directory
 #		BUILD_BOOTLOADER	: flag to enable building and including the bootloader config
 #		IO			: name of IO board to be built and included in the ROMFS (requires a valid ROMFSROOT)
 #		BOOTLOADER		: bootloader file to include for flashing via bl_update (currently NuttX only)

--- a/launch/posix_sitl.launch
+++ b/launch/posix_sitl.launch
@@ -29,7 +29,7 @@
     <arg unless="$(arg interactive)" name="px4_command_arg1" value="-d"/>
     <arg     if="$(arg interactive)" name="px4_command_arg1" value=""/>
     <node name="sitl" pkg="px4" type="px4" output="screen"
-        args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS $(arg px4_command_arg1)" required="true"/>
+        args="$(find px4)/build/px4_sitl_default/etc -s etc/init.d-posix/rcS $(arg px4_command_arg1)" required="true"/>
 
     <!-- Gazebo sim -->
     <include file="$(find gazebo_ros)/launch/empty_world.launch">

--- a/launch/px4.launch
+++ b/launch/px4.launch
@@ -13,6 +13,6 @@
     <env name="PX4_ESTIMATOR" value="$(arg est)" />
     <arg unless="$(arg interactive)" name="px4_command_arg1" value="-d"/>
     <arg     if="$(arg interactive)" name="px4_command_arg1" value=""/>
-    <node name="sitl_$(arg ID)" pkg="px4" type="px4" output="screen" args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS -i $(arg ID) $(arg px4_command_arg1)">
+    <node name="sitl_$(arg ID)" pkg="px4" type="px4" output="screen" args="$(find px4)/build/px4_sitl_default/etc -s etc/init.d-posix/rcS -i $(arg ID) $(arg px4_command_arg1)">
     </node>
 </launch>

--- a/launch/single_vehicle_spawn.launch
+++ b/launch/single_vehicle_spawn.launch
@@ -25,7 +25,7 @@
     <!-- PX4 SITL -->
     <arg unless="$(arg interactive)" name="px4_command_arg1" value=""/>
     <arg     if="$(arg interactive)" name="px4_command_arg1" value="-d"/>
-    <node name="sitl_$(arg ID)" pkg="px4" type="px4" output="screen" args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS -i $(arg ID) -w sitl_$(arg vehicle)_$(arg ID) $(arg px4_command_arg1)">
+    <node name="sitl_$(arg ID)" pkg="px4" type="px4" output="screen" args="$(find px4)/build/px4_sitl_default/etc -s etc/init.d-posix/rcS -i $(arg ID) -w sitl_$(arg vehicle)_$(arg ID) $(arg px4_command_arg1)">
     </node>
     <!-- spawn vehicle -->
     <node name="$(arg vehicle)_$(arg ID)_spawn" output="screen" pkg="gazebo_ros" type="spawn_model" args="-urdf -param rotors_description -model $(arg vehicle)_$(arg ID) -package_to_model -x $(arg x) -y $(arg y) -z $(arg z) -R $(arg R) -P $(arg P) -Y $(arg Y)"/>

--- a/launch/single_vehicle_spawn_sdf.launch
+++ b/launch/single_vehicle_spawn_sdf.launch
@@ -25,7 +25,7 @@
     <!-- PX4 SITL -->
     <arg unless="$(arg interactive)" name="px4_command_arg1" value=""/>
     <arg     if="$(arg interactive)" name="px4_command_arg1" value="-d"/>
-    <node name="sitl_$(arg ID)" pkg="px4" type="px4" output="screen" args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS -i $(arg ID) -w sitl_$(arg vehicle)_$(arg ID) $(arg px4_command_arg1)">
+    <node name="sitl_$(arg ID)" pkg="px4" type="px4" output="screen" args="$(find px4)/build/px4_sitl_default/etc -s etc/init.d-posix/rcS -i $(arg ID) -w sitl_$(arg vehicle)_$(arg ID) $(arg px4_command_arg1)">
     </node>
     <!-- spawn vehicle -->
     <node name="$(arg vehicle)_$(arg ID)_spawn" output="screen" pkg="gazebo_ros" type="spawn_model" args="-sdf -param model_description -model $(arg vehicle)_$(arg ID) -x $(arg x) -y $(arg y) -z $(arg z) -R $(arg R) -P $(arg P) -Y $(arg Y)"/>

--- a/platforms/posix/CMakeLists.txt
+++ b/platforms/posix/CMakeLists.txt
@@ -80,8 +80,8 @@ else()
 	install(
 		DIRECTORY
 			${PROJECT_SOURCE_DIR}/posix-configs
-			${PROJECT_SOURCE_DIR}/ROMFS
 			${PROJECT_SOURCE_DIR}/test
+			${CMAKE_BINARY_DIR}/etc
 			${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
 		DESTINATION
 			${PROJECT_NAME}
@@ -96,6 +96,11 @@ px4_posix_generate_symlinks(
 	PREFIX ${PX4_SHELL_COMMAND_PREFIX}
 	TARGET px4
 )
+
+if (config_romfs_root)
+	add_subdirectory(${PX4_SOURCE_DIR}/ROMFS ${PX4_BINARY_DIR}/ROMFS)
+	add_dependencies(px4 romfs_gen_files_target)
+endif()
 
 
 # board defined upload helper
@@ -155,6 +160,14 @@ elseif("${PX4_BOARD}" MATCHES "sitl")
 			${PROJECT_SOURCE_DIR}/Tools/upload_log.py
 		DESTINATION
 			${PROJECT_NAME}/Tools
+		)
+
+	# ROMFS files
+	install(
+		DIRECTORY
+			${PROJECT_SOURCE_DIR}/build/px4_sitl_default/etc
+		DESTINATION
+			${PROJECT_NAME}/build/px4_sitl_default
 		)
 
 	# sitl_gazebo built plugins

--- a/posix-configs/bbblue/px4.config
+++ b/posix-configs/bbblue/px4.config
@@ -82,9 +82,9 @@ sleep 1
 # RC port is mapped to /dev/ttyS4 (auto-detected)
 #rc_input start -d /dev/ttyS4
 
-# default: ROMFS/px4fmu_common/mixers/quad_x.main.mix, 8 output channels
-linux_pwm_out start -p bbblue_rc -m ROMFS/px4fmu_common/mixers/quad_x.main.mix
-#linux_pwm_out start -p bbblue_rc -m ROMFS/px4fmu_common/mixers/AETRFG.main.mix
+# default: etc/mixers/quad_x.main.mix, 8 output channels
+linux_pwm_out start -p bbblue_rc -m etc/mixers/quad_x.main.mix
+#linux_pwm_out start -p bbblue_rc -m etc/mixers/AETRFG.main.mix
 
 logger start -t -b 200
 

--- a/posix-configs/bbblue/px4_fw.config
+++ b/posix-configs/bbblue/px4_fw.config
@@ -78,9 +78,9 @@ sleep 1
 # RC port is mapped to /dev/ttyS4 (auto-detected)
 rc_input start -d /dev/ttyS4
 
-# default: ROMFS/px4fmu_common/mixers/quad_x.main.mix, 8 output channels
-#linux_pwm_out start -p bbblue_rc -m ROMFS/px4fmu_common/mixers/quad_x.main.mix
-linux_pwm_out start -p bbblue_rc -m ROMFS/px4fmu_common/mixers/AETRFG.main.mix
+# default: etc/mixers/quad_x.main.mix, 8 output channels
+#linux_pwm_out start -p bbblue_rc -m etc/mixers/quad_x.main.mix
+linux_pwm_out start -p bbblue_rc -m etc/mixers/AETRFG.main.mix
 
 logger start -t -b 200
 

--- a/posix-configs/ocpoc/px4.config
+++ b/posix-configs/ocpoc/px4.config
@@ -46,6 +46,6 @@ mavlink stream -d /dev/ttyPS1 -s ATTITUDE -r 50
 
 rc_input start -d /dev/ttyS2
 
-linux_pwm_out start -p ocpoc_mmap -m ROMFS/px4fmu_common/mixers/quad_x.main.mix
+linux_pwm_out start -p ocpoc_mmap -m etc/mixers/quad_x.main.mix
 logger start -t -b 200
 mavlink boot_complete

--- a/posix-configs/rpi/px4_fw.config
+++ b/posix-configs/rpi/px4_fw.config
@@ -50,7 +50,7 @@ then
 fi
 
 navio_sysfs_rc_in start
-linux_pwm_out start -m ROMFS/px4fmu_common/mixers/AETRFG.main.mix
+linux_pwm_out start -m etc/mixers/AETRFG.main.mix
 
 logger start -t -b 200
 

--- a/posix-configs/rpi/px4_hil.config
+++ b/posix-configs/rpi/px4_hil.config
@@ -36,7 +36,7 @@ mc_rate_control start
 mavlink start -x -u 14577 -r 1000000
 navio_sysfs_rc_in start
 pwm_out_sim start
-mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/quad_x.main.mix
+mixer load /dev/pwm_output0 etc/mixers/quad_x.main.mix
 
 logger start -t -b 200
 

--- a/src/drivers/linux_pwm_out/linux_pwm_out.cpp
+++ b/src/drivers/linux_pwm_out/linux_pwm_out.cpp
@@ -72,7 +72,7 @@ static bool _is_running = false;
 static char _device[64] = "/sys/class/pwm/pwmchip0";
 static char _protocol[64] = "navio";
 static int _max_num_outputs = 8; ///< maximum number of outputs the driver should use
-static char _mixer_filename[64] = "ROMFS/px4fmu_common/mixers/quad_x.main.mix";
+static char _mixer_filename[64] = "etc/mixers/quad_x.main.mix";
 
 // subscriptions
 int     _controls_subs[actuator_controls_s::NUM_ACTUATOR_CONTROL_GROUPS];
@@ -495,7 +495,7 @@ void usage()
 	PX4_INFO("       -d pwmdevice : sysfs device for pwm generation (only for Navio)");
 	PX4_INFO("                       (default /sys/class/pwm/pwmchip0)");
 	PX4_INFO("       -m mixerfile : path to mixerfile");
-	PX4_INFO("                       (default ROMFS/px4fmu_common/mixers/quad_x.main.mix)");
+	PX4_INFO("                       (default etc/mixers/quad_x.main.mix)");
 	PX4_INFO("       -p protocol : driver output protocol (navio|pca9685|ocpoc_mmap|bbblue_rc)");
 	PX4_INFO("                       (default is navio)");
 	PX4_INFO("       -n num_outputs : maximum number of outputs the driver should use");

--- a/src/drivers/pca9685_pwm_out/main.cpp
+++ b/src/drivers/pca9685_pwm_out/main.cpp
@@ -516,7 +516,7 @@ It is typically started with:
 $ pca9685_pwm_out start -a 64 -b 1
 
 Use the `mixer` command to load mixer files.
-`mixer load /dev/pca9685 ROMFS/px4fmu_common/mixers/quad_x.main.mix`
+`mixer load /dev/pca9685 etc/mixers/quad_x.main.mix`
 )DESCR_STR");
 
     PRINT_MODULE_USAGE_NAME("pca9685_pwm_out", "driver");

--- a/src/lib/parameters/CMakeLists.txt
+++ b/src/lib/parameters/CMakeLists.txt
@@ -89,7 +89,7 @@ add_custom_command(OUTPUT ${generated_serial_params_file}
 set(parameters_xml ${PX4_BINARY_DIR}/parameters.xml)
 set(parameters_json ${PX4_BINARY_DIR}/parameters.json)
 file(GLOB_RECURSE param_src_files ${PX4_SOURCE_DIR}/src/*params.c)
-add_custom_command(OUTPUT ${parameters_xml} ${parameters_json}
+add_custom_command(OUTPUT ${parameters_xml} ${parameters_json} ${parameters_json}.gz
 	COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/px_process_params.py
 		--src-path ${module_list} ${generated_params_dir}
 		--xml ${parameters_xml}

--- a/test/mavsdk_tests/process_helper.py
+++ b/test/mavsdk_tests/process_helper.py
@@ -145,7 +145,7 @@ class Px4Runner(Runner):
         self.cmd = workspace_dir + "/build/px4_sitl_default/bin/px4"
         self.cwd = workspace_dir + "/build/px4_sitl_default/tmp/rootfs"
         self.args = [
-                workspace_dir + "/ROMFS/px4fmu_common",
+                workspace_dir + "/build/px4_sitl_default/etc",
                 "-s",
                 "etc/init.d-posix/rcS",
                 "-t",


### PR DESCRIPTION
This enables the ROMFS for SITL, the same way as for NuttX builds, just w/o the image generation.
That allows to include generated files, such as the parameters metadata (here enabled for SITL for testing).

ROMFS files are now copied to the `build_<board>/etc` directory, requiring a change of SITL/posix startup parameters.

@DonLakeFlyer  @hamishwillee in SITL you can now use mavftp to request the parameter metadata under `/etc/extras/parameters.json.gz`.

Not tested with ROS yet.