### PR TITLE
bl_update:Respect page size if it matters

### DIFF
--- a/.ci/Jenkinsfile-hardware
+++ b/.ci/Jenkinsfile-hardware
@@ -714,7 +714,7 @@ pipeline {
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set DSHOT_CONFIG 600"'
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set IMU_GYRO_RATEMAX 4000"'
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set SYS_AUTOSTART 4001"' // generic quadcopter
-                    //sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set SYS_BL_UPDATE 1"'    // update bootloader
+                    sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set SYS_BL_UPDATE 1"'    // update bootloader
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set SYS_USE_IO 0"'       // for dshot
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param save"'
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "px4io forceupdate 14662 /etc/extras/px4_io-v2_default.bin"' // force px4io update

--- a/src/systemcmds/bl_update/bl_update.c
+++ b/src/systemcmds/bl_update/bl_update.c
@@ -56,6 +56,7 @@
 #if defined(CONFIG_ARCH_CHIP_STM32H7)
 #  define BL_FILE_SIZE_LIMIT	128*1024
 #  define STM_RAM_BASE        STM32_AXISRAM_BASE
+#  define PAGE_SIZE_MATTERS   1
 #else
 #  define BL_FILE_SIZE_LIMIT  16384
 #  define STM_RAM_BASE        STM32_SRAM_BASE
@@ -131,16 +132,25 @@ bl_update_main(int argc, char *argv[])
 		return 1;
 	}
 
-	uint8_t *buf = malloc(s.st_size);
+	off_t file_size = s.st_size;
+	off_t image_size = file_size;
+
+#if defined(PAGE_SIZE_MATTERS)
+	size_t page_size =  up_progmem_pagesize(0) - 1;
+	image_size = (file_size + page_size) & ~page_size;
+#endif
+
+	uint8_t *buf = malloc(image_size);
+	memset(buf, 0xff, image_size);
 
 	if (buf == NULL)
 	{
-		PX4_ERR("failed to allocate %u bytes for firmware buffer", s.st_size);
+		PX4_ERR("failed to allocate %u bytes for firmware buffer", file_size);
 		close(fd);
 		return 1;
 	}
 
-	if (read(fd, buf, s.st_size) != s.st_size)
+	if (read(fd, buf, file_size) != file_size)
 	{
 		PX4_ERR("firmware read error");
 		close(fd);
@@ -182,9 +192,9 @@ bl_update_main(int argc, char *argv[])
 
 	/* now program the bootloader - speed is not critical so use x8 mode */
 
-	size = up_progmem_write((size_t) base, buf, s.st_size);
+	size = up_progmem_write((size_t) base, buf, image_size);
 
-	if (size != s.st_size)
+	if (size != image_size)
 	{
 		PX4_ERR("program error at %p",  &base[size]);
 		goto flash_end;
@@ -197,7 +207,7 @@ bl_update_main(int argc, char *argv[])
 	PX4_INFO("verifying...");
 
 	/* now run a verify pass */
-	for (int i = 0; i < s.st_size; i++)
+	for (int i = 0; i < image_size; i++)
 	{
 		if (base[i] != buf[i]) {
 			PX4_WARN("verify failed at %i - retry update, DO NOT reboot", i);


### PR DESCRIPTION
Resolves https://github.com/PX4/Firmware/issues/15786
   Track Changes in NuttX stm32h7 flash driver:
   The STM32H7 flash driver uses up_progmem_pagesize to
   describe minimum write size to satify the block size
   requierment for ECC.

   Therefore, the image size needs to be padded to a multiple
   of up_progmem_pagesize()

