### PR TITLE
Add a USB ardupilot * type

### DIFF
--- a/Tools/upload.sh
+++ b/Tools/upload.sh
@@ -15,7 +15,7 @@ SERIAL_PORTS="/dev/tty.usbmodemPX*,/dev/tty.usbmodem*"
 fi
 
 if [ $SYSTYPE = "Linux" ]; then
-SERIAL_PORTS="/dev/serial/by-id/*_PX4_*,/dev/serial/by-id/usb-3D_Robotics*,/dev/serial/by-id/usb-The_Autopilot*,/dev/serial/by-id/usb-Bitcraze*,/dev/serial/by-id/pci-Bitcraze*,/dev/serial/by-id/usb-Gumstix*,/dev/serial/by-id/usb-UVify*,"
+SERIAL_PORTS="/dev/serial/by-id/*_PX4_*,/dev/serial/by-id/usb-3D_Robotics*,/dev/serial/by-id/usb-The_Autopilot*,/dev/serial/by-id/usb-Bitcraze*,/dev/serial/by-id/pci-Bitcraze*,/dev/serial/by-id/usb-Gumstix*,/dev/serial/by-id/usb-UVify*,/dev/serial/by-id/usb-ArduPilot*,"
 fi
 
 if [[ $SYSTYPE = *"CYGWIN"* ]]; then

--- a/platforms/nuttx/cmake/upload.cmake
+++ b/platforms/nuttx/cmake/upload.cmake
@@ -57,6 +57,7 @@ if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Linux")
 		/dev/serial/by-id/usb-Gumstix*
 		/dev/serial/by-id/usb-Hex_ProfiCNC*
 		/dev/serial/by-id/usb-UVify*
+		/dev/serial/by-id/usb-ArduPilot*
 		)
 
 elseif(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Darwin")


### PR DESCRIPTION
Bootloader is ardupilot,Then use (make Px4_ fmu-v5_ Default upload) does not recognize the USB problem
![image](https://user-images.githubusercontent.com/30532769/96332600-9c1a2f80-1097-11eb-9c7e-ca3d595fc7a7.png)
![image](https://user-images.githubusercontent.com/30532769/96332659-eef3e700-1097-11eb-8d85-4816e394ae85.png)
