### PR TITLE
Use jinja templates for multivehicle simulations

### DIFF
--- a/Tools/gazebo_sitl_multiple_run.sh
+++ b/Tools/gazebo_sitl_multiple_run.sh
@@ -29,13 +29,10 @@ function spawn_model() {
 	[ ! -d "$working_dir" ] && mkdir -p "$working_dir"
 
 	pushd "$working_dir" &>/dev/null
-	echo "starting instance $n in $(pwd)"
-	../bin/px4 -i $n -d "$build_path/etc" -w sitl_${MODEL}_${n} -s etc/init.d-posix/rcS >out.log 2>err.log &
-	python3 ${src_path}/Tools/sitl_gazebo/scripts/xacro.py ${src_path}/Tools/sitl_gazebo/models/rotors_description/urdf/${MODEL}_base.xacro \
-		rotors_description_dir:=${src_path}/Tools/sitl_gazebo/models/rotors_description mavlink_udp_port:=$(($mavlink_udp_port+$N)) \
-		mavlink_tcp_port:=$(($mavlink_tcp_port+$N))  -o /tmp/${MODEL}_${N}.urdf
+	echo "starting instance $N in $(pwd)"
+	../bin/px4 -i $N -d "$build_path/etc" -w sitl_${MODEL}_${N} -s etc/init.d-posix/rcS >out.log 2>err.log &
+	python3 ${src_path}/Tools/sitl_gazebo/scripts/jinja_gen.py ${src_path}/Tools/sitl_gazebo/models/${MODEL}/${MODEL}.sdf.jinja ${src_path}/Tools/sitl_gazebo --mavlink_tcp_port $((4560+${N})) --mavlink_udp_port $((14560+${N})) --output-file /tmp/${MODEL}_${N}.sdf
 
-	gz sdf -p  /tmp/${MODEL}_${N}.urdf > /tmp/${MODEL}_${n}.sdf
 	echo "Spawning ${MODEL}_${N}"
 
 	gz model --spawn-file=/tmp/${MODEL}_${N}.sdf --model-name=${MODEL}_${N} -x 0.0 -y $((3*${N})) -z 0.0


### PR DESCRIPTION
**Describe problem solved by this pull request**
Multivehicle simulations in gazebo was run using xacro macros to generate sdf files in the `/tmp` directory with the necessary port assignments to enable it.

However, there are several problem with this infrastructure
- xacros do not support some of the syntaxes that were added in recent sdf versions (e.g. nested models)
- PX4 uses [xacro.py](https://github.com/PX4/sitl_gazebo/blob/master/scripts/xacro.py), which is deprecated
- xacro based macros were not on the same path with the models that they represent, therefore got outdated whenever the models were updated. (see below for the current state of `standard_vtol`)
![ezgif com-video-to-gif (4)](https://user-images.githubusercontent.com/5248102/91224554-913fc000-e722-11ea-8f97-0579839cdfef.gif)

**Describe your solution**
jina2 templates are now used to generate sdf files at build time. This PR moves the multivehicle script to use jinja templates instead of xacro files. After this is merged, xacro macros will be completely removed from `sitl_gazebo`

**Test data / coverage**
Tested in Gazebo SITL:
![image](https://user-images.githubusercontent.com/5248102/94373588-9ec3dd80-0106-11eb-8e01-5c1199d51d01.png)


**Additional context**
- This requires the following changes in the `PX4/sitl_gazebo submodule: https://github.com/PX4/sitl_gazebo/pull/609 https://github.com/PX4/sitl_gazebo/pull/612
- Fixes: https://github.com/PX4/Firmware/issues/15609
