### PR TITLE
Tools ecl analysis handle estimator_innovations/estimator_innovation_variances size inconsistencies

### DIFF
--- a/Tools/ecl_ekf/plotting/pdf_report.py
+++ b/Tools/ecl_ekf/plotting/pdf_report.py
@@ -47,7 +47,26 @@ def create_pdf_report(ulog: ULog, output_plot_filename: str) -> None:
         for key in estimator_innovation_variances:
             # append 'var' to the field name such that we can distingush between innov and innov_var
             innovation_data.update({str('var_'+key): estimator_innovation_variances[key]})
-        print('found innovation data')
+
+        innovations_min_length = float('inf')
+        for key in estimator_innovations:
+            if len(estimator_innovations[key]) < innovations_min_length:
+                innovations_min_length = len(estimator_innovations[key])
+
+        variances_min_length = float('inf')
+        for key in estimator_innovation_variances:
+            if len(estimator_innovation_variances[key]) < variances_min_length:
+                variances_min_length = len(estimator_innovation_variances[key])
+
+        # ensure consistent sizing for plots
+        if (innovations_min_length != variances_min_length):
+            print("estimator_innovations and estimator_innovation_variances are different sizes, adjusting")
+            innovation_data_min_length = min(innovations_min_length, variances_min_length)
+            for key in innovation_data:
+                innovation_data[key] = innovation_data[key][0:innovation_data_min_length-1]
+
+        print('found innovation data (merged estimator_innovations + estimator_innovation_variances)')
+
     except:
         raise PreconditionError('could not find innovation data')
 

--- a/Tools/ecl_ekf/plotting/pdf_report.py
+++ b/Tools/ecl_ekf/plotting/pdf_report.py
@@ -63,7 +63,7 @@ def create_pdf_report(ulog: ULog, output_plot_filename: str) -> None:
             print("estimator_innovations and estimator_innovation_variances are different sizes, adjusting")
             innovation_data_min_length = min(innovations_min_length, variances_min_length)
             for key in innovation_data:
-                innovation_data[key] = innovation_data[key][0:innovation_data_min_length-1]
+                innovation_data[key] = innovation_data[key][0:innovation_data_min_length]
 
         print('found innovation data (merged estimator_innovations + estimator_innovation_variances)')
 


### PR DESCRIPTION
This fixes the rather annoying `Tools/ecl_ekf/process_logdata_ekf.py` failure when estimator_innovations and estimator_innovation_variances aren't exactly the same size. Quite often they're off by 1.

![Screenshot from 2020-09-24 13-33-40](https://user-images.githubusercontent.com/84712/94179514-9b142a80-fe6a-11ea-9687-4d4d2de4f49f.png)


Suggestions welcome, I suspect this code is embarrassingly unpythonic.

FYI @priseborough @kamilritz 