### PR TITLE
Blade 130x: Move actuators to faster outputs

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/16001_helicopter
+++ b/ROMFS/px4fmu_common/init.d/airframes/16001_helicopter
@@ -7,11 +7,11 @@
 #
 # @maintainer Bart Slinger <bartslinger@gmail.com>
 #
-# @output MAIN1 main motor
-# @output MAIN2 front swashplate servo
-# @output MAIN3 right swashplate servo
-# @output MAIN4 left swashplate servo
-# @output MAIN5 tail-rotor servo
+# @output AUX1 main motor
+# @output AUX2 front swashplate servo
+# @output AUX3 right swashplate servo
+# @output AUX4 left swashplate servo
+# @output AUX5 tail-rotor servo
 #
 # @board px4_fmu-v2 exclude
 # @board intel_aerofc-v1 exclude
@@ -23,7 +23,8 @@
 # Configure as helicopter (number 4 defined in commander_helper.cpp)
 set MAV_TYPE 4
 
-set MIXER blade130
+set MIXER pass
+set MIXER_AUX blade130
 
 #set PWM_OUT 1234
 


### PR DESCRIPTION
**Describe problem solved by this pull request**

The historically designated AUX outputs are directly connected to FMU and have a faster output rate.

**Describe your solution**
 This is what rotary wings should default to. It also avoids complications with loading complex mixers.

**Describe possible alternatives**
We really need to move away from always using IO, so there is no good alternative.

**Test data / coverage**
This is UNTESTED and should be tested by heli contributors.
