### PR TITLE
ekf2_main: reduce update mag bias minimum learning time to 30s

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1131,7 +1131,7 @@ void EKF2::Run()
 				}
 
 				// Start checking mag bias estimates when we have accumulated sufficient calibration time
-				if (_total_cal_time_us > 120_s) {
+				if (_total_cal_time_us > 30_s) {
 					// we have sufficient accumulated valid flight time to form a reliable bias estimate
 					// check that the state variance for each axis is within a range indicating filter convergence
 					const float max_var_allowed = 100.0f * _param_ekf2_magb_vref.get();


### PR DESCRIPTION
120 seconds of learning time in 3D fusion mode was too long for most normal flights. The learned bias is usually really good after a shorter period and was not used to update the parameters. 30s seems to be a good compromise.