### PR TITLE
removed non used parameter MPC_VELD_LP

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -450,17 +450,6 @@ PARAM_DEFINE_FLOAT(MPC_HOLD_MAX_XY, 0.8f);
 PARAM_DEFINE_FLOAT(MPC_HOLD_MAX_Z, 0.6f);
 
 /**
- * Low pass filter cut freq. for numerical velocity derivative
- *
- * @unit Hz
- * @min 0.0
- * @max 10
- * @decimal 2
- * @group Multicopter Position Control
- */
-PARAM_DEFINE_FLOAT(MPC_VELD_LP, 5.0f);
-
-/**
  * Maximum horizontal acceleration for auto mode and for manual mode
  *
  * Maximum deceleration for MPC_POS_MODE 1. Maximum acceleration and deceleration for MPC_POS_MODE 3.


### PR DESCRIPTION
This parameter added 5 years ago [Here](https://github.com/PX4/Firmware/commit/0106be3e89d36454c100b763a00dd0d76e86d935#diff-ffdc6fb3dc66ee0fd3359190869b8712R313) but it seems unused since.

Can someone confirm that? That I don't miss anything
