### PR TITLE
motor_test: Use 1-based motor indexing.

### DIFF
--- a/src/systemcmds/motor_test/motor_test.cpp
+++ b/src/systemcmds/motor_test/motor_test.cpp
@@ -68,7 +68,8 @@ void motor_test(unsigned channel, float value, uint8_t driver_instance, int time
 		PX4_INFO("motors stop command sent");
 
 	} else {
-		PX4_INFO("motor %d set to %.2f", channel, (double)value);
+		/* Adjust for 1-based motor indexing */
+		PX4_INFO("motor %d set to %.2f", channel + 1, (double)value);
 	}
 }
 
@@ -87,7 +88,7 @@ WARNING: remove all props before using this command.
 
 	PRINT_MODULE_USAGE_NAME("motor_test", "command");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("test", "Set motor(s) to a specific output value");
-	PRINT_MODULE_USAGE_PARAM_INT('m', -1, 0, 7, "Motor to test (0...7, all if not specified)", true);
+	PRINT_MODULE_USAGE_PARAM_INT('m', -1, 1, 8, "Motor to test (1...8, all if not specified)", true);
 	PRINT_MODULE_USAGE_PARAM_INT('p', 0, 0, 100, "Power (0...100)", true);
 	PRINT_MODULE_USAGE_PARAM_INT('t', 0, 0, 100, "Timeout in seconds (default=no timeout)", true);
 	PRINT_MODULE_USAGE_PARAM_INT('i', 0, 0, 4, "driver instance", true);
@@ -116,8 +117,8 @@ int motor_test_main(int argc, char *argv[])
 			break;
 
 		case 'm':
-			/* Read in motor number */
-			channel = (int)strtol(myoptarg, nullptr, 0);
+			/* Read in motor number and adjust for 1-based indexing */
+			channel = (int)strtol(myoptarg, nullptr, 0) - 1;
 			break;
 
 		case 'p':


### PR DESCRIPTION
**Describe problem solved by this pull request**

Motors in Px4 ecosystem are indexed using 1-based indexing (Airframe reference, dshot command, etc.) motor_test command is 0-based. This PR changes motor_test to use 1-based indexing.

This PR refers to Github issue #15721.

**Describe your solution**
motor_test command updated to use 1-based indexing.

**Describe possible alternatives**
Leave status quo with 0-based indexing.

**Test data / coverage**
N/A

**Additional context**
N/A