### PR TITLE
Disable secondary power source by default, fix battery param migration (take 2)

### DIFF
--- a/posix-configs/SITL/init/test/test_template.in
+++ b/posix-configs/SITL/init/test/test_template.in
@@ -11,7 +11,6 @@ param set SYS_RESTART_TYPE 0
 
 dataman start
 
-battery_simulator start
 simulator start
 tone_alarm start
 pwm_out_sim start

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -100,11 +100,6 @@ public:
 	void updateBatteryStatus(const hrt_abstime &timestamp, float voltage_v, float current_a, bool connected,
 				 int source, int priority, float throttle_normalized);
 
-	/**
-	 * Publishes the uORB battery_status message with the most recently-updated data.
-	 */
-	void publish();
-
 protected:
 	struct {
 		param_t v_empty;
@@ -158,6 +153,11 @@ protected:
 
 	bool _first_parameter_update{true};
 	void updateParams() override;
+
+	/**
+	 * Publishes the uORB battery_status message with the most recently-updated data.
+	 */
+	void publish();
 
 	/**
 	 * This function helps migrating and syncing from/to deprecated parameters. BAT_* BAT1_*

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -48,6 +48,7 @@
 #include <board_config.h>
 #include <px4_platform_common/board_common.h>
 #include <px4_platform_common/module_params.h>
+#include <matrix/math.hpp>
 
 #include <drivers/drv_hrt.h>
 #include <lib/parameters/param.h>
@@ -179,21 +180,19 @@ protected:
 		param_get(new_param, new_val);
 
 		// Check if the parameter values are different
-		if (!isFloatEqual(*old_val, *new_val)) {
+		if (!matrix::isEqualF((float)*old_val, (float)*new_val)) {
 			// If so, copy the new value over to the unchanged parameter
 			// Note: If they differ from the beginning we migrate old to new
-			if (firstcall || !isFloatEqual(*old_val, previous_old_val)) {
+			if (firstcall || !matrix::isEqualF((float)*old_val, (float)previous_old_val)) {
 				param_set_no_notification(new_param, old_val);
 				param_get(new_param, new_val);
 
-			} else if (!isFloatEqual(*new_val, previous_new_val)) {
+			} else if (!matrix::isEqualF((float)*new_val, (float)previous_new_val)) {
 				param_set_no_notification(old_param, new_val);
 				param_get(old_param, old_val);
 			}
 		}
 	}
-
-	bool isFloatEqual(float a, float b) const { return fabsf(a - b) > FLT_EPSILON; }
 
 private:
 	void sumDischarged(const hrt_abstime &timestamp, float current_a);

--- a/src/lib/battery/module.yaml
+++ b/src/lib/battery/module.yaml
@@ -133,10 +133,11 @@ parameters:
                     This requires the ESC to provide both voltage as well as current.
             type: enum
             values:
+                -1: Disabled
                 0: Power Module
                 1: External
                 2: ESCs
             reboot_required: true
             num_instances: *max_num_config_instances
             instance_start: 1
-            default: [0, 0]
+            default: [0, -1]

--- a/src/modules/esc_battery/EscBattery.cpp
+++ b/src/modules/esc_battery/EscBattery.cpp
@@ -113,7 +113,6 @@ EscBattery::Run()
 			battery_status_s::BATTERY_SOURCE_ESCS,
 			priority,
 			ctrl.control[actuator_controls_s::INDEX_THROTTLE]);
-		_battery.publish();
 	}
 }
 


### PR DESCRIPTION
Apparently https://github.com/PX4/Firmware/pull/15616 was still incorrect.

- Fixes param migration, e.g. if BAT_N_CELLS is set, migrates to BAT1_N_CELLS.
- disable secondary module by default. This avoids a GCS showing 2 battery indicators. Alternatively we could also check the 'connected' flag, but this is more explicit.

@DonLakeFlyer does this work for you?

Fixes https://github.com/PX4/Firmware/issues/15929