### PR TITLE
vscode updates and improvements

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,42 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.134.0/containers/cpp
+{
+	"name": "px4-dev-nuttx",
+	"image": "px4io/px4-dev-nuttx-bionic:2020-04-01",
+
+	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"chiehyu.vscode-astyle",
+		"dan-c-underwood.arm",
+		"fredericbonnet.cmake-test-adapter",
+		"github.vscode-pull-request-github",
+		"marus25.cortex-debug",
+		"ms-azuretools.vscode-docker",
+		"ms-iot.vscode-ros",
+		"ms-python.python",
+		"ms-vscode.cmake-tools",
+		"ms-vscode.cpptools",
+		"ms-vscode.cpptools-extension-pack",
+		"redhat.vscode-yaml",
+		"streetsidesoftware.code-spell-checker",
+		"twxs.cmake",
+		"uavcan.dsdl",
+		"wholroyd.jinja",
+		"zixuanwang.linkerscript"
+	],
+
+	"containerUser": "user",
+	"containerEnv": {
+		"LOCAL_USER_ID": "${localEnv:UID}"
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [14556],
+}

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,74 +1,15 @@
 {
     "configurations": [
         {
-            "name": "Linux",
-            "browse": {
-                "limitSymbolsToIncludedHeaders": true,
-                "databaseFilename": "${workspaceFolder}/.vscode/browse.vc.db"
-            },
-            "compileCommands": "${workspaceFolder}/.vscode/compile_commands.json",
-            "compilerPath": "/usr/bin/g++",
+            "name": "PX4",
+            "includePath": [
+                "${workspaceFolder}/**"
+            ],
+            "defines": [],
+            "macFrameworkPath": [],
             "configurationProvider": "ms-vscode.cmake-tools",
             "cppStandard": "c++14",
-            "cStandard": "c11",
-            "defines": [
-                "__PX4_LINUX",
-                "__PX4_POSIX"
-            ],
-            "forcedInclude": [
-                "${workspaceFolder}/src/include/visibility.h"
-            ],
-            "includePath": [
-                "${workspaceFolder}/boards/px4/sitl/src",
-                "${workspaceFolder}/build/px4_sitl_default",
-                "${workspaceFolder}/platforms/common/include",
-                "${workspaceFolder}/platforms/posix/include",
-                "${workspaceFolder}/platforms/posix/src/px4/common/include",
-                "${workspaceFolder}/platforms/posix/src/px4/common/include",
-                "${workspaceFolder}/platforms/posix/src/px4/generic/generic/include",
-                "${workspaceFolder}/src",
-                "${workspaceFolder}/src/include",
-                "${workspaceFolder}/src/lib",
-                "${workspaceFolder}/src/lib",
-                "${workspaceFolder}/src/lib/matrix",
-                "${workspaceFolder}/src/modules"
-            ],
-            "intelliSenseMode": "${default}"
-        },
-        {
-            "name": "Mac",
-            "browse": {
-                "limitSymbolsToIncludedHeaders": true,
-                "databaseFilename": "${workspaceFolder}/.vscode/browse.vc.db"
-            },
-            "compileCommands": "${workspaceFolder}/.vscode/compile_commands.json",
-            "compilerPath": "/usr/bin/clang++",
-            "configurationProvider": "ms-vscode.cmake-tools",
-            "cppStandard": "c++14",
-            "cStandard": "c11",
-            "defines": [
-                "__PX4_DARWIN",
-                "__PX4_POSIX"
-            ],
-            "forcedInclude": [
-                "${workspaceFolder}/src/include/visibility.h"
-            ],
-            "includePath": [
-                "${workspaceFolder}/boards/px4/sitl/src",
-                "${workspaceFolder}/build/px4_sitl_default",
-                "${workspaceFolder}/platforms/common/include",
-                "${workspaceFolder}/platforms/posix/include",
-                "${workspaceFolder}/platforms/posix/src/px4/common/include",
-                "${workspaceFolder}/platforms/posix/src/px4/common/include",
-                "${workspaceFolder}/platforms/posix/src/px4/generic/generic/include",
-                "${workspaceFolder}/src",
-                "${workspaceFolder}/src/include",
-                "${workspaceFolder}/src/lib",
-                "${workspaceFolder}/src/lib",
-                "${workspaceFolder}/src/lib/matrix",
-                "${workspaceFolder}/src/modules"
-            ],
-            "intelliSenseMode": "${default}"
+            "cStandard": "c11"
         }
     ],
     "version": 4

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
     "recommendations": [
         "chiehyu.vscode-astyle",
         "dan-c-underwood.arm",
+        "fredericbonnet.cmake-test-adapter",
         "github.vscode-pull-request-github",
         "marus25.cortex-debug",
         "ms-azuretools.vscode-docker",
@@ -11,8 +12,9 @@
         "ms-python.python",
         "ms-vscode.cmake-tools",
         "ms-vscode.cpptools",
+        "ms-vscode.cpptools-extension-pack",
         "redhat.vscode-yaml",
-        "timonwong.shellcheck",
+        "streetsidesoftware.code-spell-checker",
         "twxs.cmake",
         "uavcan.dsdl",
         "wholroyd.jinja",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,70 +3,34 @@
         "astyle.c.enable": true,
         "astyle.cpp.enable": true,
         "breadcrumbs.enabled": true,
-        "cmake.autoRestartBuild": true,
-        "cmake.buildBeforeRun": true,
-        "cmake.buildDirectory": "${workspaceFolder}/build/${variant:CONFIG}",
-        "cmake.configureOnOpen": true,
-        "cmake.copyCompileCommands": "${workspaceFolder}/.vscode/compile_commands.json",
-        "cmake.debugConfig": {
-                "name": "SITL shell (gdb)",
-                "type": "cppdbg",
-                "request": "launch",
-                "program": "${command:cmake.launchTargetPath}",
-                "args": [
-                        "${workspaceFolder}/ROMFS/px4fmu_common",
-                        "-s",
-                        "etc/init.d-posix/rcS",
-                        "-t",
-                        "${workspaceFolder}/test_data"
-                ],
-                "stopAtEntry": false,
-                "cwd": "${command:cmake.buildDirectory}/tmp",
-                "environment": [
-                        {
-                                "name": "PX4_SIM_MODEL",
-                                "value": "shell"
-                        }
-                ],
-                "externalConsole": false,
-                "linux": {
-                        "MIMode": "gdb",
-                        "setupCommands": [
-                                {
-                                        "description": "Enable pretty-printing for gdb",
-                                        "text": "-enable-pretty-printing",
-                                        "ignoreFailures": true
-                                },
-                                {
-                                        "description": "PX4 ignore wq signals",
-                                        "text": "handle SIGCONT nostop noprint nopass",
-                                        "ignoreFailures": true
-                                }
-                        ]
-                },
-                "osx": {
-                        "MIMode": "lldb",
-                        "setupCommands": [
-                                {
-                                        "text": "pro hand -p true -s false -n false SIGCONT",
-                                }
-                        ]
-                }
-        },
         "C_Cpp.autoAddFileAssociations": false,
         "C_Cpp.clang_format_fallbackStyle": "none",
-        "C_Cpp.default.browse.databaseFilename": "${workspaceRoot}/.vscode/browse.vc.db",
         "C_Cpp.default.browse.limitSymbolsToIncludedHeaders": true,
         "C_Cpp.default.cppStandard": "c++14",
         "C_Cpp.default.cStandard": "c11",
-        "C_Cpp.default.intelliSenseMode": "gcc-x64",
-        "C_Cpp.default.macFrameworkPath": null,
         "C_Cpp.formatting": "Disabled",
         "C_Cpp.intelliSenseEngine": "Default",
-        "C_Cpp.intelliSenseEngineFallback": "Enabled",
         "C_Cpp.vcpkg.enabled": false,
         "C_Cpp.workspaceParsingPriority": "low",
+        "cmake.buildBeforeRun": true,
+        "cmake.buildDirectory": "${workspaceFolder}/build/${variant:CONFIG}",
+        "cmake.buildTask": true,
+        "cmake.configureOnOpen": true,
+        "cmake.ctest.parallelJobs": 1,
+        "cmake.skipConfigureIfCachePresent": true,
+        "cmakeExplorer.buildDir": "${workspaceFolder}/build/px4_sitl_test",
+        "cmakeExplorer.parallelJobs": 1,
+        "cmakeExplorer.suiteDelimiter": "-",
         "cortex-debug.enableTelemetry": false,
+        "cSpell.allowCompoundWords": true,
+        "cSpell.diagnosticLevel": "Hint",
+        "cSpell.showStatus": false,
+        "cSpell.words": [
+                "acro",
+                "rattitude",
+                "nuttx",
+                "esc"
+        ],
         "debug.toolBarLocation": "docked",
         "editor.acceptSuggestionOnEnter": "off",
         "editor.defaultFormatter": "chiehyu.vscode-astyle",
@@ -88,7 +52,6 @@
         "git.ignoreLimitWarning": true,
         "githubPullRequests.defaultMergeMethod": "squash",
         "githubPullRequests.telemetry.enabled": false,
-        "gitlens.advanced.telemetry.enabled": false,
         "files.associations": {
                 "*.jinja": "jinja",
                 "algorithm": "cpp",
@@ -166,17 +129,15 @@
         },
         "search.showLineNumbers": true,
         "search.smartCase": true,
-        "shellcheck.exclude": [2154],
         "telemetry.enableTelemetry": false,
         "terminal.integrated.copyOnSelection": true,
-        "terminal.integrated.rightClickCopyPaste": true,
+        "terminal.integrated.rightClickBehavior": "paste",
         "terminal.integrated.scrollback": 5000,
         "window.title": "${dirty} ${activeEditorMedium}${separator}${rootName}",
         "workbench.editor.highlightModifiedTabs": true,
         "workbench.enableExperiments": false,
         "workbench.settings.enableNaturalLanguageSearch": false,
-        "workbench.statusBar.feedback.visible": false,
         "yaml.schemas": {
-                "${workspaceRoot}/validation/module_schema.yaml": "${workspaceRoot}/src/modules/*/module.yaml"
+                "${workspaceFolder}/validation/module_schema.yaml": "${workspaceFolder}/src/modules/*/module.yaml"
         }
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,11 +4,57 @@
     "version": "2.0.0",
     "tasks": [
         {
+            "label": "build",
+            "type": "shell",
+            "command": "/bin/bash",
+            "args": [
+                "-c",
+                "${command:cmake.tasksBuildCommand}"
+            ],
+            "options": {
+                "cwd": "${command:cmake.buildDirectory}"
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true,
+            },
+            "problemMatcher": {
+                "base": "$gcc",
+                "fileLocation": ["relative", "${command:cmake.buildDirectory}"]
+            },
+            "presentation":{
+                "echo": false,
+                "showReuseMessage": false,
+                "clear": true,
+                "panel": "shared",
+                "group": "build"
+            }
+        },
+        {
+            "label": "test",
+            "type": "shell",
+            "command": "make tests",
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "group": {
+                "kind": "test",
+                "isDefault": true,
+            },
+            "presentation":{
+                "echo": true,
+                "showReuseMessage": false,
+                "clear": false,
+                "panel": "shared",
+                "group": "test"
+            }
+        },
+        {
             "label": "jmavsim build",
             "type": "shell",
             "command": "ant create_run_jar copy_res",
             "options": {
-                "cwd": "${workspaceRoot}/Tools/jMAVSim"
+                "cwd": "${workspaceFolder}/Tools/jMAVSim"
             },
             "problemMatcher": [],
             "presentation":{
@@ -17,7 +63,7 @@
                 "focus": false,
                 "panel": "shared",
                 "showReuseMessage": false,
-                "clear": true
+                "clear": false,
             }
         },
         {
@@ -26,7 +72,7 @@
             "dependsOn": "jmavsim build",
             "command": "java -Djava.ext.dirs= -jar jmavsim_run.jar -r 250 -lockstep -tcp localhost:4560 -qgc",
             "options": {
-                "cwd": "${workspaceRoot}/Tools/jMAVSim/out/production",
+                "cwd": "${workspaceFolder}/Tools/jMAVSim/out/production",
                 "env": {
                     "PX4_SIM_SPEED_FACTOR": "1"
                 }
@@ -38,7 +84,7 @@
                 "focus": false,
                 "panel": "shared",
                 "showReuseMessage": false,
-                "clear": true
+                "clear": false
             },
             "problemMatcher": [
                 {
@@ -68,7 +114,7 @@
                 "focus": false,
                 "panel": "shared",
                 "showReuseMessage": false,
-                "clear": true
+                "clear": false
             },
             "problemMatcher": []
         },
@@ -77,31 +123,31 @@
             "type": "shell",
             "command": "make px4_sitl_default sitl_gazebo",
             "options": {
-                "cwd": "${workspaceRoot}"
+                "cwd": "${workspaceFolder}"
             },
             "problemMatcher": [],
             "presentation":{
                 "echo": true,
-                "reveal": "never",
+                "reveal": "always",
                 "focus": false,
                 "panel": "shared",
                 "showReuseMessage": false,
-                "clear": true
+                "clear": false,
             }
         },
         {
-            "label": "gazebo iris",
+            "label": "gazebo start",
             "type": "shell",
             "dependsOn": "gazebo build",
             "options": {
-                "cwd": "${workspaceRoot}",
+                "cwd": "${workspaceFolder}",
                 "env": {
-                    "GAZEBO_PLUGIN_PATH": "${workspaceRoot}/build/px4_sitl_default/build_gazebo",
-                    "GAZEBO_MODEL_PATH": "${workspaceRoot}/Tools/sitl_gazebo/models",
+                    "GAZEBO_PLUGIN_PATH": "${workspaceFolder}/build/px4_sitl_default/build_gazebo",
+                    "GAZEBO_MODEL_PATH": "${workspaceFolder}/Tools/sitl_gazebo/models",
                     "PX4_SIM_SPEED_FACTOR": "1"
                 }
             },
-            "command": "gzserver --verbose ${workspaceRoot}/Tools/sitl_gazebo/worlds/iris.world",
+            "command": "gzserver --verbose ${workspaceFolder}/Tools/sitl_gazebo/worlds/empty.world",
             "isBackground": true,
             "presentation": {
                 "echo": true,
@@ -109,7 +155,7 @@
                 "focus": false,
                 "panel": "shared",
                 "showReuseMessage": false,
-                "clear": true
+                "clear": false
             },
             "problemMatcher": [
                 {
@@ -130,146 +176,26 @@
             ]
         },
         {
-            "label": "gazebo plane",
+            "label": "gazebo",
             "type": "shell",
-            "dependsOn": "gazebo build",
+            "dependsOn": "gazebo start",
             "options": {
-                "cwd": "${workspaceRoot}",
+                "cwd": "${workspaceFolder}",
                 "env": {
-                    "GAZEBO_PLUGIN_PATH": "${workspaceRoot}/build/px4_sitl_default/build_gazebo",
-                    "GAZEBO_MODEL_PATH": "${workspaceRoot}/Tools/sitl_gazebo/models",
+                    "GAZEBO_PLUGIN_PATH": "${workspaceFolder}/build/px4_sitl_default/build_gazebo",
+                    "GAZEBO_MODEL_PATH": "${workspaceFolder}/Tools/sitl_gazebo/models",
                     "PX4_SIM_SPEED_FACTOR": "1"
                 }
             },
-            "command": "gzserver --verbose ${workspaceRoot}/Tools/sitl_gazebo/worlds/plane.world",
-            "isBackground": true,
+            "command": "gz model --verbose --spawn-file=${workspaceFolder}/Tools/sitl_gazebo/models/${input:vehicleModel}/${input:vehicleModel}.sdf --model-name=${input:vehicleModel} -x 1.01 -y 0.98 -z 0.83",
+            "isBackground": false,
             "presentation": {
                 "echo": true,
                 "reveal": "never",
                 "focus": false,
                 "panel": "shared",
                 "showReuseMessage": false,
-                "clear": true
-            },
-            "problemMatcher": [
-                {
-                    "pattern": [
-                        {
-                            "regexp": ".",
-                            "file": 1,
-                            "location": 2,
-                            "message": 3
-                        }
-                    ],
-                    "background": {
-                        "activeOnStart": true,
-                        "beginsPattern": ".",
-                        "endsPattern": ".",
-                    }
-                }
-            ]
-        },
-        {
-            "label": "gazebo standard_vtol",
-            "type": "shell",
-            "dependsOn": "gazebo build",
-            "options": {
-                "cwd": "${workspaceRoot}",
-                "env": {
-                    "GAZEBO_PLUGIN_PATH": "${workspaceRoot}/build/px4_sitl_default/build_gazebo",
-                    "GAZEBO_MODEL_PATH": "${workspaceRoot}/Tools/sitl_gazebo/models",
-                    "PX4_SIM_SPEED_FACTOR": "1"
-                }
-            },
-            "command": "gzserver --verbose ${workspaceRoot}/Tools/sitl_gazebo/worlds/standard_vtol.world",
-            "isBackground": true,
-            "presentation": {
-                "echo": true,
-                "reveal": "never",
-                "focus": false,
-                "panel": "shared",
-                "showReuseMessage": false,
-                "clear": true
-            },
-            "problemMatcher": [
-                {
-                    "pattern": [
-                        {
-                            "regexp": ".",
-                            "file": 1,
-                            "location": 2,
-                            "message": 3
-                        }
-                    ],
-                    "background": {
-                        "activeOnStart": true,
-                        "beginsPattern": ".",
-                        "endsPattern": ".",
-                    }
-                }
-            ]
-        },
-        {
-            "label": "gazebo tailsitter",
-            "type": "shell",
-            "dependsOn": "gazebo build",
-            "options": {
-                "cwd": "${workspaceRoot}",
-                "env": {
-                    "GAZEBO_PLUGIN_PATH": "${workspaceRoot}/build/px4_sitl_default/build_gazebo",
-                    "GAZEBO_MODEL_PATH": "${workspaceRoot}/Tools/sitl_gazebo/models",
-                    "PX4_SIM_SPEED_FACTOR": "1"
-                }
-            },
-            "command": "gzserver --verbose ${workspaceRoot}/Tools/sitl_gazebo/worlds/tailsitter.world",
-            "isBackground": true,
-            "presentation": {
-                "echo": true,
-                "reveal": "never",
-                "focus": false,
-                "panel": "shared",
-                "showReuseMessage": false,
-                "clear": true
-            },
-            "problemMatcher": [
-                {
-                    "pattern": [
-                        {
-                            "regexp": ".",
-                            "file": 1,
-                            "location": 2,
-                            "message": 3
-                        }
-                    ],
-                    "background": {
-                        "activeOnStart": true,
-                        "beginsPattern": ".",
-                        "endsPattern": ".",
-                    }
-                }
-            ]
-        },
-        {
-            "label": "gazebo tiltrotor",
-            "type": "shell",
-            "dependsOn": "gazebo build",
-            "options": {
-                "cwd": "${workspaceRoot}",
-                "env": {
-                    "GAZEBO_PLUGIN_PATH": "${workspaceRoot}/build/px4_sitl_default/build_gazebo",
-                    "GAZEBO_MODEL_PATH": "${workspaceRoot}/Tools/sitl_gazebo/models",
-                    "PX4_SIM_SPEED_FACTOR": "1"
-                }
-            },
-            "command": "gzserver --verbose ${workspaceRoot}/Tools/sitl_gazebo/worlds/tiltrotor.world",
-            "isBackground": true,
-            "presentation": {
-                "echo": true,
-                "reveal": "never",
-                "focus": false,
-                "panel": "shared",
-                "showReuseMessage": false,
-                "clear": true
+                "clear": false
             },
             "problemMatcher": [
                 {
@@ -294,10 +220,10 @@
             "type": "shell",
             "dependsOn": "gazebo build",
             "options": {
-                "cwd": "${workspaceRoot}",
+                "cwd": "${workspaceFolder}",
                 "env": {
-                    "GAZEBO_PLUGIN_PATH": "${workspaceRoot}/build/px4_sitl_default/build_gazebo",
-                    "GAZEBO_MODEL_PATH": "${workspaceRoot}/Tools/sitl_gazebo/models",
+                    "GAZEBO_PLUGIN_PATH": "${workspaceFolder}/build/px4_sitl_default/build_gazebo",
+                    "GAZEBO_MODEL_PATH": "${workspaceFolder}/Tools/sitl_gazebo/models",
                     "PX4_SIM_SPEED_FACTOR": "1"
                 }
             },
@@ -309,7 +235,7 @@
                 "focus": false,
                 "panel": "shared",
                 "showReuseMessage": false,
-                "clear": true
+                "clear": false
             },
             "problemMatcher": [
                 {
@@ -334,12 +260,42 @@
             "type": "shell",
             "command": "killall gzserver",
             "presentation": {
-                "echo": false,
-                "reveal": "never",
+                "echo": true,
+                "reveal": "silent",
                 "focus": false,
                 "panel": "shared",
                 "showReuseMessage": false,
-                "clear": true
+                "clear": false
+            },
+            "problemMatcher": [],
+            "dependsOn":["px4_sitl_cleanup"]
+        },
+        {
+            "label": "px4_sitl_cleanup",
+            "type": "shell",
+            "command": "rm -rfv /tmp/px4*",
+            "presentation": {
+                "echo": true,
+                "reveal": "silent",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": false,
+                "clear": false
+            },
+            "problemMatcher": [],
+            "dependsOn":["px4_kill"]
+        },
+        {
+            "label": "px4_kill",
+            "type": "shell",
+            "command": "killall px4 || true",
+            "presentation": {
+                "echo": true,
+                "reveal": "silent",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": false,
+                "clear": false
             },
             "problemMatcher": []
         },
@@ -348,7 +304,7 @@
             "type": "shell",
             "command": "./Tools/mavlink_shell.py",
             "options": {
-                "cwd": "${workspaceRoot}"
+                "cwd": "${workspaceFolder}"
             },
             "presentation": {
                 "echo": true,
@@ -365,7 +321,7 @@
             "type": "shell",
             "command": "miniterm.py --raw - 57600",
             "options": {
-                "cwd": "${workspaceRoot}"
+                "cwd": "${workspaceFolder}"
             },
             "presentation": {
                 "echo": true,
@@ -377,5 +333,25 @@
             },
             "problemMatcher": []
         }
+    ],
+    "inputs": [
+        {
+            "type": "pickString",
+            "id": "vehicleModel",
+            "description": "gazebo model",
+            "options": [
+              "iris",
+              "typhoon_h480",
+              "plane",
+              "plane_catapult",
+              "plane_lidar",
+              "standard_vtol",
+              "tailsitter",
+              "tiltrotor",
+              "r1_rover",
+              "boat"
+            ],
+            "default": "iris"
+          }
     ]
 }

--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -2,6 +2,7 @@
 
 
 set -e
+set -o xtrace
 
 if [ "$#" -lt 7 ]; then
 	echo usage: sitl_run.sh sitl_bin debugger program model world src_path build_path

--- a/platforms/nuttx/Debug/launch.json.in
+++ b/platforms/nuttx/Debug/launch.json.in
@@ -11,12 +11,12 @@
             "servertype": "jlink",
             "interface": "swd",
             //"ipAddress": "server:19020",
-            "cwd": "${workspaceRoot}",
+            "cwd": "${workspaceFolder}",
             "internalConsoleOptions": "openOnSessionStart",
             "preLaunchCommands": [
-                "source ${workspaceRoot}/platforms/nuttx/Debug/PX4",
-                "source ${workspaceRoot}/platforms/nuttx/Debug/NuttX",
-                "source ${workspaceRoot}/platforms/nuttx/Debug/ARMv7M",
+                "source ${workspaceFolder}/platforms/nuttx/Debug/PX4",
+                "source ${workspaceFolder}/platforms/nuttx/Debug/NuttX",
+                "source ${workspaceFolder}/platforms/nuttx/Debug/ARMv7M",
                 "set mem inaccessible-by-default off",
                 "set print pretty",
             ]
@@ -31,12 +31,12 @@
             "servertype": "bmp",
             "BMPGDBSerialPort": "/dev/ttyACM0",
             "interface": "swd",
-            "cwd": "${workspaceRoot}",
+            "cwd": "${workspaceFolder}",
             "internalConsoleOptions": "openOnSessionStart",
             "preLaunchCommands": [
-                "source ${workspaceRoot}/platforms/nuttx/Debug/PX4",
-                "source ${workspaceRoot}/platforms/nuttx/Debug/NuttX",
-                "source ${workspaceRoot}/platforms/nuttx/Debug/ARMv7M",
+                "source ${workspaceFolder}/platforms/nuttx/Debug/PX4",
+                "source ${workspaceFolder}/platforms/nuttx/Debug/NuttX",
+                "source ${workspaceFolder}/platforms/nuttx/Debug/ARMv7M",
                 "set mem inaccessible-by-default off",
                 "set print pretty",
             ]

--- a/platforms/posix/Debug/launch_sim.json.in
+++ b/platforms/posix/Debug/launch_sim.json.in
@@ -2,223 +2,25 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "SITL (gazebo iris)",
+            "name": "SITL (gazebo)",
             "type": "cppdbg",
             "request": "launch",
             "program": "${command:cmake.launchTargetPath}",
             "args": [
                 "${workspaceFolder}/ROMFS/px4fmu_common",
-                "-s",
-                "etc/init.d-posix/rcS",
-                "-t",
-                "${workspaceFolder}/test_data"
+                "-s", "etc/init.d-posix/rcS",
+                "-t", "${workspaceFolder}/test_data"
             ],
             "stopAtEntry": false,
             "cwd": "${command:cmake.buildDirectory}/tmp",
             "environment": [
                 {
                     "name": "PX4_SIM_MODEL",
-                    "value": "iris"
+                    "value": "${input:PX4_SIM_MODEL}"
                 }
             ],
             "externalConsole": false,
-            "preLaunchTask": "gazebo iris",
-            "postDebugTask": "gazebo kill",
-            "linux": {
-                "MIMode": "gdb",
-                "externalConsole": false,
-                "setupCommands": [
-                    {
-                        "description": "Enable pretty-printing for gdb",
-                        "text": "-enable-pretty-printing",
-                        "ignoreFailures": true
-                    },
-                    {
-                        "description": "PX4 ignore wq signals",
-                        "text": "handle SIGCONT nostop noprint nopass",
-                        "ignoreFailures": true
-                    }
-                ]
-            },
-            "osx": {
-                "MIMode": "lldb",
-                "externalConsole": true,
-                "setupCommands": [
-                    {
-                        "text": "pro hand -p true -s false -n false SIGCONT",
-                    }
-                ]
-            }
-        },
-        {
-            "name": "SITL (gazebo plane)",
-            "type": "cppdbg",
-            "request": "launch",
-            "program": "${command:cmake.launchTargetPath}",
-            "args": [
-                "${workspaceFolder}/ROMFS/px4fmu_common",
-                "-s",
-                "etc/init.d-posix/rcS",
-                "-t",
-                "${workspaceFolder}/test_data"
-            ],
-            "stopAtEntry": false,
-            "cwd": "${command:cmake.buildDirectory}/tmp",
-            "environment": [
-                {
-                    "name": "PX4_SIM_MODEL",
-                    "value": "plane"
-                }
-            ],
-            "externalConsole": false,
-            "preLaunchTask": "gazebo plane",
-            "postDebugTask": "gazebo kill",
-            "linux": {
-                "MIMode": "gdb",
-                "externalConsole": false,
-                "setupCommands": [
-                    {
-                        "description": "Enable pretty-printing for gdb",
-                        "text": "-enable-pretty-printing",
-                        "ignoreFailures": true
-                    },
-                    {
-                        "description": "PX4 ignore wq signals",
-                        "text": "handle SIGCONT nostop noprint nopass",
-                        "ignoreFailures": true
-                    }
-                ]
-            },
-            "osx": {
-                "MIMode": "lldb",
-                "externalConsole": true,
-                "setupCommands": [
-                    {
-                        "text": "pro hand -p true -s false -n false SIGCONT",
-                    }
-                ]
-            }
-        },
-        {
-            "name": "SITL (gazebo standard_vtol)",
-            "type": "cppdbg",
-            "request": "launch",
-            "program": "${command:cmake.launchTargetPath}",
-            "args": [
-                "${workspaceFolder}/ROMFS/px4fmu_common",
-                "-s",
-                "etc/init.d-posix/rcS",
-                "-t",
-                "${workspaceFolder}/test_data"
-            ],
-            "stopAtEntry": false,
-            "cwd": "${command:cmake.buildDirectory}/tmp",
-            "environment": [
-                {
-                    "name": "PX4_SIM_MODEL",
-                    "value": "standard_vtol"
-                }
-            ],
-            "externalConsole": false,
-            "preLaunchTask": "gazebo standard_vtol",
-            "postDebugTask": "gazebo kill",
-            "linux": {
-                "MIMode": "gdb",
-                "externalConsole": false,
-                "setupCommands": [
-                    {
-                        "description": "Enable pretty-printing for gdb",
-                        "text": "-enable-pretty-printing",
-                        "ignoreFailures": true
-                    },
-                    {
-                        "description": "PX4 ignore wq signals",
-                        "text": "handle SIGCONT nostop noprint nopass",
-                        "ignoreFailures": true
-                    }
-                ]
-            },
-            "osx": {
-                "MIMode": "lldb",
-                "externalConsole": true,
-                "setupCommands": [
-                    {
-                        "text": "pro hand -p true -s false -n false SIGCONT",
-                    }
-                ]
-            }
-        },
-        {
-            "name": "SITL (gazebo tailsitter)",
-            "type": "cppdbg",
-            "request": "launch",
-            "program": "${command:cmake.launchTargetPath}",
-            "args": [
-                "${workspaceFolder}/ROMFS/px4fmu_common",
-                "-s",
-                "etc/init.d-posix/rcS",
-                "-t",
-                "${workspaceFolder}/test_data"
-            ],
-            "stopAtEntry": false,
-            "cwd": "${command:cmake.buildDirectory}/tmp",
-            "environment": [
-                {
-                    "name": "PX4_SIM_MODEL",
-                    "value": "tailsitter"
-                }
-            ],
-            "externalConsole": false,
-            "preLaunchTask": "gazebo tailsitter",
-            "postDebugTask": "gazebo kill",
-            "linux": {
-                "MIMode": "gdb",
-                "externalConsole": false,
-                "setupCommands": [
-                    {
-                        "description": "Enable pretty-printing for gdb",
-                        "text": "-enable-pretty-printing",
-                        "ignoreFailures": true
-                    },
-                    {
-                        "description": "PX4 ignore wq signals",
-                        "text": "handle SIGCONT nostop noprint nopass",
-                        "ignoreFailures": true
-                    }
-                ]
-            },
-            "osx": {
-                "MIMode": "lldb",
-                "externalConsole": true,
-                "setupCommands": [
-                    {
-                        "text": "pro hand -p true -s false -n false SIGCONT",
-                    }
-                ]
-            }
-        },
-        {
-            "name": "SITL (gazebo tiltrotor)",
-            "type": "cppdbg",
-            "request": "launch",
-            "program": "${command:cmake.launchTargetPath}",
-            "args": [
-                "${workspaceFolder}/ROMFS/px4fmu_common",
-                "-s",
-                "etc/init.d-posix/rcS",
-                "-t",
-                "${workspaceFolder}/test_data"
-            ],
-            "stopAtEntry": false,
-            "cwd": "${command:cmake.buildDirectory}/tmp",
-            "environment": [
-                {
-                    "name": "PX4_SIM_MODEL",
-                    "value": "tiltrotor"
-                }
-            ],
-            "externalConsole": false,
-            "preLaunchTask": "gazebo tiltrotor",
+            "preLaunchTask": "gazebo",
             "postDebugTask": "gazebo kill",
             "linux": {
                 "MIMode": "gdb",
@@ -253,10 +55,8 @@
             "program": "${command:cmake.launchTargetPath}",
             "args": [
                 "${workspaceFolder}/ROMFS/px4fmu_common",
-                "-s",
-                "etc/init.d-posix/rcS",
-                "-t",
-                "${workspaceFolder}/test_data"
+                "-s", "etc/init.d-posix/rcS",
+                "-t", "${workspaceFolder}/test_data"
             ],
             "stopAtEntry": false,
             "cwd": "${command:cmake.buildDirectory}/tmp",
@@ -301,10 +101,8 @@
             "program": "${command:cmake.launchTargetPath}",
             "args": [
                 "${workspaceFolder}/ROMFS/px4fmu_common",
-                "-s",
-                "etc/init.d-posix/rcS",
-                "-t",
-                "${workspaceFolder}/test_data"
+                "-s", "etc/init.d-posix/rcS",
+                "-t", "${workspaceFolder}/test_data"
             ],
             "stopAtEntry": false,
             "cwd": "${command:cmake.buildDirectory}/tmp",
@@ -340,5 +138,25 @@
                 ]
             }
         }
+    ],
+    "inputs": [
+        {
+            "type": "pickString",
+            "id": "PX4_SIM_MODEL",
+            "description": "PX4_SIM_MODEL",
+            "options": [
+              "iris",
+              "typhoon_h480",
+              "plane",
+              "plane_catapult",
+              "plane_lidar",
+              "standard_vtol",
+              "tailsitter",
+              "tiltrotor",
+              "r1_rover",
+              "boat"
+            ],
+            "default": "iris"
+          }
     ]
 }

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -104,18 +104,18 @@ foreach(viewer ${viewers})
 					endif()
 
 					add_custom_target(${_targ_name}
-					COMMAND ${PX4_SOURCE_DIR}/Tools/sitl_run.sh
-						$<TARGET_FILE:px4>
-						${debugger}
-						${viewer}
-						${model}
-						${world}
-						${PX4_SOURCE_DIR}
-						${PX4_BINARY_DIR}
-					WORKING_DIRECTORY ${SITL_WORKING_DIR}
-					USES_TERMINAL
-					DEPENDS
-						logs_symlink
+						COMMAND ${PX4_SOURCE_DIR}/Tools/sitl_run.sh
+							$<TARGET_FILE:px4>
+							${debugger}
+							${viewer}
+							${model}
+							${world}
+							${PX4_SOURCE_DIR}
+							${PX4_BINARY_DIR}
+						WORKING_DIRECTORY ${SITL_WORKING_DIR}
+						USES_TERMINAL
+						DEPENDS
+							logs_symlink
 					)
 					list(APPEND all_posix_vmd_make_targets ${_targ_name})
 					if (viewer STREQUAL "gazebo")
@@ -140,18 +140,17 @@ foreach(viewer ${viewers})
 						endif()
 
 						add_custom_target(${_targ_name}
-						COMMAND ${PX4_SOURCE_DIR}/Tools/sitl_run.sh
-							$<TARGET_FILE:px4>
-							${debugger}
-							${viewer}
-							${model}
-							${world}
-							${PX4_SOURCE_DIR}
-							${PX4_BINARY_DIR}
-						WORKING_DIRECTORY ${SITL_WORKING_DIR}
-						USES_TERMINAL
-						DEPENDS
-							logs_symlink
+							COMMAND ${PX4_SOURCE_DIR}/Tools/sitl_run.sh
+								$<TARGET_FILE:px4>
+								${debugger}
+								${viewer}
+								${model}
+								${world}
+								${PX4_SOURCE_DIR}
+								${PX4_BINARY_DIR}
+							WORKING_DIRECTORY ${SITL_WORKING_DIR}
+							USES_TERMINAL
+							DEPENDS logs_symlink
 						)
 						list(APPEND all_posix_vmd_make_targets ${_targ_name})
 						add_dependencies(${_targ_name} px4 sitl_gazebo)

--- a/platforms/posix/cmake/sitl_tests.cmake
+++ b/platforms/posix/cmake/sitl_tests.cmake
@@ -57,15 +57,12 @@ foreach(test_name ${tests})
 	configure_file(${PX4_SOURCE_DIR}/posix-configs/SITL/init/test/test_template.in ${PX4_SOURCE_DIR}/posix-configs/SITL/init/test/test_${test_name}_generated)
 
 	add_test(NAME ${test_name_prefix}
-		COMMAND ${PX4_SOURCE_DIR}/Tools/sitl_run.sh
-			$<TARGET_FILE:px4>
-			none
-			none
-			test_${test_name}_generated
-			none
-			${PX4_SOURCE_DIR}
-			${PX4_BINARY_DIR}
-		WORKING_DIRECTORY ${SITL_WORKING_DIR})
+		COMMAND $<TARGET_FILE:px4>
+			-s ${PX4_SOURCE_DIR}/posix-configs/SITL/init/test/test_${test_name}_generated
+			-t ${PX4_SOURCE_DIR}/test_data
+			${PX4_SOURCE_DIR}/ROMFS/px4fmu_test
+		WORKING_DIRECTORY ${SITL_WORKING_DIR}
+	)
 
 	set_tests_properties(${test_name_prefix} PROPERTIES FAIL_REGULAR_EXPRESSION "${test_name} FAILED")
 	set_tests_properties(${test_name_prefix} PROPERTIES PASS_REGULAR_EXPRESSION "${test_name} PASSED")
@@ -75,38 +72,32 @@ endforeach()
 
 
 # Mavlink test requires mavlink running
-add_test(NAME mavlink
-	COMMAND ${PX4_SOURCE_DIR}/Tools/sitl_run.sh
-		$<TARGET_FILE:px4>
-		none
-		none
-		test_mavlink
-		none
-		${PX4_SOURCE_DIR}
-		${PX4_BINARY_DIR}
-	WORKING_DIRECTORY ${SITL_WORKING_DIR})
+add_test(NAME sitl-mavlink
+	COMMAND $<TARGET_FILE:px4>
+		-s ${PX4_SOURCE_DIR}/posix-configs/SITL/init/test/test_mavlink
+		-t ${PX4_SOURCE_DIR}/test_data
+		${PX4_SOURCE_DIR}/ROMFS/px4fmu_test
+	WORKING_DIRECTORY ${SITL_WORKING_DIR}
+)
 
-set_tests_properties(mavlink PROPERTIES FAIL_REGULAR_EXPRESSION "mavlink FAILED")
-set_tests_properties(mavlink PROPERTIES PASS_REGULAR_EXPRESSION "mavlink PASSED")
-sanitizer_fail_test_on_error(mavlink)
+set_tests_properties(sitl-mavlink PROPERTIES FAIL_REGULAR_EXPRESSION "mavlink FAILED")
+set_tests_properties(sitl-mavlink PROPERTIES PASS_REGULAR_EXPRESSION "mavlink PASSED")
+sanitizer_fail_test_on_error(sitl-mavlink)
 
 # A mystery why this fails on Cygwin currently.
 if(NOT CMAKE_SYSTEM_NAME STREQUAL "CYGWIN")
 	# Shutdown test
-	add_test(NAME shutdown
-		COMMAND ${PX4_SOURCE_DIR}/Tools/sitl_run.sh
-			$<TARGET_FILE:px4>
-			none
-			none
-			test_shutdown
-			none
-			${PX4_SOURCE_DIR}
-			${PX4_BINARY_DIR}
-		WORKING_DIRECTORY ${SITL_WORKING_DIR})
+	add_test(NAME sitl-shutdown
+		COMMAND $<TARGET_FILE:px4>
+			-s ${PX4_SOURCE_DIR}/posix-configs/SITL/init/test/test_shutdown
+			-t ${PX4_SOURCE_DIR}/test_data
+			${PX4_SOURCE_DIR}/ROMFS/px4fmu_test
+		WORKING_DIRECTORY ${SITL_WORKING_DIR}
+	)
 
 	#set_tests_properties(shutdown PROPERTIES FAIL_REGULAR_EXPRESSION "shutdown FAILED")
-	set_tests_properties(shutdown PROPERTIES PASS_REGULAR_EXPRESSION "Exiting NOW.")
-	sanitizer_fail_test_on_error(shutdown)
+	set_tests_properties(sitl-shutdown PROPERTIES PASS_REGULAR_EXPRESSION "Exiting NOW.")
+	sanitizer_fail_test_on_error(sitl-shutdown)
 endif()
 
 # Dynamic module loading test
@@ -135,15 +126,12 @@ foreach(cmd_name ${test_cmds})
 	configure_file(${PX4_SOURCE_DIR}/posix-configs/SITL/init/test/cmd_template.in ${PX4_SOURCE_DIR}/posix-configs/SITL/init/test/cmd_${cmd_name}_generated)
 
 	add_test(NAME posix_${cmd_name}
-		COMMAND ${PX4_SOURCE_DIR}/Tools/sitl_run.sh
-			$<TARGET_FILE:px4>
-			none
-			none
-			cmd_${cmd_name}_generated
-			none
-			${PX4_SOURCE_DIR}
-			${PX4_BINARY_DIR}
-		WORKING_DIRECTORY ${SITL_WORKING_DIR})
+		COMMAND $<TARGET_FILE:px4>
+			${PX4_SOURCE_DIR}/ROMFS/px4fmu_test
+			-s ${PX4_SOURCE_DIR}/posix-configs/SITL/init/test/cmd_${cmd_name}_generated
+			-t ${PX4_SOURCE_DIR}/test_data
+		WORKING_DIRECTORY ${SITL_WORKING_DIR}
+	)
 
 	sanitizer_fail_test_on_error(posix_${cmd_name})
 	set_tests_properties(posix_${cmd_name} PROPERTIES PASS_REGULAR_EXPRESSION "Exiting NOW.")


### PR DESCRIPTION
 - fix gazebo SITL debug
     - now prompts you to select vehicle
 - devcontainer.json container support https://code.visualstudio.com/docs/remote/containers
     - this allows you to jump straight into working within a container (px4-dev-nuttx) on a fresh machine
     - also helps with Codespaces https://github.com/features/codespaces
 - plugin updates
    - cpp extension pack, spell checking, CTest support
 - cleanup intellisense
     - the backup tag parser was a resource hog and didn't work very well
 - fix problemMatcher support so that you can click on a build failure
 

### CTest Support

![Screenshot from 2020-09-15 21-17-42](https://user-images.githubusercontent.com/84712/93280940-eeb2b400-f798-11ea-8e37-4ac7b4d6d578.png)


### Gazebo Debugging Model Select

![Screenshot from 2020-09-15 21-18-50](https://user-images.githubusercontent.com/84712/93281837-f7a48500-f79a-11ea-94b4-25e6c5c96e2f.png)
