### PR TITLE
Add support for malolo flying wing in JSBSim SITL

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1036_malolo
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1036_malolo
@@ -1,0 +1,56 @@
+#!/bin/sh
+#
+# @name Plane SITL
+#
+
+. ${R}etc/init.d/rc.fw_defaults
+
+if [ $AUTOCNF = yes ]
+then
+	param set EKF2_ARSP_THR 8
+	param set EKF2_FUSE_BETA 1
+	#param set EKF2_MAG_ACCLIM 0
+	#param set EKF2_MAG_YAWLIM 0
+
+	param set FW_LND_AIRSPD_SC 1.1
+	param set FW_LND_ANG 5
+	param set FW_THR_LND_MAX 0
+	param set FW_LND_HHDIST 30
+	param set FW_LND_FL_PMIN 9.5
+	param set FW_LND_FL_PMAX 20
+	param set FW_LND_FLALT 5
+	param set FW_LND_TLALT 15
+
+	param set FW_L1_PERIOD 25
+
+	param set FW_P_TC 0.4
+	param set FW_PR_FF 0.40
+	param set FW_PR_I 0.05
+	param set FW_PR_P 0.05
+
+	param set FW_R_TC 0.45
+	param set FW_RR_FF 0.40
+	param set FW_RR_I 0.132
+	param set FW_RR_P 0.085
+
+	param set FW_W_EN 1
+
+	param set MIS_LTRMIN_ALT 30
+	param set MIS_TAKEOFF_ALT 20
+	param set MIS_DIST_1WP 2500
+	param set MIS_DIST_WPS 10000
+
+	param set NAV_ACC_RAD 15
+	param set NAV_DLL_ACT 2
+	param set NAV_LOITER_RAD 50
+
+	param set RWTO_TKOFF 1
+	param set RWTO_MAX_PITCH 20
+	param set RWTO_MAX_ROLL 10
+	param set RWTO_PSP 8
+	param set RWTO_AIRSPD_SCL 1.8
+
+fi
+
+set MIXER_FILE etc/mixers-sitl/plane_sitl.main.mix
+set MIXER custom

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -58,6 +58,7 @@ px4_add_romfs_files(
 	1033_rascal
 	1034_rascal-electric
 	1035_techpod
+	1036_malolo
 	1040_standard_vtol
 	1041_tailsitter
 	1042_tiltrotor

--- a/Tools/setup_jsbsim.bash
+++ b/Tools/setup_jsbsim.bash
@@ -21,6 +21,9 @@ case "$MODEL" in
         rascal)
             MODEL_NAME="Rascal110-JSBSim"
             ;;
+        malolo)
+            MODEL_NAME="Malolo1"
+            ;;
         quadrotor_x)
             MODEL_NAME="quadrotor_x"
             ;;

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -177,7 +177,7 @@ foreach(viewer ${viewers})
 endforeach()
 
 # create targets for jsbsim
-set(models_jsbsim none rascal quadrotor_x hexarotor_x)
+set(models_jsbsim none rascal quadrotor_x hexarotor_x malolo)
 set(worlds_jsbsim none LSZH)
 foreach(debugger ${debuggers})
 	foreach(model ${models_jsbsim})


### PR DESCRIPTION
**Describe problem solved by this pull request**
This adds support to a flying wing vehicle called [Malolo1](http://wiki.flightgear.org/Malolo_1) to be used in JSBSim and PX4 SITL. 

**Test data / coverage**
The vehicle can be flown in PX4 SITL with the following make command
```
make px4_sitl jsbsim_malolo
```

Below shows a screenshot of the vehicle being visualized in flightgear

![image](https://user-images.githubusercontent.com/5248102/96002883-ec945180-0e39-11eb-8a83-20bae4fac671.png)

**Additional context**
- This includes other updates in the submodule, that are explained in https://github.com/PX4/px4-jsbsim-bridge/pull/10
- @hamishwillee This will be added as a separate document in the dev guide once the vehicle list is a bit more stable
