### PR TITLE
Increase uavcan main stack size

### DIFF
--- a/src/drivers/uavcan/CMakeLists.txt
+++ b/src/drivers/uavcan/CMakeLists.txt
@@ -113,6 +113,7 @@ add_custom_target(px4_uavcan_dsdlc DEPENDS px4_uavcan_dsdlc_run.stamp)
 px4_add_module(
 	MODULE drivers__uavcan
 	MAIN uavcan
+	STACK_MAIN 4096
 	INCLUDES
 		${DSDLC_OUTPUT}
 		${LIBUAVCAN_DIR}/libuavcan/include


### PR DESCRIPTION
**Describe problem solved by this pull request**
I observed hard faults when running `uavcan params list`. A stackcheck build showed that the `uavcan` task overflowed its stack.

**Describe your solution**
I increased the stack size for the `uavcan` command

**Describe possible alternatives**
None

**Test data / coverage**
Increasing stack size shouldn't cause any issues, but for what it's worth I have flown with this commit
https://review.px4.io/plot_app?log=d0f658d7-60ab-40ae-b4e2-a32aae84d942
