### PR TITLE
commander: disarm from safety relax land detector timeout

### DIFF
--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -365,7 +365,6 @@ private:
 
 	bool		_status_changed{true};
 	bool		_arm_tune_played{false};
-	bool		_was_landed{true};
 	bool		_was_armed{false};
 	bool		_failsafe_old{false};	///< check which state machines for changes, clear "changed" flag
 	bool		_have_taken_off_since_arming{false};


### PR DESCRIPTION
 - possible fix for https://github.com/PX4/Firmware/issues/15810
 - the land detector only publishes at ~ 1 Hz, so this timeout was too tight
 - the land detector was only updated after the safety button was checked

In the log from https://github.com/PX4/Firmware/issues/15810 you can see that safety was fully off much earlier in the flight, but the disarm in air didn't happen until much later.

![Screenshot from 2020-09-24 11-35-21](https://user-images.githubusercontent.com/84712/94167069-0dc8da00-fe5a-11ea-9af2-28bfa4895851.png)
