### PR TITLE
Add techpod SITL Gazebo target

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1035_techpod
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1035_techpod
@@ -1,0 +1,47 @@
+#!/bin/sh
+#
+# @name Plane SITL
+#
+
+sh /etc/init.d/rc.fw_defaults
+
+if [ $AUTOCNF = yes ]
+then
+	param set EKF2_ARSP_THR 8
+	param set EKF2_FUSE_BETA 1
+	param set EKF2_MAG_ACCLIM 0
+	param set EKF2_MAG_YAWLIM 0
+
+	param set FW_LND_AIRSPD_SC 1
+	param set FW_LND_ANG 8
+	param set FW_THR_LND_MAX 0
+
+	param set FW_L1_PERIOD 15
+
+	param set FW_P_TC 0.5
+	param set FW_PR_FF 0.40
+	param set FW_PR_I 0.05
+	param set FW_PR_P 0.05
+
+	param set FW_R_TC 0.7
+	param set FW_RR_FF 0.20
+	param set FW_RR_I 0.02
+	param set FW_RR_P 0.22
+
+	param set FW_L1_PERIOD 12
+
+	param set FW_W_EN 1
+
+	param set MIS_LTRMIN_ALT 30
+	param set MIS_TAKEOFF_ALT 30
+
+	param set NAV_ACC_RAD 15
+	param set NAV_DLL_ACT 2
+	param set NAV_LOITER_RAD 50
+
+	param set RWTO_TKOFF 1
+
+fi
+
+set MIXER_FILE etc/mixers-sitl/plane_sitl.main.mix
+set MIXER custom

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -57,6 +57,7 @@ px4_add_romfs_files(
 	1033_plane_lidar
 	1033_rascal
 	1034_rascal-electric
+	1035_techpod
 	1040_standard_vtol
 	1041_tailsitter
 	1042_tiltrotor

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -93,7 +93,7 @@ set(viewers none jmavsim gazebo)
 set(debuggers none ide gdb lldb ddd valgrind callgrind)
 set(models none shell
 	if750a iris iris_dual_gps iris_opt_flow iris_opt_flow_mockup iris_vision iris_rplidar iris_irlock iris_obs_avoid iris_rtps px4vision solo typhoon_h480
-	plane plane_cam plane_catapult plane_lidar
+	plane plane_cam plane_catapult plane_lidar techpod
 	standard_vtol tailsitter tiltrotor
 	rover r1_rover boat cloudship
 	uuv_hippocampus)


### PR DESCRIPTION
**Problem Description**
This PR adds the techpod fixedwing model to this repo. Techpod is a model that is widely used in the research community, that have accurately modeled parameters. 

This will be useful for testing vehicles with higher lift drag ratios compared to the already available cessna

**Test/Verification**
Tested in SITL Gazebo
![image](https://user-images.githubusercontent.com/5248102/95328490-e9cbb680-08a5-11eb-9ab2-ad5e47c34d12.png)

**Additional Context**
- This model is originally distributed under https://github.com/ethz-asl/rotors_simulator which has been adapted to use the sdf format.
- This PR requires https://github.com/PX4/sitl_gazebo/pull/628 to be functional (now merged and included in this PR)