### PR TITLE
fix ubuntu.sh for Ubuntu 20.04 - use gazebo11

### DIFF
--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -182,7 +182,7 @@ if [[ $INSTALL_SIM == "true" ]]; then
 		gazebo_version=11
 	else
 		java_version=14
-		gazebo_version=9
+		gazebo_version=11
 	fi
 	# Java (jmavsim or fastrtps)
 	sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -176,10 +176,13 @@ if [[ $INSTALL_SIM == "true" ]]; then
 
 	if [[ "${UBUNTU_RELEASE}" == "18.04" ]]; then
 		java_version=11
+		gazebo_version=9
 	elif [[ "${UBUNTU_RELEASE}" == "20.04" ]]; then
 		java_version=14
+		gazebo_version=11
 	else
 		java_version=14
+		gazebo_version=9
 	fi
 	# Java (jmavsim or fastrtps)
 	sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
@@ -197,14 +200,14 @@ if [[ $INSTALL_SIM == "true" ]]; then
 	wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
 	sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
 		dmidecode \
-		gazebo9 \
+		gazebo$gazebo_version \
 		gstreamer1.0-plugins-bad \
 		gstreamer1.0-plugins-base \
 		gstreamer1.0-plugins-good \
 		gstreamer1.0-plugins-ugly \
 		gstreamer1.0-libav \
 		libeigen3-dev \
-		libgazebo9-dev \
+		libgazebo$gazebo_version-dev \
 		libgstreamer-plugins-base1.0-dev \
 		libimage-exiftool-perl \
 		libopencv-dev \


### PR DESCRIPTION
**Problem**
This solves the problem of the install/update script (Tools/setup/ubuntu.sh) failing when trying to install gazebo9 in Ubuntu 20.04. 

**Solution**
This solution uses the Ubuntu release version already being checked in the script. If it is 18.04 the script uses/updates/installs gazebo9 and if on 20.04 uses/updates/installs gazebo11.

**Alternatives**
This could also be solved by checking what version of gazebo might already be installed and using that instead, however, gazebo11 should be the targeted install regardless for Ubuntu 20.04.

**Tests**
Tested on Ubuntu 20.04 and Ubuntu 18.04