### PR TITLE
Allow gzserver verbose options through command line

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -42,6 +42,13 @@ else
 	no_pxh=""
 fi
 
+# To disable user input
+if [[ -n "$VERBOSE" ]]; then
+	verbose="--verbose"
+else
+	verbose=""
+fi
+
 if [ "$model" != none ]; then
 	jmavsim_pid=`ps aux | grep java | grep "\-jar jmavsim_run.jar" | awk '{ print $2 }'`
 	if [ -n "$jmavsim_pid" ]; then
@@ -94,24 +101,25 @@ elif [ "$program" == "gazebo" ] && [ ! -n "$no_sim" ]; then
 			if [ "$world" == "none" ]; then
 				if [ -f ${src_path}/Tools/sitl_gazebo/worlds/${model}.world ]; then
 					echo "empty world, default world ${model}.world for model found"
-					gzserver "${src_path}/Tools/sitl_gazebo/worlds/${model}.world" &
+					world_path="${src_path}/Tools/sitl_gazebo/worlds/${model}.world"
 				else
 					echo "empty world, setting empty.world as default"
-					gzserver "${src_path}/Tools/sitl_gazebo/worlds/empty.world" &
+					world_path="${src_path}/Tools/sitl_gazebo/worlds/empty.world"
 				fi
 			else
 				#Spawn empty world if world with model name doesn't exist
-				gzserver "${src_path}/Tools/sitl_gazebo/worlds/${world}.world" &
+				world_path= $verbose "${src_path}/Tools/sitl_gazebo/worlds/${world}.world"
 			fi
 		else
 			if [ -f ${src_path}/Tools/sitl_gazebo/worlds/${PX4_SITL_WORLD}.world ]; then
 				# Spawn world by name if exists in the worlds directory from environment variable
-				gzserver "${src_path}/Tools/sitl_gazebo/worlds/${PX4_SITL_WORLD}.world" &
+				world_path="${src_path}/Tools/sitl_gazebo/worlds/${PX4_SITL_WORLD}.world"
 			else
 				# Spawn world from environment variable with absolute path
-				gzserver "$PX4_SITL_WORLD" &
+				world_path="$PX4_SITL_WORLD"
 			fi
 		fi
+		gzserver $verbose $world_path &
 		SIM_PID=$!
 
 		while gz model --verbose --spawn-file="${src_path}/Tools/sitl_gazebo/models/${model}/${model_name}.sdf" --model-name=${model} -x 1.01 -y 0.98 -z 0.83 2>&1 | grep -q "An instance of Gazebo is not running."; do


### PR DESCRIPTION
**Describe problem solved by this pull request**
Currently when running SITL simulations, SITL fails silently when there is something wrong with the gazebo model.
The only way to find out what was wrong about the model was to go into [sitl_run.sh](https://github.com/PX4/Firmware/blob/2128679ab3e4ba888cc3f8b1cb9b00a398847cc5/Tools/sitl_run.sh#L100) and enable the `--verbose` flag after gzserver and look at the errors. 

**Describe your solution**
This allows to add a `VERBOSE=1` in the command line to enable the verbose option on gazebo. I believe this would be useful for other simulators as well, but currently just used for gazebo.

**Test data / coverage**
To test, you can run
```
VERBOSE=1 make px4_sitl gazebo
```

For comparison:
**Without PR**
```
$ make px4_sitl gazebo
[0/1] Re-running CMake...
-- PX4 version: v1.11.0-rc3-166-gf9ff51bbe7
-- PX4 config file: /home/jaeyoung/src/Firmware/boards/px4/sitl/default.cmake
-- PX4 config: px4_sitl_default
-- PX4 platform: posix
-- PX4 lockstep: enabled
-- cmake build type: RelWithDebInfo
-- Building for code coverage
-- build type is RelWithDebInfo
-- PX4 ECL: Very lightweight Estimation & Control Library v1.9.0-rc1-445-ga204c59
-- Configuring done
-- Generating done
-- Build files have been written to: /home/jaeyoung/src/Firmware/build/px4_sitl_default
[0/8] Performing build step for 'sitl_gazebo'
ninja: no work to do.
[7/8] cd /home/jaeyoung/src/Firmware/build/px4_sitl_default/tmp && /home/jaeyoung/src/Firmware/Tools/sitl_run.sh /home/jaeyoung/src/Firmware/build/px4_sitl_default/bin/px4 none gazebo none none /home/jaeyoung/src/Firmware /home/jaeyoung/src/Firmware/build/px4_sitl_default
SITL ARGS
sitl_bin: /home/jaeyoung/src/Firmware/build/px4_sitl_default/bin/px4
debugger: none
program: gazebo
model: none
world: none
src_path: /home/jaeyoung/src/Firmware
build_path: /home/jaeyoung/src/Firmware/build/px4_sitl_default
empty model, setting iris as default
GAZEBO_PLUGIN_PATH :/home/jaeyoung/src/Firmware/build/px4_sitl_default/build_gazebo:/home/jaeyoung/src/Firmware/build/px4_sitl_default/build_gazebo:/home/jaeyoung/src/Firmware/build/px4_sitl_default/build_gazebo
GAZEBO_MODEL_PATH :/home/jaeyoung/src/Firmware/Tools/sitl_gazebo/models:/home/jaeyoung/src/Firmware/Tools/sitl_gazebo/models:/home/jaeyoung/src/Firmware/Tools/sitl_gazebo/models
LD_LIBRARY_PATH /home/jaeyoung/catkin_ws/devel/lib:/opt/ros/noetic/lib:/home/jaeyoung/src/Firmware/build/px4_sitl_default/build_gazebo:/home/jaeyoung/src/Firmware/build/px4_sitl_default/build_gazebo:/home/jaeyoung/src/Firmware/build/px4_sitl_default/build_gazebo
empty world, setting empty.world as default
```
**With PR**
```
$ VERBOSE=1 make px4_sitl gazebo
[0/4] cd /home/jaeyoung/src/Firmware/build/px4_sitl_default/build_gazebo && /usr/bin/cmake --build /home/jaeyoung/src/Firmware/build/px4_sitl_default/build_gazebo -- -j2
ninja: no work to do.
[2/4] cd /home/jaeyoung/src/Firmware/build/px4_sitl_default/build_gazebo && /usr/bin/cmake -E echo_append && /usr/bin/cmake -E touch /home/jaeyoung/src/Firmware/build/px4_sitl_default/external/Stamp/sitl_gazebo/sitl_gazebo-install
[3/4] cd /home/jaeyoung/src/Firmware/build/px4_sitl_default/platforms/posix && /usr/bin/cmake -E make_directory /home/jaeyoung/src/Firmware/build/px4_sitl_default/platforms/posix/CMakeFiles && /usr/bin/cmake -E touch /home/jaeyoung/src/Firmware/build/px4_sitl_default/platforms/posix/CMakeFiles/sitl_gazebo-complete && /usr/bin/cmake -E touch /home/jaeyoung/src/Firmware/build/px4_sitl_default/external/Stamp/sitl_gazebo/sitl_gazebo-done
[3/4] cd /home/jaeyoung/src/Firmware/build/px4_sitl_default/tmp && /home/jaeyoung/src/Firmware/Tools/sitl_run.sh /home/jaeyoung/src/Firmware/build/px4_sitl_default/bin/px4 none gazebo none none /home/jaeyoung/src/Firmware /home/jaeyoung/src/Firmware/build/px4_sitl_default
SITL ARGS
sitl_bin: /home/jaeyoung/src/Firmware/build/px4_sitl_default/bin/px4
debugger: none
program: gazebo
model: none
world: none
src_path: /home/jaeyoung/src/Firmware
build_path: /home/jaeyoung/src/Firmware/build/px4_sitl_default
empty model, setting iris as default
GAZEBO_PLUGIN_PATH :/home/jaeyoung/src/Firmware/build/px4_sitl_default/build_gazebo:/home/jaeyoung/src/Firmware/build/px4_sitl_default/build_gazebo:/home/jaeyoung/src/Firmware/build/px4_sitl_default/build_gazebo
GAZEBO_MODEL_PATH :/home/jaeyoung/src/Firmware/Tools/sitl_gazebo/models:/home/jaeyoung/src/Firmware/Tools/sitl_gazebo/models:/home/jaeyoung/src/Firmware/Tools/sitl_gazebo/models
LD_LIBRARY_PATH /home/jaeyoung/catkin_ws/devel/lib:/opt/ros/noetic/lib:/home/jaeyoung/src/Firmware/build/px4_sitl_default/build_gazebo:/home/jaeyoung/src/Firmware/build/px4_sitl_default/build_gazebo:/home/jaeyoung/src/Firmware/build/px4_sitl_default/build_gazebo
empty world, setting empty.world as default
Gazebo multi-robot simulator, version 11.1.0
Copyright (C) 2012 Open Source Robotics Foundation.
Released under the Apache 2 License.
http://gazebosim.org

[Msg] Waiting for master.
[Msg] Connected to gazebo master @ http://127.0.0.1:11345
[Msg] Publicized address: 192.168.0.248
gzserver not ready yet, trying again!
[Err] [Model.cc:99] Error Code 23 Msg: FrameAttachedToGraph error, Non-LINK vertex with name [gps0_joint] is disconnected; it should have 1 outgoing edge in MODEL attached_to graph.
[Err] [Model.cc:99] Error Code 23 Msg: Graph has __model__ scope but sink vertex named [gps0_joint] does not have FrameType LINK when starting from vertex with name [gps0_joint].
[Err] [Model.cc:99] Error Code 26 Msg: PoseRelativeToGraph error, Non-MODEL vertex with name [gps0_joint] is disconnected; it should have 1 incoming edge in MODEL relative_to graph.
[Err] [Model.cc:99] Error Code 26 Msg: PoseRelativeToGraph frame with name [gps0_joint] is disconnected; its source vertex has name [gps0_joint], but its source name should be __model__.
[Wrn] [gazebo_gps_plugin.cpp:76] [gazebo_gps_plugin]: iris::gps0 using gps topic "gps0"
[Wrn] [gazebo_gps_plugin.cpp:201] [gazebo_gps_plugin] Using default update rate of 5hz 
[Msg] Connecting to PX4 SITL using TCP
[Msg] Lockstep is enabled
[Msg] Speed factor set to: 1
[Msg] Using MAVLink protocol v2.0
SITL COMMAND: "/home/jaeyoung/src/Firmware/build/px4_sitl_default/bin/px4" "/home/jaeyoung/src/Firmware"/ROMFS/px4fmu_common -s etc/init.d-posix/rcS -t "/home/jaeyoung/src/Firmware"/test_data
INFO  [px4] Creating symlink /home/jaeyoung/src/Firmware/ROMFS/px4fmu_common -> /home/jaeyoung/src/Firmware/build/px4_sitl_default/tmp/rootfs/etc
```