### PR TITLE
sensors: force parameter update if mag device id still isn't set

### DIFF
--- a/src/modules/sensors/voted_sensors_update.cpp
+++ b/src/modules/sensors/voted_sensors_update.cpp
@@ -405,6 +405,11 @@ void VotedSensorsUpdate::magPoll(vehicle_magnetometer_s &magnetometer)
 
 		if (_mag.enabled[uorb_index] && _mag.subscription[uorb_index].update(&mag_report)) {
 
+			// force parameter update (loads calibration) if device id still isn't set
+			if (_mag_device_id[uorb_index] == 0) {
+				parametersUpdate();
+			}
+
 			// First publication with data
 			if (_mag.priority[uorb_index] == 0) {
 				_mag.priority[uorb_index] = _mag.subscription[uorb_index].get_priority();


### PR DESCRIPTION
There's a race condition when you only have 1 mag where the sensors module may not update the parameters (and load the calibration) after that first mag starts publishing data. This doesn't apply to current master where the entire calibration architecture was restructured to avoid these types of issues.

This will be part of PX4 v1.11.2.