### PR TITLE
SP Racing H7 extrem:  updated to use icm20602 drivers

### DIFF
--- a/boards/spracing/h7extreme/default.cmake
+++ b/boards/spracing/h7extreme/default.cmake
@@ -29,7 +29,7 @@ px4_add_board(
 		#imu/adis16497
 		#imu/bmi088
 		imu/mpu6000
-		#imu/invensense/icm20602
+		imu/invensense/icm20602
 		#imu/mpu9250
 		#irlock
 		lights/blinkm

--- a/boards/spracing/h7extreme/init/rc.board_sensors
+++ b/boards/spracing/h7extreme/init/rc.board_sensors
@@ -5,9 +5,10 @@
 board_adc start
 
 # Internal SPI bus ICM-20602
-mpu6000 -s -b 2 -R 11 -T 20602 start # SPI 2
+#mpu6000 -s -b 2 -R 11 -T 20602 start # SPI 2
 #mpu6000 -s -b 3 -R 10 -T 20602 start # SPI 3
-#icm20602 -s -b 2 -R 5 start # SPI 2
+icm20602 -s -b 2 -R 5 start # SPI 2
+icm20602 -s -b 3 -R 4 start # SPI 3
 
 # Internal I2C bus
 bmp388 -I start

--- a/boards/spracing/h7extreme/nuttx-config/include/board.h
+++ b/boards/spracing/h7extreme/nuttx-config/include/board.h
@@ -56,12 +56,12 @@
 /* Clocking *************************************************************************/
 /* The sp racing h7 extreme  board provides the following clock sources:
  *
- *   X1: 25 MHz crystal for HSE
+ *   X1: 8 MHz crystal for HSE
  *
  * So we have these clock source available within the STM32
  *
  *   HSI: 64 MHz RC factory-trimmed
- *   HSE: 25 MHz crystal for HSE
+ *   HSE:  8 MHz crystal for HSE
  */
 
 #define STM32_BOARD_XTAL        8000000ul
@@ -98,11 +98,11 @@
 
 /* PLL1, wide 4 - 8 MHz input, enable DIVP, DIVQ, DIVR
  *
- *   PLL1_VCO = (25,000,000 / 5) * 160 = 800 MHz
+ *   PLL1_VCO = (8,000,000 / 2) * 200 = 800 MHz
  *
  *   PLL1P = PLL1_VCO/2  = 800 MHz / 2   = 400 MHz
- *   PLL1Q = PLL1_VCO/4  = 800 MHz / 4   = 200 MHz
- *   PLL1R = PLL1_VCO/8  = 800 MHz / 8   = 100 MHz
+ *   PLL1Q = PLL1_VCO/4  = 800 MHz / 4  =  200 MHz
+ *   PLL1R = PLL1_VCO/2  = 800 MHz / 2   = 400 MHz - locked for H750
  */
 
 #define STM32_PLLCFG_PLL1CFG    (RCC_PLLCFGR_PLL1VCOSEL_WIDE | \

--- a/boards/spracing/h7extreme/nuttx-config/include/board_dma_map.h
+++ b/boards/spracing/h7extreme/nuttx-config/include/board_dma_map.h
@@ -33,83 +33,9 @@
 
 #pragma once
 
-/*
-|    DMA1    | Stream 0         | Stream 1         | Stream 2         | Stream 3         | Stream 4         | Stream 5         | Stream 6         | Stream 7         |
-|------------|------------------|------------------|------------------|------------------|------------------|------------------|------------------|------------------|
-| Channel 0  | SPI3_RX_1        | SPDIFRX_DT       | SPI3_RX_2        | SPI2_RX          | SPI2_TX          | SPI3_TX_1        | SPDIFRX_CS       | SPI3_TX_2        |
-| Channel 1  | I2C1_RX          | I2C3_RX          | TIM7_UP_1        | -                | TIM7_UP_2        |  I2C1_RX_1       | I2C1_TX          | I2C1_TX_1        |
-| Channel 2  | TIM4_CH1         | -                | I2C4_RX          | TIM4_CH2         | -                | I2C4_RX          | TIM4_UP          | TIM4_CH3         |
-| Channel 3  | -                | TIM2_UP_1        | I2C3_RX_1        | -                | I2C3_TX          | TIM2_CH1         | TIM2_CH2         | TIM2_UP_2        |
-|            |                  |   TIM2_CH3       |                  |                  |                  |                  |   TIM2_CH4_1     |   TIM2_CH4_2     |
-| Channel 4  | UART5_RX         | USART3_RX        | UART4_RX         | USART3_TX_1      | UART4_TX         | USART2_RX        | USART2_TX        | UART5_TX         |
-| Channel 5  | UART8_TX         | UART7_TX         | TIM3_CH4         | UART7_RX         | TIM3_CH1         | TIM3_CH2         | UART8_RX         | TIM3_CH3         |
-|            |                  |                  |   TIM3_UP        |                  |   TIM3_TRIG      |                  |                  |                  |
-| Channel 6  | TIM5_CH3         | TIM5_CH4_1       | TIM5_CH1         | TIM5_CH4_2       | TIM5_CH2         | -                | TIM5_UP_2        | -                |
-|            |   TIM5_UP_1      |   TIM5_TRIG_1    |                  |   TIM5_TRIG_2    |                  |                  |                  |                  |
-| Channel 7  | -                | TIM6_UP          | I2C2_RX          | I2C2_RX_1        | USART3_TX_2      | DAC1             | DAC2             | I2C2_TX          |
-| Channel 8  | I2C3_TX          | I2C4_RX          | -                | -                | I2C2_TX          | -                | I2C4_TX          | -                |
-| Channel 9  | -                | SPI2_RX          | -                | -                | -                | -                | SPI2_TX          | -                |
-|            |                  |                  |                  |                  |                  |                  |                  |                  |
-| Usage      |                  |                  | TIM3_UP          |                  |                  | USART2_RX        | TIM5_UP_2        |                  |
-
-
-|    DMA2    | Stream 0         | Stream 1         | Stream 2         | Stream 3         | Stream 4         | Stream 5         | Stream 6         | Stream 7         |
-|------------|------------------|------------------|------------------|------------------|------------------|------------------|------------------|------------------|
-| Channel 0  | ADC1_1           | SAI1_A           | TIM8_CH1_1       | SAI1_A_1         | ADC1_2           | SAI1_B_1         | TIM1_CH1_1       | SAI2_B_2         |
-|            |                  |                  |   TIM8_CH2_1     |                  |                  |                  |   TIM1_CH2_1     |                  |
-|            |                  |                  |   TIM8_CH3_1     |                  |                  |                  |   TIM1_CH3_1     |                  |
-| Channel 1  | -                | DCMI_1           | ADC2_1           | ADC2_2           | SAI1_B           | SPI6_TX          | SPI6_RX          | DCMI_2           |
-| Channel 2  | ADC3_1           | ADC3_2           | -                | SPI5_RX_1        | SPI5_TX_1        | CRYP_OUT         | CRYP_IN          | HASH_IN          |
-| Channel 3  | SPI1_RX_1        | -                | SPI1_RX_2        | SPI1_TX_1        | SAI2_A           | SPI1_TX_2        | SAI2_B           | QUADSPI          |
-| Channel 4  | SPI4_RX_1        | SPI4_TX_1        | USART1_RX_1      | SDMMC1_1         | -                | USART1_RX_2      | SDMMC1_2         | USART1_TX        |
-| Channel 5  | -                | USART6_RX_1      | USART6_RX_2      | SPI4_RX_2        | SPI4_TX_2        | -                | USART6_TX_1      | USART6_TX_2      |
-| Channel 6  | TIM1_TRIG_1      | TIM1_CH1_2       | TIM1_CH2_2       | TIM1_CH1         | TIM1_CH4         | TIM1_UP          | TIM1_CH3_2       | -                |
-|            |                  |                  |                  |                  |   TIM1_TRIG_2    |                  |                  |                  |
-|            |                  |                  |                  |                  |   TIM1_COM       |                  |                  |                  |
-| Channel 7  | -                | TIM8_UP          | TIM8_CH1_2       | TIM8_CH2_2       | TIM8_CH3_2       | SPI5_RX_2        | SPI5_TX_2        | TIM8_CH4         |
-|            |                  |                  |                  |                  |                  |                  |                  |   TIM8_TRIG      |
-|            |                  |                  |                  |                  |                  |                  |                  |   TIM8_COM       |
-| Channel 8  | DSFDM1_FLT0      | DSFDM1_FLT1      | DSFDM1_FLT2      | DSFDM1_FLT3      | DSFDM1_FLT0      | DSFDM1_FLT1      | DSFDM1_FLT2      | DSFDM1_FLT3      |
-| Channel 9  | JPEG_IN          | JPEG_OUT         | SPI4_TX          | JPEG_IN          | JPEG_OUT         | SPI5_RX          | -                | -                |
-| Channel 10 | SAI1_B           | SAI2_B           | SAI2_A           | -                | -                | -                | SAI1_A           | -                |
-| Channel 11 | SDMMC2           | -                | QUADSPI          | -                | -                | SDMMC2           | -                | -                |
-|            |                  |                  |                  |                  |                  |                  |                  |                  |
-| Usage      | SPI4_RX_1        | TIM8_UP          |                  |                  | SPI4_TX_2        | TIM1_UP          |                  |                  |
- */
-
-#define STM32_DMA_MAP(d,s,c)       ((d) << 6 | (s) << 3 | (c))
-
-#define DMA_CHAN0                 (0)
-#define DMA_CHAN4                 (4)
-#define DMA_CHAN5                 (5)
-
-#define DMAMAP_SPI2_RX             STM32_DMA_MAP(DMA1,DMA_STREAM3,DMA_CHAN0)
-#define DMAMAP_SPI2_TX             STM32_DMA_MAP(DMA1,DMA_STREAM4,DMA_CHAN0)
-#define DMAMAP_SPI3_RX_2           STM32_DMA_MAP(DMA1,DMA_STREAM2,DMA_CHAN0)
-#define DMAMAP_SPI3_TX_1           STM32_DMA_MAP(DMA1,DMA_STREAM5,DMA_CHAN0)
-#define DMAMAP_SPI4_RX_1           STM32_DMA_MAP(DMA2,DMA_STREAM0,DMA_CHAN4)
-#define DMAMAP_SPI4_TX_2           STM32_DMA_MAP(DMA2,DMA_STREAM4,DMA_CHAN5)
-
-// DMA1 Channel/Stream Selections
-//--------------------------------------------//---------------------------//----------------
-//      DMAMAP_TIM5_UP_1                      // DMA1, Stream 0, Channel 6    (DSHOT)
-//      AVAILABLE                             // DMA1, Stream 1
-#define DMAMAP_SPI3_RX DMAMAP_SPI3_RX_2       // DMA1, Stream 2, Channel 0    (SPI sensors ICM20602 2)
-//      DMAMAP_SPI2_RX                        // DMA1, Stream 3, Channel 0    (SPI sensors ICM20602 1)
-//      DMAMAP_SPI2_TX                        // DMA1, Stream 4, Channel 0    (SPI sensors ICM20602 1)
-#define DMAMAP_SPI3_TX DMAMAP_SPI3_TX_1       // DMA1, Stream 5, Channel 0    (SPI sensors ICM20602 2)
-//      DMAMAP_TIM4_UP                        // DMA1, Stream 6, Channel 2    (DSHOT)
-//      AVAILABLE                             // DMA1, Stream 7
-
-
-//  DMA2 Channel/Stream Selections
-//--------------------------------------------//---------------------------//----------------
-#define DMAMAP_SPI4_RX DMAMAP_SPI4_RX_1       // DMA2, Stream 0, Channel 4    (SPI OSD)
-//      DMAMAP_TIM8_UP                        // DMA2, Stream 1, Channel 7    (DSHOT)
-//      AVAILABLE                             // DMA1, Stream 2
-//      AVAILABLE                             // DMA1, Stream 3
-#define DMAMAP_SPI4_TX DMAMAP_SPI4_TX_2       // DMA2, Stream 4, Channel 5    (SPI OSD)
-//      AVAILABLE                             // DMA2, Stream 5
-//      AVAILABLE                             // DMA1, Stream 6
-//      AVAILABLE                             // DMA1, Stream 7
-
+#define DMAMAP_SPI2_RX    DMAMAP_DMA12_SPI2RX_0      //(SPI Gyro 1)
+#define DMAMAP_SPI2_TX    DMAMAP_DMA12_SPI2TX_0      //(SPI Gyro 1)
+#define DMAMAP_SPI3_RX    DMAMAP_DMA12_SPI3RX_0      //(SPI Gyro 2)
+#define DMAMAP_SPI3_TX    DMAMAP_DMA12_SPI3TX_0      //(SPI Gyro 2)
+#define DMAMAP_SPI4_RX    DMAMAP_DMA12_SPI4RX_0      //(SPI OSD)
+#define DMAMAP_SPI4_TX    DMAMAP_DMA12_SPI4TX_0      //(SPI OSD)


### PR DESCRIPTION
**Describe problem solved by this pull request**
Previously the board used mpu6000 drivers, now it is updated to use icm20602.
Both gyros are enabled. 

**Describe your solution**
Not sure what helped but it seems in the meantime something fixed DMA for SPI, and now gyros started working with updates in this commit.
I've just enabled DMA mux (I tried this same method before but this is the first time that it works)

![image](https://user-images.githubusercontent.com/10188706/97038470-2ae0ed80-156b-11eb-984b-2c2bd21a303c.png)
![image](https://user-images.githubusercontent.com/10188706/97039054-13563480-156c-11eb-88cf-4188418a5116.png)


