### PR TITLE
rotations: sync rotation enum, SENS_BOARD_ROT, CAL_MAGx_ROT with MAV_SENSOR_ORIENTATION

### DIFF
--- a/src/lib/conversion/RotationTest.cpp
+++ b/src/lib/conversion/RotationTest.cpp
@@ -97,23 +97,10 @@ TEST(Rotations, duplicates)
 				if (j == ROTATION_ROLL_180_YAW_90 && i == ROTATION_PITCH_180_YAW_270) { continue; }
 
 
-				// ROTATION_ROLL_180_PITCH_90 (29) = ROTATION_PITCH_90_YAW_180 (43)
-				if (i == ROTATION_ROLL_180_PITCH_90 && j == ROTATION_PITCH_90_YAW_180) { continue; }
-
-				if (j == ROTATION_ROLL_180_PITCH_90 && i == ROTATION_PITCH_90_YAW_180) { continue; }
-
-
 				// ROTATION_ROLL_90_PITCH_180 (31) = ROTATION_ROLL_270_YAW_180 (41)
 				if (i == ROTATION_ROLL_90_PITCH_180 && j == ROTATION_ROLL_270_YAW_180) { continue; }
 
 				if (j == ROTATION_ROLL_90_PITCH_180 && i == ROTATION_ROLL_270_YAW_180) { continue; }
-
-
-				// ROTATION_ROLL_90_PITCH_180_YAW_90 (36) = ROTATION_ROLL_270_YAW_270 (42)
-				if (i == ROTATION_ROLL_90_PITCH_180_YAW_90 && j == ROTATION_ROLL_270_YAW_270) { continue; }
-
-				if (j == ROTATION_ROLL_90_PITCH_180_YAW_90 && i == ROTATION_ROLL_270_YAW_270) { continue; }
-
 
 
 				// otherwise all rotations should be different

--- a/src/lib/conversion/rotation.cpp
+++ b/src/lib/conversion/rotation.cpp
@@ -245,23 +245,6 @@ rotate_3f(enum Rotation rot, float &x, float &y, float &z)
 			return;
 		}
 
-	case ROTATION_PITCH_9_YAW_180: {
-			const float tmpx = x;
-			const float tmpy = y;
-			const float tmpz = z;
-			x = -0.987688f * tmpx +  0.000000f * tmpy + -0.156434f * tmpz;
-			y =  0.000000f * tmpx + -1.000000f * tmpy +  0.000000f * tmpz;
-			z = -0.156434f * tmpx +  0.000000f * tmpy +  0.987688f * tmpz;
-			return;
-		}
-
-	case ROTATION_PITCH_45: {
-			tmp = M_SQRT1_2_F * x + M_SQRT1_2_F * z;
-			z = M_SQRT1_2_F * z - M_SQRT1_2_F * x;
-			x = tmp;
-			return;
-		}
-
 	case ROTATION_PITCH_315: {
 			tmp = M_SQRT1_2_F * x - M_SQRT1_2_F * z;
 			z = M_SQRT1_2_F * z + M_SQRT1_2_F * x;
@@ -285,10 +268,7 @@ rotate_3f(enum Rotation rot, float &x, float &y, float &z)
 			return;
 		}
 
-	case ROTATION_ROLL_180_PITCH_90:
-
-	// FALLTHROUGH
-	case ROTATION_PITCH_90_YAW_180: {
+	case ROTATION_ROLL_180_PITCH_90: {
 			tmp = x;
 			x = -z;
 			y = -y;
@@ -339,10 +319,7 @@ rotate_3f(enum Rotation rot, float &x, float &y, float &z)
 			return;
 		}
 
-	case ROTATION_ROLL_90_PITCH_180_YAW_90:
-
-	// FALLTHROUGH
-	case ROTATION_ROLL_270_YAW_270: {
+	case ROTATION_ROLL_90_PITCH_180_YAW_90: {
 			tmp = x;
 			x = z;
 			z = -y;

--- a/src/lib/conversion/rotation.h
+++ b/src/lib/conversion/rotation.h
@@ -91,10 +91,7 @@ enum Rotation {
 	ROTATION_PITCH_315           = 39,
 	ROTATION_ROLL_90_PITCH_315   = 40,
 	ROTATION_ROLL_270_YAW_180    = 41,
-	ROTATION_ROLL_270_YAW_270    = 42,
-	ROTATION_PITCH_90_YAW_180    = 43,
-	ROTATION_PITCH_9_YAW_180     = 44,
-	ROTATION_PITCH_45            = 45,
+
 	ROTATION_MAX
 };
 
@@ -147,10 +144,6 @@ const rot_lookup_t rot_lookup[] = {
 	{  0, 315,   0 },
 	{ 90, 315,   0 },
 	{270,   0, 180 },
-	{270,   0, 270 },
-	{  0,  90, 180 },
-	{  0,   9, 180 },
-	{  0,  45,   0 },
 };
 
 /**

--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -739,15 +739,6 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub, int32_t cal_ma
 
 							// FALLTHROUGH
 							case ROTATION_ROLL_270_YAW_180:  // skip 41, same as 31 ROTATION_ROLL_90_PITCH_180
-
-							// FALLTHROUGH
-							case ROTATION_ROLL_270_YAW_270:  // skip 42, same as 36 ROTATION_ROLL_90_PITCH_180_YAW_90
-
-							// FALLTHROUGH
-							case ROTATION_PITCH_90_YAW_180:  // skip 43, same as 29 ROTATION_ROLL_180_PITCH_90
-
-							// FALLTHROUGH
-							case ROTATION_PITCH_9_YAW_180: // skip, too close to ROTATION_YAW_180
 								MSE[r] = FLT_MAX;
 								break;
 
@@ -804,9 +795,6 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub, int32_t cal_ma
 
 							switch (worker_data.calibration[cur_mag].rotation_enum()) {
 							case ROTATION_ROLL_90_PITCH_68_YAW_293:
-
-							// FALLTHROUGH
-							case ROTATION_PITCH_9_YAW_180:
 								PX4_INFO("[cal] External Mag: %d (%d), keeping manually configured rotation %d", cur_mag,
 									 worker_data.calibration[cur_mag].device_id(), worker_data.calibration[cur_mag].rotation_enum());
 								continue;

--- a/src/modules/mavlink/CMakeLists.txt
+++ b/src/modules/mavlink/CMakeLists.txt
@@ -39,6 +39,7 @@ px4_add_module(
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 		-Wno-address-of-packed-member # TODO: fix in c_library_v2
+		-Wno-enum-compare # ROTATION <-> MAV_SENSOR_ROTATION
 		#-DDEBUG_BUILD
 	INCLUDES
 		${PX4_SOURCE_DIR}/mavlink/include/mavlink

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -123,6 +123,53 @@
 using matrix::Vector3f;
 using matrix::wrap_2pi;
 
+// ensure PX4 rotation enum and MAV_SENSOR_ROTATION align
+static_assert(MAV_SENSOR_ROTATION_NONE == ROTATION_NONE, "Roll: 0, Pitch: 0, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_YAW_45 == ROTATION_YAW_45, "Roll: 0, Pitch: 0, Yaw: 45");
+static_assert(MAV_SENSOR_ROTATION_YAW_90 == ROTATION_YAW_90, "Roll: 0, Pitch: 0, Yaw: 90");
+static_assert(MAV_SENSOR_ROTATION_YAW_135 == ROTATION_YAW_135, "Roll: 0, Pitch: 0, Yaw: 135");
+static_assert(MAV_SENSOR_ROTATION_YAW_180 == ROTATION_YAW_180, "Roll: 0, Pitch: 0, Yaw: 180");
+static_assert(MAV_SENSOR_ROTATION_YAW_225 == ROTATION_YAW_225, "Roll: 0, Pitch: 0, Yaw: 225");
+static_assert(MAV_SENSOR_ROTATION_YAW_270 == ROTATION_YAW_270, "Roll: 0, Pitch: 0, Yaw: 270");
+static_assert(MAV_SENSOR_ROTATION_YAW_315 == ROTATION_YAW_315, "Roll: 0, Pitch: 0, Yaw: 315");
+static_assert(MAV_SENSOR_ROTATION_ROLL_180 == ROTATION_ROLL_180, "Roll: 180, Pitch: 0, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_ROLL_180_YAW_45 == ROTATION_ROLL_180_YAW_45, "Roll: 180, Pitch: 0, Yaw: 45");
+static_assert(MAV_SENSOR_ROTATION_ROLL_180_YAW_90 == ROTATION_ROLL_180_YAW_90, "Roll: 180, Pitch: 0, Yaw: 90");
+static_assert(MAV_SENSOR_ROTATION_ROLL_180_YAW_135 == ROTATION_ROLL_180_YAW_135, "Roll: 180, Pitch: 0, Yaw: 135");
+static_assert(MAV_SENSOR_ROTATION_PITCH_180 == ROTATION_PITCH_180, "Roll: 0, Pitch: 180, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_ROLL_180_YAW_225 == ROTATION_ROLL_180_YAW_225, "Roll: 180, Pitch: 0, Yaw: 225");
+static_assert(MAV_SENSOR_ROTATION_ROLL_180_YAW_270 == ROTATION_ROLL_180_YAW_270, "Roll: 180, Pitch: 0, Yaw: 270");
+static_assert(MAV_SENSOR_ROTATION_ROLL_180_YAW_315 == ROTATION_ROLL_180_YAW_315, "Roll: 180, Pitch: 0, Yaw: 315");
+static_assert(MAV_SENSOR_ROTATION_ROLL_90 == ROTATION_ROLL_90, "Roll: 90, Pitch: 0, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_ROLL_90_YAW_45 == ROTATION_ROLL_90_YAW_45, "Roll: 90, Pitch: 0, Yaw: 45");
+static_assert(MAV_SENSOR_ROTATION_ROLL_90_YAW_90 == ROTATION_ROLL_90_YAW_90, "Roll: 90, Pitch: 0, Yaw: 90");
+static_assert(MAV_SENSOR_ROTATION_ROLL_90_YAW_135 == ROTATION_ROLL_90_YAW_135, "Roll: 90, Pitch: 0, Yaw: 135");
+static_assert(MAV_SENSOR_ROTATION_ROLL_270 == ROTATION_ROLL_270, "Roll: 270, Pitch: 0, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_ROLL_270_YAW_45 == ROTATION_ROLL_270_YAW_45, "Roll: 270, Pitch: 0, Yaw: 45");
+static_assert(MAV_SENSOR_ROTATION_ROLL_270_YAW_90 == ROTATION_ROLL_270_YAW_90, "Roll: 270, Pitch: 0, Yaw: 90");
+static_assert(MAV_SENSOR_ROTATION_ROLL_270_YAW_135 == ROTATION_ROLL_270_YAW_135, "Roll: 270, Pitch: 0, Yaw: 135");
+static_assert(MAV_SENSOR_ROTATION_PITCH_90 == ROTATION_PITCH_90, "Roll: 0, Pitch: 90, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_PITCH_270 == ROTATION_PITCH_270, "Roll: 0, Pitch: 270, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_PITCH_180_YAW_90 == ROTATION_PITCH_180_YAW_90, "Roll: 0, Pitch: 180, Yaw: 90");
+static_assert(MAV_SENSOR_ROTATION_PITCH_180_YAW_270 == ROTATION_PITCH_180_YAW_270, "Roll: 0, Pitch: 180, Yaw: 270");
+static_assert(MAV_SENSOR_ROTATION_ROLL_90_PITCH_90 == ROTATION_ROLL_90_PITCH_90, "Roll: 90, Pitch: 90, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_ROLL_180_PITCH_90 == ROTATION_ROLL_180_PITCH_90, "Roll: 180, Pitch: 90, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_ROLL_270_PITCH_90 == ROTATION_ROLL_270_PITCH_90, "Roll: 270, Pitch: 90, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_ROLL_90_PITCH_180 == ROTATION_ROLL_90_PITCH_180, "Roll: 90, Pitch: 180, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_ROLL_270_PITCH_180 == ROTATION_ROLL_270_PITCH_180, "Roll: 270, Pitch: 180, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_ROLL_90_PITCH_270 == ROTATION_ROLL_90_PITCH_270, "Roll: 90, Pitch: 270, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_ROLL_180_PITCH_270 == ROTATION_ROLL_180_PITCH_270, "Roll: 180, Pitch: 270, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_ROLL_270_PITCH_270 == ROTATION_ROLL_270_PITCH_270, "Roll: 270, Pitch: 270, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_ROLL_90_PITCH_180_YAW_90 == ROTATION_ROLL_90_PITCH_180_YAW_90,
+	      "Roll: 90, Pitch: 180, Yaw: 90");
+static_assert(MAV_SENSOR_ROTATION_ROLL_90_YAW_270 == ROTATION_ROLL_90_YAW_270, "Roll: 90, Pitch: 0, Yaw: 270");
+static_assert(MAV_SENSOR_ROTATION_ROLL_90_PITCH_68_YAW_293 == ROTATION_ROLL_90_PITCH_68_YAW_293,
+	      "Roll: 90, Pitch: 68, Yaw: 293");
+static_assert(MAV_SENSOR_ROTATION_PITCH_315 == ROTATION_PITCH_315, "Pitch: 315");
+static_assert(MAV_SENSOR_ROTATION_ROLL_90_PITCH_315 == ROTATION_ROLL_90_PITCH_315, "Roll: 90, Pitch: 315");
+static_assert(MAV_SENSOR_ROTATION_ROLL_270_YAW_180 == ROTATION_ROLL_270_YAW_180, "Roll: 270, Yaw: 180");
+static_assert(42 == ROTATION_MAX, "Keep MAV_SENSOR_ROTATION and PX4 Rotation in sync");
+
 static uint16_t cm_uint16_from_m_float(float m)
 {
 	if (m < 0.0f) {

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -131,19 +131,26 @@ PARAM_DEFINE_FLOAT(SENS_DPRES_ANSC, 0);
  * @value 23 Roll 270°, Yaw 135°
  * @value 24 Pitch 90°
  * @value 25 Pitch 270°
- * @value 26 Roll 270°, Yaw 270°
- * @value 27 Roll 180°, Pitch 270°
- * @value 28 Pitch 90°, Yaw 180
- * @value 29 Pitch 90°, Roll 90°
- * @value 30 Yaw 293°, Pitch 68°, Roll 90° (Solo)
- * @value 31 Pitch 90°, Roll 270°
- * @value 32 Pitch 9°, Yaw 180°
- * @value 33 Pitch 45°
- * @value 34 Pitch 315°
- * @value 35 Roll 90°, Yaw 270°
+ * @value 26 Pitch 180°, Yaw 90°
+ * @value 27 Pitch 180°, Yaw 270°
+ * @value 28 Roll 90°, Pitch 90°
+ * @value 29 Roll 180°, Pitch 90°
+ * @value 30 Roll 270°, Pitch 90°
+ * @value 31 Roll 90°, Pitch 180°
+ * @value 32 Roll 270°, Pitch 180°
+ * @value 33 Roll 90°, Pitch 270°
+ * @value 34 Roll 180°, Pitch 270°
+ * @value 35 Roll 270°, Pitch 270°
+ * @value 36 Roll 90°, Pitch 180°, Yaw 90°
+ * @value 37 Roll 90°, Yaw 270°
+ * @value 38 Roll 90°, Pitch 68°, Yaw 293°
+ * @value 39 Pitch 315°
+ * @value 40 Roll 90°, Pitch 315°
+ * @value 41 Roll 270°, Yaw 180°
  *
+ * @min -1
+ * @max 41
  * @reboot_required true
- *
  * @group Sensors
  */
 PARAM_DEFINE_INT32(SENS_BOARD_ROT, 0);

--- a/src/modules/sensors/sensor_params_mag0.c
+++ b/src/modules/sensors/sensor_params_mag0.c
@@ -105,13 +105,9 @@ PARAM_DEFINE_INT32(CAL_MAG0_PRIO, -1);
  * @value 39 Pitch 315°
  * @value 40 Roll 90°, Pitch 315°
  * @value 41 Roll 270°, Yaw 180°
- * @value 42 Roll 270°, Yaw 270°
- * @value 43 Pitch 90°, Yaw 180°
- * @value 44 Pitch 9°, Yaw 180°
- * @value 45 Pitch 45°
  *
  * @min -1
- * @max 45
+ * @max 41
  * @reboot_required true
  * @category system
  * @group Sensor Calibration

--- a/src/modules/sensors/sensor_params_mag1.c
+++ b/src/modules/sensors/sensor_params_mag1.c
@@ -105,13 +105,9 @@ PARAM_DEFINE_INT32(CAL_MAG1_PRIO, -1);
  * @value 39 Pitch 315°
  * @value 40 Roll 90°, Pitch 315°
  * @value 41 Roll 270°, Yaw 180°
- * @value 42 Roll 270°, Yaw 270°
- * @value 43 Pitch 90°, Yaw 180°
- * @value 44 Pitch 9°, Yaw 180°
- * @value 45 Pitch 45°
  *
  * @min -1
- * @max 45
+ * @max 41
  * @reboot_required true
  * @category system
  * @group Sensor Calibration

--- a/src/modules/sensors/sensor_params_mag2.c
+++ b/src/modules/sensors/sensor_params_mag2.c
@@ -105,13 +105,9 @@ PARAM_DEFINE_INT32(CAL_MAG2_PRIO, -1);
  * @value 39 Pitch 315°
  * @value 40 Roll 90°, Pitch 315°
  * @value 41 Roll 270°, Yaw 180°
- * @value 42 Roll 270°, Yaw 270°
- * @value 43 Pitch 90°, Yaw 180°
- * @value 44 Pitch 9°, Yaw 180°
- * @value 45 Pitch 45°
  *
  * @min -1
- * @max 45
+ * @max 41
  * @reboot_required true
  * @category system
  * @group Sensor Calibration

--- a/src/modules/sensors/sensor_params_mag3.c
+++ b/src/modules/sensors/sensor_params_mag3.c
@@ -105,13 +105,9 @@ PARAM_DEFINE_INT32(CAL_MAG3_PRIO, -1);
  * @value 39 Pitch 315°
  * @value 40 Roll 90°, Pitch 315°
  * @value 41 Roll 270°, Yaw 180°
- * @value 42 Roll 270°, Yaw 270°
- * @value 43 Pitch 90°, Yaw 180°
- * @value 44 Pitch 9°, Yaw 180°
- * @value 45 Pitch 45°
  *
  * @min -1
- * @max 45
+ * @max 41
  * @reboot_required true
  * @category system
  * @group Sensor Calibration


### PR DESCRIPTION
  - fixes https://github.com/PX4/Firmware/issues/15771

We had slightly different options across rotation enum, SENS_BOARD_ROT, CAL_MAGx_ROT, and MAV_SENSOR_ORIENTATION. This has been an ongoing problem at different points and it's extremely frustrating for the occasional user that hits this. I think the only sane thing to do is bring them altogether and keep it that way.

In this PR I've deleted a few rotations. If we want them they have to go in mavlink first and we'll bring them back.
 - ROTATION_PITCH_9_YAW_180: added for Bebop, which we no longer support https://github.com/PX4/Firmware/pull/5598
 - ROTATION_PITCH_45: https://github.com/PX4/Firmware/pull/8593
      - needs to be added to mavlink if actually used
      - we already shifted the number earlier this year (https://github.com/PX4/Firmware/pull/14797) without any notification or param translation
 - ROTATION_ROLL_270_YAW_270 (duplicate of ROTATION_ROLL_90_PITCH_180_YAW_90/MAV_SENSOR_ROTATION_ROLL_90_PITCH_180_YAW_90)
 - ROTATION_PITCH_90_YAW_180 (duplicate of ROTATION_ROLL_180_PITCH_90/MAV_SENSOR_ROTATION_ROLL_180_PITCH_90)