### PR TITLE
sensor_calibration: silence error if priority is -1 (uninitialized parameter value)

### DIFF
--- a/src/lib/sensor_calibration/Accelerometer.cpp
+++ b/src/lib/sensor_calibration/Accelerometer.cpp
@@ -142,11 +142,17 @@ void Accelerometer::ParametersUpdate()
 		// CAL_ACCx_PRIO
 		_priority = GetCalibrationParam(SensorString(), "PRIO", _calibration_index);
 
-		if (_priority < 0 || _priority > 100) {
-			// reset to default
-			PX4_ERR("%s %d invalid priority %d, resetting to %d", SensorString(), _calibration_index, _priority, DEFAULT_PRIORITY);
-			SetCalibrationParam(SensorString(), "PRIO", _calibration_index, DEFAULT_PRIORITY);
-			_priority = DEFAULT_PRIORITY;
+		if ((_priority < 0) || (_priority > 100)) {
+			// reset to default, -1 is the uninitialized parameter value
+			int32_t new_priority = DEFAULT_PRIORITY;
+
+			if (_priority != -1) {
+				PX4_ERR("%s %d (%d) invalid priority %d, resetting to %d", SensorString(), _device_id, _calibration_index, _priority,
+					new_priority);
+			}
+
+			SetCalibrationParam(SensorString(), "PRIO", _calibration_index, new_priority);
+			_priority = new_priority;
 		}
 
 		bool calibration_changed = false;

--- a/src/lib/sensor_calibration/Gyroscope.cpp
+++ b/src/lib/sensor_calibration/Gyroscope.cpp
@@ -142,11 +142,17 @@ void Gyroscope::ParametersUpdate()
 		// CAL_GYROx_PRIO
 		_priority = GetCalibrationParam(SensorString(), "PRIO", _calibration_index);
 
-		if (_priority < 0 || _priority > 100) {
-			// reset to default
-			PX4_ERR("%s %d invalid priority %d, resetting to %d", SensorString(), _calibration_index, _priority, DEFAULT_PRIORITY);
-			SetCalibrationParam(SensorString(), "PRIO", _calibration_index, DEFAULT_PRIORITY);
-			_priority = DEFAULT_PRIORITY;
+		if ((_priority < 0) || (_priority > 100)) {
+			// reset to default, -1 is the uninitialized parameter value
+			int32_t new_priority = DEFAULT_PRIORITY;
+
+			if (_priority != -1) {
+				PX4_ERR("%s %d (%d) invalid priority %d, resetting to %d", SensorString(), _device_id, _calibration_index, _priority,
+					new_priority);
+			}
+
+			SetCalibrationParam(SensorString(), "PRIO", _calibration_index, new_priority);
+			_priority = new_priority;
 		}
 
 		bool calibration_changed = false;

--- a/src/lib/sensor_calibration/Magnetometer.cpp
+++ b/src/lib/sensor_calibration/Magnetometer.cpp
@@ -149,10 +149,14 @@ void Magnetometer::ParametersUpdate()
 		_priority = GetCalibrationParam(SensorString(), "PRIO", _calibration_index);
 
 		if ((_priority < 0) || (_priority > 100)) {
-			// reset to default
+			// reset to default, -1 is the uninitialized parameter value
 			int32_t new_priority = _external ? DEFAULT_EXTERNAL_PRIORITY : DEFAULT_PRIORITY;
-			PX4_ERR("%s %d (%d) invalid priority %d, resetting to %d",
-				SensorString(), _device_id, _calibration_index, _priority, new_priority);
+
+			if (_priority != -1) {
+				PX4_ERR("%s %d (%d) invalid priority %d, resetting to %d", SensorString(), _device_id, _calibration_index, _priority,
+					new_priority);
+			}
+
 			SetCalibrationParam(SensorString(), "PRIO", _calibration_index, new_priority);
 			_priority = new_priority;
 		}


### PR DESCRIPTION
Silence this unnecessary error when initially setting per sensor priorities (now parameters). 

![Screenshot from 2020-09-16 09-47-18](https://user-images.githubusercontent.com/84712/93346589-23a72100-f802-11ea-8bf6-d07a2e43c08f.png)
