### PR TITLE
[Port 1.11] mc_pos_control: fix z velocity derivative sign

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -481,7 +481,7 @@ MulticopterPositionControl::set_vehicle_states(const float &vel_sp_z)
 			_states.velocity(2) = _local_pos.z_deriv * weighting + _local_pos.vz * (1.0f - weighting);
 		}
 
-		_states.acceleration(2) = _vel_z_deriv.update(-_states.velocity(2));
+		_states.acceleration(2) = _vel_z_deriv.update(_states.velocity(2));
 
 	} else {
 		_states.velocity(2) = _states.acceleration(2) = NAN;


### PR DESCRIPTION
**Describe problem solved by this pull request**
1:1 port of https://github.com/PX4/Firmware/pull/15836
I checked and the issue is not present on 1.10 but on 1.11. So this is the backport.
