### PR TITLE
mavlink: fix compiler warning

### DIFF
--- a/src/modules/mavlink/CMakeLists.txt
+++ b/src/modules/mavlink/CMakeLists.txt
@@ -40,6 +40,7 @@ px4_add_module(
 		-Wno-cast-align # TODO: fix and enable
 		-Wno-address-of-packed-member # TODO: fix in c_library_v2
 		-Wno-enum-compare # ROTATION <-> MAV_SENSOR_ROTATION
+		-Wno-sign-compare # ROTATION <-> MAV_SENSOR_ROTATION
 		#-DDEBUG_BUILD
 	INCLUDES
 		${PX4_SOURCE_DIR}/mavlink/include/mavlink


### PR DESCRIPTION
Fixes:
```
src/modules/mavlink/mavlink_messages.cpp:127:40: error: comparison between types ‘MAV_SENSOR_ORIENTATION’ and ‘Rotation’ [-Werror=sign-compare]
  127 | static_assert(MAV_SENSOR_ROTATION_NONE == ROTATION_NONE, "Roll: 0, Pitch: 0, Yaw: 0");
      |               ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
```