### PR TITLE
ROMFS: 50000_generic_ground_vehicle remove fmu-v2 exclude

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/50000_generic_ground_vehicle
+++ b/ROMFS/px4fmu_common/init.d/airframes/50000_generic_ground_vehicle
@@ -12,7 +12,6 @@
 #
 # @maintainer
 #
-# @board px4_fmu-v2 exclude
 # @board intel_aerofc-v1 exclude
 # @board bitcraze_crazyflie exclude
 #


### PR DESCRIPTION
This allows px4_fmu-v2_rover to function until we have a better mechanism for including or excluding ROMFS dependencies.
https://github.com/PX4/Firmware/issues/15711