### PR TITLE
lis2mdl: reduce update rate from 50Hz to 20Hz to reduce spikes

### DIFF
--- a/src/drivers/magnetometer/lis2mdl/lis2mdl.h
+++ b/src/drivers/magnetometer/lis2mdl/lis2mdl.h
@@ -50,8 +50,8 @@
  * LIS2MDL internal constants and data structures.
  */
 
-/* Max measurement rate is 50Hz */
-#define LIS2MDL_CONVERSION_INTERVAL     (1000000 / 50)
+/* Max measurement rate is 20Hz */
+#define LIS2MDL_CONVERSION_INTERVAL     (1000000 / 20)
 
 #define ADDR_WHO_AM_I                   0x4f
 #define ID_WHO_AM_I                     0x40
@@ -72,7 +72,7 @@
 #define ADDR_OUT_T_H                    0x6f
 
 #define CFG_REG_A_TEMP_COMP_EN          (1 << 7)
-#define CFG_REG_A_ODR                   (2 << 2) /* 50Hz (100Hz creates spikes randomly) */
+#define CFG_REG_A_ODR                   (1 << 2) /* 20Hz (100Hz or 50Hz creates spikes randomly) */
 #define CFG_REG_A_MD                    (0 << 0) /* continuous mode */
 
 #define CFG_REG_B_LPF                   (1 << 0) /* LPF */


### PR DESCRIPTION
This PR reduces the update rate of the lis2mdl mag from 50Hz to 20Hz, which has showed to produce less random spikes in the output.

50Hz, with spike:
![image](https://user-images.githubusercontent.com/26798987/96090391-6a9f3980-0ec8-11eb-8355-4f65e9b8adda.png)


20Hz:
![image](https://user-images.githubusercontent.com/26798987/96090223-2f9d0600-0ec8-11eb-8b4f-1a61fff0bb3f.png)
