### PR TITLE
Fix the world path being corrupting when spawning none-default world

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -112,7 +112,7 @@ elif [ "$program" == "gazebo" ] && [ ! -n "$no_sim" ]; then
 				fi
 			else
 				#Spawn empty world if world with model name doesn't exist
-				world_path= $verbose "${src_path}/Tools/sitl_gazebo/worlds/${world}.world"
+				world_path="${src_path}/Tools/sitl_gazebo/worlds/${world}.world"
 			fi
 		else
 			if [ -f ${src_path}/Tools/sitl_gazebo/worlds/${PX4_SITL_WORLD}.world ]; then


### PR DESCRIPTION
**Describe problem solved by this pull request**
This fixes a bug in the SITL startup scripts, where the world file path was being corrupted when using non-default world paths


**Additional context**
- This was a bug introduced from https://github.com/PX4/Firmware/pull/15720
- Fixes https://github.com/PX4/sitl_gazebo/issues/603
