### PR TITLE
Revert MPC_LAND_ALT1/2 to original defaults to prevent slowing down too late

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -688,7 +688,7 @@ PARAM_DEFINE_FLOAT(MPC_YAWRAUTO_MAX, 45.0f);
  * @decimal 1
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_LAND_ALT1, 5.0f);
+PARAM_DEFINE_FLOAT(MPC_LAND_ALT1, 10.0f);
 
 /**
  * Altitude for 2. step of slow landing (landing)
@@ -703,7 +703,7 @@ PARAM_DEFINE_FLOAT(MPC_LAND_ALT1, 5.0f);
  * @decimal 1
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_LAND_ALT2, 2.0f);
+PARAM_DEFINE_FLOAT(MPC_LAND_ALT2, 5.0f);
 
 /**
  * Position control smooth takeoff ramp time constant


### PR DESCRIPTION
**Describe problem solved by this pull request**
This reverts commit 59bd3e9f6e72db5d1751fc11fe6dccaf1c69b05e from https://github.com/PX4/Firmware/pull/14560. I checked and this change was only introduced because the vertical velocity in position mode got constrained (too much) when getting closer to the ground when testing the relatively samll pixhawk vision. Since then the horizontal slow down was more or less disabled by only limiting to 10 m/s in https://github.com/PX4/Firmware/pull/15029. Also the defaults should represent safe values for a wide variety of suppoerted vehicles and can be adjusted if not "itght" enough for certain use cases.

Since that change we had multiple incidents where also larger drones slowed down too late and hit the ground quite hard and I consider it a safety critical issue. The cases seem to have various root causes from not enough thrust to distance sensor acceptance delay issues. Most if not all of them could have been prevented by just starting slow down earlier. So this seems an easy and useful fix since the original change was probably tyring to solve the same issue as https://github.com/PX4/Firmware/pull/15029.

**Test data / coverage**
It's restoring the original defaults that were tested a lot.

**Additional context**
Testpilot @fury1895 confirmed that usually he needs to increase the values from the defaults for safe operation.