### PR TITLE
parameter markdown table - remove styling

### DIFF
--- a/src/lib/parameters/px4params/markdownout.py
+++ b/src/lib/parameters/px4params/markdownout.py
@@ -11,7 +11,7 @@ class MarkdownTablesOutput():
                   "\n")
         for group in groups:
             result += '## %s\n\n' % group.GetName()
-            result += '<table style="width: 100%; table-layout:fixed; font-size:1.5rem; overflow: auto; display:block;">\n'
+            result += '<table>\n'
             result += ' <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>\n'
             result += ' <thead>\n'
             result += '   <tr><th>Name</th><th>Description</th><th>Min > Max (Incr.)</th><th>Default</th><th>Units</th></tr>\n'


### PR DESCRIPTION
The styling on this table is a "hangover" from the original generated docs. I want to remove it as it affects rendering on [vuepress version of docs](https://docs.px4.io/v1.testing/en/advanced_config/parameter_reference.html). 

This change has no effect on gitbook, and IMO is "better HTML".