### PR TITLE
mavlink: increase stack 2650 -> 2848 bytes

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2726,7 +2726,7 @@ Mavlink::start(int argc, char *argv[])
 	px4_task_spawn_cmd(buf,
 			   SCHED_DEFAULT,
 			   SCHED_PRIORITY_DEFAULT,
-			   2650 + MAVLINK_NET_ADDED_STACK,
+			   2848 + MAVLINK_NET_ADDED_STACK,
 			   (px4_main_t)&Mavlink::start_helper,
 			   (char *const *)argv);
 


### PR DESCRIPTION
<img width="571" alt="Screen Shot 2020-09-25 at 8 50 31 PM" src="https://user-images.githubusercontent.com/84712/94326246-c5501000-ff70-11ea-8267-2eb26d1e5c32.png">


Seems related to the NuttX upgrade.

