### PR TITLE
multiple devices for mtd, separate (factory) calibration storage

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -166,8 +166,17 @@ else
 	#
 	# Load parameters.
 	#
+	# if MTD has a secondary storage it is used for (factory) calibration data
+	if mtd has-secondary
+	then
+		if mtd start -i 1 /fs/mtd_caldata
+		then
+			param load /fs/mtd_caldata
+		fi
+	fi
+
 	param select $PARAM_FILE
-	if ! param load
+	if ! param import
 	then
 		param reset_all
 	fi

--- a/boards/px4/fmu-v5x/src/board_config.h
+++ b/boards/px4/fmu-v5x/src/board_config.h
@@ -116,6 +116,8 @@
 #define GPIO_I2C4_DRDY1_BMP388      /* PG5  */  (GPIO_INPUT|GPIO_FLOAT|GPIO_EXTI|GPIO_PORTG|GPIO_PIN5)
 #define GPIO_PG6                    /* PG6  */  (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTG|GPIO_PIN6)
 
+#define PX4_I2C_BUS_MTD 4
+
 /*
  * ADC channels
  *

--- a/src/lib/parameters/flashparams/flashparams.cpp
+++ b/src/lib/parameters/flashparams/flashparams.cpp
@@ -76,7 +76,7 @@ struct param_wbuf_s {
 };
 
 static int
-param_export_internal(bool only_unsaved)
+param_export_internal(bool only_unsaved, param_filter_func filter)
 {
 	struct param_wbuf_s *s = nullptr;
 	struct bson_encoder_s encoder;
@@ -102,6 +102,10 @@ param_export_internal(bool only_unsaved)
 		 * one hasn't, then skip it
 		 */
 		if (only_unsaved && !s->unsaved) {
+			continue;
+		}
+
+		if (filter && !filter(s->param)) {
 			continue;
 		}
 
@@ -345,9 +349,9 @@ out:
 	return result;
 }
 
-int flash_param_save(bool only_unsaved)
+int flash_param_save(bool only_unsaved, param_filter_func filter)
 {
-	return param_export_internal(only_unsaved);
+	return param_export_internal(only_unsaved, filter);
 }
 
 int flash_param_load()

--- a/src/lib/parameters/flashparams/flashparams.cpp
+++ b/src/lib/parameters/flashparams/flashparams.cpp
@@ -362,5 +362,5 @@ int flash_param_load()
 
 int flash_param_import()
 {
-	return param_import_internal(false);
+	return param_import_internal(true);
 }

--- a/src/lib/parameters/flashparams/flashparams.h
+++ b/src/lib/parameters/flashparams/flashparams.h
@@ -63,7 +63,7 @@ __EXPORT int param_set_external(param_t param, const void *val, bool mark_saved,
 __EXPORT const void *param_get_value_ptr_external(param_t param);
 
 /* The interface hooks to the Flash based storage. The caller is responsible for locking */
-__EXPORT int flash_param_save(bool only_unsaved);
+__EXPORT int flash_param_save(bool only_unsaved, param_filter_func filter);
 __EXPORT int flash_param_load();
 __EXPORT int flash_param_import();
 

--- a/src/lib/parameters/param.h
+++ b/src/lib/parameters/param.h
@@ -308,10 +308,11 @@ __EXPORT int		param_export(int fd, bool only_unsaved, param_filter_func filter);
  * This function merges the imported parameters with the current parameter set.
  *
  * @param fd		File descriptor to import from (-1 selects the FLASH storage).
+ * @param mark_saved	Whether to mark imported parameters as already saved
  * @return		Zero on success, nonzero if an error occurred during import.
  *			Note that in the failure case, parameters may be inconsistent.
  */
-__EXPORT int		param_import(int fd);
+__EXPORT int		param_import(int fd, bool mark_saved);
 
 /**
  * Load parameters from a file.

--- a/src/lib/parameters/param.h
+++ b/src/lib/parameters/param.h
@@ -278,6 +278,8 @@ __EXPORT void		param_reset_all(void);
  */
 __EXPORT void		param_reset_excludes(const char *excludes[], int num_excludes);
 
+typedef bool(*param_filter_func)(param_t handle);
+
 /**
  * Reset only specific parameters to their default values.
  *
@@ -294,9 +296,11 @@ __EXPORT void		param_reset_specific(const char *resets[], int num_resets);
  *
  * @param fd		File descriptor to export to (-1 selects the FLASH storage).
  * @param only_unsaved	Only export changed parameters that have not yet been exported.
+ * @param filter	Filter parameters to be exported. The method should return true if
+ * 			the parameter should be exported. No filtering if nullptr is passed.
  * @return		Zero on success, nonzero on failure.
  */
-__EXPORT int		param_export(int fd, bool only_unsaved);
+__EXPORT int		param_export(int fd, bool only_unsaved, param_filter_func filter);
 
 /**
  * Import parameters from a file, discarding any unrecognized parameters.

--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -1300,13 +1300,13 @@ param_import_internal(int fd, bool mark_saved)
 }
 
 int
-param_import(int fd)
+param_import(int fd, bool mark_saved)
 {
 	if (fd < 0) {
 		return flash_param_import();
 	}
 
-	return param_import_internal(fd, false);
+	return param_import_internal(fd, mark_saved);
 }
 
 int

--- a/src/lib/parameters/parameters_shmem.cpp
+++ b/src/lib/parameters/parameters_shmem.cpp
@@ -991,7 +991,7 @@ param_save_default()
 		goto do_exit;
 	}
 
-	res = param_export(fd, false);
+	res = param_export(fd, false, nullptr);
 
 	if (res != OK) {
 		PX4_ERR("failed to write parameters to file: %s", filename);
@@ -1088,7 +1088,7 @@ param_load_default_no_notify()
 }
 
 int
-param_export(int fd, bool only_unsaved)
+param_export(int fd, bool only_unsaved, param_filter_func filter)
 {
 	perf_begin(param_export_perf);
 
@@ -1126,6 +1126,10 @@ param_export(int fd, bool only_unsaved)
 		 * one hasn't, then skip it
 		 */
 		if (only_unsaved && !s->unsaved) {
+			continue;
+		}
+
+		if (filter && !filter(s->param)) {
 			continue;
 		}
 

--- a/src/lib/parameters/parameters_shmem.cpp
+++ b/src/lib/parameters/parameters_shmem.cpp
@@ -1073,7 +1073,7 @@ param_load_default_no_notify()
 		return 1;
 	}
 
-	int result = param_import(fd_load);
+	int result = param_import(fd_load, true);
 
 	close(fd_load);
 
@@ -1351,10 +1351,10 @@ param_import_internal(int fd, bool mark_saved)
 }
 
 int
-param_import(int fd)
+param_import(int fd, bool mark_saved)
 {
 #if !defined(FLASH_BASED_PARAMS)
-	return param_import_internal(fd, false);
+	return param_import_internal(fd, mark_saved);
 #else
 	(void)fd; // unused
 	// no need for locking here

--- a/src/lib/systemlib/system_params.c
+++ b/src/lib/systemlib/system_params.c
@@ -235,6 +235,19 @@ PARAM_DEFINE_INT32(SYS_HAS_MAG, 1);
 PARAM_DEFINE_INT32(SYS_HAS_BARO, 1);
 
 /**
+ * Enable factory calibration mode
+ *
+ * If enabled, future sensor calibrations will be stored to /fs/mtd_caldata.
+ *
+ * Note: this is only supported on boards with a separate calibration storage
+ * /fs/mtd_caldata.
+ *
+ * @boolean
+ * @group System
+ */
+PARAM_DEFINE_INT32(SYS_FAC_CAL_MODE, 0);
+
+/**
  * Bootloader update
  *
  * If enabled, update the bootloader on the next boot.

--- a/src/modules/commander/CMakeLists.txt
+++ b/src/modules/commander/CMakeLists.txt
@@ -45,6 +45,7 @@ px4_add_module(
 		Commander.cpp
 		commander_helper.cpp
 		esc_calibration.cpp
+		factory_calibration_storage.cpp
 		gyro_calibration.cpp
 		level_calibration.cpp
 		mag_calibration.cpp

--- a/src/modules/commander/accelerometer_calibration.cpp
+++ b/src/modules/commander/accelerometer_calibration.cpp
@@ -124,6 +124,7 @@
 #include "calibration_messages.h"
 #include "calibration_routines.h"
 #include "commander_helper.h"
+#include "factory_calibration_storage.h"
 
 #include <px4_platform_common/defines.h>
 #include <px4_platform_common/posix.h>
@@ -342,6 +343,13 @@ int do_accel_calibration(orb_advert_t *mavlink_log_pub)
 		return PX4_ERROR;
 	}
 
+	FactoryCalibrationStorage factory_storage;
+
+	if (factory_storage.open() != PX4_OK) {
+		calibration_log_critical(mavlink_log_pub, "ERROR: cannot open calibration storage");
+		return PX4_ERROR;
+	}
+
 	/* measure and calculate offsets & scales */
 	accel_worker_data_t worker_data{};
 	worker_data.mavlink_log_pub = mavlink_log_pub;
@@ -420,6 +428,10 @@ int do_accel_calibration(orb_advert_t *mavlink_log_pub)
 			}
 		}
 
+		if (!failed && factory_storage.store() != PX4_OK) {
+			failed = true;
+		}
+
 		if (param_save) {
 			param_notify_changes();
 		}
@@ -441,6 +453,13 @@ int do_accel_calibration_quick(orb_advert_t *mavlink_log_pub)
 
 	bool param_save = false;
 	bool failed = true;
+
+	FactoryCalibrationStorage factory_storage;
+
+	if (factory_storage.open() != PX4_OK) {
+		calibration_log_critical(mavlink_log_pub, "ERROR: cannot open calibration storage");
+		return PX4_ERROR;
+	}
 
 	// sensor thermal corrections (optional)
 	uORB::Subscription sensor_correction_sub{ORB_ID(sensor_correction)};
@@ -557,6 +576,10 @@ int do_accel_calibration_quick(orb_advert_t *mavlink_log_pub)
 				}
 			}
 		}
+	}
+
+	if (!failed && factory_storage.store() != PX4_OK) {
+		failed = true;
 	}
 
 	if (param_save) {

--- a/src/modules/commander/factory_calibration_storage.cpp
+++ b/src/modules/commander/factory_calibration_storage.cpp
@@ -1,0 +1,107 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+
+#include <lib/parameters/param.h>
+#include <px4_platform_common/log.h>
+
+#include "factory_calibration_storage.h"
+
+
+static const char *CALIBRATION_STORAGE = "/fs/mtd_caldata";
+
+static bool filter_calibration_params(param_t handle)
+{
+	const char *name = param_name(handle);
+	// filter all non-calibration params
+	return strncmp(name, "CAL_", 4) == 0 || strncmp(name, "TC_", 3) == 0;
+}
+
+FactoryCalibrationStorage::FactoryCalibrationStorage()
+{
+	int32_t param = 0;
+	param_get(param_find("SYS_FAC_CAL_MODE"), &param);
+	_enabled = param == 1;
+}
+
+int FactoryCalibrationStorage::open()
+{
+	if (_fd >= 0) {
+		cleanup();
+	}
+
+	if (!_enabled) {
+		return 0;
+	}
+
+	_fd = ::open(CALIBRATION_STORAGE, O_RDWR);
+
+	if (_fd == -1) {
+		return -errno;
+	}
+
+	PX4_INFO("Storing parameters to factory storage %s", CALIBRATION_STORAGE);
+	param_control_autosave(false);
+	return 0;
+}
+
+int FactoryCalibrationStorage::store()
+{
+	if (!_enabled) {
+		return 0;
+	}
+
+	int ret = param_export(_fd, false, filter_calibration_params);
+
+	if (ret != 0) {
+		PX4_ERR("param export failed (%i)", ret);
+	}
+
+	return ret;
+}
+
+void FactoryCalibrationStorage::cleanup()
+{
+	if (_enabled) {
+		param_control_autosave(true);
+	}
+
+	if (_fd >= 0) {
+		close(_fd);
+		_fd = -1;
+	}
+}
+

--- a/src/modules/commander/factory_calibration_storage.h
+++ b/src/modules/commander/factory_calibration_storage.h
@@ -1,0 +1,64 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+/**
+ * @class FactoryCalibrationStorage
+ * Stores calibration parameters to a separate storage, if enabled by parameter
+ */
+class FactoryCalibrationStorage
+{
+public:
+	FactoryCalibrationStorage();
+	~FactoryCalibrationStorage() { cleanup(); }
+
+	/**
+	 * open the storage & disable param autosaving
+	 * @return 0 on success, <0 error otherwise
+	 */
+	int open();
+
+	/**
+	 * store the calibration parameters
+	 * Note: this method requires a lot of stack
+	 * @return 0 on success, <0 error otherwise
+	 */
+	int store();
+
+private:
+	void cleanup();
+
+	bool _enabled{false};
+	int _fd{-1};
+};

--- a/src/modules/commander/gyro_calibration.cpp
+++ b/src/modules/commander/gyro_calibration.cpp
@@ -38,6 +38,7 @@
  */
 
 #include <px4_platform_common/px4_config.h>
+#include "factory_calibration_storage.h"
 #include "gyro_calibration.h"
 #include "calibration_messages.h"
 #include "calibration_routines.h"
@@ -285,6 +286,13 @@ int do_gyro_calibration(orb_advert_t *mavlink_log_pub)
 		res = PX4_ERROR;
 	}
 
+	FactoryCalibrationStorage factory_storage;
+
+	if (factory_storage.open() != PX4_OK) {
+		calibration_log_critical(mavlink_log_pub, "ERROR: cannot open calibration storage");
+		res = PX4_ERROR;
+	}
+
 	if (res == PX4_OK) {
 		// set offset parameters to new values
 		bool param_save = false;
@@ -314,6 +322,10 @@ int do_gyro_calibration(orb_advert_t *mavlink_log_pub)
 				calibration_log_critical(mavlink_log_pub, "calibration save failed");
 				break;
 			}
+		}
+
+		if (!failed && factory_storage.store() != PX4_OK) {
+			failed = true;
 		}
 
 		if (param_save) {

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -245,6 +245,7 @@ Sensors::Sensors(bool hil_enabled) :
 	param_find("SENS_BOARD_Y_OFF");
 	param_find("SENS_BOARD_Z_OFF");
 
+	param_find("SYS_FAC_CAL_MODE");
 	param_find("SYS_PARAM_VER");
 	param_find("SYS_AUTOSTART");
 	param_find("SYS_AUTOCONFIG");

--- a/src/systemcmds/mtd/mtd.cpp
+++ b/src/systemcmds/mtd/mtd.cpp
@@ -80,6 +80,8 @@ int mtd_main(int argc, char *argv[])
 
 #else
 
+struct mtd_instance_s;
+
 #  if defined(BOARD_HAS_MTD_PARTITION_OVERRIDE)
 #    define MTD_PARTITION_TABLE  BOARD_HAS_MTD_PARTITION_OVERRIDE
 #  else
@@ -88,28 +90,45 @@ int mtd_main(int argc, char *argv[])
 
 
 #ifdef CONFIG_MTD_RAMTRON
-static int	ramtron_attach(void);
+static int	ramtron_attach(mtd_instance_s &instance);
 #else
 
 #ifndef PX4_I2C_BUS_MTD
 #error "Board needs to define PX4_I2C_BUS_MTD for onboard EEPROM bus"
 #endif
 
-
-static int	at24xxx_attach(void);
 #endif
-static int	mtd_start(const char *partition_names[], unsigned n_partitions);
-static int	mtd_erase(const char *partition_names[], unsigned n_partitions);
-static int	mtd_readtest(const char *partition_names[], unsigned n_partitions);
-static int	mtd_rwtest(const char *partition_names[], unsigned n_partitions);
-static int	mtd_print_info(void);
-static int	mtd_get_geometry(unsigned long *blocksize, unsigned long *erasesize, unsigned long *neraseblocks,
-				 unsigned *blkpererase, unsigned *nblocks, unsigned *partsize, unsigned n_partitions);
 
-static bool attached = false;
-static bool started = false;
-static struct mtd_dev_s *mtd_dev;
-static unsigned n_partitions_current = 0;
+#ifdef PX4_I2C_BUS_MTD
+static int	at24xxx_attach(mtd_instance_s &instance);
+#endif
+
+static int	mtd_start(mtd_instance_s &instance, const char *partition_names[], unsigned n_partitions);
+static int	mtd_erase(const char *partition_names[], unsigned n_partitions);
+static int	mtd_readtest(const mtd_instance_s &instance, const char *partition_names[], unsigned n_partitions);
+static int	mtd_rwtest(const mtd_instance_s &instance, const char *partition_names[], unsigned n_partitions);
+static int	mtd_print_info(int instance);
+static int	mtd_get_geometry(const mtd_instance_s &instance, unsigned long *blocksize, unsigned long *erasesize,
+				 unsigned long *neraseblocks,
+				 unsigned *blkpererase, unsigned *nblocks, unsigned *partsize);
+
+struct mtd_instance_s {
+	int (*attach)(mtd_instance_s &instance);
+	bool attached;
+	bool started;
+	struct mtd_dev_s *mtd_dev;
+	unsigned n_partitions_current;
+};
+
+static mtd_instance_s instances[] = {
+#ifdef CONFIG_MTD_RAMTRON
+	{&ramtron_attach, false, false, nullptr, 0},
+#endif
+#ifdef PX4_I2C_BUS_MTD
+	{&at24xxx_attach, false, false, nullptr, 0},
+#endif
+};
+static constexpr int num_instances = arraySize(instances);
 
 /* note, these will be equally sized */
 static const char *partition_names_default[] = MTD_PARTITION_TABLE;
@@ -118,12 +137,22 @@ static const int n_partitions_default = arraySize(partition_names_default);
 static int
 mtd_status(void)
 {
-	if (!attached) {
-		PX4_ERR("MTD driver not started");
+	int ret = 0;
+	bool running = false;
+
+	for (int i = 0; i < num_instances; ++i) {
+		if (instances[i].attached) {
+			ret |= mtd_print_info(i);
+			running = true;
+		}
+	}
+
+	if (!running) {
+		PX4_INFO("MTD driver not started");
 		return 1;
 	}
 
-	return mtd_print_info();
+	return ret;
 }
 
 static void	print_usage(void)
@@ -137,6 +166,10 @@ static void	print_usage(void)
 	PRINT_MODULE_USAGE_COMMAND_DESCR("readtest", "Perform read test");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("rwtest", "Perform read-write test");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("erase", "Erase partition(s)");
+	PRINT_MODULE_USAGE_COMMAND_DESCR("has-secondary", "Check if the board has configured a secondary device");
+
+	PRINT_MODULE_USAGE_PARAM_COMMENT("The commands 'start', 'readtest' and 'rwtest' have an optional instance index:");
+	PRINT_MODULE_USAGE_PARAM_INT('i', 0, 0, 1, "storage index (if the board has multiple storages)", true);
 
 	PRINT_MODULE_USAGE_PARAM_COMMENT("The commands 'start', 'readtest', 'rwtest' and 'erase' have an optional parameter:");
 	PRINT_MODULE_USAGE_ARG("<partition_name1> [<partition_name2> ...]",
@@ -146,32 +179,46 @@ static void	print_usage(void)
 int mtd_main(int argc, char *argv[])
 {
 	if (argc >= 2) {
+		int instance = 0;
+		int partition_index = 2;
+
+		if (argc > 3 && !strcmp(argv[2], "-i")) {
+			instance = strtol(argv[3], nullptr, 10);
+
+			if (instance < 0 || instance >= num_instances) {
+				PX4_ERR("invalid instance");
+				return -1;
+			}
+
+			partition_index += 2;
+		}
+
 		if (!strcmp(argv[1], "start")) {
 
 			/* start mapping according to user request */
-			if (argc >= 3) {
-				return mtd_start((const char **)(argv + 2), argc - 2);
+			if (argc > partition_index) {
+				return mtd_start(instances[instance], (const char **)(argv + partition_index), argc - partition_index);
 
 			} else {
-				return mtd_start(partition_names_default, n_partitions_default);
+				return mtd_start(instances[instance], partition_names_default, n_partitions_default);
 			}
 		}
 
 		if (!strcmp(argv[1], "readtest")) {
-			if (argc >= 3) {
-				return mtd_readtest((const char **)(argv + 2), argc - 2);
+			if (argc > partition_index) {
+				return mtd_readtest(instances[instance], (const char **)(argv + partition_index), argc - partition_index);
 
 			} else {
-				return mtd_readtest(partition_names_default, n_partitions_default);
+				return mtd_readtest(instances[instance], partition_names_default, n_partitions_default);
 			}
 		}
 
 		if (!strcmp(argv[1], "rwtest")) {
-			if (argc >= 3) {
-				return mtd_rwtest((const char **)(argv + 2), argc - 2);
+			if (argc > partition_index) {
+				return mtd_rwtest(instances[instance], (const char **)(argv + partition_index), argc - partition_index);
 
 			} else {
-				return mtd_rwtest(partition_names_default, n_partitions_default);
+				return mtd_rwtest(instances[instance], partition_names_default, n_partitions_default);
 			}
 		}
 
@@ -180,12 +227,16 @@ int mtd_main(int argc, char *argv[])
 		}
 
 		if (!strcmp(argv[1], "erase")) {
-			if (argc >= 3) {
-				return mtd_erase((const char **)(argv + 2), argc - 2);
+			if (argc > partition_index) {
+				return mtd_erase((const char **)(argv + partition_index), argc - partition_index);
 
 			} else {
 				return mtd_erase(partition_names_default, n_partitions_default);
 			}
+		}
+
+		if (!strcmp(argv[1], "has-secondary")) {
+			return num_instances > 1 ? 0 : 1;
 		}
 	}
 
@@ -199,7 +250,7 @@ struct mtd_dev_s *mtd_partition(FAR struct mtd_dev_s *mtd,
 
 #ifdef CONFIG_MTD_RAMTRON
 static int
-ramtron_attach(void)
+ramtron_attach(mtd_instance_s &instance)
 {
 	/* initialize the right spi */
 	struct spi_dev_s *spi = px4_spibus_initialize(px4_find_spi_bus(SPIDEV_FLASH(0)));
@@ -218,9 +269,9 @@ ramtron_attach(void)
 	/* start the RAMTRON driver, attempt 5 times */
 
 	for (int i = 0; i < 5; i++) {
-		mtd_dev = ramtron_initialize(spi);
+		instance.mtd_dev = ramtron_initialize(spi);
 
-		if (mtd_dev) {
+		if (instance.mtd_dev) {
 			/* abort on first valid result */
 			if (i > 0) {
 				PX4_WARN("mtd needed %d attempts to attach", i + 1);
@@ -231,12 +282,12 @@ ramtron_attach(void)
 	}
 
 	/* if last attempt is still unsuccessful, abort */
-	if (mtd_dev == nullptr) {
+	if (instance.mtd_dev == nullptr) {
 		PX4_ERR("failed to initialize mtd driver");
 		return 1;
 	}
 
-	int ret = mtd_dev->ioctl(mtd_dev, MTDIOC_SETSPEED, (unsigned long)10 * 1000 * 1000);
+	int ret = instance.mtd_dev->ioctl(instance.mtd_dev, MTDIOC_SETSPEED, (unsigned long)10 * 1000 * 1000);
 
 	if (ret != OK) {
 		// FIXME: From the previous warning call, it looked like this should have been fatal error instead. Tried
@@ -245,13 +296,15 @@ ramtron_attach(void)
 		PX4_WARN("failed to set bus speed");
 	}
 
-	attached = true;
+	instance.attached = true;
 	return 0;
 }
-#else
+#endif
+
+#ifdef PX4_I2C_BUS_MTD
 
 static int
-at24xxx_attach(void)
+at24xxx_attach(mtd_instance_s &instance)
 {
 	/* find the right I2C */
 	struct i2c_master_s *i2c = px4_i2cbus_initialize(PX4_I2C_BUS_MTD);
@@ -263,9 +316,9 @@ at24xxx_attach(void)
 
 	/* start the MTD driver, attempt 5 times */
 	for (int i = 0; i < 5; i++) {
-		mtd_dev = at24c_initialize(i2c);
+		instance.mtd_dev = at24c_initialize(i2c);
 
-		if (mtd_dev) {
+		if (instance.mtd_dev) {
 			/* abort on first valid result */
 			if (i > 0) {
 				PX4_WARN("EEPROM needed %d attempts to attach", i + 1);
@@ -276,47 +329,44 @@ at24xxx_attach(void)
 	}
 
 	/* if last attempt is still unsuccessful, abort */
-	if (mtd_dev == nullptr) {
+	if (instance.mtd_dev == nullptr) {
 		PX4_ERR("failed to initialize EEPROM driver");
 		return 1;
 	}
 
-	attached = true;
+	instance.attached = true;
 	return 0;
 }
 #endif
 
 static int
-mtd_start(const char *partition_names[], unsigned n_partitions)
+mtd_start(mtd_instance_s &instance, const char *partition_names[], unsigned n_partitions)
 {
 	int ret;
 
-	if (started) {
+	if (instance.started) {
 		PX4_ERR("mtd already mounted");
 		return 1;
 	}
 
-	if (!attached) {
-#ifdef CONFIG_MTD_RAMTRON
-		ret = ramtron_attach();
-#else
-		ret = at24xxx_attach();
-#endif
+	if (!instance.attached) {
+		ret = instance.attach(instance);
 
 		if (ret != 0) {
 			return ret;
 		}
 	}
 
-	if (!mtd_dev) {
-		PX4_ERR("Failed to create RAMTRON FRAM MTD instance");
+	if (!instance.mtd_dev) {
+		PX4_ERR("Failed to create MTD instance");
 		return 1;
 	}
 
 	unsigned long blocksize, erasesize, neraseblocks;
 	unsigned blkpererase, nblocks, partsize;
 
-	ret = mtd_get_geometry(&blocksize, &erasesize, &neraseblocks, &blkpererase, &nblocks, &partsize, n_partitions);
+	instance.n_partitions_current = n_partitions;
+	ret = mtd_get_geometry(instance, &blocksize, &erasesize, &neraseblocks, &blkpererase, &nblocks, &partsize);
 
 	if (ret) {
 		return ret;
@@ -334,7 +384,7 @@ mtd_start(const char *partition_names[], unsigned n_partitions)
 
 		/* Create the partition */
 
-		part[i] = mtd_partition(mtd_dev, offset, nblocks);
+		part[i] = mtd_partition(instance.mtd_dev, offset, nblocks);
 
 		if (!part[i]) {
 			PX4_ERR("mtd_partition failed. offset=%lu nblocks=%lu",
@@ -344,13 +394,21 @@ mtd_start(const char *partition_names[], unsigned n_partitions)
 
 		/* Initialize to provide an FTL block driver on the MTD FLASH interface */
 
-		snprintf(blockname, sizeof(blockname), "/dev/mtdblock%d", i);
+		ret = -1;
 
-		ret = ftl_initialize(i, part[i]);
+		for (int dev_index = 0; ret != 0; ++dev_index) {
+			snprintf(blockname, sizeof(blockname), "/dev/mtdblock%d", i + dev_index);
 
-		if (ret < 0) {
-			PX4_ERR("ftl_initialize %s failed: %d", blockname, ret);
-			return 1;
+			ret = ftl_initialize(i + dev_index, part[i]);
+
+			if (ret == -EEXIST) {
+				continue;
+			}
+
+			if (ret < 0 || dev_index >= 9) {
+				PX4_ERR("ftl_initialize %s failed: %d", blockname, ret);
+				return 1;
+			}
 		}
 
 		/* Now create a character device on the block device */
@@ -363,20 +421,19 @@ mtd_start(const char *partition_names[], unsigned n_partitions)
 		}
 	}
 
-	n_partitions_current = n_partitions;
-
-	started = true;
+	instance.started = true;
 	return 0;
 }
 
-int mtd_get_geometry(unsigned long *blocksize, unsigned long *erasesize, unsigned long *neraseblocks,
-		     unsigned *blkpererase, unsigned *nblocks, unsigned *partsize, unsigned n_partitions)
+int mtd_get_geometry(const mtd_instance_s &instance, unsigned long *blocksize, unsigned long *erasesize,
+		     unsigned long *neraseblocks,
+		     unsigned *blkpererase, unsigned *nblocks, unsigned *partsize)
 {
 	/* Get the geometry of the FLASH device */
 
 	FAR struct mtd_geometry_s geo;
 
-	int ret = mtd_dev->ioctl(mtd_dev, MTDIOC_GEOMETRY, (unsigned long)((uintptr_t)&geo));
+	int ret = instance.mtd_dev->ioctl(instance.mtd_dev, MTDIOC_GEOMETRY, (unsigned long)((uintptr_t)&geo));
 
 	if (ret < 0) {
 		PX4_ERR("mtd->ioctl failed: %d", ret);
@@ -393,7 +450,7 @@ int mtd_get_geometry(unsigned long *blocksize, unsigned long *erasesize, unsigne
 	 */
 
 	*blkpererase = geo.erasesize / geo.blocksize;
-	*nblocks     = (geo.neraseblocks / n_partitions) * *blkpererase;
+	*nblocks     = (geo.neraseblocks / instance.n_partitions_current) * *blkpererase;
 	*partsize    = *nblocks * geo.blocksize;
 
 	return ret;
@@ -402,13 +459,12 @@ int mtd_get_geometry(unsigned long *blocksize, unsigned long *erasesize, unsigne
 /*
   get partition size in bytes
  */
-static ssize_t mtd_get_partition_size(void)
+static ssize_t mtd_get_partition_size(const mtd_instance_s &instance)
 {
 	unsigned long blocksize, erasesize, neraseblocks;
 	unsigned blkpererase, nblocks, partsize = 0;
 
-	int ret = mtd_get_geometry(&blocksize, &erasesize, &neraseblocks, &blkpererase, &nblocks, &partsize,
-				   n_partitions_current);
+	int ret = mtd_get_geometry(instance, &blocksize, &erasesize, &neraseblocks, &blkpererase, &nblocks, &partsize);
 
 	if (ret != OK) {
 		PX4_ERR("Failed to get geometry");
@@ -418,28 +474,24 @@ static ssize_t mtd_get_partition_size(void)
 	return partsize;
 }
 
-int mtd_print_info(void)
+int mtd_print_info(int instance)
 {
-	if (!attached) {
-		return 1;
-	}
-
 	unsigned long blocksize, erasesize, neraseblocks;
 	unsigned blkpererase, nblocks, partsize;
 
-	int ret = mtd_get_geometry(&blocksize, &erasesize, &neraseblocks, &blkpererase, &nblocks, &partsize,
-				   n_partitions_current);
+	int ret = mtd_get_geometry(instances[instance], &blocksize, &erasesize, &neraseblocks, &blkpererase, &nblocks,
+				   &partsize);
 
 	if (ret) {
 		return ret;
 	}
 
-	PX4_INFO("Flash Geometry:");
+	PX4_INFO("Flash Geometry of instance %i:", instance);
 
 	printf("  blocksize:      %lu\n", blocksize);
 	printf("  erasesize:      %lu\n", erasesize);
 	printf("  neraseblocks:   %lu\n", neraseblocks);
-	printf("  No. partitions: %u\n", n_partitions_current);
+	printf("  No. partitions: %u\n", instances[instance].n_partitions_current);
 	printf("  Partition size: %u Blocks (%u bytes)\n", nblocks, partsize);
 	printf("  TOTAL SIZE: %u KiB\n", neraseblocks * erasesize / 1024);
 
@@ -479,9 +531,9 @@ mtd_erase(const char *partition_names[], unsigned n_partitions)
   bad reads (the ramtron driver does return an error)
  */
 int
-mtd_readtest(const char *partition_names[], unsigned n_partitions)
+mtd_readtest(const mtd_instance_s &instance, const char *partition_names[], unsigned n_partitions)
 {
-	ssize_t expected_size = mtd_get_partition_size();
+	ssize_t expected_size = mtd_get_partition_size(instance);
 
 	if (expected_size == 0) {
 		return 1;
@@ -522,9 +574,9 @@ mtd_readtest(const char *partition_names[], unsigned n_partitions)
   data isn't the same
  */
 int
-mtd_rwtest(const char *partition_names[], unsigned n_partitions)
+mtd_rwtest(const mtd_instance_s &instance, const char *partition_names[], unsigned n_partitions)
 {
-	ssize_t expected_size = mtd_get_partition_size();
+	ssize_t expected_size = mtd_get_partition_size(instance);
 
 	if (expected_size == 0) {
 		return 1;

--- a/src/systemcmds/param/param.cpp
+++ b/src/systemcmds/param/param.cpp
@@ -83,7 +83,7 @@ enum class COMPARE_ERROR_LEVEL {
 static int 	do_save(const char *param_file_name);
 static int	do_save_default();
 static int 	do_load(const char *param_file_name);
-static int	do_import(const char *param_file_name);
+static int	do_import(const char *param_file_name = nullptr);
 static int	do_show(const char *search_string, bool only_changed);
 static int	do_show_for_airframe();
 static int	do_show_all();
@@ -213,7 +213,7 @@ param_main(int argc, char *argv[])
 				return do_import(argv[2]);
 
 			} else {
-				return do_import(param_get_default_file());
+				return do_import();
 			}
 		}
 
@@ -428,6 +428,12 @@ do_load(const char *param_file_name)
 static int
 do_import(const char *param_file_name)
 {
+	bool mark_saved = false;
+	if (param_file_name == nullptr) {
+		param_file_name = param_get_default_file();
+		mark_saved = true; // if imported from default storage, mark as saved
+	}
+
 	int fd = -1;
 	if (param_file_name) { // passing NULL means to select the flash storage
 		fd = open(param_file_name, O_RDONLY);
@@ -438,7 +444,7 @@ do_import(const char *param_file_name)
 		}
 	}
 
-	int result = param_import(fd);
+	int result = param_import(fd, mark_saved);
 	if (fd >= 0) {
 		close(fd);
 	}

--- a/src/systemcmds/param/param.cpp
+++ b/src/systemcmds/param/param.cpp
@@ -381,7 +381,7 @@ do_save(const char *param_file_name)
 		return 1;
 	}
 
-	int result = param_export(fd, false);
+	int result = param_export(fd, false, nullptr);
 	close(fd);
 
 	if (result < 0) {

--- a/src/systemcmds/tests/test_parameters.cpp
+++ b/src/systemcmds/tests/test_parameters.cpp
@@ -363,7 +363,7 @@ bool ParameterTest::exportImportAll()
 		return false;
 	}
 
-	int result = param_export(fd, false);
+	int result = param_export(fd, false, nullptr);
 
 	if (result != PX4_OK) {
 		PX4_ERR("param_export failed");
@@ -516,7 +516,7 @@ bool ParameterTest::exportImportAll()
 		return false;
 	}
 
-	result = param_import(fd);
+	result = param_import(fd, false);
 	close(fd);
 
 	if (result < 0) {


### PR DESCRIPTION
- extends support for mtd to multiple devices
- extend `param_import` & `param_export` API's
- enables the EEPROM on the v5x IMU board and uses it as secondary storage (under `/fs/mtd_caldata`)
- if the device is enabled, parameters are loaded from that before the general parameters. This allows to store factory calibration parameters in `/fs/mtd_caldata`, allowing users to recalibrate and reset to factory.
- A parameter (`SYS_FAC_CAL_MODE`) is used to determine where to store the params after calibration. This could alternatively be done via a vehicle command or just an nsh command.

### Workflow
- enable `SYS_FAC_CAL_MODE`
- do sensor calibrations
- disable `SYS_FAC_CAL_MODE`

For later we can use separate parameter names for factory defaults.