### PR TITLE
mavlink: expose kill switch status

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -3972,6 +3972,7 @@ protected:
 			msg.buttons |= (manual_control_setpoint.loiter_switch << (shift * 3));
 			msg.buttons |= (manual_control_setpoint.acro_switch << (shift * 4));
 			msg.buttons |= (manual_control_setpoint.offboard_switch << (shift * 5));
+			msg.buttons |= (manual_control_setpoint.kill_switch << (shift * 6));
 
 			mavlink_msg_manual_control_send_struct(_mavlink->get_channel(), &msg);
 


### PR DESCRIPTION
Kill switch status is important information. For example, we don't want to start the autonomous flight if kill switch is on. This could be dangerous in some situations as well.

`MANUAL_CONTROL`'s `buttons` seems consistent place for it.

_The change seems trivial, haven't tested._