### PR TITLE
Add rc.boat_defaults to ROMFS

### DIFF
--- a/ROMFS/px4fmu_common/init.d/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d/CMakeLists.txt
@@ -36,6 +36,7 @@ add_subdirectory(airframes)
 px4_add_romfs_files(
 	rc.airship_apps
 	rc.airship_defaults
+	rc.boat_defaults
 	rc.fw_apps
 	rc.fw_defaults
 	rc.interface


### PR DESCRIPTION
**Describe problem solved by this pull request**
`rc.boat_defaults` were not being added to the ROMFS in https://github.com/PX4/Firmware/pull/15714

**Describe your solution**
This adds the missing `rc.boat_defautls` to ROMFS

**Test data / coverage**
Tested with
```
make px4_sitl gazebo_boat
```

**Additional context**
Fixes https://github.com/PX4/Firmware/issues/15922
