### PR TITLE
Check that home position is valid in RTL

### DIFF
--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -76,6 +76,10 @@ void RTL::find_RTL_destination()
 		return;
 	}
 
+	if (!_navigator->home_position_valid()) {
+		return;
+	}
+
 	_destination_check_time = hrt_absolute_time();
 
 	// get home position:


### PR DESCRIPTION
**Describe problem solved by this pull request**
On startup the RTL can run without a valid home position yet

**Describe your solution**
Don't run the RTL if the home position isn't valid yet
