### PR TITLE
commander: fix switch to loiter

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2172,7 +2172,7 @@ Commander::run()
 		 * as finished even though we only just started with the takeoff. Therefore, we also
 		 * check the timestamp of the mission_result topic. */
 		if (_internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_TAKEOFF
-		    && (_mission_result_sub.get().timestamp > _internal_state.timestamp)
+		    && (_mission_result_sub.get().timestamp >= _internal_state.timestamp)
 		    && _mission_result_sub.get().finished) {
 
 			const bool mission_available = (_mission_result_sub.get().timestamp > _boot_timestamp)


### PR DESCRIPTION
Sometimes, the mission_result timestamp is the same as the internal_state timestamp which would meant that we would not switch to LOITER even though the takeoff is clearly done at that point.

**Note: this is against `release/1.11`!**

This fixes the integration tests for MAVSDK, see:
https://github.com/mavlink/MAVSDK/runs/1160302183