### PR TITLE
ekf2_main: update stored mag bias variances

### DIFF
--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -125,8 +125,8 @@ private:
 				const estimator_innovations_s &innov);
 	void resetPreFlightChecks();
 
-	template<typename Param>
-	void update_mag_bias(Param &mag_bias_param, int axis_index);
+	template<typename Param1, typename Param2>
+	void update_mag_bias(Param1 &mag_bias_param, Param2 &mag_bias_var_param, int axis_index);
 
 	template<typename Param>
 	bool update_mag_decl(Param &mag_decl_param);
@@ -481,8 +481,12 @@ private:
 		(ParamFloat<px4::params::EKF2_MAGBIAS_Z>) _param_ekf2_magbias_z,		///< Z magnetometer bias (mGauss)
 		(ParamInt<px4::params::EKF2_MAGBIAS_ID>)
 		_param_ekf2_magbias_id,		///< ID of the magnetometer sensor used to learn the bias values
-		(ParamFloat<px4::params::EKF2_MAGB_VREF>)
-		_param_ekf2_magb_vref, ///< Assumed error variance of previously saved magnetometer bias estimates (mGauss**2)
+		(ParamFloat<px4::params::EKF2_MAGB_VAR_X>)
+		_param_ekf2_magb_var_x, ///< Error variance of previously saved magnetometer x bias estimate (mGauss**2)
+		(ParamFloat<px4::params::EKF2_MAGB_VAR_Y>)
+		_param_ekf2_magb_var_y, ///< Error variance of previously saved magnetometer y bias estimate (mGauss**2)
+		(ParamFloat<px4::params::EKF2_MAGB_VAR_Z>)
+		_param_ekf2_magb_var_z, ///< Error variance of previously saved magnetometer z bias estimate (mGauss**2)
 		(ParamFloat<px4::params::EKF2_MAGB_K>)
 		_param_ekf2_magb_k,	///< maximum fraction of the learned magnetometer bias that is saved at each disarm
 

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -1122,6 +1122,7 @@ PARAM_DEFINE_INT32(EKF2_MAGBIAS_ID, 0);
  *
  * @group EKF2
  * @unit mgauss^2
+ * @volatile
  * @decimal 8
  */
 PARAM_DEFINE_FLOAT(EKF2_MAGB_VAR_X, 2.5E-7f);
@@ -1132,6 +1133,7 @@ PARAM_DEFINE_FLOAT(EKF2_MAGB_VAR_X, 2.5E-7f);
  *
  * @group EKF2
  * @unit mgauss^2
+ * @volatile
  * @decimal 8
  */
 PARAM_DEFINE_FLOAT(EKF2_MAGB_VAR_Y, 2.5E-7f);
@@ -1142,6 +1144,7 @@ PARAM_DEFINE_FLOAT(EKF2_MAGB_VAR_Y, 2.5E-7f);
  *
  * @group EKF2
  * @unit mgauss^2
+ * @volatile
  * @decimal 8
  */
 PARAM_DEFINE_FLOAT(EKF2_MAGB_VAR_Z, 2.5E-7f);

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -1117,15 +1117,34 @@ PARAM_DEFINE_FLOAT(EKF2_MAGBIAS_Z, 0.0f);
 PARAM_DEFINE_INT32(EKF2_MAGBIAS_ID, 0);
 
 /**
- * State variance assumed for magnetometer bias storage.
- * This is a reference variance used to calculate the fraction of learned magnetometer bias that will be used to update the stored value. Smaller values will make the stored bias data adjust more slowly from flight to flight. Larger values will make it adjust faster.
+ * State variance for magnetometer x-axis bias storage
+ * This is a reference variance used to calculate the fraction of learned magnetometer bias that will be used to update the stored value.
  *
  * @group EKF2
- * @reboot_required true
  * @unit mgauss^2
  * @decimal 8
  */
-PARAM_DEFINE_FLOAT(EKF2_MAGB_VREF, 2.5E-7f);
+PARAM_DEFINE_FLOAT(EKF2_MAGB_VAR_X, 2.5E-7f);
+
+/**
+ * State variance for magnetometer y-axis bias storage
+ * This is a reference variance used to calculate the fraction of learned magnetometer bias that will be used to update the stored value.
+ *
+ * @group EKF2
+ * @unit mgauss^2
+ * @decimal 8
+ */
+PARAM_DEFINE_FLOAT(EKF2_MAGB_VAR_Y, 2.5E-7f);
+
+/**
+ * State variance for magnetometer z-axis bias storage
+ * This is a reference variance used to calculate the fraction of learned magnetometer bias that will be used to update the stored value.
+ *
+ * @group EKF2
+ * @unit mgauss^2
+ * @decimal 8
+ */
+PARAM_DEFINE_FLOAT(EKF2_MAGB_VAR_Z, 2.5E-7f);
 
 /**
  * Maximum fraction of learned mag bias saved at each disarm.


### PR DESCRIPTION
Instead of using a fixed mag bias variance to compute the influence of the currently estimated mag bias on the previously saved parameter, we now also save the variance of the parameter.

The value is automatically updated and the only remaining tuning parameter is `EKF2_MAGB_K`, which is more intuitive.