### PR TITLE
dps310: fix c11 coeffecient

### DIFF
--- a/src/drivers/barometer/dps310/DPS310.cpp
+++ b/src/drivers/barometer/dps310/DPS310.cpp
@@ -135,7 +135,7 @@ DPS310::reset()
 	getTwosComplement(_calibration.c01, 16);
 
 	// 0x1A c11 [15:8] + 0x1B c11 [7:0]
-	_calibration.c11 = ((uint32_t)coef[8] << 8) | (uint32_t)coef[9];
+	_calibration.c11 = ((uint32_t)coef[10] << 8) | (uint32_t)coef[11];
 	getTwosComplement(_calibration.c11, 16);
 
 	// 0x1C c20 [15:8] + 0x1D c20 [7:0]


### PR DESCRIPTION
Pressure was off by 4 millibar, took a look at the driver and found a copy/paste bug. Fixed it and now it agrees with my other barometers.