### PR TITLE
Fix proposal for hardfault with batt_smbus module

### DIFF
--- a/src/lib/drivers/smbus/SMBus.cpp
+++ b/src/lib/drivers/smbus/SMBus.cpp
@@ -122,7 +122,7 @@ int SMBus::block_read(const uint8_t cmd_code, void *data, const uint8_t length, 
 	rx_data[0] = (device_address << 1) | 0x00;
 	rx_data[1] = cmd_code;
 	rx_data[2] = (device_address << 1) | 0x01;
-	byte_count = math::min(rx_data[3], 32);
+	byte_count = math::min(rx_data[3], (uint8_t)32);
 
 	// ensure data is not longer than given buffer
 	memcpy(data, &rx_data[4], math::min(byte_count, length));

--- a/src/lib/drivers/smbus/SMBus.cpp
+++ b/src/lib/drivers/smbus/SMBus.cpp
@@ -127,7 +127,7 @@ int SMBus::block_read(const uint8_t cmd_code, void *data, const uint8_t length, 
 	uint8_t cpy_len=byte_count;
 	if(byte_count > length) cpy_len=length;
 
-	memcpy(data, &rx_data[4], cpy_len);
+	memcpy(data, &rx_data[4], math::min(byte_count, length));
 
 	if (use_pec) {
 		uint8_t pec = get_pec(rx_data, byte_count + 4);

--- a/src/lib/drivers/smbus/SMBus.cpp
+++ b/src/lib/drivers/smbus/SMBus.cpp
@@ -45,6 +45,7 @@
  */
 
 #include "SMBus.hpp"
+#include <mathlib/mathlib.h>
 
 SMBus::SMBus(int bus_num, uint16_t address) :
 	I2C(DRV_BAT_DEVTYPE_SMBUS, MODULE_NAME, bus_num, address, 100000)

--- a/src/lib/drivers/smbus/SMBus.cpp
+++ b/src/lib/drivers/smbus/SMBus.cpp
@@ -123,7 +123,11 @@ int SMBus::block_read(const uint8_t cmd_code, void *data, const uint8_t length, 
 	rx_data[2] = (device_address << 1) | 0x01;
 	byte_count = rx_data[3];
 
-	memcpy(data, &rx_data[4], byte_count);
+	// ensure data is not longer than given buffer
+	uint8_t cpy_len=byte_count;
+	if(byte_count > length) cpy_len=length;
+
+	memcpy(data, &rx_data[4], cpy_len);
 
 	if (use_pec) {
 		uint8_t pec = get_pec(rx_data, byte_count + 4);

--- a/src/lib/drivers/smbus/SMBus.cpp
+++ b/src/lib/drivers/smbus/SMBus.cpp
@@ -124,9 +124,6 @@ int SMBus::block_read(const uint8_t cmd_code, void *data, const uint8_t length, 
 	byte_count = rx_data[3];
 
 	// ensure data is not longer than given buffer
-	uint8_t cpy_len=byte_count;
-	if(byte_count > length) cpy_len=length;
-
 	memcpy(data, &rx_data[4], math::min(byte_count, length));
 
 	if (use_pec) {

--- a/src/lib/drivers/smbus/SMBus.cpp
+++ b/src/lib/drivers/smbus/SMBus.cpp
@@ -122,7 +122,7 @@ int SMBus::block_read(const uint8_t cmd_code, void *data, const uint8_t length, 
 	rx_data[0] = (device_address << 1) | 0x00;
 	rx_data[1] = cmd_code;
 	rx_data[2] = (device_address << 1) | 0x01;
-	byte_count = rx_data[3];
+	byte_count = math::min(rx_data[3], 32);
 
 	// ensure data is not longer than given buffer
 	memcpy(data, &rx_data[4], math::min(byte_count, length));

--- a/src/lib/drivers/smbus/SMBus.cpp
+++ b/src/lib/drivers/smbus/SMBus.cpp
@@ -106,7 +106,7 @@ int SMBus::write_word(const uint8_t cmd_code, uint16_t data)
 
 int SMBus::block_read(const uint8_t cmd_code, void *data, const uint8_t length, const bool use_pec)
 {
-	unsigned byte_count = 0;
+	uint8_t byte_count = 0;
 	// addr(wr), cmd_code, addr(r), byte_count, data (32 bytes max), pec
 	uint8_t rx_data[32 + 5];
 


### PR DESCRIPTION
Added buffer length check to SMBus::block_read (triggered hardfault in batt_smbus module by writing beyond buffer end due to device returning longer byte_count than requested/expected)

I ran into a hardfault when reading Smart Battery data with SMBus::block_read.

The fault is triggered in line 126 of
/Firmware/src/lib/drivers/smbus/SMBus.cpp
when memcpy writes beyond the end of the buffer “data” provided by the caller.

In my case the smbus device returned a byte count larger than the requested length (13 instead of 8 bytes).

I fixed this by adding a check for the length limit before the memcpy call, see

I experienced hardfaults working on a SMBUS battery driver based on batt_smbus. They werde triggered by the device returning a bigger byte_count value than was requested (13 bytes in byte_count versus a buffer length of 8 in my case), which lead to memcpy(data, &rx_data[4], byte_count); writing beyond the limit of the provided buffer.

As a fix I added a buffer length check to SMBus::block_read to force the maximum received data length to the length of the buffer provided by the caller.

I experienced that issue with a 3DR Solo battery among others.
