### PR TITLE
gitmodules update NuttX branches

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,11 +37,11 @@
 [submodule "platforms/nuttx/NuttX/nuttx"]
 	path = platforms/nuttx/NuttX/nuttx
 	url = https://github.com/PX4/NuttX.git
-	branch = px4_firmware_nuttx-8.2
+	branch = px4_firmware_nuttx-9.1.0+
 [submodule "platforms/nuttx/NuttX/apps"]
 	path = platforms/nuttx/NuttX/apps
 	url = https://github.com/PX4/NuttX-apps.git
-	branch = px4_firmware_nuttx-8.2
+	branch = px4_firmware_nuttx-9.1.0+
 [submodule "platforms/qurt/dspal"]
 	path = platforms/qurt/dspal
 	url = https://github.com/ATLFlight/dspal.git


### PR DESCRIPTION
This mainly helps tooling update to the tip of the tracking branch.

I've also updated the default branches in https://github.com/PX4/NuttX and https://github.com/PX4/NuttX-apps and enabled appropriate branch protection to ensure any commit we reference in PX4/Firmware never disappears.