### PR TITLE
output_limit: use add_library instead of px4_add_library

### DIFF
--- a/src/lib/output_limit/CMakeLists.txt
+++ b/src/lib/output_limit/CMakeLists.txt
@@ -31,4 +31,6 @@
 #
 ############################################################################
 
-px4_add_library(output_limit output_limit.cpp)
+add_library(output_limit output_limit.cpp)
+target_link_libraries(output_limit PRIVATE prebuild_targets)
+


### PR DESCRIPTION
px4_add_library adds uorb dependencies, which since cf26f24387d added libm.
This in turn led to build failures for px4_io-v2 in the form of:
`__aeabi_f2d' wf_sqrt.c:(.text.sqrtf+0x54): undefined reference to __aeabi_ddiv'`

fixes https://github.com/PX4/Firmware/issues/15982