### PR TITLE
FlightTasks: fix reActivate not calling the parent overrided method

### DIFF
--- a/src/lib/flight_tasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
+++ b/src/lib/flight_tasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
@@ -72,6 +72,8 @@ bool FlightTaskAutoLineSmoothVel::activate(const vehicle_local_position_setpoint
 
 void FlightTaskAutoLineSmoothVel::reActivate()
 {
+	FlightTaskAutoMapper::reActivate();
+
 	// On ground, reset acceleration and velocity to zero
 	for (int i = 0; i < 2; ++i) {
 		_trajectory[i].reset(0.f, 0.f, _position(i));

--- a/src/lib/flight_tasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.cpp
+++ b/src/lib/flight_tasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.cpp
@@ -63,6 +63,7 @@ bool FlightTaskManualAltitudeSmoothVel::activate(const vehicle_local_position_se
 
 void FlightTaskManualAltitudeSmoothVel::reActivate()
 {
+	FlightTaskManualAltitude::reActivate();
 	// The task is reacivated while the vehicle is on the ground. To detect takeoff in mc_pos_control_main properly
 	// using the generated jerk, reset the z derivatives to zero
 	_smoothing.reset(0.f, 0.f, _position(2));

--- a/src/lib/flight_tasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.hpp
+++ b/src/lib/flight_tasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.hpp
@@ -58,11 +58,11 @@ protected:
 	void _ekfResetHandlerPositionZ() override;
 	void _ekfResetHandlerVelocityZ() override;
 
-	DEFINE_PARAMETERS(
-		(ParamFloat<px4::params::MPC_JERK_MAX>) _param_mpc_jerk_max,
-		(ParamFloat<px4::params::MPC_ACC_UP_MAX>) _param_mpc_acc_up_max,
-		(ParamFloat<px4::params::MPC_ACC_DOWN_MAX>) _param_mpc_acc_down_max
-	)
+	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTaskManualAltitude,
+					(ParamFloat<px4::params::MPC_JERK_MAX>) _param_mpc_jerk_max,
+					(ParamFloat<px4::params::MPC_ACC_UP_MAX>) _param_mpc_acc_up_max,
+					(ParamFloat<px4::params::MPC_ACC_DOWN_MAX>) _param_mpc_acc_down_max
+				       )
 
 private:
 	void _updateTrajConstraints();

--- a/src/lib/flight_tasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
+++ b/src/lib/flight_tasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
@@ -66,6 +66,7 @@ bool FlightTaskManualPositionSmoothVel::activate(const vehicle_local_position_se
 
 void FlightTaskManualPositionSmoothVel::reActivate()
 {
+	FlightTaskManualPosition::reActivate();
 	// The task is reacivated while the vehicle is on the ground. To detect takeoff in mc_pos_control_main properly
 	// using the generated jerk, reset the z derivatives to zero
 	_smoothing_xy.reset(Vector2f(), Vector2f(_velocity), Vector2f(_position));


### PR DESCRIPTION
**Describe problem solved by this pull request**
The orriding child class should call the `reActivate()` function of the parent. Otherwise e.g. the base reactivate logic gets overriden and skipped.
