### PR TITLE
Fix NuttX build under Cygwin

### DIFF
--- a/platforms/nuttx/NuttX/Make.defs.in
+++ b/platforms/nuttx/NuttX/Make.defs.in
@@ -33,19 +33,45 @@
 #
 ############################################################################
 
+# Set flags for the NuttX build system for Cygwin
+# They are already used by Config.mk
+ifneq (, $(findstring CYGWIN, $(shell uname)))
+  CONFIG_HOST_CYGWIN := y
+  CONFIG_WINDOWS_CYGWIN := y
+  CONFIG_CYGWIN_WINTOOL := y
+endif
+
 include $(TOPDIR)/.config
 include $(TOPDIR)/tools/Config.mk
+
+# Replace each space separated word in the string that contains "cygdrive"
+# with the windows path and escaped backslashes
+# e.g. [hello -I /cygdrive/c -I/cygdrive/c] -> [hello -I C:\\ ]
+define cygwin_to_windows_paths
+$(subst \,\\,$(foreach word,$(1),$(shell \
+if [[ "$(word)" == *"cygdrive"* ]]; then \
+  cygpath -w "$(word)"; \
+else \
+  echo $(word); \
+fi \
+)))
+endef
 
 CINCPATH := $(shell $(INCDIR) -s "$(CC)" $(TOPDIR)$(DELIM)include)
 CXXINCPATH := $(shell $(INCDIR) -s "$(CC)" $(TOPDIR)$(DELIM)include$(DELIM)cxx)
 
 ARCHINCLUDES += $(CINCPATH)
 ARCHXXINCLUDES += $(CINCPATH) $(CXXINCPATH)
+ARCHSCRIPT = -T$(BOARD_DIR)$(DELIM)scripts$(DELIM)flash.ld
 
-ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
-  ARCHSCRIPT = -T "$(shell cygpath -w $(BOARD_DIR)$(DELIM)scripts$(DELIM)flash.ld)"
-else
-  ARCHSCRIPT = -T$(BOARD_DIR)$(DELIM)scripts$(DELIM)flash.ld
+ifeq ($(CONFIG_BOARD_USE_PROBES),y)
+   ARCHINCLUDES += -I $(TOPDIR)/arch/$(CONFIG_ARCH)/src/$(CONFIG_ARCH_CHIP) -I $(TOPDIR)/arch/$(CONFIG_ARCH)/src/common
+   ARCHXXINCLUDES += -I $(TOPDIR)/arch/$(CONFIG_ARCH)/src/$(CONFIG_ARCH_CHIP) -I $(TOPDIR)/arch/$(CONFIG_ARCH)/src/common
+endif
+
+ifneq (, $(findstring CYGWIN, $(shell uname)))
+  ARCHINCLUDES := $(call cygwin_to_windows_paths,$(ARCHINCLUDES))
+  ARCHXXINCLUDES := $(call cygwin_to_windows_paths,$(ARCHXXINCLUDES))
 endif
 
 CC = ${CMAKE_C_COMPILER}
@@ -60,11 +86,6 @@ OBJDUMP = ${CMAKE_OBJDUMP}
 
 ARCHCCVERSION = $(shell $(CC) -v 2>&1 | sed -n '/^gcc version/p' | sed -e 's/^gcc version \([0-9\.]\)/\1/g' -e 's/[-\ ].*//g' -e '1q')
 ARCHCCMAJOR = $(shell echo $(ARCHCCVERSION) | cut -d'.' -f1)
-
-ifeq ($(CONFIG_BOARD_USE_PROBES),y)
-   ARCHINCLUDES += -I$(TOPDIR)/arch/$(CONFIG_ARCH)/src/$(CONFIG_ARCH_CHIP) -I$(TOPDIR)/arch/$(CONFIG_ARCH)/src/common
-   ARCHXXINCLUDES += -I$(TOPDIR)/arch/$(CONFIG_ARCH)/src/$(CONFIG_ARCH_CHIP)  -I$(TOPDIR)/arch/$(CONFIG_ARCH)/src/common
-endif
 
 ifeq ($(CONFIG_DEBUG_CUSTOMOPT),y)
    MAXOPTIMIZATION = $(CONFIG_DEBUG_OPTLEVEL)


### PR DESCRIPTION
**Describe problem solved by this pull request**
NuttX build using the [Cygwin Toolchain](https://dev.px4.io/master/en/setup/dev_env_windows_cygwin.html) is broken since the NuttX 9.1.0+ upgrade #15139 . The pr was merged nevertheless to unblock core developers using the new NuttX version and with the intent to fix the build shortly after. PX4 stable v1.11 was the officially recommended version to build in case you ran into any problems.

Fixes #15760 

**Describe your solution**
It took me quite some time to figure out:
- NuttX has a new way of configuring the build environment now using multiple flags
- Those flags have to be set before including Config.mk
- The new way of assembling `ARCHINCLUDES` even before the makefile made a new way of converting the include paths that are already inside compile flags necessary
- Backslashes in the compile flags for some reason get parsed and have to be escaped. I did not invest time in findign exactly where that happens but it's most likely within the NuttX build system and when escaping them it all works fine.

**Test data / coverage**
So far I build `px4_fmu-v4` locally but didn't do any hardware tests yet.

**Additional context**
![image](https://user-images.githubusercontent.com/4668506/97007005-04a65800-1541-11eb-987c-c2ab0f30dff1.png)

