### PR TITLE
cmake: remove sitl_gazebo build -j2

### DIFF
--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -17,8 +17,8 @@ pipeline {
         sh 'make distclean'
         sh 'ccache -s'
         sh 'git fetch --tags'
-        sh 'make px4_sitl_default'
-        sh 'make px4_sitl_default sitl_gazebo'
+        sh 'NO_NINJA_BUILD=1 make px4_sitl_default'
+        sh 'NO_NINJA_BUILD=1 make px4_sitl_default sitl_gazebo'
         sh 'make px4_sitl_default package'
         sh 'ccache -s'
         stash(name: "px4_sitl_package", includes: "build/px4_sitl_default/*.bz2")

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -45,7 +45,7 @@ ExternalProject_Add(sitl_gazebo
 	USES_TERMINAL_BUILD true
 	EXCLUDE_FROM_ALL true
 	BUILD_ALWAYS 1
-	BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> -- -j2
+	BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR>
 )
 
 ExternalProject_Add(mavsdk_tests


### PR DESCRIPTION
 - allow ninja build to automatically determine parallelism

This was needed for build slaves with limited memory, let's see if it's still needed.


@bperseghetti 
