### PR TITLE
Add apt-get update after adding gazebo list

### DIFF
--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -198,6 +198,8 @@ if [[ $INSTALL_SIM == "true" ]]; then
 	# Gazebo
 	sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
 	wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
+	# Update list, since new gazebo-stable.list has been added
+	sudo apt-get update -y --quiet
 	sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
 		dmidecode \
 		gazebo$gazebo_version \


### PR DESCRIPTION
**Describe problem solved by this pull request**
I ran `./Tools/setup/ubuntu.sh` on a fresh instance of Ubuntu 20.04. Unfortunately, at the end of the process, I was faced with an error above:
```
E: Unable to locate package gazebo11
E: Unable to locate package libgazebo11-dev
```

**Describe your solution**
I found out that `ubuntu.sh`, after adding new entry to source list, does not update it via `apt-get update`. I've added that line between adding gazebo to source list and installing gazebo.

**Describe possible alternatives**
No alternative solutions found, it's pretty straightforward.

**Test data / coverage**
Remove `gazebo11` and `libgazebo11-dev` packages, then removed `/etc/apt/sources.list.d/gazebo-stable.list` file and run `apt-get update`. Then re-run `ubuntu.sh` with a fix and confirmed that no error is presented to me.

**Additional context**
n/a
