### PR TITLE
sensors/vehicle_imu: vehicle_imu_status add mean accel and gyro

### DIFF
--- a/msg/vehicle_imu_status.msg
+++ b/msg/vehicle_imu_status.msg
@@ -1,9 +1,9 @@
-uint64 timestamp          # time since system start (microseconds)
+uint64 timestamp                # time since system start (microseconds)
 
-uint32 accel_device_id    # unique device ID for the sensor that does not change between power cycles
-uint32 gyro_device_id    # unique device ID for the sensor that does not change between power cycles
+uint32 accel_device_id          # unique device ID for the sensor that does not change between power cycles
+uint32 gyro_device_id           # unique device ID for the sensor that does not change between power cycles
 
-uint32[3] accel_clipping        # clipping per axis
+uint32[3] accel_clipping        # total clipping per axis
 
 uint32 accel_error_count
 uint32 gyro_error_count
@@ -12,5 +12,11 @@ uint16 accel_rate_hz
 uint16 gyro_rate_hz
 
 float32 accel_vibration_metric  # high frequency vibration level in the IMU delta velocity data (m/s)
-float32 gyro_vibration_metric  # high frequency vibration level in the IMU delta velocity data (m/s)
-float32 gyro_coning_vibration  # Level of coning vibration in the IMU delta angles (rad^2)
+float32 gyro_vibration_metric   # high frequency vibration level in the IMU delta velocity data (m/s)
+float32 gyro_coning_vibration   # Level of coning vibration in the IMU delta angles (rad^2)
+
+float32[3] mean_accel           # average accelerometer readings since last publication
+float32[3] mean_gyro            # average gyroscope readings since last publication
+
+float32 temperature_accel
+float32 temperature_gyro

--- a/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
@@ -107,6 +107,13 @@ private:
 	unsigned _gyro_last_generation{0};
 	unsigned _consecutive_data_gap{0};
 
+	matrix::Vector3f _accel_sum{};
+	matrix::Vector3f _gyro_sum{};
+	int _accel_sum_count{0};
+	int _gyro_sum_count{0};
+	float _accel_temperature{0};
+	float _gyro_temperature{0};
+
 	matrix::Vector3f _delta_angle_prev{0.f, 0.f, 0.f};	// delta angle from the previous IMU measurement
 	matrix::Vector3f _delta_velocity_prev{0.f, 0.f, 0.f};	// delta velocity from the previous IMU measurement
 


### PR DESCRIPTION
 - this PR adds the average accel and gyro readings to the `vehicle_imu_status` message, reset on every publication (10 Hz)
 - this makes it slightly easier to gather long term data for an Allan variance

related: https://github.com/PX4/Firmware/issues/6250
