### PR TITLE
mavlink_messages: cast rotation types for assert

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -124,50 +124,91 @@ using matrix::Vector3f;
 using matrix::wrap_2pi;
 
 // ensure PX4 rotation enum and MAV_SENSOR_ROTATION align
-static_assert(MAV_SENSOR_ROTATION_NONE == ROTATION_NONE, "Roll: 0, Pitch: 0, Yaw: 0");
-static_assert(MAV_SENSOR_ROTATION_YAW_45 == ROTATION_YAW_45, "Roll: 0, Pitch: 0, Yaw: 45");
-static_assert(MAV_SENSOR_ROTATION_YAW_90 == ROTATION_YAW_90, "Roll: 0, Pitch: 0, Yaw: 90");
-static_assert(MAV_SENSOR_ROTATION_YAW_135 == ROTATION_YAW_135, "Roll: 0, Pitch: 0, Yaw: 135");
-static_assert(MAV_SENSOR_ROTATION_YAW_180 == ROTATION_YAW_180, "Roll: 0, Pitch: 0, Yaw: 180");
-static_assert(MAV_SENSOR_ROTATION_YAW_225 == ROTATION_YAW_225, "Roll: 0, Pitch: 0, Yaw: 225");
-static_assert(MAV_SENSOR_ROTATION_YAW_270 == ROTATION_YAW_270, "Roll: 0, Pitch: 0, Yaw: 270");
-static_assert(MAV_SENSOR_ROTATION_YAW_315 == ROTATION_YAW_315, "Roll: 0, Pitch: 0, Yaw: 315");
-static_assert(MAV_SENSOR_ROTATION_ROLL_180 == ROTATION_ROLL_180, "Roll: 180, Pitch: 0, Yaw: 0");
-static_assert(MAV_SENSOR_ROTATION_ROLL_180_YAW_45 == ROTATION_ROLL_180_YAW_45, "Roll: 180, Pitch: 0, Yaw: 45");
-static_assert(MAV_SENSOR_ROTATION_ROLL_180_YAW_90 == ROTATION_ROLL_180_YAW_90, "Roll: 180, Pitch: 0, Yaw: 90");
-static_assert(MAV_SENSOR_ROTATION_ROLL_180_YAW_135 == ROTATION_ROLL_180_YAW_135, "Roll: 180, Pitch: 0, Yaw: 135");
-static_assert(MAV_SENSOR_ROTATION_PITCH_180 == ROTATION_PITCH_180, "Roll: 0, Pitch: 180, Yaw: 0");
-static_assert(MAV_SENSOR_ROTATION_ROLL_180_YAW_225 == ROTATION_ROLL_180_YAW_225, "Roll: 180, Pitch: 0, Yaw: 225");
-static_assert(MAV_SENSOR_ROTATION_ROLL_180_YAW_270 == ROTATION_ROLL_180_YAW_270, "Roll: 180, Pitch: 0, Yaw: 270");
-static_assert(MAV_SENSOR_ROTATION_ROLL_180_YAW_315 == ROTATION_ROLL_180_YAW_315, "Roll: 180, Pitch: 0, Yaw: 315");
-static_assert(MAV_SENSOR_ROTATION_ROLL_90 == ROTATION_ROLL_90, "Roll: 90, Pitch: 0, Yaw: 0");
-static_assert(MAV_SENSOR_ROTATION_ROLL_90_YAW_45 == ROTATION_ROLL_90_YAW_45, "Roll: 90, Pitch: 0, Yaw: 45");
-static_assert(MAV_SENSOR_ROTATION_ROLL_90_YAW_90 == ROTATION_ROLL_90_YAW_90, "Roll: 90, Pitch: 0, Yaw: 90");
-static_assert(MAV_SENSOR_ROTATION_ROLL_90_YAW_135 == ROTATION_ROLL_90_YAW_135, "Roll: 90, Pitch: 0, Yaw: 135");
-static_assert(MAV_SENSOR_ROTATION_ROLL_270 == ROTATION_ROLL_270, "Roll: 270, Pitch: 0, Yaw: 0");
-static_assert(MAV_SENSOR_ROTATION_ROLL_270_YAW_45 == ROTATION_ROLL_270_YAW_45, "Roll: 270, Pitch: 0, Yaw: 45");
-static_assert(MAV_SENSOR_ROTATION_ROLL_270_YAW_90 == ROTATION_ROLL_270_YAW_90, "Roll: 270, Pitch: 0, Yaw: 90");
-static_assert(MAV_SENSOR_ROTATION_ROLL_270_YAW_135 == ROTATION_ROLL_270_YAW_135, "Roll: 270, Pitch: 0, Yaw: 135");
-static_assert(MAV_SENSOR_ROTATION_PITCH_90 == ROTATION_PITCH_90, "Roll: 0, Pitch: 90, Yaw: 0");
-static_assert(MAV_SENSOR_ROTATION_PITCH_270 == ROTATION_PITCH_270, "Roll: 0, Pitch: 270, Yaw: 0");
-static_assert(MAV_SENSOR_ROTATION_PITCH_180_YAW_90 == ROTATION_PITCH_180_YAW_90, "Roll: 0, Pitch: 180, Yaw: 90");
-static_assert(MAV_SENSOR_ROTATION_PITCH_180_YAW_270 == ROTATION_PITCH_180_YAW_270, "Roll: 0, Pitch: 180, Yaw: 270");
-static_assert(MAV_SENSOR_ROTATION_ROLL_90_PITCH_90 == ROTATION_ROLL_90_PITCH_90, "Roll: 90, Pitch: 90, Yaw: 0");
-static_assert(MAV_SENSOR_ROTATION_ROLL_180_PITCH_90 == ROTATION_ROLL_180_PITCH_90, "Roll: 180, Pitch: 90, Yaw: 0");
-static_assert(MAV_SENSOR_ROTATION_ROLL_270_PITCH_90 == ROTATION_ROLL_270_PITCH_90, "Roll: 270, Pitch: 90, Yaw: 0");
-static_assert(MAV_SENSOR_ROTATION_ROLL_90_PITCH_180 == ROTATION_ROLL_90_PITCH_180, "Roll: 90, Pitch: 180, Yaw: 0");
-static_assert(MAV_SENSOR_ROTATION_ROLL_270_PITCH_180 == ROTATION_ROLL_270_PITCH_180, "Roll: 270, Pitch: 180, Yaw: 0");
-static_assert(MAV_SENSOR_ROTATION_ROLL_90_PITCH_270 == ROTATION_ROLL_90_PITCH_270, "Roll: 90, Pitch: 270, Yaw: 0");
-static_assert(MAV_SENSOR_ROTATION_ROLL_180_PITCH_270 == ROTATION_ROLL_180_PITCH_270, "Roll: 180, Pitch: 270, Yaw: 0");
-static_assert(MAV_SENSOR_ROTATION_ROLL_270_PITCH_270 == ROTATION_ROLL_270_PITCH_270, "Roll: 270, Pitch: 270, Yaw: 0");
-static_assert(MAV_SENSOR_ROTATION_ROLL_90_PITCH_180_YAW_90 == ROTATION_ROLL_90_PITCH_180_YAW_90,
+static_assert(MAV_SENSOR_ROTATION_NONE == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_NONE),
+	      "Roll: 0, Pitch: 0, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_YAW_45 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_YAW_45),
+	      "Roll: 0, Pitch: 0, Yaw: 45");
+static_assert(MAV_SENSOR_ROTATION_YAW_90 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_YAW_90),
+	      "Roll: 0, Pitch: 0, Yaw: 90");
+static_assert(MAV_SENSOR_ROTATION_YAW_135 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_YAW_135),
+	      "Roll: 0, Pitch: 0, Yaw: 135");
+static_assert(MAV_SENSOR_ROTATION_YAW_180 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_YAW_180),
+	      "Roll: 0, Pitch: 0, Yaw: 180");
+static_assert(MAV_SENSOR_ROTATION_YAW_225 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_YAW_225),
+	      "Roll: 0, Pitch: 0, Yaw: 225");
+static_assert(MAV_SENSOR_ROTATION_YAW_270 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_YAW_270),
+	      "Roll: 0, Pitch: 0, Yaw: 270");
+static_assert(MAV_SENSOR_ROTATION_YAW_315 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_YAW_315),
+	      "Roll: 0, Pitch: 0, Yaw: 315");
+static_assert(MAV_SENSOR_ROTATION_ROLL_180 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_ROLL_180),
+	      "Roll: 180, Pitch: 0, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_ROLL_180_YAW_45 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_ROLL_180_YAW_45),
+	      "Roll: 180, Pitch: 0, Yaw: 45");
+static_assert(MAV_SENSOR_ROTATION_ROLL_180_YAW_90 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_ROLL_180_YAW_90),
+	      "Roll: 180, Pitch: 0, Yaw: 90");
+static_assert(MAV_SENSOR_ROTATION_ROLL_180_YAW_135 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_ROLL_180_YAW_135),
+	      "Roll: 180, Pitch: 0, Yaw: 135");
+static_assert(MAV_SENSOR_ROTATION_PITCH_180 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_PITCH_180),
+	      "Roll: 0, Pitch: 180, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_ROLL_180_YAW_225 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_ROLL_180_YAW_225),
+	      "Roll: 180, Pitch: 0, Yaw: 225");
+static_assert(MAV_SENSOR_ROTATION_ROLL_180_YAW_270 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_ROLL_180_YAW_270),
+	      "Roll: 180, Pitch: 0, Yaw: 270");
+static_assert(MAV_SENSOR_ROTATION_ROLL_180_YAW_315 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_ROLL_180_YAW_315),
+	      "Roll: 180, Pitch: 0, Yaw: 315");
+static_assert(MAV_SENSOR_ROTATION_ROLL_90 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_ROLL_90),
+	      "Roll: 90, Pitch: 0, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_ROLL_90_YAW_45 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_ROLL_90_YAW_45),
+	      "Roll: 90, Pitch: 0, Yaw: 45");
+static_assert(MAV_SENSOR_ROTATION_ROLL_90_YAW_90 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_ROLL_90_YAW_90),
+	      "Roll: 90, Pitch: 0, Yaw: 90");
+static_assert(MAV_SENSOR_ROTATION_ROLL_90_YAW_135 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_ROLL_90_YAW_135),
+	      "Roll: 90, Pitch: 0, Yaw: 135");
+static_assert(MAV_SENSOR_ROTATION_ROLL_270 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_ROLL_270),
+	      "Roll: 270, Pitch: 0, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_ROLL_270_YAW_45 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_ROLL_270_YAW_45),
+	      "Roll: 270, Pitch: 0, Yaw: 45");
+static_assert(MAV_SENSOR_ROTATION_ROLL_270_YAW_90 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_ROLL_270_YAW_90),
+	      "Roll: 270, Pitch: 0, Yaw: 90");
+static_assert(MAV_SENSOR_ROTATION_ROLL_270_YAW_135 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_ROLL_270_YAW_135),
+	      "Roll: 270, Pitch: 0, Yaw: 135");
+static_assert(MAV_SENSOR_ROTATION_PITCH_90 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_PITCH_90),
+	      "Roll: 0, Pitch: 90, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_PITCH_270 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_PITCH_270),
+	      "Roll: 0, Pitch: 270, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_PITCH_180_YAW_90 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_PITCH_180_YAW_90),
+	      "Roll: 0, Pitch: 180, Yaw: 90");
+static_assert(MAV_SENSOR_ROTATION_PITCH_180_YAW_270 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_PITCH_180_YAW_270),
+	      "Roll: 0, Pitch: 180, Yaw: 270");
+static_assert(MAV_SENSOR_ROTATION_ROLL_90_PITCH_90 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_ROLL_90_PITCH_90),
+	      "Roll: 90, Pitch: 90, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_ROLL_180_PITCH_90 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_ROLL_180_PITCH_90),
+	      "Roll: 180, Pitch: 90, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_ROLL_270_PITCH_90 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_ROLL_270_PITCH_90),
+	      "Roll: 270, Pitch: 90, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_ROLL_90_PITCH_180 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_ROLL_90_PITCH_180),
+	      "Roll: 90, Pitch: 180, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_ROLL_270_PITCH_180 == static_cast<MAV_SENSOR_ORIENTATION>
+	      (ROTATION_ROLL_270_PITCH_180), "Roll: 270, Pitch: 180, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_ROLL_90_PITCH_270 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_ROLL_90_PITCH_270),
+	      "Roll: 90, Pitch: 270, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_ROLL_180_PITCH_270 == static_cast<MAV_SENSOR_ORIENTATION>
+	      (ROTATION_ROLL_180_PITCH_270), "Roll: 180, Pitch: 270, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_ROLL_270_PITCH_270 == static_cast<MAV_SENSOR_ORIENTATION>
+	      (ROTATION_ROLL_270_PITCH_270), "Roll: 270, Pitch: 270, Yaw: 0");
+static_assert(MAV_SENSOR_ROTATION_ROLL_90_PITCH_180_YAW_90 == static_cast<MAV_SENSOR_ORIENTATION>
+	      (ROTATION_ROLL_90_PITCH_180_YAW_90),
 	      "Roll: 90, Pitch: 180, Yaw: 90");
-static_assert(MAV_SENSOR_ROTATION_ROLL_90_YAW_270 == ROTATION_ROLL_90_YAW_270, "Roll: 90, Pitch: 0, Yaw: 270");
-static_assert(MAV_SENSOR_ROTATION_ROLL_90_PITCH_68_YAW_293 == ROTATION_ROLL_90_PITCH_68_YAW_293,
+static_assert(MAV_SENSOR_ROTATION_ROLL_90_YAW_270 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_ROLL_90_YAW_270),
+	      "Roll: 90, Pitch: 0, Yaw: 270");
+static_assert(MAV_SENSOR_ROTATION_ROLL_90_PITCH_68_YAW_293 == static_cast<MAV_SENSOR_ORIENTATION>
+	      (ROTATION_ROLL_90_PITCH_68_YAW_293),
 	      "Roll: 90, Pitch: 68, Yaw: 293");
-static_assert(MAV_SENSOR_ROTATION_PITCH_315 == ROTATION_PITCH_315, "Pitch: 315");
-static_assert(MAV_SENSOR_ROTATION_ROLL_90_PITCH_315 == ROTATION_ROLL_90_PITCH_315, "Roll: 90, Pitch: 315");
-static_assert(MAV_SENSOR_ROTATION_ROLL_270_YAW_180 == ROTATION_ROLL_270_YAW_180, "Roll: 270, Yaw: 180");
+static_assert(MAV_SENSOR_ROTATION_PITCH_315 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_PITCH_315), "Pitch: 315");
+static_assert(MAV_SENSOR_ROTATION_ROLL_90_PITCH_315 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_ROLL_90_PITCH_315),
+	      "Roll: 90, Pitch: 315");
+static_assert(MAV_SENSOR_ROTATION_ROLL_270_YAW_180 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_ROLL_270_YAW_180),
+	      "Roll: 270, Yaw: 180");
 static_assert(42 == ROTATION_MAX, "Keep MAV_SENSOR_ROTATION and PX4 Rotation in sync");
 
 static uint16_t cm_uint16_from_m_float(float m)


### PR DESCRIPTION
**Describe problem solved by this pull request**
Compiling `make sitl_px4` with GCC 10.1 I get the following errors
```
../../src/modules/mavlink/mavlink_messages.cpp:127:40: error: comparison between types ‘MAV_SENSOR_ORIENTATION’ and ‘Rotation’ [-Werror=sign-compare]
  127 | static_assert(MAV_SENSOR_ROTATION_NONE == ROTATION_NONE, "Roll: 0, Pitch: 0, Yaw: 0");
```
for all the static asserts added in https://github.com/PX4/Firmware/pull/15784/files#diff-e605251d3710c0f7f0c065b242004e9cR127

**Describe your solution**
I statically cast the internal values which have the internal `Rotation` type defined in https://github.com/PX4/Firmware/blob/d5295ef4e10accd8b5cba07c9afd03367af540d2/src/lib/conversion/rotation.h#L51 to the MAVLink defined `MAV_SENSOR_ORIENTATION` type defined in https://github.com/mavlink/c_library_v2/blob/e3d00c443602ff81cc57123fbc3b50c250b3e9ad/common/common.h#L921 before comparing the actual value. If I'm not mistaken this should not lead to wrong comparisons because of wrapping since the integer value is preserved and doesn't get wrapped with the number of entries in the enum.

**Describe possible alternatives**
We could write a macro to make it more readable.

**Test data / coverage**
Compiles again with the change and supposedly does the same checks.
