### PR TITLE
uORB: Subscription add copy/move constructor and assignment

### DIFF
--- a/src/modules/uORB/Subscription.hpp
+++ b/src/modules/uORB/Subscription.hpp
@@ -85,18 +85,10 @@ public:
 	}
 
 	// Copy constructor
-	Subscription(const Subscription &other)
-	{
-		_orb_id = other._orb_id;
-		_instance = other._instance;
-	}
+	Subscription(const Subscription &other) : _orb_id(other._orb_id), _instance(other._instance) {}
 
 	// Move constructor
-	Subscription(const Subscription &&other) noexcept
-	{
-		_orb_id = other._orb_id;
-		_instance = other._instance;
-	};
+	Subscription(const Subscription &&other) noexcept : _orb_id(other._orb_id), _instance(other._instance) {}
 
 	// copy assignment
 	Subscription &operator=(const Subscription &other)
@@ -114,7 +106,7 @@ public:
 		_orb_id = other._orb_id;
 		_instance = other._instance;
 		return *this;
-	};
+	}
 
 	~Subscription()
 	{

--- a/src/modules/uORB/Subscription.hpp
+++ b/src/modules/uORB/Subscription.hpp
@@ -84,6 +84,38 @@ public:
 		subscribe();
 	}
 
+	// Copy constructor
+	Subscription(const Subscription &other)
+	{
+		_orb_id = other._orb_id;
+		_instance = other._instance;
+	}
+
+	// Move constructor
+	Subscription(const Subscription &&other) noexcept
+	{
+		_orb_id = other._orb_id;
+		_instance = other._instance;
+	};
+
+	// copy assignment
+	Subscription &operator=(const Subscription &other)
+	{
+		unsubscribe();
+		_orb_id = other._orb_id;
+		_instance = other._instance;
+		return *this;
+	}
+
+	// move assignment
+	Subscription &operator=(Subscription &&other) noexcept
+	{
+		unsubscribe();
+		_orb_id = other._orb_id;
+		_instance = other._instance;
+		return *this;
+	};
+
 	~Subscription()
 	{
 		unsubscribe();


### PR DESCRIPTION
The only part of the code base that uses this is logger when the LoggerSubscription is copied into the allocated subscription array.