### PR TITLE
commander: preflight check don't read mag device_id

### DIFF
--- a/src/modules/commander/Arming/PreFlightCheck/checks/magnetometerCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/magnetometerCheck.cpp
@@ -69,7 +69,7 @@ bool PreFlightCheck::magnetometerCheck(orb_advert_t *mavlink_log_pub, vehicle_st
 
 		if (!calibration_valid) {
 			if (report_fail) {
-				mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Compass #%u %u uncalibrated", instance, device_id);
+				mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Compass #%u uncalibrated", instance);
 			}
 		}
 


### PR DESCRIPTION
QGC reading the device id is a bit annoying and not that useful to a user. This is in sync with accel and gyro checks. 