### PR TITLE
fix arm authorization

### DIFF
--- a/src/modules/commander/Arming/ArmAuthorization/ArmAuthorization.cpp
+++ b/src/modules/commander/Arming/ArmAuthorization/ArmAuthorization.cpp
@@ -230,7 +230,7 @@ void arm_auth_update(hrt_abstime now, bool param_update)
 					 "Arm auth: Authorized for the next %u seconds",
 					 command_ack.result_param2);
 			state = ARM_AUTH_MISSION_APPROVED;
-			auth_timeout = now + (command_ack.result_param2 * 1000000);
+			auth_timeout = command_ack.timestamp + (command_ack.result_param2 * 1000000);
 			return;
 
 		case vehicle_command_ack_s::VEHICLE_RESULT_TEMPORARILY_REJECTED:

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2012,7 +2012,8 @@ Commander::run()
 			/* allow a grace period for re-arming: preflight checks don't need to pass during that time,
 			 * for example for accidential in-air disarming */
 			const bool in_arming_grace_period = (_last_disarmed_timestamp != 0)
-							    && (hrt_elapsed_time(&_last_disarmed_timestamp) < 5_s);
+							    && (hrt_elapsed_time(&_last_disarmed_timestamp)
+								< _param_com_arm_grace_t.get() * 1_s);
 
 			const bool arm_switch_to_arm_transition = !_param_arm_switch_is_button.get() &&
 					(_last_manual_control_setpoint_arm_switch == manual_control_setpoint_s::SWITCH_POS_OFF) &&

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -225,6 +225,7 @@ private:
 		(ParamBool<px4::params::COM_ARM_MIS_REQ>) _param_arm_mission_required,
 		(ParamBool<px4::params::COM_ARM_AUTH_REQ>) _param_arm_auth_required,
 		(ParamBool<px4::params::COM_ARM_CHK_ESCS>) _param_escs_checks_required,
+		(ParamFloat<px4::params::COM_ARM_GRACE_T>) _param_com_arm_grace_t,
 
 		(ParamInt<px4::params::COM_FLIGHT_UUID>) _param_flight_uuid,
 		(ParamInt<px4::params::COM_TAKEOFF_ACT>) _param_takeoff_finished_action,

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -698,6 +698,17 @@ PARAM_DEFINE_INT32(COM_ARM_AUTH, 256010);
 PARAM_DEFINE_INT32(COM_ARM_AUTH_REQ, 0);
 
 /**
+ * Arming grace duration.
+ *
+ * Duration after disarm during which arming is authorized without prearm checks
+ *
+ * @group Commander
+ * @unit s
+ * @min 0
+ */
+PARAM_DEFINE_FLOAT(COM_ARM_GRACE_T, 5);
+
+/**
  * Loss of position failsafe activation delay.
  *
  * This sets number of seconds that the position checks need to be failed before the failsafe will activate.


### PR DESCRIPTION
**Describe problem solved by this pull request**
Our drones are supposed to wait an authorization before arming.  But, in some case, it was possible to arm without receiving an authorization. 

The first case is just after disarming. This is due to the "arming_grace_period" fixed to 5s. A commit in this PR add a parameter that allows to change this duration.

The second case is because of an old "command_ack" kept in uorb topic. This PR use command_ack.timestamp to be sure that the authorization is not obsolete.


