### PR TITLE
Remove exception of actuator scaling for airships

### DIFF
--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -89,7 +89,8 @@ mavlink_hil_actuator_controls_t Simulator::actuator_controls_from_outputs()
 	int _system_type = _param_mav_type.get();
 
 	/* scale outputs depending on system type */
-	if (_system_type == MAV_TYPE_QUADROTOR ||
+	if (_system_type == MAV_TYPE_AIRSHIP ||
+	    _system_type == MAV_TYPE_QUADROTOR ||
 	    _system_type == MAV_TYPE_HEXAROTOR ||
 	    _system_type == MAV_TYPE_OCTOROTOR ||
 	    _system_type == MAV_TYPE_VTOL_DUOROTOR ||
@@ -102,6 +103,7 @@ mavlink_hil_actuator_controls_t Simulator::actuator_controls_from_outputs()
 		unsigned n;
 
 		switch (_system_type) {
+		case MAV_TYPE_AIRSHIP:
 		case MAV_TYPE_VTOL_DUOROTOR:
 			n = 2;
 			break;
@@ -139,25 +141,6 @@ mavlink_hil_actuator_controls_t Simulator::actuator_controls_from_outputs()
 
 			} else {
 				/* send 0 when disarmed and for disabled channels */
-				msg.controls[i] = 0.0f;
-			}
-		}
-
-	} else if (_system_type == MAV_TYPE_AIRSHIP) {
-		/* airship: scale starboard and port throttle to 0..1 and other channels (tilt, tail thruster) to -1..1 */
-		for (unsigned i = 0; i < 16; i++) {
-			if (armed) {
-				if (i < 2) {
-					/* scale PWM out PWM_DEFAULT_MIN..PWM_DEFAULT_MAX us to 0..1 for rotors */
-					msg.controls[i] = (_actuator_outputs.output[i] - PWM_DEFAULT_MIN) / (PWM_DEFAULT_MAX - PWM_DEFAULT_MIN);
-
-				} else {
-					/* scale PWM out PWM_DEFAULT_MIN..PWM_DEFAULT_MAX us to -1..1 for other channels */
-					msg.controls[i] = (_actuator_outputs.output[i] - pwm_center) / ((PWM_DEFAULT_MAX - PWM_DEFAULT_MIN) / 2);
-				}
-
-			} else {
-				/* set 0 for disabled channels */
 				msg.controls[i] = 0.0f;
 			}
 		}


### PR DESCRIPTION
**Describe problem solved by this pull request**
Actuator scaling for simulators for `MAV_TYPE_AIRSHIP` was unnecessarily being handled as an exception, while it could be just handled as part of the regular logic.

**Describe your solution**
This removes the exception handling of airship type vehicles when scaling actuators for the simulator

**Test data / coverage**

**Additional context**
This problem arises partly because we have actuator scaling in the simulator mavlink module. IMHO, there should be no actuator scaling when packing it on the actuator control messages, and should be handled by the simulators itself.