### PR TITLE
sensor_calibration: explicitly add link dependencies

### DIFF
--- a/src/lib/sensor_calibration/CMakeLists.txt
+++ b/src/lib/sensor_calibration/CMakeLists.txt
@@ -41,3 +41,5 @@ px4_add_library(sensor_calibration
 	Utilities.cpp
 	Utilities.hpp
 )
+
+target_link_libraries(sensor_calibration PRIVATE conversion parameters)


### PR DESCRIPTION
We don't notice most of these because the common dependencies are pulled in by multiple other modules.