### PR TITLE
lib/battery: fix duplicate uORB publish and minor cleanup

### DIFF
--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -42,17 +42,18 @@
 
 #pragma once
 
-#include <uORB/uORB.h>
-#include <uORB/PublicationMulti.hpp>
-#include <uORB/topics/battery_status.h>
-#include <drivers/drv_hrt.h>
-#include <px4_platform_common/module_params.h>
-#include <parameters/param.h>
-#include <board_config.h>
-#include <px4_platform_common/board_common.h>
 #include <math.h>
 #include <float.h>
+
+#include <board_config.h>
+#include <px4_platform_common/board_common.h>
+#include <px4_platform_common/module_params.h>
+
+#include <drivers/drv_hrt.h>
+#include <lib/parameters/param.h>
 #include <lib/ecl/AlphaFilter/AlphaFilter.hpp>
+#include <uORB/PublicationMulti.hpp>
+#include <uORB/topics/battery_status.h>
 
 /**
  * BatteryBase is a base class for any type of battery.
@@ -96,7 +97,7 @@ public:
 	 * @param priority: The brick number -1. The term priority refers to the Vn connection on the LTC4417
 	 * @param throttle_normalized: Throttle of the vehicle, between 0 and 1
 	 */
-	void updateBatteryStatus(hrt_abstime timestamp, float voltage_v, float current_a, bool connected,
+	void updateBatteryStatus(const hrt_abstime &timestamp, float voltage_v, float current_a, bool connected,
 				 int source, int priority, float throttle_normalized);
 
 	/**
@@ -126,7 +127,7 @@ protected:
 		param_t v_load_drop_old;
 		param_t r_internal_old;
 		param_t source_old;
-	} _param_handles;
+	} _param_handles{};
 
 	struct {
 		float v_empty;
@@ -149,9 +150,9 @@ protected:
 		float v_load_drop_old;
 		float r_internal_old;
 		int source_old;
-	} _params;
+	} _params{};
 
-	battery_status_s _battery_status;
+	battery_status_s _battery_status{};
 
 	const int _index;
 
@@ -192,25 +193,25 @@ protected:
 		}
 	}
 
-	bool isFloatEqual(float a, float b) { return fabsf(a - b) > FLT_EPSILON; }
+	bool isFloatEqual(float a, float b) const { return fabsf(a - b) > FLT_EPSILON; }
 
 private:
-	void sumDischarged(hrt_abstime timestamp, float current_a);
+	void sumDischarged(const hrt_abstime &timestamp, float current_a);
 	void estimateRemaining(const float voltage_v, const float current_a, const float throttle);
 	void determineWarning(bool connected);
 	void computeScale();
 
 	uORB::PublicationMulti<battery_status_s> _battery_status_pub{ORB_ID(battery_status)};
 
-	bool _battery_initialized = false;
+	bool _battery_initialized{false};
 	AlphaFilter<float> _voltage_filter_v;
 	AlphaFilter<float> _current_filter_a;
 	AlphaFilter<float> _throttle_filter;
-	float _discharged_mah = 0.f;
-	float _discharged_mah_loop = 0.f;
-	float _remaining_voltage = -1.f;		///< normalized battery charge level remaining based on voltage
-	float _remaining = -1.f;			///< normalized battery charge level, selected based on config param
-	float _scale = 1.f;
-	uint8_t _warning;
-	hrt_abstime _last_timestamp;
+	float _discharged_mah{0.f};
+	float _discharged_mah_loop{0.f};
+	float _remaining_voltage{-1.f};		///< normalized battery charge level remaining based on voltage
+	float _remaining{-1.f};			///< normalized battery charge level, selected based on config param
+	float _scale{1.f};
+	uint8_t _warning{battery_status_s::BATTERY_WARNING_NONE};
+	hrt_abstime _last_timestamp{0};
 };

--- a/src/modules/battery_status/battery_status.cpp
+++ b/src/modules/battery_status/battery_status.cpp
@@ -57,6 +57,7 @@
 #include <lib/battery/battery.h>
 #include <lib/conversion/rotation.h>
 #include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionCallback.hpp>
 #include <uORB/Publication.hpp>
 #include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/parameter_update.h>
@@ -101,7 +102,7 @@ private:
 
 	uORB::Subscription	_actuator_ctrl_0_sub{ORB_ID(actuator_controls_0)};		/**< attitude controls sub */
 	uORB::Subscription	_parameter_update_sub{ORB_ID(parameter_update)};				/**< notification of parameter updates */
-	uORB::Subscription	_adc_report_sub{ORB_ID(adc_report)};
+	uORB::SubscriptionCallbackWorkItem _adc_report_sub{this, ORB_ID(adc_report)};
 
 	static constexpr uint32_t SAMPLE_FREQUENCY_HZ = 100;
 	static constexpr uint32_t SAMPLE_INTERVAL_US  = 1_s / SAMPLE_FREQUENCY_HZ;
@@ -280,9 +281,7 @@ BatteryStatus::task_spawn(int argc, char *argv[])
 bool
 BatteryStatus::init()
 {
-	ScheduleOnInterval(SAMPLE_INTERVAL_US);
-
-	return true;
+	return _adc_report_sub.registerCallback();
 }
 
 int BatteryStatus::custom_command(int argc, char *argv[])


### PR DESCRIPTION
While debugging I noticed `battery_status` was publishing at 200 Hz.