### PR TITLE
positionControl: add check on sign before sqrtf

### DIFF
--- a/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
@@ -164,7 +164,12 @@ void PositionControl::_velocityControl(const float dt)
 	// Get allowed horizontal thrust after prioritizing vertical control
 	const float thrust_max_squared = _lim_thr_max * _lim_thr_max;
 	const float thrust_z_squared = _thr_sp(2) * _thr_sp(2);
-	float thrust_max_xy = sqrtf(thrust_max_squared - thrust_z_squared);
+	const float thrust_max_xy_squared = thrust_max_squared - thrust_z_squared;
+	float thrust_max_xy = 0;
+
+	if (thrust_max_xy_squared > 0) {
+		thrust_max_xy = sqrtf(thrust_max_xy_squared);
+	}
 
 	// Saturate thrust in horizontal direction
 	const Vector2f thrust_sp_xy(_thr_sp);


### PR DESCRIPTION
**Describe problem solved by this pull request**

We crashed a drone because of this: in really high winds, the vertical thrust saturate and it horizontal thrust saturation disappeared so the drone began to tilt too much to compensate the wind and start going down very quickly (and crashed).

In PositionControl.cpp/_velocityController function (on v1.10 branch), when vertical thrust is superior to MPC_THR_MAX, it is saturated to MPC_THR_MAX. But horizontal thrust max saturation become NAN, resulting in no horizontal saturation.
I can reproduce `_param_mpc_thr_max.get() * _param_mpc_thr_max.get() - _thr_sp(2) * _thr_sp(2)` beginning slightly < 0
So as the square root of this is used ...

I have not been able to reproduce the bug on master.
On master and 1.11, vertical thrust is also saturated to MPC_THR_MAX and then the calculation is split as :
```
const float thrust_max_squared = _lim_thr_max * _lim_thr_max;
const float thrust_z_squared = _thr_sp(2) * _thr_sp(2);
float thrust_max_xy = sqrtf(thrust_max_squared - thrust_z_squared);
```
It seems to be enough to fix the bug.


**Describe your solution**
I added a sign check before sqrt on my firmware based on v1.10.
This security can be added to master even if the bug is not seen.


**Additional context**
![throttle_sat](https://user-images.githubusercontent.com/59083163/96883889-2cce8200-1481-11eb-8575-df337c7fab5b.png)

https://github.com/PX4/Firmware/issues/16029#issuecomment-714507664
