### PR TITLE
px4_raspberrypi: fix mavlink over UART (/dev/ttyAMA0)

### DIFF
--- a/posix-configs/rpi/px4.config
+++ b/posix-configs/rpi/px4.config
@@ -45,9 +45,12 @@ mc_rate_control start
 
 mavlink start -x -u 14556 -r 1000000
 
-if [ -f /dev/ttyUSB0 ]
+if [ -c /dev/ttyUSB0 ]
 then
 	mavlink start -x -d /dev/ttyUSB0
+elif [ -c /dev/ttyAMA0 ]
+then
+	mavlink start -x -d /dev/ttyAMA0
 fi
 
 navio_sysfs_rc_in start

--- a/posix-configs/rpi/px4_fw.config
+++ b/posix-configs/rpi/px4_fw.config
@@ -44,9 +44,12 @@ fw_pos_control_l1 start
 
 mavlink start -x -u 14556 -r 1000000
 
-if [ -f /dev/ttyUSB0 ]
+if [ -c /dev/ttyUSB0 ]
 then
 	mavlink start -x -d /dev/ttyUSB0
+elif [ -c /dev/ttyAMA0 ]
+then
+	mavlink start -x -d /dev/ttyAMA0
 fi
 
 navio_sysfs_rc_in start

--- a/posix-configs/rpi/px4_test.config
+++ b/posix-configs/rpi/px4_test.config
@@ -44,9 +44,12 @@ mc_att_control start
 
 mavlink start -x -u 14556 -r 1000000
 
-if [ -f /dev/ttyUSB0 ]
+if [ -c /dev/ttyUSB0 ]
 then
 	mavlink start -x -d /dev/ttyUSB0
+elif [ -c /dev/ttyAMA0 ]
+then
+	mavlink start -x -d /dev/ttyAMA0
 fi
 
 navio_sysfs_rc_in start


### PR DESCRIPTION
**Describe problem solved by this pull request**

Correctly configure telemetry over the UART interface in addition to the existing configuration over /dev/ttyUSB0.

**Describe your solution**

[/dev/ttyAMA0](https://docs.emlid.com/navio2/ardupilot/hardware-setup/#uart-radio) is the primary interface for telemetry radio as defined in the Navio2 [hardware setup page](https://docs.emlid.com/navio2/ardupilot/hardware-setup/) documentation. The proposed changeset adds functionality over UART: it checks first if /dev/ttyUSB0 exists, which translates to possibly telemetry radio being attached through one of the USB ports on RPi ([usb-radio](https://docs.emlid.com/navio2/ardupilot/hardware-setup/#usb-radio)); if not, the code falls back to configuring over UART (/dev/ttyAMA0).

Use stricter check for character special file (-c) rather than just file (-f).

cmdline.txt needs to be edited to remove 'console=serial0,115200' as an additional configuration step to free up the /dev/ttyAMA0 interface. This should be documented in [docs.px4.io](https://docs.px4.io/master/en/flight_controller/raspberry_pi_navio2.html). Presumably, this change is exactly what Emlid does when they spin their prebuilt image, to make UART work in the Raspberry Pi OS distro they support.

**Test data / coverage**
Tested with a major manufacturer's telemetry kit and Navio2 attached to RPi. Before this changeset, telemetry was not coming through the UART port. After the changes were applied, relevant mavlink data flows correctly through the UART port, over the wireless connection and gets displayed in QGroundControl.

**Additional context**
https://docs.emlid.com/navio2/ardupilot/hardware-setup/