### PR TITLE
Airspeed_validated: rename airspeed_equivalent to airspeed_calibrated

### DIFF
--- a/msg/airspeed_validated.msg
+++ b/msg/airspeed_validated.msg
@@ -1,10 +1,10 @@
 uint64 timestamp			# time since system start (microseconds)
 
 float32 indicated_airspeed_m_s		# indicated airspeed in m/s (IAS), set to NAN if invalid
-float32 equivalent_airspeed_m_s     # equivalent airspeed in m/s (accounts for instrumentation errors) (EAS), set to NAN if invalid
+float32 calibrated_airspeed_m_s     # calibrated airspeed in m/s (CAS, accounts for instrumentation errors), set to NAN if invalid
 float32 true_airspeed_m_s			# true filtered airspeed in m/s (TAS), set to NAN if invalid
 
-float32 equivalent_ground_minus_wind_m_s # EAS calculated from groundspeed - windspeed, where windspeed is estimated based on a zero-sideslip assumption, set to NAN if invalid
+float32 calibrated_ground_minus_wind_m_s # CAS calculated from groundspeed - windspeed, where windspeed is estimated based on a zero-sideslip assumption, set to NAN if invalid
 float32 true_ground_minus_wind_m_s 		# TAS calculated from groundspeed - windspeed, where windspeed is estimated based on a zero-sideslip assumption, set to NAN if invalid
 
 bool airspeed_sensor_measurement_valid # True if data from at least one airspeed sensor is declared valid.

--- a/msg/airspeed_validated.msg
+++ b/msg/airspeed_validated.msg
@@ -1,12 +1,12 @@
-uint64 timestamp			# time since system start (microseconds)
+uint64 timestamp				# time since system start (microseconds)
 
-float32 indicated_airspeed_m_s		# indicated airspeed in m/s (IAS), set to NAN if invalid
-float32 calibrated_airspeed_m_s     # calibrated airspeed in m/s (CAS, accounts for instrumentation errors), set to NAN if invalid
+float32 indicated_airspeed_m_s			# indicated airspeed in m/s (IAS), set to NAN if invalid
+float32 calibrated_airspeed_m_s     		# calibrated airspeed in m/s (CAS, accounts for instrumentation errors), set to NAN if invalid
 float32 true_airspeed_m_s			# true filtered airspeed in m/s (TAS), set to NAN if invalid
 
-float32 calibrated_ground_minus_wind_m_s # CAS calculated from groundspeed - windspeed, where windspeed is estimated based on a zero-sideslip assumption, set to NAN if invalid
+float32 calibrated_ground_minus_wind_m_s 	# CAS calculated from groundspeed - windspeed, where windspeed is estimated based on a zero-sideslip assumption, set to NAN if invalid
 float32 true_ground_minus_wind_m_s 		# TAS calculated from groundspeed - windspeed, where windspeed is estimated based on a zero-sideslip assumption, set to NAN if invalid
 
-bool airspeed_sensor_measurement_valid # True if data from at least one airspeed sensor is declared valid.
+bool airspeed_sensor_measurement_valid 		# True if data from at least one airspeed sensor is declared valid.
 
-int8 selected_airspeed_index # 1-3: airspeed sensor index, 0: groundspeed-windspeed, -1: airspeed invalid
+int8 selected_airspeed_index 			# 1-3: airspeed sensor index, 0: groundspeed-windspeed, -1: airspeed invalid

--- a/src/lib/airspeed/airspeed.cpp
+++ b/src/lib/airspeed/airspeed.cpp
@@ -45,16 +45,6 @@
 #include <px4_platform_common/defines.h>
 #include <lib/ecl/geo/geo.h>
 
-/**
- * Calculate indicated airspeed.
- *
- * Note that the indicated airspeed is not the true airspeed because it
- * lacks the air density compensation. Use the calc_true_airspeed functions to get
- * the true airspeed.
- *
- * @param differential_pressure total_ pressure - static pressure
- * @return indicated airspeed in m/s
- */
 float calc_IAS_corrected(enum AIRSPEED_COMPENSATION_MODEL pmodel, enum AIRSPEED_SENSOR_MODEL smodel,
 			 float tube_len, float tube_dia_mm, float differential_pressure, float pressure_ambient, float temperature_celsius)
 {
@@ -185,15 +175,6 @@ float calc_IAS_corrected(enum AIRSPEED_COMPENSATION_MODEL pmodel, enum AIRSPEED_
 	return (differential_pressure > 0.0f) ? airspeed_corrected : -airspeed_corrected;
 }
 
-/**
- * Calculate indicated airspeed (IAS).
- *
- * Note that the indicated airspeed is not the true airspeed because it
- * lacks the air density and instrument error compensation.
- *
- * @param differential_pressure total_ pressure - static pressure
- * @return IAS in m/s
- */
 float calc_IAS(float differential_pressure)
 {
 	if (differential_pressure > 0.0f) {
@@ -205,16 +186,6 @@ float calc_IAS(float differential_pressure)
 
 }
 
-/**
- * Calculate true airspeed (TAS) from equivalent airspeed (EAS).
- *
- * Note that the true airspeed is NOT the groundspeed, because of the effects of wind
- *
- * @param speed_equivalent current equivalent airspeed
- * @param pressure_ambient pressure at the side of the tube/airplane
- * @param temperature_celsius air temperature in degrees celcius
- * @return TAS in m/s
- */
 float calc_TAS_from_EAS(float speed_equivalent, float pressure_ambient, float temperature_celsius)
 {
 	if (!PX4_ISFINITE(temperature_celsius)) {
@@ -225,31 +196,11 @@ float calc_TAS_from_EAS(float speed_equivalent, float pressure_ambient, float te
 					temperature_celsius));
 }
 
-/**
- * Calculate equivalent airspeed (EAS) from indicated airspeed (IAS).
- * Note that we neglect the conversion from CAS (calibrated airspeed) to EAS.
- *
- * @param speed_indicated current indicated airspeed
- * @param scale scale from IAS to CAS (accounting for instrument and pitot position erros)
- * @return EAS in m/s
- */
 float calc_EAS_from_IAS(float speed_indicated, float scale)
 {
 	return speed_indicated * scale;
 }
 
-/**
- * Directly calculate true airspeed (TAS)
- *
- * Here we assume to have no instrument or pitot position error (IAS = CAS),
- * and neglect the CAS to EAS conversion (CAS = EAS).
- * Note that the true airspeed is NOT the groundspeed, because of the effects of wind.
- *
- * @param total_pressure pressure inside the pitot/prandtl tube
- * @param static_pressure pressure at the side of the tube/airplane
- * @param temperature_celsius air temperature in degrees celcius
- * @return true airspeed in m/s
- */
 float calc_TAS(float total_pressure, float static_pressure, float temperature_celsius)
 {
 	float density = get_air_density(static_pressure, temperature_celsius);
@@ -277,16 +228,6 @@ float get_air_density(float static_pressure, float temperature_celsius)
 	return static_pressure / (CONSTANTS_AIR_GAS_CONST * (temperature_celsius - CONSTANTS_ABSOLUTE_NULL_CELSIUS));
 }
 
-/**
- * Calculate equivalent airspeed (EAS) from true airspeed (TAS).
- * It is the inverse function to calc_TAS_from_EAS()
- *
- *
- * @param speed_true current true airspeed
- * @param pressure_ambient pressure at the side of the tube/airplane
- * @param temperature_celsius air temperature in degrees celcius
- * @return EAS in m/s
- */
 float calc_EAS_from_TAS(float speed_true, float pressure_ambient, float temperature_celsius)
 {
 	return speed_true * sqrtf(get_air_density(pressure_ambient, temperature_celsius) / CONSTANTS_AIR_DENSITY_SEA_LEVEL_15C);

--- a/src/lib/airspeed/airspeed.cpp
+++ b/src/lib/airspeed/airspeed.cpp
@@ -186,17 +186,17 @@ float calc_IAS(float differential_pressure)
 
 }
 
-float calc_TAS_from_EAS(float speed_equivalent, float pressure_ambient, float temperature_celsius)
+float calc_TAS_from_CAS(float speed_calibrated, float pressure_ambient, float temperature_celsius)
 {
 	if (!PX4_ISFINITE(temperature_celsius)) {
 		temperature_celsius = 15.f; // ICAO Standard Atmosphere 15 degrees celcius
 	}
 
-	return speed_equivalent * sqrtf(CONSTANTS_AIR_DENSITY_SEA_LEVEL_15C / get_air_density(pressure_ambient,
+	return speed_calibrated * sqrtf(CONSTANTS_AIR_DENSITY_SEA_LEVEL_15C / get_air_density(pressure_ambient,
 					temperature_celsius));
 }
 
-float calc_EAS_from_IAS(float speed_indicated, float scale)
+float calc_CAS_from_IAS(float speed_indicated, float scale)
 {
 	return speed_indicated * scale;
 }
@@ -228,7 +228,7 @@ float get_air_density(float static_pressure, float temperature_celsius)
 	return static_pressure / (CONSTANTS_AIR_GAS_CONST * (temperature_celsius - CONSTANTS_ABSOLUTE_NULL_CELSIUS));
 }
 
-float calc_EAS_from_TAS(float speed_true, float pressure_ambient, float temperature_celsius)
+float calc_CAS_from_TAS(float speed_true, float pressure_ambient, float temperature_celsius)
 {
 	return speed_true * sqrtf(get_air_density(pressure_ambient, temperature_celsius) / CONSTANTS_AIR_DENSITY_SEA_LEVEL_15C);
 }

--- a/src/lib/airspeed/airspeed.h
+++ b/src/lib/airspeed/airspeed.h
@@ -86,34 +86,32 @@ __EXPORT float calc_IAS_corrected(enum AIRSPEED_COMPENSATION_MODEL pmodel,
 __EXPORT float calc_IAS(float differential_pressure);
 
 /**
- * Calculate true airspeed (TAS) from equivalent airspeed (EAS).
+ * Calculate true airspeed (TAS) from calibrated airspeed (CAS).
  *
  * Note that the true airspeed is NOT the groundspeed, because of the effects of wind
  *
- * @param speed_equivalent current equivalent airspeed
+ * @param speed_equivalent current calibrated airspeed
  * @param pressure_ambient pressure at the side of the tube/airplane
  * @param temperature_celsius air temperature in degrees celcius
  * @return TAS in m/s
  */
-__EXPORT float calc_TAS_from_EAS(float speed_indicated, float pressure_ambient,
+__EXPORT float calc_TAS_from_CAS(float speed_indicated, float pressure_ambient,
 				 float temperature_celsius);
 
 /**
- * Calculate equivalent airspeed (EAS) from indicated airspeed (IAS).
- * Note that we neglect the conversion from CAS (calibrated airspeed) to EAS.
+ * Calculate calibrated airspeed (CAS) from indicated airspeed (IAS).
  *
  * @param speed_indicated current indicated airspeed
  * @param scale scale from IAS to CAS (accounting for instrument and pitot position erros)
- * @return EAS in m/s
+ * @return CAS in m/s
  */
-__EXPORT float calc_EAS_from_IAS(float speed_indicated, float scale);
+__EXPORT float calc_CAS_from_IAS(float speed_indicated, float scale);
 
 
 /**
  * Directly calculate true airspeed (TAS)
  *
- * Here we assume to have no instrument or pitot position error (IAS = CAS),
- * and neglect the CAS to EAS conversion (CAS = EAS).
+ * Here we assume to have no instrument or pitot position error (IAS = CAS).
  * Note that the true airspeed is NOT the groundspeed, because of the effects of wind.
  *
  * @param total_pressure pressure inside the pitot/prandtl tube
@@ -132,16 +130,16 @@ __EXPORT float calc_TAS(float total_pressure, float static_pressure, float tempe
 __EXPORT float get_air_density(float static_pressure, float temperature_celsius);
 
 /**
- * Calculate equivalent airspeed (EAS) from true airspeed (TAS).
- * It is the inverse function to calc_TAS_from_EAS()
+ * Calculate calibrated airspeed (CAS) from true airspeed (TAS).
+ * It is the inverse function to calc_TAS_from_CAS()
  *
  *
  * @param speed_true current true airspeed
  * @param pressure_ambient pressure at the side of the tube/airplane
  * @param temperature_celsius air temperature in degrees celcius
- * @return EAS in m/s
+ * @return CAS in m/s
  */
-__EXPORT float calc_EAS_from_TAS(float speed_true, float pressure_ambient,
+__EXPORT float calc_CAS_from_TAS(float speed_true, float pressure_ambient,
 				 float temperature_celsius);
 
 __END_DECLS

--- a/src/lib/airspeed/airspeed.h
+++ b/src/lib/airspeed/airspeed.h
@@ -58,7 +58,7 @@ enum AIRSPEED_COMPENSATION_MODEL {
 };
 
 /**
- * Calculate indicated airspeed (IAS).
+ * Calculate indicated airspeed (IAS) and correct for friction inside pitot and tube.
  *
  * Note that the indicated airspeed is not the true airspeed because it
  * lacks the air density compensation. Use the calc_true_airspeed functions to get
@@ -88,7 +88,7 @@ __EXPORT float calc_IAS(float differential_pressure);
 /**
  * Calculate true airspeed (TAS) from calibrated airspeed (CAS).
  *
- * Note that the true airspeed is NOT the groundspeed, because of the effects of wind
+ * Note that the true airspeed is NOT the groundspeed, because of the effects of wind.
  *
  * @param speed_equivalent current calibrated airspeed
  * @param pressure_ambient pressure at the side of the tube/airplane
@@ -109,7 +109,7 @@ __EXPORT float calc_CAS_from_IAS(float speed_indicated, float scale);
 
 
 /**
- * Directly calculate true airspeed (TAS)
+ * Directly calculate true airspeed (TAS).
  *
  * Here we assume to have no instrument or pitot position error (IAS = CAS).
  * Note that the true airspeed is NOT the groundspeed, because of the effects of wind.
@@ -132,7 +132,6 @@ __EXPORT float get_air_density(float static_pressure, float temperature_celsius)
 /**
  * Calculate calibrated airspeed (CAS) from true airspeed (TAS).
  * It is the inverse function to calc_TAS_from_CAS()
- *
  *
  * @param speed_true current true airspeed
  * @param pressure_ambient pressure at the side of the tube/airplane

--- a/src/lib/airspeed_validator/AirspeedValidator.hpp
+++ b/src/lib/airspeed_validator/AirspeedValidator.hpp
@@ -79,10 +79,10 @@ public:
 	void update_airspeed_validator(const airspeed_validator_update_data &input_data);
 
 	float get_IAS() { return _IAS; }
-	float get_EAS() { return _EAS; }
+	float get_CAS() { return _CAS; }
 	float get_TAS() { return _TAS; }
 	bool get_airspeed_valid() { return _airspeed_valid; }
-	float get_EAS_scale() {return _EAS_scale;}
+	float get_CAS_scale() {return _CAS_scale;}
 
 	wind_estimate_s get_wind_estimator_states(uint64_t timestamp);
 
@@ -115,15 +115,15 @@ private:
 	WindEstimator _wind_estimator{}; ///< wind estimator instance running in this particular airspeedValidator
 
 	// wind estimator parameter
-	bool _wind_estimator_scale_estimation_on{false};	///< online scale estimation (IAS-->CAS/EAS) is on
+	bool _wind_estimator_scale_estimation_on{false};	///< online scale estimation (IAS-->CAS) is on
 	float _airspeed_scale_manual{1.0f}; ///< manually entered airspeed scale
 
 	// general states
 	bool _in_fixed_wing_flight{false}; ///< variable to bypass innovation and load factor checks
 	float _IAS{0.0f}; ///< indicated airsped in m/s
-	float _EAS{0.0f}; ///< equivalent airspeed in m/s
+	float _CAS{0.0f}; ///< calibrated airspeed in m/s
 	float _TAS{0.0f}; ///< true airspeed in m/s
-	float _EAS_scale{1.0f}; ///< scale factor from IAS to EAS
+	float _CAS_scale{1.0f}; ///< scale factor from IAS to CAS
 
 	uint64_t	_time_last_airspeed{0};		///< time last airspeed measurement was received (uSec)
 
@@ -162,8 +162,8 @@ private:
 				   float lpos_vy,
 				   float lpos_vz,
 				   float lpos_evh, float lpos_evv, const float att_q[4]);
-	void update_EAS_scale();
-	void update_EAS_TAS(float air_pressure_pa, float air_temperature_celsius);
+	void update_CAS_scale();
+	void update_CAS_TAS(float air_pressure_pa, float air_temperature_celsius);
 	void check_airspeed_innovation(uint64_t timestamp, float estimator_status_vel_test_ratio,
 				       float estimator_status_mag_test_ratio);
 	void check_load_factor(float accel_z);

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -240,7 +240,7 @@ FixedwingAttitudeControl::vehicle_land_detected_poll()
 float FixedwingAttitudeControl::get_airspeed_and_update_scaling()
 {
 	_airspeed_validated_sub.update();
-	const bool airspeed_valid = PX4_ISFINITE(_airspeed_validated_sub.get().equivalent_airspeed_m_s)
+	const bool airspeed_valid = PX4_ISFINITE(_airspeed_validated_sub.get().calibrated_airspeed_m_s)
 				    && (hrt_elapsed_time(&_airspeed_validated_sub.get().timestamp) < 1_s);
 
 	// if no airspeed measurement is available out best guess is to use the trim airspeed
@@ -248,7 +248,7 @@ float FixedwingAttitudeControl::get_airspeed_and_update_scaling()
 
 	if ((_param_fw_arsp_mode.get() == 0) && airspeed_valid) {
 		/* prevent numerical drama by requiring 0.5 m/s minimal speed */
-		airspeed = math::max(0.5f, _airspeed_validated_sub.get().equivalent_airspeed_m_s);
+		airspeed = math::max(0.5f, _airspeed_validated_sub.get().calibrated_airspeed_m_s);
 
 	} else {
 		// VTOL: if we have no airspeed available and we are in hover mode then assume the lowest airspeed possible

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -176,16 +176,16 @@ FixedwingPositionControl::airspeed_poll()
 		const airspeed_validated_s &airspeed_validated = _airspeed_validated_sub.get();
 		_eas2tas = 1.0f; //this is the default value, taken in case of invalid airspeed
 
-		if (PX4_ISFINITE(airspeed_validated.equivalent_airspeed_m_s)
+		if (PX4_ISFINITE(airspeed_validated.calibrated_airspeed_m_s)
 		    && PX4_ISFINITE(airspeed_validated.true_airspeed_m_s)
-		    && (airspeed_validated.equivalent_airspeed_m_s > 0.0f)) {
+		    && (airspeed_validated.calibrated_airspeed_m_s > 0.0f)) {
 
 			airspeed_valid = true;
 
 			_airspeed_last_valid = airspeed_validated.timestamp;
-			_airspeed = airspeed_validated.equivalent_airspeed_m_s;
+			_airspeed = airspeed_validated.calibrated_airspeed_m_s;
 
-			_eas2tas = constrain(airspeed_validated.true_airspeed_m_s / airspeed_validated.equivalent_airspeed_m_s, 0.9f, 2.0f);
+			_eas2tas = constrain(airspeed_validated.true_airspeed_m_s / airspeed_validated.calibrated_airspeed_m_s, 0.9f, 2.0f);
 		}
 
 	} else {

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -48,7 +48,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("actuator_controls_0", 100);
 	add_topic("actuator_controls_1", 100);
 	add_topic("airspeed", 1000);
-	add_topic("airspeed_validated", 1000);
+	add_topic("airspeed_validated", 200);
 	add_topic("camera_capture");
 	add_topic("camera_trigger");
 	add_topic("camera_trigger_secondary");

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -1707,7 +1707,7 @@ protected:
 			_airspeed_validated_sub.copy(&airspeed_validated);
 
 			mavlink_vfr_hud_t msg{};
-			msg.airspeed = airspeed_validated.equivalent_airspeed_m_s;
+			msg.airspeed = airspeed_validated.calibrated_airspeed_m_s;
 			msg.groundspeed = sqrtf(lpos.vx * lpos.vx + lpos.vy * lpos.vy);
 			msg.heading = math::degrees(wrap_2pi(lpos.heading));
 

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -388,8 +388,8 @@ void Sensors::diff_pres_poll()
 						  diff_pres.differential_pressure_filtered_pa, air_data.baro_pressure_pa,
 						  air_temperature_celsius);
 
-		airspeed.true_airspeed_m_s = calc_TAS_from_EAS(airspeed.indicated_airspeed_m_s, air_data.baro_pressure_pa,
-					     air_temperature_celsius); // assume that EAS = IAS as we don't have an EAS-scale here
+		airspeed.true_airspeed_m_s = calc_TAS_from_CAS(airspeed.indicated_airspeed_m_s, air_data.baro_pressure_pa,
+					     air_temperature_celsius); // assume that CAS = IAS as we don't have an CAS-scale here
 
 		airspeed.air_temperature_celsius = air_temperature_celsius;
 

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -174,7 +174,7 @@ void Standard::update_vtol_state()
 		} else if (_vtol_schedule.flight_mode == vtol_mode::TRANSITION_TO_FW) {
 			// continue the transition to fw mode while monitoring airspeed for a final switch to fw mode
 
-			const bool airspeed_triggers_transition = PX4_ISFINITE(_airspeed_validated->equivalent_airspeed_m_s)
+			const bool airspeed_triggers_transition = PX4_ISFINITE(_airspeed_validated->calibrated_airspeed_m_s)
 					&& !_params->airspeed_disabled;
 			const bool minimum_trans_time_elapsed = time_since_trans_start > _params->front_trans_time_min;
 
@@ -182,7 +182,7 @@ void Standard::update_vtol_state()
 
 			if (minimum_trans_time_elapsed) {
 				if (airspeed_triggers_transition) {
-					transition_to_fw = _airspeed_validated->equivalent_airspeed_m_s >= _params->transition_airspeed;
+					transition_to_fw = _airspeed_validated->calibrated_airspeed_m_s >= _params->transition_airspeed;
 
 				} else {
 					transition_to_fw = true;
@@ -247,16 +247,16 @@ void Standard::update_transition_state()
 
 		// do blending of mc and fw controls if a blending airspeed has been provided and the minimum transition time has passed
 		if (_airspeed_trans_blend_margin > 0.0f &&
-		    PX4_ISFINITE(_airspeed_validated->equivalent_airspeed_m_s) &&
-		    _airspeed_validated->equivalent_airspeed_m_s > 0.0f &&
-		    _airspeed_validated->equivalent_airspeed_m_s >= _params->airspeed_blend &&
+		    PX4_ISFINITE(_airspeed_validated->calibrated_airspeed_m_s) &&
+		    _airspeed_validated->calibrated_airspeed_m_s > 0.0f &&
+		    _airspeed_validated->calibrated_airspeed_m_s >= _params->airspeed_blend &&
 		    time_since_trans_start > _params->front_trans_time_min) {
 
-			mc_weight = 1.0f - fabsf(_airspeed_validated->equivalent_airspeed_m_s - _params->airspeed_blend) /
+			mc_weight = 1.0f - fabsf(_airspeed_validated->calibrated_airspeed_m_s - _params->airspeed_blend) /
 				    _airspeed_trans_blend_margin;
 			// time based blending when no airspeed sensor is set
 
-		} else if (_params->airspeed_disabled || !PX4_ISFINITE(_airspeed_validated->equivalent_airspeed_m_s)) {
+		} else if (_params->airspeed_disabled || !PX4_ISFINITE(_airspeed_validated->calibrated_airspeed_m_s)) {
 			mc_weight = 1.0f - time_since_trans_start / _params->front_trans_time_min;
 			mc_weight = math::constrain(2.0f * mc_weight, 0.0f, 1.0f);
 

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -122,14 +122,14 @@ void Tailsitter::update_vtol_state()
 		case vtol_mode::TRANSITION_FRONT_P1: {
 
 
-				const bool airspeed_triggers_transition = PX4_ISFINITE(_airspeed_validated->equivalent_airspeed_m_s)
+				const bool airspeed_triggers_transition = PX4_ISFINITE(_airspeed_validated->calibrated_airspeed_m_s)
 						&& !_params->airspeed_disabled;
 
 				bool transition_to_fw = false;
 
 				if (pitch <= PITCH_TRANSITION_FRONT_P1) {
 					if (airspeed_triggers_transition) {
-						transition_to_fw = _airspeed_validated->equivalent_airspeed_m_s >= _params->transition_airspeed;
+						transition_to_fw = _airspeed_validated->calibrated_airspeed_m_s >= _params->transition_airspeed;
 
 					} else {
 						transition_to_fw = true;

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -148,14 +148,14 @@ void Tiltrotor::update_vtol_state()
 
 				float time_since_trans_start = (float)(hrt_absolute_time() - _vtol_schedule.transition_start) * 1e-6f;
 
-				const bool airspeed_triggers_transition = PX4_ISFINITE(_airspeed_validated->equivalent_airspeed_m_s)
+				const bool airspeed_triggers_transition = PX4_ISFINITE(_airspeed_validated->calibrated_airspeed_m_s)
 						&& !_params->airspeed_disabled;
 
 				bool transition_to_p2 = false;
 
 				if (time_since_trans_start > _params->front_trans_time_min) {
 					if (airspeed_triggers_transition) {
-						transition_to_p2 = _airspeed_validated->equivalent_airspeed_m_s >= _params->transition_airspeed;
+						transition_to_p2 = _airspeed_validated->calibrated_airspeed_m_s >= _params->transition_airspeed;
 
 					} else {
 						transition_to_p2 = _tilt_control >= _params_tiltrotor.tilt_transition &&
@@ -300,19 +300,19 @@ void Tiltrotor::update_transition_state()
 		_mc_yaw_weight = 1.0f;
 
 		// reduce MC controls once the plane has picked up speed
-		if (!_params->airspeed_disabled && PX4_ISFINITE(_airspeed_validated->equivalent_airspeed_m_s) &&
-		    _airspeed_validated->equivalent_airspeed_m_s > ARSP_YAW_CTRL_DISABLE) {
+		if (!_params->airspeed_disabled && PX4_ISFINITE(_airspeed_validated->calibrated_airspeed_m_s) &&
+		    _airspeed_validated->calibrated_airspeed_m_s > ARSP_YAW_CTRL_DISABLE) {
 			_mc_yaw_weight = 0.0f;
 		}
 
-		if (!_params->airspeed_disabled && PX4_ISFINITE(_airspeed_validated->equivalent_airspeed_m_s) &&
-		    _airspeed_validated->equivalent_airspeed_m_s >= _params->airspeed_blend) {
-			_mc_roll_weight = 1.0f - (_airspeed_validated->equivalent_airspeed_m_s - _params->airspeed_blend) /
+		if (!_params->airspeed_disabled && PX4_ISFINITE(_airspeed_validated->calibrated_airspeed_m_s) &&
+		    _airspeed_validated->calibrated_airspeed_m_s >= _params->airspeed_blend) {
+			_mc_roll_weight = 1.0f - (_airspeed_validated->calibrated_airspeed_m_s - _params->airspeed_blend) /
 					  (_params->transition_airspeed - _params->airspeed_blend);
 		}
 
 		// without airspeed do timed weight changes
-		if ((_params->airspeed_disabled || !PX4_ISFINITE(_airspeed_validated->equivalent_airspeed_m_s)) &&
+		if ((_params->airspeed_disabled || !PX4_ISFINITE(_airspeed_validated->calibrated_airspeed_m_s)) &&
 		    time_since_trans_start > _params->front_trans_time_min) {
 			_mc_roll_weight = 1.0f - (time_since_trans_start - _params->front_trans_time_min) /
 					  (_params->front_trans_time_openloop - _params->front_trans_time_min);


### PR DESCRIPTION
**Describe problem solved by this pull request**
With the introduction of the airspeed selector, we added an airspeed corrected for position and instrumental error, to be used instead of indicated airspeed in most of the px4 control modules (like attitude and position controller). We called it `equivalent_airspeed` (EAS), as this was the airspeed type that was already expected by TECS (See [equivalent airspeed](https://en.wikipedia.org/wiki/Equivalent_airspeed))

The correct name of the airspeed we now call EAS would be CAS (calibrated airspeed), as we don't do any correction for compressibility effects, assuming we're always operating in regions where EAS=CAS. Also, CAS is more common than EAS, and the concept of having an equivalent airspeed was creating some confusion I've realized recently. If modules require EAS instead of CAS (as e.g. TECS does), then it is cleaner to feed in CAS there and explain that we assume EAS=CAS. 

**Describe your solution**
Rename `equivalent_airspeed` to `calibrated_airspeed`.

**Test data / coverage**
SITL tested.

**Additional context**
I've further cleaned up a couple of things and increased the logging rate of airspeed_validated from 1Hz to 5Hz, as 1Hz is too slow for low-level log analysis. 

