### PR TITLE
mc_pos_control: fix z velocity derivative sign

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -481,7 +481,7 @@ MulticopterPositionControl::set_vehicle_states(const float &vel_sp_z)
 			_states.velocity(2) = _local_pos.z_deriv * weighting + _local_pos.vz * (1.0f - weighting);
 		}
 
-		_states.acceleration(2) = _vel_z_deriv.update(-_states.velocity(2));
+		_states.acceleration(2) = _vel_z_deriv.update(_states.velocity(2));
 
 	} else {
 		_states.velocity(2) = _states.acceleration(2) = NAN;


### PR DESCRIPTION
**Describe problem solved by this pull request**
It seems that z velocity derivative part off multi-copter position controller has a sign error.


**Describe your solution**
Change sign

**Test data / coverage**
On master with SIH, try to set MPC_Z_VEL_D_ACC to 2 : vertical oscillations begin. Then try to set it to -2 or even -4 : the drone stabilizes. 

![acc_z_sign](https://user-images.githubusercontent.com/59083163/94403567-ea5da200-016d-11eb-9873-583160d6ba43.png)


**Additional context**
As MPC_Z_VEL_D_ACC default value is 0, it has no impact.

@MaEtUgR: this regression seems linked to this commit: 38093e4
