### PR TITLE
cmake NuttX build fix path to git dir

### DIFF
--- a/platforms/nuttx/NuttX/CMakeLists.txt
+++ b/platforms/nuttx/NuttX/CMakeLists.txt
@@ -68,7 +68,7 @@ list(REMOVE_ITEM copy_nuttx_files ${NUTTX_SRC_DIR}/nuttx/.git)
 add_custom_command(
 	OUTPUT ${PX4_BINARY_DIR}/NuttX/nuttx_copy.stamp
 	COMMAND ${NUTTX_COPY_CMD} ${NUTTX_COPY_CMD_OPTS} ${CP_SRC} ${CP_DST}
-	COMMAND echo "gitdir: ${nuttx_git_dir}" > ${CP_DST}/nuttx/.git
+	COMMAND echo "gitdir: ${nuttx_git_dir}" > ${PX4_BINARY_DIR}/NuttX/nuttx/.git
 	COMMAND ${CMAKE_COMMAND} -E touch ${PX4_BINARY_DIR}/NuttX/nuttx_copy.stamp
 	DEPENDS
 		git_nuttx


### PR DESCRIPTION
 - this relative path was incorrect for the px4io build with Makefile generator

FYI @davids5 