### PR TITLE
commander: calibration restore sleep after CAL_QGC_DONE_MSG/CAL_QGC_FAILED_MSG

### DIFF
--- a/src/modules/commander/accelerometer_calibration.cpp
+++ b/src/modules/commander/accelerometer_calibration.cpp
@@ -442,11 +442,13 @@ int do_accel_calibration(orb_advert_t *mavlink_log_pub)
 
 		if (!failed) {
 			calibration_log_info(mavlink_log_pub, CAL_QGC_DONE_MSG, sensor_name);
+			px4_usleep(600000); // give this message enough time to propagate
 			return PX4_OK;
 		}
 	}
 
 	calibration_log_critical(mavlink_log_pub, CAL_QGC_FAILED_MSG, sensor_name);
+	px4_usleep(600000); // give this message enough time to propagate
 	return PX4_ERROR;
 }
 

--- a/src/modules/commander/gyro_calibration.cpp
+++ b/src/modules/commander/gyro_calibration.cpp
@@ -338,10 +338,13 @@ int do_gyro_calibration(orb_advert_t *mavlink_log_pub)
 
 		if (!failed) {
 			calibration_log_info(mavlink_log_pub, CAL_QGC_DONE_MSG, sensor_name);
+			px4_usleep(600000); // give this message enough time to propagate
 			return PX4_OK;
 		}
 	}
 
 	calibration_log_critical(mavlink_log_pub, CAL_QGC_FAILED_MSG, sensor_name);
+	px4_usleep(600000); // give this message enough time to propagate
+
 	return PX4_ERROR;
 }

--- a/src/modules/commander/level_calibration.cpp
+++ b/src/modules/commander/level_calibration.cpp
@@ -175,10 +175,12 @@ out:
 
 	if (success) {
 		calibration_log_info(mavlink_log_pub, CAL_QGC_DONE_MSG, "level");
+		px4_usleep(600000); // give this message enough time to propagate
 		return 0;
 
 	} else {
 		calibration_log_critical(mavlink_log_pub, CAL_QGC_FAILED_MSG, "level");
+		px4_usleep(600000); // give this message enough time to propagate
 		return 1;
 	}
 }


### PR DESCRIPTION
These do seem to help on slow SiK serial radios.