### PR TITLE
Pr jsbsim run

### DIFF
--- a/Tools/setup_jsbsim.bash
+++ b/Tools/setup_jsbsim.bash
@@ -19,15 +19,12 @@ export FG_AIRCRAFT="${SRC_DIR}/Tools/jsbsim_bridge/models"
 # Need more architectural discussions to make this more scalable
 case "$MODEL" in
         rascal)
-            AIRCRAFT_DIR="Rascal"
             MODEL_NAME="Rascal110-JSBSim"
             ;;
         quadrotor_x)
-            AIRCRAFT_DIR="quadrotor_x"
             MODEL_NAME="quadrotor_x"
             ;;
         hexarotor_x)
-            AIRCRAFT_DIR="hexarotor_x"
             MODEL_NAME="hexarotor_x"
             ;;
         *)
@@ -36,5 +33,4 @@ case "$MODEL" in
 
 esac
 
-export JSBSIM_AIRCRAFT_DIR="$AIRCRAFT_DIR"
 export JSBSIM_AIRCRAFT_MODEL="$MODEL_NAME"

--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -57,10 +57,11 @@ if [ "$program" == "jmavsim" ]; then
 fi
 
 if [ "$model" == "" ] || [ "$model" == "none" ]; then
-	echo "empty model, setting iris as default"
 	if [ "$program" == "jsbsim" ]; then
+		echo "empty model, setting rascal as default for jsbsim"
 		model="rascal"
 	else
+		echo "empty model, setting iris as default"
 		model="iris"
 	fi
 fi
@@ -163,7 +164,7 @@ elif [ "$program" == "jsbsim" ] && [ -z "$no_sim" ]; then
 			--disable-ai-models &> /dev/null &
 		FGFS_PID=$!
 	fi
-	"${build_path}/build_jsbsim_bridge/jsbsim_bridge" "models/${JSBSIM_AIRCRAFT_DIR}" $JSBSIM_AIRCRAFT_MODEL ${model} "${src_path}/Tools/jsbsim_bridge/scene/${world}.xml" $HEADLESS 2> /dev/null &
+	"${build_path}/build_jsbsim_bridge/jsbsim_bridge" ${model} -s "${src_path}/Tools/jsbsim_bridge/scene/${world}.xml" 2> /dev/null &
 	JSBSIM_PID=$!
 fi
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
This PR cleans up the startup scripts for running the jsbsim bridge. This has been possible by https://github.com/Auterion/px4-jsbsim-bridge/pull/10 and introducing configuration management to the bridge.

**Describe your solution**
Cleanup unnecessary command line arguments that were being passed. `setup_jsbsim.bash` is still needed to handle different file names for the flightgear visualization. 

**Test data / coverage**
Tested for all of the three models in the jsbsim bridge through the make command.
```
make px4_sitl jsbsim_rascal
```
