### PR TITLE
sensors/vehicle_gps_position: only register callbacks once topic published

### DIFF
--- a/src/modules/uORB/SubscriptionCallback.hpp
+++ b/src/modules/uORB/SubscriptionCallback.hpp
@@ -68,22 +68,24 @@ public:
 
 	bool registerCallback()
 	{
-		if (_subscription.get_node() && _subscription.get_node()->register_callback(this)) {
-			// registered
-			_registered = true;
+		if (!_registered) {
+			if (_subscription.get_node() && _subscription.get_node()->register_callback(this)) {
+				// registered
+				_registered = true;
 
-		} else {
-			// force topic creation by subscribing with old API
-			int fd = orb_subscribe_multi(_subscription.get_topic(), _subscription.get_instance());
+			} else {
+				// force topic creation by subscribing with old API
+				int fd = orb_subscribe_multi(_subscription.get_topic(), _subscription.get_instance());
 
-			// try to register callback again
-			if (_subscription.subscribe()) {
-				if (_subscription.get_node() && _subscription.get_node()->register_callback(this)) {
-					_registered = true;
+				// try to register callback again
+				if (_subscription.subscribe()) {
+					if (_subscription.get_node() && _subscription.get_node()->register_callback(this)) {
+						_registered = true;
+					}
 				}
-			}
 
-			orb_unsubscribe(fd);
+				orb_unsubscribe(fd);
+			}
 		}
 
 		return _registered;
@@ -130,6 +132,8 @@ public:
 	}
 
 	virtual void call() = 0;
+
+	bool registered() const { return _registered; }
 
 protected:
 


### PR DESCRIPTION
 - this avoids creating unnecessary uORB device nodes for GPS instances that might never exist

