### PR TITLE
sensors/vehicle_imu: continue consuming raw data if falling behind

### DIFF
--- a/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
@@ -100,6 +100,8 @@ private:
 	hrt_abstime _last_timestamp_sample_accel{0};
 	hrt_abstime _last_timestamp_sample_gyro{0};
 
+	uint32_t _imu_integration_interval_us{4000};
+
 	IntervalAverage _accel_interval{};
 	IntervalAverage _gyro_interval{};
 


### PR DESCRIPTION
In `sensors/vehicle_imu` raw gyro & accel data are integrated and published at `IMU_INTEG_RATE`. Up to 8 of these messages are queued (at the uORB leve), allowing the integrator to run at a much lower rate than the driver, but still consume all data. This PR adds a special case to continue consuming and integrating raw data if the integrator gets too far behind the raw data.
 
This is actually a fix/workaround for potential lockstep issues (https://github.com/PX4/Firmware/pull/15926), but it makes sense in general.