### PR TITLE
load_mon get mem_usage by reading /proc/meminfo on Linux

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -210,6 +210,7 @@ if ! replay tryapplyparams
 then
 	simulator start -c $simulator_tcp_port
 fi
+load_mon start
 battery_simulator start
 tone_alarm start
 rc_update start

--- a/boards/px4/sitl/default.cmake
+++ b/boards/px4/sitl/default.cmake
@@ -36,7 +36,7 @@ px4_add_board(
 		fw_pos_control_l1
 		land_detector
 		landing_target_estimator
-		#load_mon
+		load_mon
 		local_position_estimator
 		logger
 		mavlink

--- a/boards/px4/sitl/nolockstep.cmake
+++ b/boards/px4/sitl/nolockstep.cmake
@@ -36,7 +36,7 @@ px4_add_board(
 		fw_pos_control_l1
 		land_detector
 		landing_target_estimator
-		#load_mon
+		load_mon
 		local_position_estimator
 		logger
 		mavlink

--- a/boards/px4/sitl/rtps.cmake
+++ b/boards/px4/sitl/rtps.cmake
@@ -36,7 +36,7 @@ px4_add_board(
 		fw_pos_control_l1
 		land_detector
 		landing_target_estimator
-		#load_mon
+		load_mon
 		local_position_estimator
 		logger
 		mavlink

--- a/boards/px4/sitl/test.cmake
+++ b/boards/px4/sitl/test.cmake
@@ -35,7 +35,7 @@ px4_add_board(
 		fw_pos_control_l1
 		land_detector
 		landing_target_estimator
-		#load_mon
+		load_mon
 		local_position_estimator
 		logger
 		mavlink

--- a/src/modules/load_mon/LoadMon.cpp
+++ b/src/modules/load_mon/LoadMon.cpp
@@ -211,6 +211,7 @@ void LoadMon::cpuload()
 	}
 
 	fseek(_proc_fd, 0, SEEK_SET);
+	//rewind(_proc_fd);
 
 	if (parsedCount == 5) {
 		int32_t kb_main_cached = kb_page_cache + kb_slab_reclaimable;

--- a/src/modules/load_mon/LoadMon.cpp
+++ b/src/modules/load_mon/LoadMon.cpp
@@ -151,7 +151,7 @@ void LoadMon::cpuload()
 	int parsedCount = 0;
 	FILE *meminfo = fopen("/proc/meminfo", "r");
 
-	if (meminfo == NULL) {
+	if (meminfo == nullptr) {
 		PX4_ERR("Could not open /proc/meminfo");
 	}
 

--- a/src/modules/load_mon/LoadMon.cpp
+++ b/src/modules/load_mon/LoadMon.cpp
@@ -86,6 +86,17 @@ void LoadMon::start()
 
 void LoadMon::Run()
 {
+#if defined (__PX4_LINUX)
+
+	if (_proc_fd == nullptr) {	// init fd
+		_proc_fd = fopen("/proc/meminfo", "r");
+
+		if (_proc_fd == nullptr) {
+			PX4_ERR("Failed to open /proc/meminfo");
+		}
+	}
+
+#endif
 	perf_begin(_cycle_perf);
 
 	cpuload();
@@ -100,6 +111,9 @@ void LoadMon::Run()
 
 	if (should_exit()) {
 		ScheduleClear();
+#if defined (__PX4_LINUX)
+		fclose(_proc_fd);
+#endif
 		exit_and_cleanup();
 	}
 
@@ -153,17 +167,12 @@ void LoadMon::cpuload()
 	int32_t kb_slab_reclaimable = -1;
 	int32_t kb_main_buffers = -1;
 	int parsedCount = 0;
-	FILE *meminfo = fopen("/proc/meminfo", "r");
 
-	if (meminfo == nullptr) {
+	if (_proc_fd == nullptr) {
 		PX4_ERR("Could not open /proc/meminfo");
 	}
 
-	while (fgets(line, sizeof(line), meminfo)) {
-		if (parsedCount == 5) {
-			break;
-		}
-
+	while (fgets(line, sizeof(line), _proc_fd)) {
 		if (sscanf(line, "MemTotal: %d kB", &kb_main_total) == 1) {
 			++parsedCount;
 			continue;
@@ -190,7 +199,7 @@ void LoadMon::cpuload()
 		}
 	}
 
-	fclose(meminfo);
+	fseek(_proc_fd, 0, SEEK_END);
 
 	if (parsedCount == 5) {
 		int32_t kb_main_cached = kb_page_cache + kb_slab_reclaimable;

--- a/src/modules/load_mon/LoadMon.cpp
+++ b/src/modules/load_mon/LoadMon.cpp
@@ -211,7 +211,6 @@ void LoadMon::cpuload()
 	}
 
 	fseek(_proc_fd, 0, SEEK_SET);
-	//rewind(_proc_fd);
 
 	if (parsedCount == 5) {
 		int32_t kb_main_cached = kb_page_cache + kb_slab_reclaimable;

--- a/src/modules/load_mon/LoadMon.cpp
+++ b/src/modules/load_mon/LoadMon.cpp
@@ -147,7 +147,11 @@ void LoadMon::cpuload()
 	/* following calculation is based on free(1)
 	 * https://gitlab.com/procps-ng/procps/-/blob/master/proc/sysinfo.c */
 	char line[256];
-	int32_t kb_main_total = -1, kb_main_free = -1, kb_page_cache = -1, kb_slab_reclaimable = -1, kb_main_buffers = -1;
+	int32_t kb_main_total = -1;
+	int32_t kb_main_free = -1;
+	int32_t kb_page_cache = -1;
+	int32_t kb_slab_reclaimable = -1;
+	int32_t kb_main_buffers = -1;
 	int parsedCount = 0;
 	FILE *meminfo = fopen("/proc/meminfo", "r");
 

--- a/src/modules/load_mon/LoadMon.cpp
+++ b/src/modules/load_mon/LoadMon.cpp
@@ -168,51 +168,52 @@ void LoadMon::cpuload()
 	int32_t kb_main_buffers = -1;
 	int parsedCount = 0;
 
-	if (_proc_fd == nullptr) {
-		PX4_ERR("Could not open /proc/meminfo");
-	}
+	if (_proc_fd != nullptr) {
+		while (fgets(line, sizeof(line), _proc_fd)) {
+			if (sscanf(line, "MemTotal: %d kB", &kb_main_total) == 1) {
+				++parsedCount;
+				continue;
+			}
 
-	while (fgets(line, sizeof(line), _proc_fd)) {
-		if (sscanf(line, "MemTotal: %d kB", &kb_main_total) == 1) {
-			++parsedCount;
-			continue;
+			if (sscanf(line, "MemFree: %d kB", &kb_main_free) == 1) {
+				++parsedCount;
+				continue;
+			}
+
+			if (sscanf(line, "Cached: %d kB", &kb_page_cache) == 1) {
+				++parsedCount;
+				continue;
+			}
+
+			if (sscanf(line, "SReclaimable: %d kB", &kb_slab_reclaimable) == 1) {
+				++parsedCount;
+				continue;
+			}
+
+			if (sscanf(line, "Buffers: %d kB", &kb_main_buffers) == 1) {
+				++parsedCount;
+				continue;
+			}
 		}
 
-		if (sscanf(line, "MemFree: %d kB", &kb_main_free) == 1) {
-			++parsedCount;
-			continue;
+		fseek(_proc_fd, 0, SEEK_END);
+
+		if (parsedCount == 5) {
+			int32_t kb_main_cached = kb_page_cache + kb_slab_reclaimable;
+			int32_t mem_used = kb_main_total - kb_main_free - kb_main_cached - kb_main_buffers;
+
+			if (mem_used < 0) {
+				mem_used = kb_main_total - kb_main_free;
+			}
+
+			cpuload.ram_usage = (float)mem_used / kb_main_total;
+
+		} else {
+			PX4_ERR("Could not parse /proc/meminfo");
+			cpuload.ram_usage = -1;
 		}
-
-		if (sscanf(line, "Cached: %d kB", &kb_page_cache) == 1) {
-			++parsedCount;
-			continue;
-		}
-
-		if (sscanf(line, "SReclaimable: %d kB", &kb_slab_reclaimable) == 1) {
-			++parsedCount;
-			continue;
-		}
-
-		if (sscanf(line, "Buffers: %d kB", &kb_main_buffers) == 1) {
-			++parsedCount;
-			continue;
-		}
-	}
-
-	fseek(_proc_fd, 0, SEEK_END);
-
-	if (parsedCount == 5) {
-		int32_t kb_main_cached = kb_page_cache + kb_slab_reclaimable;
-		int32_t mem_used = kb_main_total - kb_main_free - kb_main_cached - kb_main_buffers;
-
-		if (mem_used < 0) {
-			mem_used = kb_main_total - kb_main_free;
-		}
-
-		cpuload.ram_usage = (float)mem_used / kb_main_total;
 
 	} else {
-		PX4_ERR("Could not parse /proc/meminfo");
 		cpuload.ram_usage = -1;
 	}
 

--- a/src/modules/load_mon/LoadMon.cpp
+++ b/src/modules/load_mon/LoadMon.cpp
@@ -208,7 +208,6 @@ void LoadMon::cpuload()
 	// get ram usage
 	struct mallinfo mem = mallinfo();
 	cpuload.ram_usage = (float)mem.uordblks / mem.arena;
-	PX4_WARN("used: %d total: %d", mem.uordblks, mem.arena);
 	cpuload.load = 1.f - interval_idletime / interval;
 #endif
 	cpuload.timestamp = hrt_absolute_time();

--- a/src/modules/load_mon/LoadMon.cpp
+++ b/src/modules/load_mon/LoadMon.cpp
@@ -73,15 +73,30 @@ int LoadMon::task_spawn(int argc, char *argv[])
 	_object.store(obj);
 	_task_id = task_id_is_work_queue;
 
-	/* Schedule a cycle to start things. */
-	obj->start();
+	if (obj->start() == PX4_OK) {
+		return PX4_OK;
+	}
 
-	return 0;
+	delete obj;
+	_object.store(nullptr);
+	_task_id = -1;
+
+	return PX4_ERROR;
 }
 
-void LoadMon::start()
+int LoadMon::start()
 {
+#if defined(__PX4_LINUX)
+	_proc_fd = fopen("/proc/meminfo", "r");
+
+	if (_proc_fd == nullptr) {
+		PX4_ERR("Could not open /proc/meminfo");
+		return PX4_ERROR;
+	}
+
+#endif
 	ScheduleOnInterval(500_ms); // 2 Hz
+	return PX4_OK;
 }
 
 void LoadMon::Run()
@@ -100,6 +115,15 @@ void LoadMon::Run()
 
 	if (should_exit()) {
 		ScheduleClear();
+
+#if defined(__PX4_LINUX)
+
+		if (_proc_fd != nullptr) {
+			fclose(_proc_fd);
+		}
+
+#endif
+
 		exit_and_cleanup();
 	}
 
@@ -153,16 +177,12 @@ void LoadMon::cpuload()
 	int32_t kb_slab_reclaimable = -1;
 	int32_t kb_main_buffers = -1;
 	int parsedCount = 0;
-	FILE *meminfo = fopen("/proc/meminfo", "r");
 
-	if (meminfo == nullptr) {
-		PX4_ERR("Could not open /proc/meminfo");
-	}
-
-	while (fgets(line, sizeof(line), meminfo)) {
-		if (parsedCount == 5) {
-			break;
-		}
+	while (fgets(line, sizeof(line), _proc_fd) == line) {
+		/* It seems we must dump out all of contents to force fresh /proc/meminfo */
+		//if (parsedCount == 5) {
+		//	break;
+		//}
 
 		if (sscanf(line, "MemTotal: %d kB", &kb_main_total) == 1) {
 			++parsedCount;
@@ -190,7 +210,8 @@ void LoadMon::cpuload()
 		}
 	}
 
-	fclose(meminfo);
+	fseek(_proc_fd, 0, SEEK_SET);
+	//rewind(_proc_fd);
 
 	if (parsedCount == 5) {
 		int32_t kb_main_cached = kb_page_cache + kb_slab_reclaimable;

--- a/src/modules/load_mon/LoadMon.hpp
+++ b/src/modules/load_mon/LoadMon.hpp
@@ -50,6 +50,9 @@
 
 #if defined(__PX4_LINUX)
 #include <sys/times.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <fcntl.h>
 #endif
 
 namespace load_mon
@@ -72,7 +75,7 @@ public:
 	/** @see ModuleBase */
 	static int print_usage(const char *reason = nullptr);
 
-	void start();
+	int start();
 
 private:
 	/** Do a compute and schedule the next cycle. */
@@ -93,6 +96,7 @@ private:
 	uORB::Publication<cpuload_s> _cpuload_pub {ORB_ID(cpuload)};
 
 #if defined(__PX4_LINUX)
+	FILE *_proc_fd = nullptr;
 	/* calculate usage directly from clock ticks on Linux */
 	clock_t _last_total_time_stamp{};
 	clock_t _last_spent_time_stamp{};

--- a/src/modules/load_mon/LoadMon.hpp
+++ b/src/modules/load_mon/LoadMon.hpp
@@ -50,9 +50,6 @@
 
 #if defined(__PX4_LINUX)
 #include <sys/times.h>
-#include <stdio.h>
-#include <sys/stat.h>
-#include <fcntl.h>
 #endif
 
 namespace load_mon
@@ -75,7 +72,7 @@ public:
 	/** @see ModuleBase */
 	static int print_usage(const char *reason = nullptr);
 
-	int start();
+	void start();
 
 private:
 	/** Do a compute and schedule the next cycle. */
@@ -96,7 +93,6 @@ private:
 	uORB::Publication<cpuload_s> _cpuload_pub {ORB_ID(cpuload)};
 
 #if defined(__PX4_LINUX)
-	FILE *_proc_fd = nullptr;
 	/* calculate usage directly from clock ticks on Linux */
 	clock_t _last_total_time_stamp{};
 	clock_t _last_spent_time_stamp{};

--- a/src/modules/load_mon/LoadMon.hpp
+++ b/src/modules/load_mon/LoadMon.hpp
@@ -48,7 +48,6 @@
 
 #if defined(__PX4_LINUX)
 #include <sys/times.h>
-#include <malloc.h>
 #endif
 
 namespace load_mon

--- a/src/modules/load_mon/LoadMon.hpp
+++ b/src/modules/load_mon/LoadMon.hpp
@@ -33,7 +33,9 @@
 
 #pragma once
 
+#if defined(__PX4_NUTTX)
 #include <malloc.h>
+#endif
 #include <drivers/drv_hrt.h>
 #include <lib/perf/perf_counter.h>
 #include <px4_platform_common/px4_config.h>

--- a/src/modules/load_mon/LoadMon.hpp
+++ b/src/modules/load_mon/LoadMon.hpp
@@ -93,6 +93,7 @@ private:
 	uORB::Publication<cpuload_s> _cpuload_pub {ORB_ID(cpuload)};
 
 #if defined(__PX4_LINUX)
+	FILE *_proc_fd = nullptr;
 	/* calculate usage directly from clock ticks on Linux */
 	clock_t _last_total_time_stamp{};
 	clock_t _last_spent_time_stamp{};


### PR DESCRIPTION
**Describe problem solved by this pull request**
`load_mon` get memory allocation information by parsing `/proc/meminfo`.
This provides the same behavior as [free(1)](https://gitlab.com/procps-ng/procps/-/blob/master/proc/sysinfo.c). The module measures system-wide memory usage, without swap included.
Enabled in SITL as well.