### PR TITLE
List.hpp: let operator* return a reference

### DIFF
--- a/src/include/containers/List.hpp
+++ b/src/include/containers/List.hpp
@@ -126,12 +126,12 @@ public:
 
 		operator T() const { return node; }
 		operator T &() { return node; }
-		T operator* () const { return node; }
+		const T &operator* () const { return node; }
 		Iterator &operator++ ()
 		{
 			if (node) {
 				node = node->getSibling();
-			};
+			}
 
 			return *this;
 		}


### PR DESCRIPTION
So that clang 12 does not complain:
loop variable 'child' is always a copy because the range of type 'List<ModuleParams *>' does not return a reference

I'm not entirely sure if the warning refers to the `operator*` or Iterator returned by `begin()`.

Fix for #15756.