### PR TITLE
Switch VERBOSE to VERBOSE_SIM

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -43,7 +43,7 @@ else
 fi
 
 # To disable user input
-if [[ -n "$VERBOSE" ]]; then
+if [[ -n "$VERBOSE_SIM" ]]; then
 	verbose="--verbose"
 else
 	verbose=""


### PR DESCRIPTION
**Describe problem solved by this pull request**
`VERBOSE=1` was added in https://github.com/PX4/Firmware/pull/15720 to enable verbose outputs from the simulation. However, the term `VERBOSE` is not exactly accurate since it configures the verbose output of the gazebo simulation and nothing else. 

**Describe your solution**
This changes the environment variable `VERBOSE` to `VERBOSE_SIM`, to explicitly state that it configures the verbose output of the simulation
