### PR TITLE
gyro_fft: improve peak detection, add start parameter

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -526,6 +526,11 @@ else
 		bst start -X
 	fi
 
+	if param compare IMU_GYRO_FFT_EN 1
+	then
+		gyro_fft start
+	fi
+
 	#
 	# Optional board supplied extras: rc.board_extras
 	#

--- a/msg/sensor_gyro_fft.msg
+++ b/msg/sensor_gyro_fft.msg
@@ -7,11 +7,6 @@ float32 dt                # delta time between samples (microseconds)
 
 float32 resolution_hz
 
-uint8[3] peak_index_0
-uint8[3] peak_index_1
-
-float32[3] peak_frequency_0 # largest frequency peak found per sensor axis (0 if none)
-float32[3] peak_frequency_1 # second largest frequency peak found per sensor axis (0 if none)
-
-uint8[3] peak_index_quinns
-float32[3] peak_frequency_quinns
+float32[2] peak_frequency_x # x axis peak frequencies
+float32[2] peak_frequency_y # y axis peak frequencies
+float32[2] peak_frequency_z # z axis peak frequencies

--- a/src/examples/gyro_fft/CMakeLists.txt
+++ b/src/examples/gyro_fft/CMakeLists.txt
@@ -71,7 +71,7 @@ px4_add_module(
 	MODULE modules__gyro_fft
 	MAIN gyro_fft
 	STACK_MAIN
-		8192
+		4096
 	COMPILE_FLAGS
 		${MAX_CUSTOM_OPT_LEVEL}
 	INCLUDES

--- a/src/examples/gyro_fft/GyroFFT.hpp
+++ b/src/examples/gyro_fft/GyroFFT.hpp
@@ -74,6 +74,9 @@ public:
 	bool init();
 
 private:
+	static constexpr uint16_t FFT_LENGTH = 2048;
+
+	float EstimatePeakFrequency(q15_t fft[FFT_LENGTH * 2], uint8_t peak_index);
 	void Run() override;
 	bool SensorSelectionUpdate(bool force = false);
 	void VehicleIMUStatusUpdate();
@@ -95,10 +98,9 @@ private:
 
 	uint32_t _selected_sensor_device_id{0};
 
-	static constexpr uint16_t FFT_LENGTH = 1024;
-	arm_rfft_instance_q15 _rfft_q15[3];
+	arm_rfft_instance_q15 _rfft_q15;
 
-	q15_t _data_buffer[3][FFT_LENGTH] {};
+	q15_t _gyro_data_buffer[3][FFT_LENGTH] {};
 	q15_t _hanning_window[FFT_LENGTH] {};
 	q15_t _fft_input_buffer[FFT_LENGTH] {};
 	q15_t _fft_outupt_buffer[FFT_LENGTH * 2] {};

--- a/src/examples/gyro_fft/parameters.c
+++ b/src/examples/gyro_fft/parameters.c
@@ -32,6 +32,15 @@
  ****************************************************************************/
 
 /**
+* IMU gyro FFT enable.
+*
+* @boolean
+* @reboot_required true
+* @group Sensors
+*/
+PARAM_DEFINE_INT32(IMU_GYRO_FFT_EN, 0);
+
+/**
 * IMU gyro FFT minimum frequency.
 *
 * @min 1
@@ -40,7 +49,7 @@
 * @reboot_required true
 * @group Sensors
 */
-PARAM_DEFINE_FLOAT(IMU_GYRO_FFT_MIN, 30.0f);
+PARAM_DEFINE_FLOAT(IMU_GYRO_FFT_MIN, 50.0f);
 
 /**
 * IMU gyro FFT maximum frequency.


### PR DESCRIPTION
 - add new parameter `IMU_GYRO_FFT_EN` to start
 - add 75% overlap in buffer to increase FFT update rate
 - space out FFT calls (no more than 1 per cycle)
 - increase `IMU_GYRO_FFT_MIN` default
 - decrease main stack usage