### PR TITLE
Commander: fix rc override threshold scaling

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1428,9 +1428,6 @@ Commander::run()
 
 			status.rc_input_mode = _param_rc_in_off.get();
 
-			// percentage (* 0.01) needs to be doubled because RC total interval is 2, not 1
-			_min_stick_change = _param_min_stick_change.get() * 0.02f;
-
 			rc_arm_hyst = _param_rc_arm_hyst.get() * COMMANDER_MONITORING_LOOPSPERMSEC;
 
 			_arm_requirements.arm_authorization = _param_arm_auth_required.get();
@@ -1908,10 +1905,12 @@ Commander::run()
 
 		if ((override_auto_mode || override_offboard_mode) && is_rotary_wing
 		    && !in_low_battery_failsafe && !_geofence_warning_action_on) {
+			const float minimum_stick_deflection = 0.01f * _param_com_rc_stick_ov.get();
+
 			// transition to previous state if sticks are touched
 			if (hrt_elapsed_time(&_manual_control_setpoint.timestamp) < 1_s && // don't use uninitialized or old messages
-			    ((fabsf(_manual_control_setpoint.x) > _min_stick_change) ||
-			     (fabsf(_manual_control_setpoint.y) > _min_stick_change))) {
+			    ((fabsf(_manual_control_setpoint.x) > minimum_stick_deflection) ||
+			     (fabsf(_manual_control_setpoint.y) > minimum_stick_deflection))) {
 				// revert to position control in any case
 				main_state_transition(status, commander_state_s::MAIN_STATE_POSCTL, status_flags, &_internal_state);
 				mavlink_log_info(&mavlink_log_pub, "Pilot took over control using sticks");

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -232,7 +232,7 @@ private:
 		(ParamInt<px4::params::COM_RC_OVERRIDE>) _param_rc_override,
 		(ParamInt<px4::params::COM_RC_IN_MODE>) _param_rc_in_off,
 		(ParamInt<px4::params::COM_RC_ARM_HYST>) _param_rc_arm_hyst,
-		(ParamFloat<px4::params::COM_RC_STICK_OV>) _param_min_stick_change,
+		(ParamFloat<px4::params::COM_RC_STICK_OV>) _param_com_rc_stick_ov,
 
 		(ParamInt<px4::params::COM_FLTMODE1>) _param_fltmode_1,
 		(ParamInt<px4::params::COM_FLTMODE2>) _param_fltmode_2,
@@ -353,7 +353,6 @@ private:
 	hrt_abstime	_rc_signal_lost_timestamp{0};		///< Time at which the RC reception was lost
 	int32_t		_flight_mode_slots[manual_control_setpoint_s::MODE_SLOT_NUM] {};
 	uint8_t		_last_manual_control_setpoint_arm_switch{0};
-	float		_min_stick_change{};
 	uint32_t	_stick_off_counter{0};
 	uint32_t	_stick_on_counter{0};
 

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -186,21 +186,6 @@ PARAM_DEFINE_FLOAT(COM_EF_TIME, 10.0f);
 PARAM_DEFINE_FLOAT(COM_RC_LOSS_T, 0.5f);
 
 /**
- * RC stick override threshold
- *
- * If an RC stick is moved more than by this amount the system will interpret this as
- * override request by the pilot.
- *
- * @group Commander
- * @unit %
- * @min 5
- * @max 80
- * @decimal 0
- * @increment 0.05
- */
-PARAM_DEFINE_FLOAT(COM_RC_STICK_OV, 50.0f);
-
-/**
  * Home set horizontal threshold
  *
  * The home position will be set if the estimated positioning accuracy is below the threshold.
@@ -632,8 +617,8 @@ PARAM_DEFINE_INT32(COM_ARM_MAG_STR, 1);
 /**
  * Enable RC stick override of auto and/or offboard modes
  *
- * When RC stick override is enabled, moving the RC sticks immediately gives control back
- * to the pilot (switches to manual position mode):
+ * When RC stick override is enabled, moving the RC sticks according to COM_RC_STICK_OV
+ * immediately gives control back to the pilot (switches to manual position mode):
  * bit 0: Enable for auto modes (except for in critical battery reaction),
  * bit 1: Enable for offboard mode.
  *
@@ -646,6 +631,21 @@ PARAM_DEFINE_INT32(COM_ARM_MAG_STR, 1);
  * @group Commander
  */
 PARAM_DEFINE_INT32(COM_RC_OVERRIDE, 1);
+
+/**
+ * RC stick override threshold
+ *
+ * If COM_RC_OVERRIDE is enabled and the joystick input controlling the horizontally axis (right stick for RC in mode 2)
+ * is moved more than this threshold from the center the autopilot switches to position mode and the pilot takes over control.
+ *
+ * @group Commander
+ * @unit %
+ * @min 5
+ * @max 80
+ * @decimal 0
+ * @increment 0.05
+ */
+PARAM_DEFINE_FLOAT(COM_RC_STICK_OV, 30.0f);
 
 /**
  * Require valid mission to arm


### PR DESCRIPTION
**Describe problem solved by this pull request**
RC override is broken on master since https://github.com/PX4/Firmware/pull/15495

**Describe your solution**
- Fix RC override threshold scaling
- Improve parameter description for threshold
- Lower the threshold a bit according to my testing

**Test data / coverage**
SITL tested with Joystick input.
